### PR TITLE
Reduce concurrent ingest CPU and memory overhead

### DIFF
--- a/App/FeatureSet/Telemetry/Services/LogPipelineService.ts
+++ b/App/FeatureSet/Telemetry/Services/LogPipelineService.ts
@@ -28,7 +28,7 @@ import {
   matchGrokPattern,
 } from "Common/Utils/Grok/Grok";
 import logger from "Common/Server/Utils/Logger";
-import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
+import PipelineCache from "../Utils/PipelineCache";
 import getPipelineProcessorConfig from "../Utils/PipelineProcessorConfig";
 
 export interface LoadedPipeline {
@@ -67,22 +67,22 @@ const MAX_CACHED_PROJECTS: number = 10_000;
 const MAX_LOGGED_INVALID_GROK_PATTERNS: number = 1000;
 const loggedInvalidGrokPatterns: Set<string> = new Set<string>();
 
-const pipelineCache: InMemoryTTLCache<Array<LoadedPipeline>> =
-  new InMemoryTTLCache<Array<LoadedPipeline>>(MAX_CACHED_PROJECTS);
+const pipelineCache: PipelineCache<Array<LoadedPipeline>> = new PipelineCache<
+  Array<LoadedPipeline>
+>(MAX_CACHED_PROJECTS, CACHE_TTL_MS);
 
 export class LogPipelineService {
   public static async loadPipelines(
     projectId: ObjectID,
   ): Promise<Array<LoadedPipeline>> {
-    const cacheKey: string = projectId.toString();
-    const cached: Array<LoadedPipeline> | undefined =
-      pipelineCache.get(cacheKey);
+    return pipelineCache.getOrLoad(projectId.toString(), () => {
+      return LogPipelineService.loadPipelinesFromDatabase(projectId);
+    });
+  }
 
-    // Empty arrays are truthy — zero-pipeline projects stay negatively cached.
-    if (cached) {
-      return cached;
-    }
-
+  private static async loadPipelinesFromDatabase(
+    projectId: ObjectID,
+  ): Promise<Array<LoadedPipeline>> {
     const pipelineService: DatabaseService<LogPipeline> =
       new DatabaseService<LogPipeline>(LogPipeline);
 
@@ -143,7 +143,6 @@ export class LogPipelineService {
       });
     }
 
-    pipelineCache.set(cacheKey, loaded, CACHE_TTL_MS);
     return loaded;
   }
 

--- a/App/FeatureSet/Telemetry/Services/OtelMetricsIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/OtelMetricsIngestService.ts
@@ -30,7 +30,7 @@ import logger, {
 } from "Common/Server/Utils/Logger";
 import CaptureSpan from "Common/Server/Utils/Telemetry/CaptureSpan";
 import MetricType from "Common/Models/DatabaseModels/MetricType";
-import Service from "Common/Models/DatabaseModels/Service";
+import MetricCatalog from "../Utils/MetricCatalog";
 import MetricsQueueService from "./Queue/MetricsQueueService";
 import OtelIngestBaseService from "./OtelIngestBaseService";
 import ServiceType from "Common/Types/Telemetry/ServiceType";
@@ -629,7 +629,9 @@ export default class OtelMetricsIngestService extends OtelIngestBaseService {
       const dbMetrics: Array<JSONObject> = [];
       const serviceDictionary: Dictionary<TelemetryServiceMetadata> = {};
 
-      const metricNameServiceNameMap: Dictionary<MetricType> = {};
+      const metricCatalog: MetricCatalog = new MetricCatalog();
+      const metricNameServiceNameMap: Dictionary<MetricType> =
+        metricCatalog.metricNameServiceNameMap;
       let totalMetricsProcessed: number = 0;
       const projectId: ObjectID = (req as TelemetryRequest).projectId;
 
@@ -997,41 +999,13 @@ export default class OtelMetricsIngestService extends OtelIngestBaseService {
           ) {
             hostHeartbeatHostNames.add(heartbeatHostName);
             const heartbeatMetricName: string = "oneuptime.host.heartbeat";
-            if (!metricNameServiceNameMap[heartbeatMetricName]) {
-              const heartbeatMetricType: MetricType = new MetricType();
-              heartbeatMetricType.name = heartbeatMetricName;
-              heartbeatMetricType.description =
-                "Synthetic heartbeat emitted by OneUptime each time the host's OTel collector ships a metric batch. Use `count > 0` over a window to detect host up/down.";
-              heartbeatMetricType.unit = "1";
-              heartbeatMetricType.services = [];
-              metricNameServiceNameMap[heartbeatMetricName] =
-                heartbeatMetricType;
-            }
-            /*
-             * Only associate a real Service row (OpenTelemetry type).
-             * The host heartbeat's primaryEntityId is a Host/DockerHost/
-             * KubernetesCluster id, which has no matching Service row,
-             * so pushing it would fail the MetricType.services FK. The
-             * heartbeat MetricType is still cataloged above without a
-             * service link.
-             */
-            if (
-              serviceMetadata.primaryEntityType === ServiceType.OpenTelemetry &&
-              metricNameServiceNameMap[heartbeatMetricName]!.services!.filter(
-                (svc: Service) => {
-                  return (
-                    svc.id?.toString() ===
-                    serviceMetadata.primaryEntityId!.toString()
-                  );
-                },
-              ).length === 0
-            ) {
-              const heartbeatService: Service = new Service();
-              heartbeatService.id = serviceMetadata.primaryEntityId!;
-              metricNameServiceNameMap[heartbeatMetricName]!.services!.push(
-                heartbeatService,
-              );
-            }
+            metricCatalog.addMetric({
+              name: heartbeatMetricName,
+              description:
+                "Synthetic heartbeat emitted by OneUptime each time the host's OTel collector ships a metric batch. Use `count > 0` over a window to detect host up/down.",
+              unit: "1",
+              serviceMetadata,
+            });
             /*
              * Stamp the heartbeat with the host's newest datapoint
              * timestamp in this payload, not the ingest wall clock.
@@ -1144,47 +1118,12 @@ export default class OtelMetricsIngestService extends OtelIngestBaseService {
                   ] as string;
                   const metricUnit: string = metric["unit"] as string;
 
-                  if (metricName) {
-                    if (!metricNameServiceNameMap[metricName]) {
-                      metricNameServiceNameMap[metricName] = new MetricType();
-                      metricNameServiceNameMap[metricName]!.name = metricName;
-                      metricNameServiceNameMap[metricName]!.description =
-                        metricDescription;
-                      metricNameServiceNameMap[metricName]!.unit = metricUnit;
-                      metricNameServiceNameMap[metricName]!.services = [];
-                    }
-
-                    /*
-                     * MetricType.services is a ManyToMany to the
-                     * Service table (join keyed on primaryEntityId). Only
-                     * OpenTelemetry-type telemetry has a real Service
-                     * row; associating Host / DockerHost /
-                     * KubernetesCluster / Unknown telemetry here would
-                     * insert a join row whose primaryEntityId has no matching
-                     * Service and fail the FK. The metric name itself is
-                     * still cataloged above (just without a service
-                     * link), and the datapoints carry the primaryEntityId in
-                     * ClickHouse regardless.
-                     */
-                    if (
-                      serviceMetadata.primaryEntityType ===
-                        ServiceType.OpenTelemetry &&
-                      metricNameServiceNameMap[metricName]!.services!.filter(
-                        (service: Service) => {
-                          return (
-                            service.id?.toString() ===
-                            serviceMetadata.primaryEntityId!.toString()
-                          );
-                        },
-                      ).length === 0
-                    ) {
-                      const newService: Service = new Service();
-                      newService.id = serviceMetadata.primaryEntityId!;
-                      metricNameServiceNameMap[metricName]!.services!.push(
-                        newService,
-                      );
-                    }
-                  }
+                  metricCatalog.addMetric({
+                    name: metricName,
+                    description: metricDescription,
+                    unit: metricUnit,
+                    serviceMetadata,
+                  });
 
                   /*
                    * The per-metric invariant attribute base: every datapoint
@@ -1632,7 +1571,7 @@ export default class OtelMetricsIngestService extends OtelIngestBaseService {
        * losing it must never fail a batch whose telemetry already landed.
        */
       await TelemetryUtil.indexMetricNameServiceNameMap({
-        metricNameServiceNameMap: metricNameServiceNameMap,
+        metricNameServiceNameMap: metricCatalog.metricNameServiceNameMap,
         projectId: projectId,
       }).catch((err: Error) => {
         logger.error("Error indexing metric name service name map");

--- a/App/FeatureSet/Telemetry/Services/TracePipelineService.ts
+++ b/App/FeatureSet/Telemetry/Services/TracePipelineService.ts
@@ -18,7 +18,7 @@ import {
   evaluateCompiledFilter,
 } from "../Utils/LogFilterEvaluator";
 import logger from "Common/Server/Utils/Logger";
-import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
+import PipelineCache from "../Utils/PipelineCache";
 import getPipelineProcessorConfig from "../Utils/PipelineProcessorConfig";
 
 export interface LoadedTracePipeline {
@@ -39,22 +39,24 @@ interface CompiledCategoryConfig extends CategoryProcessorConfig {
 const CACHE_TTL_MS: number = 60 * 1000; // 60 seconds
 const MAX_CACHED_PROJECTS: number = 10_000;
 
-const pipelineCache: InMemoryTTLCache<Array<LoadedTracePipeline>> =
-  new InMemoryTTLCache<Array<LoadedTracePipeline>>(MAX_CACHED_PROJECTS);
+const pipelineCache: PipelineCache<Array<LoadedTracePipeline>> =
+  new PipelineCache<Array<LoadedTracePipeline>>(
+    MAX_CACHED_PROJECTS,
+    CACHE_TTL_MS,
+  );
 
 export class TracePipelineService {
   public static async loadPipelines(
     projectId: ObjectID,
   ): Promise<Array<LoadedTracePipeline>> {
-    const cacheKey: string = projectId.toString();
-    const cached: Array<LoadedTracePipeline> | undefined =
-      pipelineCache.get(cacheKey);
+    return pipelineCache.getOrLoad(projectId.toString(), () => {
+      return TracePipelineService.loadPipelinesFromDatabase(projectId);
+    });
+  }
 
-    // Empty arrays are truthy — zero-pipeline projects stay negatively cached.
-    if (cached) {
-      return cached;
-    }
-
+  private static async loadPipelinesFromDatabase(
+    projectId: ObjectID,
+  ): Promise<Array<LoadedTracePipeline>> {
     const pipelineService: DatabaseService<TracePipeline> =
       new DatabaseService<TracePipeline>(TracePipeline);
 
@@ -115,7 +117,6 @@ export class TracePipelineService {
       });
     }
 
-    pipelineCache.set(cacheKey, loaded, CACHE_TTL_MS);
     return loaded;
   }
 

--- a/App/FeatureSet/Telemetry/Utils/MetricCatalog.ts
+++ b/App/FeatureSet/Telemetry/Utils/MetricCatalog.ts
@@ -39,8 +39,12 @@ export default class MetricCatalog {
     if (!metricType) {
       metricType = new MetricType();
       metricType.name = data.name;
-      metricType.description = data.description;
-      metricType.unit = data.unit;
+      if (data.description !== undefined) {
+        metricType.description = data.description;
+      }
+      if (data.unit !== undefined) {
+        metricType.unit = data.unit;
+      }
       metricType.services = [];
       this.metricNameServiceNameMap[data.name] = metricType;
     }

--- a/App/FeatureSet/Telemetry/Utils/MetricCatalog.ts
+++ b/App/FeatureSet/Telemetry/Utils/MetricCatalog.ts
@@ -1,0 +1,82 @@
+import MetricType from "Common/Models/DatabaseModels/MetricType";
+import Service from "Common/Models/DatabaseModels/Service";
+import { TelemetryServiceMetadata } from "Common/Server/Services/OpenTelemetryIngestService";
+import Dictionary from "Common/Types/Dictionary";
+import ServiceType from "Common/Types/Telemetry/ServiceType";
+
+/*
+ * One catalog per ingest request. A collector can export the same metric
+ * from thousands of services; searching its growing services array on
+ * every resource makes catalog construction quadratic. The membership
+ * sets keep that work linear while the arrays retain first-seen order
+ * for the existing catalog writer. Both are released with the request.
+ */
+export default class MetricCatalog {
+  public readonly metricNameServiceNameMap: Dictionary<MetricType> = {};
+
+  /*
+   * Most exports carry one service: avoid allocating a Set for every metric
+   * until the collector actually combines distinct services in this request.
+   */
+  private readonly serviceIdsByMetricName: Map<string, string | Set<string>> =
+    new Map();
+
+  public addMetric(data: {
+    name: string;
+    description: string | undefined;
+    unit: string | undefined;
+    serviceMetadata: Pick<
+      TelemetryServiceMetadata,
+      "primaryEntityId" | "primaryEntityType"
+    >;
+  }): void {
+    if (!data.name) {
+      return;
+    }
+
+    let metricType: MetricType | undefined =
+      this.metricNameServiceNameMap[data.name];
+    if (!metricType) {
+      metricType = new MetricType();
+      metricType.name = data.name;
+      metricType.description = data.description;
+      metricType.unit = data.unit;
+      metricType.services = [];
+      this.metricNameServiceNameMap[data.name] = metricType;
+    }
+
+    /*
+     * MetricType.services references real Service rows only. Hosts,
+     * clusters and other primary entities still get a metric catalog
+     * entry, but must never be linked through this Service foreign key.
+     */
+    if (data.serviceMetadata.primaryEntityType !== ServiceType.OpenTelemetry) {
+      return;
+    }
+
+    const serviceId: string = data.serviceMetadata.primaryEntityId.toString();
+    const serviceIds: string | Set<string> | undefined =
+      this.serviceIdsByMetricName.get(data.name);
+    if (
+      typeof serviceIds === "string"
+        ? serviceIds === serviceId
+        : serviceIds?.has(serviceId)
+    ) {
+      return;
+    }
+
+    const service: Service = new Service();
+    service.id = data.serviceMetadata.primaryEntityId;
+    metricType.services!.push(service);
+    if (serviceIds === undefined) {
+      this.serviceIdsByMetricName.set(data.name, serviceId);
+    } else if (typeof serviceIds === "string") {
+      this.serviceIdsByMetricName.set(
+        data.name,
+        new Set([serviceIds, serviceId]),
+      );
+    } else {
+      serviceIds.add(serviceId);
+    }
+  }
+}

--- a/App/FeatureSet/Telemetry/Utils/PipelineCache.ts
+++ b/App/FeatureSet/Telemetry/Utils/PipelineCache.ts
@@ -63,6 +63,21 @@ export default class PipelineCache<T> {
      * but do not populate the cache or share work until a slot becomes free.
      * Without ownership, an old overflow load could overwrite a newer result.
      */
+    if (this.loading.size >= this.maxEntries) {
+      /*
+       * Quiet projects must not occupy every slot forever after a stalled load.
+       * In insertion order, checking the oldest slot makes admission O(1).
+       */
+      const oldest: [string, PendingLoad<T>] | undefined = this.loading
+        .entries()
+        .next().value;
+      if (
+        oldest &&
+        (now < oldest[1].startedAt || now - oldest[1].startedAt > this.ttlMs)
+      ) {
+        this.loading.delete(oldest[0]);
+      }
+    }
     if (this.loading.size < this.maxEntries) {
       tracked = true;
       this.loading.set(key, { promise: pending, startedAt: now });

--- a/App/FeatureSet/Telemetry/Utils/PipelineCache.ts
+++ b/App/FeatureSet/Telemetry/Utils/PipelineCache.ts
@@ -1,0 +1,73 @@
+import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
+
+interface PendingLoad<T> {
+  promise: Promise<T>;
+  startedAt: number;
+}
+
+/** Shares overlapping loads without keeping a second copy of a project's config. */
+export default class PipelineCache<T> {
+  private readonly cache: InMemoryTTLCache<T>;
+  private readonly loading: Map<string, PendingLoad<T>> = new Map();
+
+  public constructor(
+    private readonly maxEntries: number,
+    private readonly ttlMs: number,
+  ) {
+    this.cache = new InMemoryTTLCache<T>(maxEntries);
+  }
+
+  public async getOrLoad(key: string, load: () => Promise<T>): Promise<T> {
+    const cached: T | undefined = this.cache.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const existing: PendingLoad<T> | undefined = this.loading.get(key);
+    const now: number = Date.now();
+    if (
+      existing &&
+      now >= existing.startedAt &&
+      now - existing.startedAt <= this.ttlMs
+    ) {
+      return existing.promise;
+    }
+    /*
+     * A stalled database request must not pin all future loads for this project.
+     * Its original callers still receive its outcome; later callers may retry.
+     */
+    this.loading.delete(key);
+
+    let tracked: boolean = false;
+    // Defer the loader until the promise is registered, including sync failures.
+    const pending: Promise<T> = Promise.resolve()
+      .then(load)
+      .then((value: T): T => {
+        /*
+         * Start freshness at completion: a slow load must still get a full TTL.
+         * A superseded slow load must not overwrite newer configuration.
+         */
+        if (tracked && this.loading.get(key)?.promise === pending) {
+          this.cache.set(key, value, this.ttlMs);
+        }
+        return value;
+      })
+      .finally((): void => {
+        if (this.loading.get(key)?.promise === pending) {
+          this.loading.delete(key);
+        }
+      });
+
+    /*
+     * Cap auxiliary state too. Overflow projects still receive their result,
+     * but do not populate the cache or share work until a slot becomes free.
+     * Without ownership, an old overflow load could overwrite a newer result.
+     */
+    if (this.loading.size < this.maxEntries) {
+      tracked = true;
+      this.loading.set(key, { promise: pending, startedAt: now });
+    }
+
+    return pending;
+  }
+}

--- a/App/Tests/Telemetry/MetricCatalog.test.ts
+++ b/App/Tests/Telemetry/MetricCatalog.test.ts
@@ -1,0 +1,259 @@
+import MetricCatalog from "../../FeatureSet/Telemetry/Utils/MetricCatalog";
+import MetricType from "Common/Models/DatabaseModels/MetricType";
+import Service from "Common/Models/DatabaseModels/Service";
+import ObjectID from "Common/Types/ObjectID";
+import ServiceType from "Common/Types/Telemetry/ServiceType";
+
+function addMetric(
+  catalog: MetricCatalog,
+  serviceId: ObjectID,
+  data: {
+    name?: string;
+    description?: string;
+    unit?: string;
+    primaryEntityType?: ServiceType;
+  } = {},
+): void {
+  catalog.addMetric({
+    name: data.name ?? "requests.total",
+    description: data.description,
+    unit: data.unit,
+    serviceMetadata: {
+      primaryEntityId: serviceId,
+      primaryEntityType: data.primaryEntityType ?? ServiceType.OpenTelemetry,
+    },
+  });
+}
+
+function serviceIds(catalog: MetricCatalog, name: string): Array<string> {
+  return catalog.metricNameServiceNameMap[name]!.services!.map(
+    (service: Service) => {
+      return service.id!.toString();
+    },
+  );
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("request-scoped metric catalog", () => {
+  test("retains the first description, unit and service encounter order", () => {
+    const catalog: MetricCatalog = new MetricCatalog();
+    const firstId: ObjectID = ObjectID.generate();
+    const secondId: ObjectID = ObjectID.generate();
+
+    addMetric(catalog, firstId, { description: "First", unit: "requests" });
+    const firstMetric: MetricType =
+      catalog.metricNameServiceNameMap["requests.total"]!;
+    const firstServices: Array<Service> = firstMetric.services!;
+    addMetric(catalog, secondId, { description: "Second", unit: "1" });
+    addMetric(catalog, firstId, { description: "Third", unit: "bytes" });
+
+    expect(catalog.metricNameServiceNameMap["requests.total"]).toBe(
+      firstMetric,
+    );
+    expect(firstMetric.services).toBe(firstServices);
+    expect(firstMetric).toBeInstanceOf(MetricType);
+    expect(firstMetric.name).toBe("requests.total");
+    expect(firstMetric.description).toBe("First");
+    expect(firstMetric.unit).toBe("requests");
+    expect(
+      firstServices.every((service: Service) => {
+        return service instanceof Service;
+      }),
+    ).toBe(true);
+    expect(serviceIds(catalog, "requests.total")).toEqual([
+      firstId.toString(),
+      secondId.toString(),
+    ]);
+  });
+
+  test("deduplicates distinct ObjectID instances with the same value", () => {
+    const catalog: MetricCatalog = new MetricCatalog();
+    const serviceId: ObjectID = ObjectID.generate();
+
+    for (let index: number = 0; index < 100; index++) {
+      addMetric(catalog, new ObjectID(serviceId.toString()));
+    }
+
+    expect(serviceIds(catalog, "requests.total")).toEqual([
+      serviceId.toString(),
+    ]);
+  });
+
+  test("tracks service membership independently for each metric", () => {
+    const catalog: MetricCatalog = new MetricCatalog();
+    const firstId: ObjectID = ObjectID.generate();
+    const secondId: ObjectID = ObjectID.generate();
+
+    addMetric(catalog, firstId, { name: "requests.total" });
+    addMetric(catalog, secondId, { name: "requests.total" });
+    addMetric(catalog, secondId, { name: "request.duration" });
+    addMetric(catalog, firstId, { name: "request.duration" });
+    addMetric(catalog, firstId, { name: "requests.total" });
+
+    expect(Object.keys(catalog.metricNameServiceNameMap)).toEqual([
+      "requests.total",
+      "request.duration",
+    ]);
+    expect(serviceIds(catalog, "requests.total")).toEqual([
+      firstId.toString(),
+      secondId.toString(),
+    ]);
+    expect(serviceIds(catalog, "request.duration")).toEqual([
+      secondId.toString(),
+      firstId.toString(),
+    ]);
+  });
+
+  test.each(
+    Object.values(ServiceType).filter((type: ServiceType) => {
+      return type !== ServiceType.OpenTelemetry;
+    }),
+  )(
+    "catalogs %s metrics without adding a Service foreign key",
+    (type: ServiceType) => {
+      const catalog: MetricCatalog = new MetricCatalog();
+      const entityId: ObjectID = ObjectID.generate();
+      const stringify: jest.SpyInstance = jest.spyOn(entityId, "toString");
+
+      addMetric(catalog, entityId, {
+        primaryEntityType: type,
+        description: "Infrastructure metric",
+        unit: "1",
+      });
+
+      expect(stringify).not.toHaveBeenCalled();
+      expect(serviceIds(catalog, "requests.total")).toEqual([]);
+      expect(
+        catalog.metricNameServiceNameMap["requests.total"]!.description,
+      ).toBe("Infrastructure metric");
+    },
+  );
+
+  test("can add a real service after an infrastructure-only observation", () => {
+    const catalog: MetricCatalog = new MetricCatalog();
+    const sharedId: ObjectID = ObjectID.generate();
+
+    addMetric(catalog, sharedId, {
+      primaryEntityType: ServiceType.Host,
+      description: "Host metric",
+    });
+    addMetric(catalog, sharedId, { description: "Service metric" });
+    addMetric(catalog, ObjectID.generate(), {
+      primaryEntityType: ServiceType.KubernetesCluster,
+    });
+
+    expect(serviceIds(catalog, "requests.total")).toEqual([
+      sharedId.toString(),
+    ]);
+    expect(
+      catalog.metricNameServiceNameMap["requests.total"]!.description,
+    ).toBe("Host metric");
+  });
+
+  test("keeps originally absent metadata and ignores unnamed metrics", () => {
+    const catalog: MetricCatalog = new MetricCatalog();
+    const serviceId: ObjectID = ObjectID.generate();
+
+    addMetric(catalog, serviceId, { name: "" });
+    expect(catalog.metricNameServiceNameMap).toEqual({});
+    addMetric(catalog, serviceId);
+    addMetric(catalog, serviceId, { description: "Later", unit: "1" });
+
+    expect(
+      catalog.metricNameServiceNameMap["requests.total"]!.description,
+    ).toBeUndefined();
+    expect(
+      catalog.metricNameServiceNameMap["requests.total"]!.unit,
+    ).toBeUndefined();
+  });
+
+  test("does not share membership or mutable model objects across requests", () => {
+    const first: MetricCatalog = new MetricCatalog();
+    const second: MetricCatalog = new MetricCatalog();
+    const serviceId: ObjectID = ObjectID.generate();
+
+    addMetric(first, serviceId, { description: "First request" });
+    addMetric(second, serviceId, { description: "Second request" });
+
+    expect(serviceIds(first, "requests.total")).toEqual([serviceId.toString()]);
+    expect(serviceIds(second, "requests.total")).toEqual([
+      serviceId.toString(),
+    ]);
+    expect(first.metricNameServiceNameMap["requests.total"]).not.toBe(
+      second.metricNameServiceNameMap["requests.total"],
+    );
+    expect(
+      first.metricNameServiceNameMap["requests.total"]!.services![0],
+    ).not.toBe(second.metricNameServiceNameMap["requests.total"]!.services![0]);
+    expect(second.metricNameServiceNameMap["requests.total"]!.description).toBe(
+      "Second request",
+    );
+  });
+
+  test("catalogs 4,000 services repeatedly without reading existing Service IDs", () => {
+    const catalog: MetricCatalog = new MetricCatalog();
+    const ids: Array<ObjectID> = Array.from({ length: 4_000 }, () => {
+      return ObjectID.generate();
+    });
+
+    for (const id of ids) {
+      addMetric(catalog, id);
+    }
+
+    /*
+     * Accessing existing links during another insertion would reintroduce
+     * the growing-array scan. Throwing getters enforce this without a
+     * machine-speed-dependent timeout or a benchmark threshold in CI.
+     */
+    for (const service of catalog.metricNameServiceNameMap["requests.total"]!
+      .services!) {
+      Object.defineProperty(service, "id", {
+        get: () => {
+          throw new Error("A previous Service link was scanned");
+        },
+      });
+    }
+
+    for (let round: number = 0; round < 3; round++) {
+      for (const id of ids) {
+        addMetric(catalog, new ObjectID(id.toString()));
+      }
+    }
+    addMetric(catalog, ObjectID.generate());
+
+    expect(
+      catalog.metricNameServiceNameMap["requests.total"]!.services,
+    ).toHaveLength(4_001);
+  });
+
+  test("performs a linear number of ObjectID conversions for a large export", () => {
+    const count: number = 2_000;
+    const ids: Array<ObjectID> = Array.from({ length: count }, () => {
+      return ObjectID.generate();
+    });
+    const stringify: jest.SpyInstance = jest.spyOn(
+      ObjectID.prototype,
+      "toString",
+    );
+    const catalog: MetricCatalog = new MetricCatalog();
+
+    for (let round: number = 0; round < 3; round++) {
+      for (const id of ids) {
+        addMetric(catalog, id);
+      }
+    }
+
+    /*
+     * One membership-key conversion per observation plus one conversion
+     * in Service.id's setter per unique link. The old filter path also
+     * converted both IDs on every comparison, growing quadratically.
+     */
+    expect(stringify).toHaveBeenCalledTimes(count * 4);
+    expect(
+      catalog.metricNameServiceNameMap["requests.total"]!.services,
+    ).toHaveLength(count);
+  });
+});

--- a/App/Tests/Telemetry/MetricCatalog.test.ts
+++ b/App/Tests/Telemetry/MetricCatalog.test.ts
@@ -170,6 +170,22 @@ describe("request-scoped metric catalog", () => {
     ).toBeUndefined();
   });
 
+  test("preserves explicitly empty description and unit from the first observation", () => {
+    const catalog: MetricCatalog = new MetricCatalog();
+    const serviceId: ObjectID = ObjectID.generate();
+
+    addMetric(catalog, serviceId, { description: "", unit: "" });
+    addMetric(catalog, ObjectID.generate(), {
+      description: "Later description",
+      unit: "requests",
+    });
+
+    expect(
+      catalog.metricNameServiceNameMap["requests.total"]!.description,
+    ).toBe("");
+    expect(catalog.metricNameServiceNameMap["requests.total"]!.unit).toBe("");
+  });
+
   test("does not share membership or mutable model objects across requests", () => {
     const first: MetricCatalog = new MetricCatalog();
     const second: MetricCatalog = new MetricCatalog();

--- a/App/Tests/Telemetry/OtelMetricsIngestCatalog.test.ts
+++ b/App/Tests/Telemetry/OtelMetricsIngestCatalog.test.ts
@@ -44,6 +44,12 @@ let metadataByName: Map<string, TelemetryServiceMetadata>;
 let rows: Array<JSONObject>;
 let indexCatalog: jest.SpyInstance;
 
+type IngestTestMethods = Record<string, any> & {
+  resolveTelemetryResource: (data: {
+    attributes: JSONArray;
+  }) => Promise<TelemetryServiceMetadata>;
+};
+
 function makeMetric(
   data: {
     name?: string;
@@ -126,8 +132,8 @@ function catalogServiceIds(
 beforeEach(() => {
   metadataByName = new Map();
   rows = [];
-  const ingest: Record<string, any> =
-    OtelMetricsIngestService as unknown as Record<string, any>;
+  const ingest: IngestTestMethods =
+    OtelMetricsIngestService as unknown as IngestTestMethods;
   jest.spyOn(ingest, "runBatchHostEnrichment").mockResolvedValue(undefined);
   for (const method of AUTO_DISCOVERY_METHODS) {
     jest.spyOn(ingest, method).mockResolvedValue(null);

--- a/App/Tests/Telemetry/OtelMetricsIngestCatalog.test.ts
+++ b/App/Tests/Telemetry/OtelMetricsIngestCatalog.test.ts
@@ -1,0 +1,390 @@
+import OtelMetricsIngestService from "../../FeatureSet/Telemetry/Services/OtelMetricsIngestService";
+import MetricPipelineRuleService from "../../FeatureSet/Telemetry/Services/MetricPipelineRuleService";
+import { TelemetryRequest } from "Common/Server/Middleware/TelemetryIngest";
+import {
+  OtelAggregationTemporality,
+  TelemetryServiceMetadata,
+} from "Common/Server/Services/OpenTelemetryIngestService";
+import TelemetryFanInWriter, {
+  FanInInsertTarget,
+} from "Common/Server/Utils/Telemetry/TelemetryFanInWriter";
+import TelemetryUtil from "Common/Server/Utils/Telemetry/Telemetry";
+import MetricType from "Common/Models/DatabaseModels/MetricType";
+import { AggregationTemporality } from "Common/Models/AnalyticsModels/Metric";
+import Service from "Common/Models/DatabaseModels/Service";
+import Dictionary from "Common/Types/Dictionary";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import ServiceType from "Common/Types/Telemetry/ServiceType";
+
+/*
+ * OTLP request -> real metric walk, heartbeat and row construction ->
+ * catalog writer. Mock database discovery and the persistence boundaries;
+ * catalog construction and per-buffer flushing run unchanged.
+ */
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const SERVICE_ID: ObjectID = ObjectID.generate();
+const OTHER_SERVICE_ID: ObjectID = ObjectID.generate();
+
+const AUTO_DISCOVERY_METHODS: Array<string> = [
+  "autoDiscoverKubernetesCluster",
+  "autoDiscoverDockerHost",
+  "autoDiscoverPodmanHost",
+  "autoDiscoverProxmoxCluster",
+  "autoDiscoverCephCluster",
+  "autoDiscoverDockerSwarmCluster",
+  "autoDiscoverIoTFleet",
+  "autoDiscoverHost",
+  "autoDiscoverServerless",
+  "autoDiscoverCloudResource",
+  "autoDiscoverRum",
+];
+
+let metadataByName: Map<string, TelemetryServiceMetadata>;
+let rows: Array<JSONObject>;
+let indexCatalog: jest.SpyInstance;
+
+function makeMetric(
+  data: {
+    name?: string;
+    description?: string;
+    unit?: string;
+    points?: number;
+  } = {},
+): JSONObject {
+  return {
+    name: data.name ?? "Requests.Total",
+    description: data.description ?? "First description",
+    unit: data.unit ?? "1",
+    gauge: {
+      dataPoints: Array.from({ length: data.points ?? 1 }, () => {
+        return { asInt: 1, timeUnixNano: `${Date.now()}000000` };
+      }),
+    },
+  };
+}
+
+function resource(
+  data: {
+    serviceId?: ObjectID;
+    type?: ServiceType;
+    hostName?: string;
+    metrics?: JSONArray;
+    scopes?: number;
+  } = {},
+): JSONObject {
+  const id: ObjectID = data.serviceId ?? SERVICE_ID;
+  const name: string = `${data.type ?? ServiceType.OpenTelemetry}/${id.toString()}`;
+  metadataByName.set(name, {
+    serviceName: name,
+    primaryEntityId: id,
+    primaryEntityType: data.type ?? ServiceType.OpenTelemetry,
+    dataRententionInDays: 15,
+    serviceRetentionConfig: null,
+    serviceRetentionInDays: null,
+    projectRetentionConfig: null,
+    projectRetentionInDays: 15,
+  });
+  const attributes: JSONArray = [
+    { key: "service.name", value: { stringValue: name } },
+  ];
+  if (data.hostName) {
+    attributes.push({
+      key: "host.name",
+      value: { stringValue: data.hostName },
+    });
+  }
+  return {
+    resource: { attributes },
+    scopeMetrics: Array.from({ length: data.scopes ?? 1 }, () => {
+      return { metrics: data.metrics ?? [makeMetric()] };
+    }),
+  };
+}
+
+function request(resources: JSONArray): TelemetryRequest {
+  return {
+    projectId: PROJECT_ID,
+    body: { resourceMetrics: resources },
+    headers: {},
+  } as unknown as TelemetryRequest;
+}
+
+function catalog(index: number = 0): Dictionary<MetricType> {
+  return indexCatalog.mock.calls[index]![0].metricNameServiceNameMap;
+}
+
+function catalogServiceIds(
+  metrics: Dictionary<MetricType>,
+  name: string,
+): Array<string> {
+  return metrics[name]!.services!.map((service: Service) => {
+    return service.id!.toString();
+  });
+}
+
+beforeEach(() => {
+  metadataByName = new Map();
+  rows = [];
+  const ingest: Record<string, any> =
+    OtelMetricsIngestService as unknown as Record<string, any>;
+  jest.spyOn(ingest, "runBatchHostEnrichment").mockResolvedValue(undefined);
+  for (const method of AUTO_DISCOVERY_METHODS) {
+    jest.spyOn(ingest, method).mockResolvedValue(null);
+  }
+  jest
+    .spyOn(ingest, "resolveTelemetryResource")
+    .mockImplementation(async (data: { attributes: JSONArray }) => {
+      const name: string = (data.attributes[0]!["value"] as JSONObject)[
+        "stringValue"
+      ] as string;
+      const metadata: TelemetryServiceMetadata = metadataByName.get(name)!;
+      return {
+        ...metadata,
+        primaryEntityId: new ObjectID(metadata.primaryEntityId.toString()),
+      };
+    });
+  jest.spyOn(MetricPipelineRuleService, "loadRules").mockResolvedValue({
+    projectRules: [],
+    rulesByServiceId: new Map(),
+  });
+  jest
+    .spyOn(TelemetryFanInWriter, "submit")
+    .mockImplementation(
+      async (_target: FanInInsertTarget, batch: Array<JSONObject>) => {
+        rows.push(...batch);
+        return { flushed: Promise.resolve() };
+      },
+    );
+  indexCatalog = jest
+    .spyOn(TelemetryUtil, "indexMetricNameServiceNameMap")
+    .mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("metric ingest catalog integration", () => {
+  test("deduplicates across scopes/resources while preserving rows and first metadata", async () => {
+    const req: TelemetryRequest = request([
+      resource({ scopes: 2, metrics: [makeMetric({ points: 2 })] }),
+      resource({
+        serviceId: OTHER_SERVICE_ID,
+        metrics: [
+          makeMetric({
+            name: "requests.total",
+            description: "Later",
+            unit: "bytes",
+          }),
+        ],
+      }),
+      resource(),
+    ]);
+
+    await OtelMetricsIngestService.processMetricsFromQueue(req);
+
+    expect(indexCatalog).toHaveBeenCalledTimes(1);
+    expect(indexCatalog.mock.calls[0]![0].projectId).toBe(PROJECT_ID);
+    expect(Object.keys(catalog())).toEqual(["requests.total"]);
+    expect(catalogServiceIds(catalog(), "requests.total")).toEqual([
+      SERVICE_ID.toString(),
+      OTHER_SERVICE_ID.toString(),
+    ]);
+    expect(catalog()["requests.total"]!.description).toBe("First description");
+    expect(catalog()["requests.total"]!.unit).toBe("1");
+    expect(rows).toHaveLength(6);
+    expect(
+      rows.every((row: JSONObject) => {
+        return row["name"] === "requests.total";
+      }),
+    ).toBe(true);
+    expect(req.body).toBeNull();
+  });
+
+  test("retains all service links across multiple row-buffer flushes", async () => {
+    const ids: Array<ObjectID> = Array.from({ length: 300 }, () => {
+      return ObjectID.generate();
+    });
+    const resources: JSONArray = ids.map((id: ObjectID) => {
+      return resource({
+        serviceId: id,
+        metrics: [
+          makeMetric({ points: 2 }),
+          makeMetric({ name: "Request.Duration", points: 2 }),
+        ],
+      });
+    });
+
+    await OtelMetricsIngestService.processMetricsFromQueue(request(resources));
+
+    expect(rows).toHaveLength(1_200);
+    expect(TelemetryFanInWriter.submit).toHaveBeenCalledTimes(2);
+    const expectedIds: Array<string> = ids.map((id: ObjectID) => {
+      return id.toString();
+    });
+    expect(catalogServiceIds(catalog(), "requests.total")).toEqual(expectedIds);
+    expect(catalogServiceIds(catalog(), "request.duration")).toEqual(
+      expectedIds,
+    );
+  });
+
+  test("shares catalog membership between synthetic and submitted host heartbeats", async () => {
+    await OtelMetricsIngestService.processMetricsFromQueue(
+      request([
+        resource({ hostName: "host-one" }),
+        resource({
+          hostName: "host-one",
+          metrics: [makeMetric({ name: "oneuptime.host.heartbeat" })],
+        }),
+        resource({ serviceId: OTHER_SERVICE_ID, hostName: "host-two" }),
+      ]),
+    );
+
+    expect(catalogServiceIds(catalog(), "oneuptime.host.heartbeat")).toEqual([
+      SERVICE_ID.toString(),
+      OTHER_SERVICE_ID.toString(),
+    ]);
+    expect(catalog()["oneuptime.host.heartbeat"]!.description).toContain(
+      "Synthetic heartbeat",
+    );
+    expect(
+      rows.filter((row: JSONObject) => {
+        return row["name"] === "oneuptime.host.heartbeat";
+      }),
+    ).toHaveLength(3);
+  });
+
+  test("keeps user metric metadata when observed before a synthetic heartbeat", async () => {
+    await OtelMetricsIngestService.processMetricsFromQueue(
+      request([
+        resource({
+          metrics: [
+            makeMetric({
+              name: "oneuptime.host.heartbeat",
+              description: "User metric",
+              unit: "beats",
+            }),
+          ],
+        }),
+        resource({ hostName: "host-one" }),
+      ]),
+    );
+
+    expect(catalog()["oneuptime.host.heartbeat"]!.description).toBe(
+      "User metric",
+    );
+    expect(catalog()["oneuptime.host.heartbeat"]!.unit).toBe("beats");
+    expect(catalogServiceIds(catalog(), "oneuptime.host.heartbeat")).toEqual([
+      SERVICE_ID.toString(),
+    ]);
+  });
+
+  test("catalogs infrastructure metrics and heartbeats without invalid Service links", async () => {
+    const types: Array<ServiceType> = Object.values(ServiceType).filter(
+      (type: ServiceType) => {
+        return type !== ServiceType.OpenTelemetry;
+      },
+    );
+    await OtelMetricsIngestService.processMetricsFromQueue(
+      request(
+        types.map((type: ServiceType) => {
+          return resource({ type, hostName: `host-${type}` });
+        }),
+      ),
+    );
+
+    expect(rows).toHaveLength(types.length * 2);
+    expect(catalogServiceIds(catalog(), "requests.total")).toEqual([]);
+    expect(catalogServiceIds(catalog(), "oneuptime.host.heartbeat")).toEqual(
+      [],
+    );
+  });
+
+  test("keeps concurrent request catalogs independent", async () => {
+    await Promise.all([
+      OtelMetricsIngestService.processMetricsFromQueue(request([resource()])),
+      OtelMetricsIngestService.processMetricsFromQueue(
+        request([
+          resource({ metrics: [makeMetric({ description: "Other request" })] }),
+        ]),
+      ),
+    ]);
+
+    expect(indexCatalog).toHaveBeenCalledTimes(2);
+    expect(catalogServiceIds(catalog(0), "requests.total")).toEqual([
+      SERVICE_ID.toString(),
+    ]);
+    expect(catalogServiceIds(catalog(1), "requests.total")).toEqual([
+      SERVICE_ID.toString(),
+    ]);
+    expect(catalog(0)["requests.total"]).not.toBe(catalog(1)["requests.total"]);
+    expect(
+      new Set([
+        catalog(0)["requests.total"]!.description,
+        catalog(1)["requests.total"]!.description,
+      ]),
+    ).toEqual(new Set(["First description", "Other request"]));
+  });
+
+  test("continues updating counter semantics on the cataloged metric", async () => {
+    const counter: JSONObject = {
+      name: "requests.total",
+      description: "Counter description",
+      unit: "requests",
+      sum: {
+        aggregationTemporality: OtelAggregationTemporality.Cumulative,
+        isMonotonic: true,
+        dataPoints: [{ asInt: 10, timeUnixNano: `${Date.now()}000000` }],
+      },
+    };
+    await OtelMetricsIngestService.processMetricsFromQueue(
+      request([
+        resource({ metrics: [counter] }),
+        resource({
+          serviceId: OTHER_SERVICE_ID,
+          metrics: [
+            {
+              ...counter,
+              sum: {
+                ...(counter["sum"] as JSONObject),
+                aggregationTemporality: OtelAggregationTemporality.Delta,
+                isMonotonic: false,
+              },
+            },
+          ],
+        }),
+        /*
+         * A later gauge does not supply counter semantics and must not
+         * erase the last explicitly observed values on the catalog entry.
+         */
+        resource(),
+      ]),
+    );
+
+    expect(rows).toHaveLength(3);
+    expect(catalog()["requests.total"]!.aggregationTemporality).toBe(
+      AggregationTemporality.Delta,
+    );
+    expect(catalog()["requests.total"]!.isMonotonic).toBe(false);
+    expect(catalog()["requests.total"]!.description).toBe(
+      "Counter description",
+    );
+    expect(catalogServiceIds(catalog(), "requests.total")).toEqual([
+      SERVICE_ID.toString(),
+      OTHER_SERVICE_ID.toString(),
+    ]);
+  });
+
+  test("continues to treat a catalog write failure as non-fatal after rows land", async () => {
+    indexCatalog.mockRejectedValueOnce(new Error("Catalog unavailable"));
+    const req: TelemetryRequest = request([resource()]);
+
+    await expect(
+      OtelMetricsIngestService.processMetricsFromQueue(req),
+    ).resolves.toBeUndefined();
+
+    expect(rows).toHaveLength(1);
+    expect(req.body).toBeNull();
+  });
+});

--- a/App/Tests/Telemetry/PipelineCache.test.ts
+++ b/App/Tests/Telemetry/PipelineCache.test.ts
@@ -297,6 +297,32 @@ describe("pipeline cache shared loads", () => {
     expect(refresh).toHaveBeenCalledTimes(1);
   });
 
+  test.each([101, -1])(
+    "an abandoned project releases ownership capacity when the clock reaches %i",
+    async (time: number) => {
+      const now: jest.SpyInstance = jest.spyOn(Date, "now").mockReturnValue(0);
+      const cache: PipelineCache<string> = new PipelineCache(1, 100);
+      const abandoned: Deferred<string> = deferred();
+      const old: Promise<string> = cache.getOrLoad("abandoned", () => {
+        return abandoned.promise;
+      });
+      now.mockReturnValue(time);
+      const load: jest.Mock = jest.fn().mockResolvedValue("active");
+      expect(
+        await Promise.all([
+          cache.getOrLoad("active", load),
+          cache.getOrLoad("active", load),
+        ]),
+      ).toEqual(["active", "active"]);
+      expect(await cache.getOrLoad("active", load)).toBe("active");
+      expect(load).toHaveBeenCalledTimes(1);
+      abandoned.resolve("old");
+      expect(await old).toBe("old");
+      expect(await cache.getOrLoad("active", load)).toBe("active");
+      expect(load).toHaveBeenCalledTimes(1);
+    },
+  );
+
   test("completion releases pending slots across repeated unique project bursts", async () => {
     const cache: PipelineCache<number> = new PipelineCache(2, 100);
     const load: jest.Mock = jest.fn().mockResolvedValue(1);

--- a/App/Tests/Telemetry/PipelineCache.test.ts
+++ b/App/Tests/Telemetry/PipelineCache.test.ts
@@ -1,0 +1,326 @@
+import PipelineCache from "../../FeatureSet/Telemetry/Utils/PipelineCache";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise: Promise<T> = new Promise<T>(
+    (res: (value: T) => void, rej: (error: Error) => void) => {
+      resolve = res;
+      reject = rej;
+    },
+  );
+  return { promise, resolve, reject };
+}
+
+// A microtask turn lets the registered loader run without real timers or I/O.
+async function startLoads(): Promise<void> {
+  await Promise.resolve();
+}
+
+describe("pipeline cache shared loads", () => {
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("shares one load and one result across 10,000 simultaneous callers", async () => {
+    const cache: PipelineCache<Array<string>> = new PipelineCache(10, 100);
+    const source: Deferred<Array<string>> = deferred();
+    const load: jest.Mock = jest.fn(() => {
+      return source.promise;
+    });
+    const calls: Array<Promise<Array<string>>> = Array.from(
+      { length: 10_000 },
+      () => {
+        return cache.getOrLoad("project", load);
+      },
+    );
+    await startLoads();
+    expect(load).toHaveBeenCalledTimes(1);
+    const value: Array<string> = ["pipeline"];
+    source.resolve(value);
+    for (const result of await Promise.all(calls)) {
+      expect(result).toBe(value);
+    }
+    expect(await cache.getOrLoad("project", load)).toBe(value);
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([[], false, 0, "", null])(
+    "caches a valid empty result: %p",
+    async (value: unknown) => {
+      const cache: PipelineCache<unknown> = new PipelineCache(10, 100);
+      const load: jest.Mock = jest.fn().mockResolvedValue(value);
+      expect(await cache.getOrLoad("project", load)).toBe(value);
+      expect(await cache.getOrLoad("project", load)).toBe(value);
+      expect(load).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test("loads different projects independently while a project is stalled", async () => {
+    const cache: PipelineCache<string> = new PipelineCache(10, 100);
+    const stalled: Deferred<string> = deferred();
+    const first: Promise<string> = cache.getOrLoad("one", () => {
+      return stalled.promise;
+    });
+    expect(
+      await cache.getOrLoad("two", async () => {
+        return "second";
+      }),
+    ).toBe("second");
+    stalled.resolve("first");
+    expect(await first).toBe("first");
+  });
+
+  test("all waiters observe failure and the next call can retry", async () => {
+    const cache: PipelineCache<string> = new PipelineCache(10, 100);
+    const source: Deferred<string> = deferred();
+    const load: jest.Mock = jest.fn(() => {
+      return source.promise;
+    });
+    const calls: Array<Promise<string>> = Array.from({ length: 1_000 }, () => {
+      return cache.getOrLoad("project", load);
+    });
+    const settled: Promise<Array<PromiseSettledResult<string>>> =
+      Promise.allSettled(calls);
+    const error: Error = new Error("database unavailable");
+    source.reject(error);
+    for (const result of await settled) {
+      expect(result).toEqual({ status: "rejected", reason: error });
+    }
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(
+      await cache.getOrLoad("project", async () => {
+        return "recovered";
+      }),
+    ).toBe("recovered");
+  });
+
+  test("synchronous loader failures are shared and do not poison retries", async () => {
+    const cache: PipelineCache<string> = new PipelineCache(10, 100);
+    const error: Error = new Error("constructor failure");
+    const load: jest.Mock = jest.fn(() => {
+      throw error;
+    });
+    const results: Array<PromiseSettledResult<string>> =
+      await Promise.allSettled([
+        cache.getOrLoad("project", load),
+        cache.getOrLoad("project", load),
+      ]);
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(results).toEqual([
+      { status: "rejected", reason: error },
+      { status: "rejected", reason: error },
+    ]);
+    await expect(cache.getOrLoad("project", load)).rejects.toBe(error);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  test("TTL begins on completion and expired callers share one refresh", async () => {
+    const now: jest.SpyInstance = jest.spyOn(Date, "now").mockReturnValue(0);
+    const cache: PipelineCache<string> = new PipelineCache(10, 100);
+    const source: Deferred<string> = deferred();
+    const load: jest.Mock = jest.fn(() => {
+      return source.promise;
+    });
+    const first: Promise<string> = cache.getOrLoad("project", load);
+    now.mockReturnValue(500);
+    source.resolve("old");
+    await first;
+    now.mockReturnValue(600);
+    expect(await cache.getOrLoad("project", load)).toBe("old");
+    expect(load).toHaveBeenCalledTimes(1);
+    now.mockReturnValue(601);
+    const refresh: jest.Mock = jest.fn().mockResolvedValue("new");
+    expect(
+      await Promise.all(
+        Array.from({ length: 1_000 }, () => {
+          return cache.getOrLoad("project", refresh);
+        }),
+      ),
+    ).toEqual(Array(1_000).fill("new"));
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("failed refresh does not return stale values and can retry", async () => {
+    const now: jest.SpyInstance = jest.spyOn(Date, "now").mockReturnValue(0);
+    const cache: PipelineCache<string> = new PipelineCache(10, 100);
+    await cache.getOrLoad("project", async () => {
+      return "old";
+    });
+    now.mockReturnValue(101);
+    await expect(
+      cache.getOrLoad("project", async () => {
+        throw new Error("refresh failed");
+      }),
+    ).rejects.toThrow("refresh failed");
+    expect(
+      await cache.getOrLoad("project", async () => {
+        return "new";
+      }),
+    ).toBe("new");
+  });
+
+  test("a stalled load stops attracting callers after the sharing TTL", async () => {
+    const now: jest.SpyInstance = jest.spyOn(Date, "now").mockReturnValue(0);
+    const cache: PipelineCache<string> = new PipelineCache(1, 100);
+    const old: Deferred<string> = deferred();
+    const first: Promise<string> = cache.getOrLoad("project", () => {
+      return old.promise;
+    });
+    now.mockReturnValue(101);
+    const refresh: jest.Mock = jest.fn().mockResolvedValue("new");
+    expect(await cache.getOrLoad("project", refresh)).toBe("new");
+    old.resolve("old");
+    expect(await first).toBe("old");
+    // Late completion delivers to the old caller but cannot roll back the cache.
+    expect(await cache.getOrLoad("project", refresh)).toBe("new");
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["resolve", "reject"])(
+    "superseded load %s does not remove a pending replacement",
+    async (outcome: string) => {
+      const now: jest.SpyInstance = jest.spyOn(Date, "now").mockReturnValue(0);
+      const cache: PipelineCache<string> = new PipelineCache(1, 100);
+      const old: Deferred<string> = deferred();
+      const next: Deferred<string> = deferred();
+      const first: Promise<string> = cache.getOrLoad("project", () => {
+        return old.promise;
+      });
+      const firstResult: Promise<Array<PromiseSettledResult<string>>> =
+        Promise.allSettled([first]);
+      now.mockReturnValue(101);
+      const refresh: jest.Mock = jest.fn(() => {
+        return next.promise;
+      });
+      const replacement: Promise<string> = cache.getOrLoad("project", refresh);
+      if (outcome === "resolve") {
+        old.resolve("old");
+      } else {
+        old.reject(new Error("old failed"));
+      }
+      await firstResult;
+      const latest: Promise<string> = cache.getOrLoad("project", refresh);
+      next.resolve("new");
+      expect(await Promise.all([replacement, latest])).toEqual(["new", "new"]);
+      expect(refresh).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test("a backward clock jump cannot extend sharing of stalled work", async () => {
+    const now: jest.SpyInstance = jest.spyOn(Date, "now").mockReturnValue(100);
+    const cache: PipelineCache<string> = new PipelineCache(1, 100);
+    const source: Deferred<string> = deferred();
+    const old: Promise<string> = cache.getOrLoad("project", () => {
+      return source.promise;
+    });
+    now.mockReturnValue(50);
+    expect(
+      await cache.getOrLoad("project", async () => {
+        return "new";
+      }),
+    ).toBe("new");
+    source.resolve("old");
+    expect(await old).toBe("old");
+  });
+
+  test("evicts completed entries at capacity", async () => {
+    const cache: PipelineCache<string> = new PipelineCache(2, 100);
+    const load: jest.Mock = jest.fn().mockResolvedValue("value");
+    await cache.getOrLoad("one", load);
+    await cache.getOrLoad("two", load);
+    await cache.getOrLoad("three", load);
+    expect(load).toHaveBeenCalledTimes(3);
+    await cache.getOrLoad("two", load);
+    await cache.getOrLoad("three", load);
+    expect(load).toHaveBeenCalledTimes(3);
+    await cache.getOrLoad("one", load);
+    expect(load).toHaveBeenCalledTimes(4);
+  });
+
+  test("bounds pending entries, allows overflow, and recovers slots after rejection", async () => {
+    const cache: PipelineCache<string> = new PipelineCache(1, 100);
+    const source: Deferred<string> = deferred();
+    const held: Promise<string> = cache.getOrLoad("held", () => {
+      return source.promise;
+    });
+    const rejected: Promise<Array<PromiseSettledResult<string>>> =
+      Promise.allSettled([held]);
+    const overflow: jest.Mock = jest.fn().mockResolvedValue("overflow");
+    expect(
+      await Promise.all([
+        cache.getOrLoad("overflow", overflow),
+        cache.getOrLoad("overflow", overflow),
+      ]),
+    ).toEqual(["overflow", "overflow"]);
+    expect(overflow).toHaveBeenCalledTimes(2);
+    // Overflow loads have no ownership slot, so they do not populate the cache.
+    await cache.getOrLoad("overflow", overflow);
+    expect(overflow).toHaveBeenCalledTimes(3);
+    source.reject(new Error("failed"));
+    await rejected;
+    const next: jest.Mock = jest.fn().mockResolvedValue("next");
+    await Promise.all([
+      cache.getOrLoad("next", next),
+      cache.getOrLoad("next", next),
+    ]);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("an old overflow load cannot overwrite a later tracked result", async () => {
+    const cache: PipelineCache<string> = new PipelineCache(1, 100);
+    const held: Deferred<string> = deferred();
+    const old: Deferred<string> = deferred();
+    const heldCall: Promise<string> = cache.getOrLoad("held", () => {
+      return held.promise;
+    });
+    const overflow: Promise<string> = cache.getOrLoad("project", () => {
+      return old.promise;
+    });
+    held.resolve("held");
+    await heldCall;
+    const refresh: jest.Mock = jest.fn().mockResolvedValue("new");
+    expect(await cache.getOrLoad("project", refresh)).toBe("new");
+    old.resolve("old");
+    expect(await overflow).toBe("old");
+    expect(await cache.getOrLoad("project", refresh)).toBe("new");
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("completion releases pending slots across repeated unique project bursts", async () => {
+    const cache: PipelineCache<number> = new PipelineCache(2, 100);
+    const load: jest.Mock = jest.fn().mockResolvedValue(1);
+    for (let round: number = 0; round < 100; round++) {
+      await Promise.all(
+        Array.from({ length: 20 }, () => {
+          return cache.getOrLoad(`project-${round}`, load);
+        }),
+      );
+    }
+    expect(load).toHaveBeenCalledTimes(100);
+  });
+
+  test("instances keep signal-specific results isolated even for identical project IDs", async () => {
+    const logs: PipelineCache<string> = new PipelineCache(10, 100);
+    const traces: PipelineCache<string> = new PipelineCache(10, 100);
+    const result: Array<string> = await Promise.all([
+      logs.getOrLoad("project", async () => {
+        return "logs";
+      }),
+      traces.getOrLoad("project", async () => {
+        return "traces";
+      }),
+    ]);
+    expect(result).toEqual(["logs", "traces"]);
+  });
+});

--- a/App/Tests/Telemetry/PipelineLoadCoalescing.test.ts
+++ b/App/Tests/Telemetry/PipelineLoadCoalescing.test.ts
@@ -1,0 +1,320 @@
+import LogPipelineService, {
+  LoadedPipeline,
+} from "../../FeatureSet/Telemetry/Services/LogPipelineService";
+import TracePipelineService, {
+  LoadedTracePipeline,
+} from "../../FeatureSet/Telemetry/Services/TracePipelineService";
+import ObjectID from "Common/Types/ObjectID";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
+import * as FilterEvaluator from "../../FeatureSet/Telemetry/Utils/LogFilterEvaluator";
+
+jest.mock("Common/Server/Services/DatabaseService", () => {
+  return {
+    __esModule: true,
+    default: class DatabaseServiceStub {
+      public hardDeleteItemsOlderThanInDays(): void {}
+      public setDoNotAllowDelete(): void {}
+      public findBy(...args: Array<unknown>): Promise<Array<unknown>> {
+        return mockFindBy(...args);
+      }
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return { __esModule: true, default: { error: jest.fn() } };
+});
+
+const mockFindBy: jest.Mock = jest.fn();
+type Pipelines = Array<LoadedPipeline> | Array<LoadedTracePipeline>;
+interface Adapter {
+  signal: string;
+  foreignKey: string;
+  load: (projectId: ObjectID) => Promise<Pipelines>;
+}
+const adapters: Array<Adapter> = [
+  {
+    signal: "logs",
+    foreignKey: "logPipelineId",
+    load: LogPipelineService.loadPipelines,
+  },
+  {
+    signal: "traces",
+    foreignKey: "tracePipelineId",
+    load: TracePipelineService.loadPipelines,
+  },
+];
+
+function pipeline(name: string): {
+  _id: string;
+  name: string;
+  filterQuery: string;
+  sortOrder: number;
+} {
+  return {
+    _id: ObjectID.generate().toString(),
+    name,
+    filterQuery: "",
+    sortOrder: 1,
+  };
+}
+
+describe.each(adapters)(
+  "$signal overlapping database loads",
+  (adapter: Adapter) => {
+    afterEach(() => {
+      mockFindBy.mockReset();
+      jest.restoreAllMocks();
+    });
+
+    test("1,000 concurrent ingests load 20 pipelines only once and share compiled filters", async () => {
+      const project: ObjectID = ObjectID.generate();
+      const rows: Array<ReturnType<typeof pipeline>> = Array.from(
+        { length: 20 },
+        (_: unknown, index: number) => {
+          return pipeline(`pipeline-${index}`);
+        },
+      );
+      const processors: Array<{ _id: string; configuration: string }> = [
+        { _id: "processor", configuration: "{}" },
+      ];
+      mockFindBy.mockResolvedValue(processors).mockResolvedValueOnce(rows);
+      const compile: jest.SpyInstance = jest.spyOn(
+        FilterEvaluator,
+        "compileFilter",
+      );
+      const results: Array<Pipelines> = await Promise.all(
+        Array.from({ length: 1_000 }, () => {
+          return adapter.load(new ObjectID(project.toString()));
+        }),
+      );
+      expect(mockFindBy).toHaveBeenCalledTimes(21);
+      expect(compile).toHaveBeenCalledTimes(20);
+      const first: Pipelines = results[0]!;
+      expect(
+        first.map((item: LoadedPipeline | LoadedTracePipeline) => {
+          return item.pipeline.name;
+        }),
+      ).toEqual(
+        rows.map((item: ReturnType<typeof pipeline>) => {
+          return item.name;
+        }),
+      );
+      for (const result of results) {
+        expect(result).toBe(first);
+        expect(result[0]!.processors).toBe(processors);
+      }
+      expect(await adapter.load(project)).toBe(first);
+      expect(mockFindBy).toHaveBeenCalledTimes(21);
+    });
+
+    test("preserves project scope, enabled filters, limits and database ordering", async () => {
+      const project: ObjectID = ObjectID.generate();
+      const row: ReturnType<typeof pipeline> = pipeline("enabled");
+      mockFindBy.mockResolvedValueOnce([row]).mockResolvedValueOnce([]);
+      const loaded: Pipelines = await adapter.load(project);
+      expect(loaded[0]!.pipeline).toBe(row);
+      expect(mockFindBy).toHaveBeenNthCalledWith(1, {
+        query: { projectId: project, isEnabled: true },
+        skip: 0,
+        limit: LIMIT_MAX,
+        sort: { sortOrder: SortOrder.Ascending },
+        select: { _id: true, name: true, filterQuery: true, sortOrder: true },
+        props: { isRoot: true },
+      });
+      expect(mockFindBy).toHaveBeenNthCalledWith(2, {
+        query: { [adapter.foreignKey]: row._id, isEnabled: true },
+        skip: 0,
+        limit: LIMIT_MAX,
+        sort: { sortOrder: SortOrder.Ascending },
+        select: {
+          _id: true,
+          name: true,
+          processorType: true,
+          configuration: true,
+          sortOrder: true,
+        },
+        props: { isRoot: true },
+      });
+    });
+
+    test("a cold project with no pipelines performs one query for the whole burst", async () => {
+      mockFindBy.mockResolvedValue([]);
+      const project: ObjectID = ObjectID.generate();
+      const results: Array<Pipelines> = await Promise.all(
+        Array.from({ length: 1_000 }, () => {
+          return adapter.load(project);
+        }),
+      );
+      expect(mockFindBy).toHaveBeenCalledTimes(1);
+      expect(results[0]).toEqual([]);
+      for (const result of results) {
+        expect(result).toBe(results[0]);
+      }
+      expect(await adapter.load(project)).toBe(results[0]);
+      expect(mockFindBy).toHaveBeenCalledTimes(1);
+    });
+
+    test("different projects retain their own results during overlapping loads", async () => {
+      const first: ObjectID = ObjectID.generate();
+      const second: ObjectID = ObjectID.generate();
+      const firstRow: ReturnType<typeof pipeline> = pipeline("first");
+      const secondRow: ReturnType<typeof pipeline> = pipeline("second");
+      mockFindBy.mockImplementation(
+        async (args: { query: { projectId?: ObjectID } }) => {
+          if (args.query.projectId) {
+            return args.query.projectId.toString() === first.toString()
+              ? [firstRow]
+              : [secondRow];
+          }
+          return [];
+        },
+      );
+      const results: Array<Pipelines> = await Promise.all([
+        adapter.load(first),
+        adapter.load(second),
+        adapter.load(first),
+        adapter.load(second),
+      ]);
+      expect(mockFindBy).toHaveBeenCalledTimes(4);
+      expect(results[0]![0]!.pipeline).toBe(firstRow);
+      expect(results[1]![0]!.pipeline).toBe(secondRow);
+      expect(results[0]).toBe(results[2]);
+      expect(results[1]).toBe(results[3]);
+      expect(results[0]).not.toBe(results[1]);
+    });
+
+    test.each(["pipelines", "processors"])(
+      "a failed %s query rejects every waiter and is retried",
+      async (stage: string) => {
+        const project: ObjectID = ObjectID.generate();
+        const row: ReturnType<typeof pipeline> = pipeline("pipeline");
+        const error: Error = new Error("database failure");
+        if (stage === "processors") {
+          mockFindBy.mockResolvedValueOnce([row]);
+        }
+        mockFindBy.mockRejectedValueOnce(error);
+        const results: Array<PromiseSettledResult<Pipelines>> =
+          await Promise.allSettled(
+            Array.from({ length: 100 }, () => {
+              return adapter.load(project);
+            }),
+          );
+        for (const result of results) {
+          expect(result).toEqual({ status: "rejected", reason: error });
+        }
+        expect(mockFindBy).toHaveBeenCalledTimes(stage === "pipelines" ? 1 : 2);
+        mockFindBy
+          .mockReset()
+          .mockResolvedValueOnce([row])
+          .mockResolvedValueOnce([]);
+        const recovered: Pipelines = await adapter.load(project);
+        expect(recovered[0]!.pipeline).toBe(row);
+        expect(mockFindBy).toHaveBeenCalledTimes(2);
+      },
+    );
+
+    test("partially loaded pipelines are never exposed when a later query fails", async () => {
+      const project: ObjectID = ObjectID.generate();
+      const first: ReturnType<typeof pipeline> = pipeline("first");
+      const second: ReturnType<typeof pipeline> = pipeline("second");
+      mockFindBy
+        .mockResolvedValueOnce([first, second])
+        .mockResolvedValueOnce([])
+        .mockRejectedValueOnce(new Error("second failed"));
+      const results: Array<PromiseSettledResult<Pipelines>> =
+        await Promise.allSettled([
+          adapter.load(project),
+          adapter.load(project),
+        ]);
+      expect(
+        results.map((result: PromiseSettledResult<Pipelines>) => {
+          return result.status;
+        }),
+      ).toEqual(["rejected", "rejected"]);
+      mockFindBy
+        .mockReset()
+        .mockResolvedValueOnce([first, second])
+        .mockResolvedValue([]);
+      expect(await adapter.load(project)).toHaveLength(2);
+      expect(mockFindBy).toHaveBeenCalledTimes(3);
+    });
+
+    test("coalesces refresh after expiry and exposes edited configuration", async () => {
+      const now: jest.SpyInstance = jest.spyOn(Date, "now").mockReturnValue(0);
+      const project: ObjectID = ObjectID.generate();
+      const old: ReturnType<typeof pipeline> = pipeline("old");
+      const replacement: ReturnType<typeof pipeline> = pipeline("replacement");
+      mockFindBy.mockResolvedValueOnce([old]).mockResolvedValueOnce([]);
+      const original: Pipelines = await adapter.load(project);
+      now.mockReturnValue(60_001);
+      mockFindBy
+        .mockReset()
+        .mockResolvedValueOnce([replacement])
+        .mockResolvedValueOnce([]);
+      const results: Array<Pipelines> = await Promise.all(
+        Array.from({ length: 1_000 }, () => {
+          return adapter.load(project);
+        }),
+      );
+      expect(mockFindBy).toHaveBeenCalledTimes(2);
+      expect(results[0]).not.toBe(original);
+      expect(results[0]![0]!.pipeline.name).toBe("replacement");
+      expect(original[0]!.pipeline.name).toBe("old");
+      for (const result of results) {
+        expect(result).toBe(results[0]);
+      }
+    });
+
+    test("does not resolve any waiter until the final processor query completes", async () => {
+      const project: ObjectID = ObjectID.generate();
+      let finish!: (value: Array<unknown>) => void;
+      const processors: Promise<Array<unknown>> = new Promise(
+        (resolve: (value: Array<unknown>) => void) => {
+          finish = resolve;
+        },
+      );
+      mockFindBy
+        .mockResolvedValueOnce([pipeline("first"), pipeline("second")])
+        .mockResolvedValueOnce([])
+        .mockReturnValueOnce(processors);
+      const complete: jest.Mock = jest.fn();
+      const first: Promise<Pipelines> = adapter
+        .load(project)
+        .then((result: Pipelines) => {
+          complete();
+          return result;
+        });
+      for (let turn: number = 0; turn < 10; turn++) {
+        await Promise.resolve();
+      }
+      const second: Promise<Pipelines> = adapter.load(project);
+      expect(mockFindBy).toHaveBeenCalledTimes(3);
+      expect(complete).not.toHaveBeenCalled();
+      finish([]);
+      const results: Array<Pipelines> = await Promise.all([first, second]);
+      expect(results[0]).toHaveLength(2);
+      expect(results[0]).toBe(results[1]);
+    });
+  },
+);
+
+test("log and trace loads for the same project never share signal configuration", async () => {
+  const project: ObjectID = ObjectID.generate();
+  const logs: ReturnType<typeof pipeline> = pipeline("logs");
+  const traces: ReturnType<typeof pipeline> = pipeline("traces");
+  mockFindBy
+    .mockReset()
+    .mockResolvedValueOnce([logs])
+    .mockResolvedValueOnce([traces])
+    .mockResolvedValue([]);
+  const result: Array<Pipelines> = await Promise.all([
+    LogPipelineService.loadPipelines(project),
+    TracePipelineService.loadPipelines(project),
+  ]);
+  expect(result[0]![0]!.pipeline).toBe(logs);
+  expect(result[1]![0]!.pipeline).toBe(traces);
+  expect(mockFindBy).toHaveBeenCalledTimes(4);
+  mockFindBy.mockReset();
+});

--- a/App/Tests/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.test.ts
+++ b/App/Tests/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.test.ts
@@ -1,4 +1,4 @@
-import { FindOperator } from "typeorm";
+import type { FindOperator } from "Common/Server/Types/Database/QueryHelper";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import OneUptimeDate from "Common/Types/Date";

--- a/App/Tests/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.test.ts
+++ b/App/Tests/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.test.ts
@@ -1,4 +1,4 @@
-import { FindOperator } from "typeorm";
+import type { FindOperator } from "Common/Server/Types/Database/QueryHelper";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import OneUptimeDate from "Common/Types/Date";

--- a/App/Tests/Workers/Utils/MonitorSweep.test.ts
+++ b/App/Tests/Workers/Utils/MonitorSweep.test.ts
@@ -3,12 +3,13 @@ import Semaphore, {
   SemaphoreLockTimeoutError,
 } from "Common/Server/Infrastructure/Semaphore";
 import MonitorService from "Common/Server/Services/MonitorService";
-import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import QueryHelper, {
+  type FindOperator,
+} from "Common/Server/Types/Database/QueryHelper";
 import FindBy from "Common/Server/Types/Database/FindBy";
 import logger from "Common/Server/Utils/Logger";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import ObjectID from "Common/Types/ObjectID";
-import { FindOperator } from "typeorm";
 import runMonitorSweep, {
   MONITOR_SWEEP_BATCH_SIZE,
   MONITOR_SWEEP_CONCURRENCY,

--- a/App/scripts/benchmark-metric-catalog.ts
+++ b/App/scripts/benchmark-metric-catalog.ts
@@ -1,0 +1,171 @@
+/*
+ * Run from App:
+ * node --require ts-node/register/transpile-only scripts/benchmark-metric-catalog.ts
+ *
+ * Isolates metric catalog construction; does not measure database work or
+ * full ingest throughput. The baseline is the former growing-array filter.
+ * Includes a single-service export to expose the membership index overhead
+ * as well as collector exports combining hundreds/thousands of services.
+ */
+import { performance } from "perf_hooks";
+import MetricCatalog from "../FeatureSet/Telemetry/Utils/MetricCatalog";
+import MetricType from "Common/Models/DatabaseModels/MetricType";
+import Service from "Common/Models/DatabaseModels/Service";
+import Dictionary from "Common/Types/Dictionary";
+import ObjectID from "Common/Types/ObjectID";
+import ServiceType from "Common/Types/Telemetry/ServiceType";
+
+interface Scenario {
+  services: number;
+  metrics: number;
+  repetitions: number;
+}
+
+interface Observation {
+  name: string;
+  description: string;
+  unit: string;
+  serviceMetadata: {
+    primaryEntityId: ObjectID;
+    primaryEntityType: ServiceType;
+  };
+}
+
+interface BenchmarkResult {
+  mode: string;
+  services: number;
+  metrics: number;
+  observations: number;
+  milliseconds: number;
+  cpuMilliseconds: number;
+  existingServiceIdReads: number;
+}
+
+function observations(scenario: Scenario): Array<Observation> {
+  const ids: Array<ObjectID> = Array.from({ length: scenario.services }, () => {
+    return ObjectID.generate();
+  });
+  const result: Array<Observation> = [];
+  for (let round: number = 0; round < scenario.repetitions; round++) {
+    for (const id of ids) {
+      for (let metric: number = 0; metric < scenario.metrics; metric++) {
+        result.push({
+          name: `metric.${metric}`,
+          description: "Benchmark metric",
+          unit: "1",
+          serviceMetadata: {
+            primaryEntityId: id,
+            primaryEntityType: ServiceType.OpenTelemetry,
+          },
+        });
+      }
+    }
+  }
+  return result;
+}
+
+function measure(
+  indexed: boolean,
+  scenario: Scenario,
+  inputs: Array<Observation>,
+): BenchmarkResult {
+  const catalog: MetricCatalog = new MetricCatalog();
+  const baseline: Dictionary<MetricType> = {};
+  let existingServiceIdReads: number = 0;
+  const cpuStart: NodeJS.CpuUsage = process.cpuUsage();
+  const start: number = performance.now();
+
+  for (const input of inputs) {
+    if (indexed) {
+      catalog.addMetric(input);
+      continue;
+    }
+
+    if (!baseline[input.name]) {
+      const metric: MetricType = new MetricType();
+      metric.name = input.name;
+      metric.description = input.description;
+      metric.unit = input.unit;
+      metric.services = [];
+      baseline[input.name] = metric;
+    }
+
+    const metric: MetricType = baseline[input.name]!;
+    // The historical getter allocates a fresh ObjectID for every read.
+    existingServiceIdReads += metric.services!.length;
+    if (
+      metric.services!.filter((service: Service) => {
+        return (
+          service.id?.toString() ===
+          input.serviceMetadata.primaryEntityId.toString()
+        );
+      }).length === 0
+    ) {
+      const service: Service = new Service();
+      service.id = input.serviceMetadata.primaryEntityId;
+      metric.services!.push(service);
+    }
+  }
+
+  const milliseconds: number = performance.now() - start;
+  const cpu: NodeJS.CpuUsage = process.cpuUsage(cpuStart);
+  const output: Dictionary<MetricType> = indexed
+    ? catalog.metricNameServiceNameMap
+    : baseline;
+
+  if (Object.keys(output).length !== scenario.metrics) {
+    throw new Error("Metric count mismatch");
+  }
+  for (const metric of Object.values(output)) {
+    if (!metric || metric.services?.length !== scenario.services) {
+      throw new Error("Service link count mismatch");
+    }
+    const ids: Array<string> = metric.services.map((service: Service) => {
+      return service.id!.toString();
+    });
+    const expected: Array<string> = inputs
+      .filter((input: Observation) => {
+        return input.name === metric.name;
+      })
+      .slice(0, scenario.services)
+      .map((input: Observation) => {
+        return input.serviceMetadata.primaryEntityId.toString();
+      });
+    if (JSON.stringify(ids) !== JSON.stringify(expected)) {
+      throw new Error("Service link order mismatch");
+    }
+  }
+
+  return {
+    mode: indexed ? "indexed" : "baseline",
+    services: scenario.services,
+    metrics: scenario.metrics,
+    observations: inputs.length,
+    milliseconds: Math.round(milliseconds * 100) / 100,
+    cpuMilliseconds: Math.round((cpu.user + cpu.system) / 10) / 100,
+    existingServiceIdReads,
+  };
+}
+
+const warmup: Scenario = { services: 100, metrics: 4, repetitions: 2 };
+const warmupInputs: Array<Observation> = observations(warmup);
+measure(false, warmup, warmupInputs);
+measure(true, warmup, warmupInputs);
+
+const results: Array<BenchmarkResult> = [];
+for (const scenario of [
+  { services: 1, metrics: 10, repetitions: 1_000 },
+  { services: 500, metrics: 4, repetitions: 3 },
+  { services: 2_000, metrics: 4, repetitions: 3 },
+]) {
+  const inputs: Array<Observation> = observations(scenario);
+  for (let round: number = 0; round < 3; round++) {
+    for (const indexed of round % 2 === 0 ? [false, true] : [true, false]) {
+      results.push(measure(indexed, scenario, inputs));
+    }
+  }
+}
+
+process.stdout.write(
+  `${JSON.stringify({ node: process.version, results }, null, 2)}\n`,
+);

--- a/App/scripts/benchmark-pipeline-loads.js
+++ b/App/scripts/benchmark-pipeline-loads.js
@@ -1,0 +1,167 @@
+/*
+ * Run from the repository root, using separate processes for before and after:
+ *
+ * git show 0b23baed11:App/FeatureSet/Telemetry/Services/LogPipelineService.ts > /tmp/oneuptime-log-pipeline-before.ts
+ * node --expose-gc App/scripts/benchmark-pipeline-loads.js /tmp/oneuptime-log-pipeline-before.ts
+ * node --expose-gc App/scripts/benchmark-pipeline-loads.js
+ *
+ * Executes the selected service unchanged with asynchronous database stubs.
+ * The cache and filter compiler are real source. This measures redundant query
+ * calls/configuration graphs in one cold-project burst, not Postgres latency,
+ * network usage, or total ingestion throughput. Results retain all callers'
+ * returned graphs to model overlapping ingest requests consuming their config.
+ */
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const ts = require("typescript");
+
+if (typeof global.gc !== "function") {
+  throw new Error("Run with node --expose-gc.");
+}
+
+const root = path.resolve(__dirname, "../..");
+const sourcePath = path.resolve(
+  process.argv[2] ||
+    path.join(root, "App/FeatureSet/Telemetry/Services/LogPipelineService.ts"),
+);
+const callers = 1000;
+const pipelineCount = 20;
+let queries = 0;
+let filterCompilations = 0;
+
+const stubs = {
+  "Common/Models/DatabaseModels/LogPipeline": class LogPipeline {},
+  "Common/Models/DatabaseModels/LogPipelineProcessor": class LogPipelineProcessor {},
+  "Common/Server/Services/DatabaseService": class DatabaseService {
+    async findBy(data) {
+      queries++;
+      await Promise.resolve();
+      if (data.query.projectId) {
+        return Array.from({ length: pipelineCount }, (_, index) => ({
+          _id: `pipeline-${index}`,
+          name: `pipeline-${index}`,
+          sortOrder: index,
+          filterQuery: "attributes.level = 'error' AND body LIKE 'request %'",
+        }));
+      }
+      return [
+        {
+          _id: `processor-${data.query.logPipelineId}`,
+          name: "category",
+          configuration: JSON.stringify({
+            targetKey: "category",
+            categories: [
+              { name: "errors", filterQuery: "attributes.level = 'error'" },
+            ],
+          }),
+        },
+      ];
+    }
+  },
+  "Common/Types/BaseDatabase/SortOrder": { Ascending: "ASC" },
+  "Common/Types/Database/LimitMax": 10000,
+  "Common/Types/Log/LogPipelineProcessorType": {},
+  "Common/Types/Log/LogSeverity": {},
+  "Common/Utils/Grok/Grok": {},
+  "Common/Server/Utils/Logger": { error: () => {} },
+  "../Utils/PipelineProcessorConfig": () => ({}),
+};
+const sources = {
+  "Common/Server/Infrastructure/InMemoryTTLCache":
+    "Common/Server/Infrastructure/InMemoryTTLCache.ts",
+  "../Utils/PipelineCache": "App/FeatureSet/Telemetry/Utils/PipelineCache.ts",
+  "../Utils/LogFilterEvaluator":
+    "App/FeatureSet/Telemetry/Utils/LogFilterEvaluator.ts",
+};
+const modules = new Map();
+function load(file) {
+  if (modules.has(file)) {
+    return modules.get(file);
+  }
+  const code = ts.transpileModule(fs.readFileSync(file, "utf8"), {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+  }).outputText;
+  const sandbox = {
+    exports: {},
+    require: (name) => {
+      if (Object.hasOwn(stubs, name)) {
+        return stubs[name];
+      }
+      if (Object.hasOwn(sources, name)) {
+        return load(path.join(root, sources[name]));
+      }
+      throw new Error(`Unexpected import: ${name}`);
+    },
+  };
+  vm.runInNewContext(code, sandbox, { filename: file });
+  if (file.endsWith("LogFilterEvaluator.ts")) {
+    const compile = sandbox.exports.compileFilter;
+    sandbox.exports.compileFilter = (query) => {
+      filterCompilations++;
+      return compile(query);
+    };
+  }
+  modules.set(file, sandbox.exports);
+  return sandbox.exports;
+}
+const service = load(sourcePath).default;
+async function collectGarbage() {
+  for (let index = 0; index < 3; index++) {
+    global.gc();
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+async function main() {
+  await service.loadPipelines({ toString: () => "warmup" });
+  queries = 0;
+  filterCompilations = 0;
+  await collectGarbage();
+  const heapBefore = process.memoryUsage().heapUsed;
+  const cpuBefore = process.cpuUsage();
+  const results = await Promise.all(
+    Array.from({ length: callers }, () =>
+      service.loadPipelines({ toString: () => "project" }),
+    ),
+  );
+  const cpu = process.cpuUsage(cpuBefore);
+  if (
+    results.some(
+      (result) =>
+        result.length !== pipelineCount ||
+        result.some((item) => item.processors.length !== 1),
+    )
+  ) {
+    throw new Error("Loaded pipeline/processor count mismatch.");
+  }
+  await collectGarbage();
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        node: process.version,
+        sourcePath,
+        callers,
+        pipelineCount,
+        databaseQueries: queries,
+        filterCompilations,
+        distinctConfigurationGraphs: new Set(results).size,
+        cpuMilliseconds: (cpu.user + cpu.system) / 1000,
+        retainedHeapMiB: Number(
+          ((process.memoryUsage().heapUsed - heapBefore) / 1024 / 1024).toFixed(
+            2,
+          ),
+        ),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/Common/Scripts/benchmark-fanin-capacity.js
+++ b/Common/Scripts/benchmark-fanin-capacity.js
@@ -1,0 +1,181 @@
+/*
+ * Isolated fan-in admission benchmark against the actual writer source.
+ * Run with the supported Node runtime from the repository root:
+ *
+ *   node --expose-gc Common/Scripts/benchmark-fanin-capacity.js
+ *
+ * Compare in separate processes, extracting the previous source without
+ * modifying the checkout (the revision is the pre-change master):
+ *
+ *   git show 0b23baed11:Common/Server/Utils/Telemetry/TelemetryFanInWriter.ts > /tmp/oneuptime-fanin-before.ts
+ *   node --expose-gc Common/Scripts/benchmark-fanin-capacity.js /tmp/oneuptime-fanin-before.ts
+ *
+ * 200 producers submit chunks sequentially and await all their acceptance
+ * acknowledgements at the end, as ingest jobs do. ClickHouse remains blocked
+ * during measurement. The only changes between runs are the selected writer
+ * source. I/O, logging, shutdown registration and token generation are stubbed.
+ * Heap deltas include rows still held by blocked callers, not just admitted
+ * buffers; exact values vary with V8. These are isolated workload measurements,
+ * not estimates of total deployment memory savings or throughput.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const ts = require("typescript");
+
+if (typeof global.gc !== "function") {
+  throw new Error("Run this benchmark with node --expose-gc.");
+}
+
+const sourcePath = path.resolve(
+  process.argv[2] ||
+    path.join(__dirname, "../Server/Utils/Telemetry/TelemetryFanInWriter.ts"),
+);
+const code = ts.transpileModule(fs.readFileSync(sourcePath, "utf8"), {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2020,
+    esModuleInterop: true,
+  },
+}).outputText;
+let nextToken = 0;
+const overrides = {
+  "../Logger": { debug() {}, info() {}, warn() {}, error() {} },
+  "../../../Types/Sleep": {
+    sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  },
+  "../../../Utils/UUID": {
+    generateTimeOrdered: () => String(nextToken++),
+  },
+  "../GracefulShutdown": {
+    __esModule: true,
+    default: { registerHandler() {} },
+    ShutdownPriority: { Buffers: 1 },
+  },
+  "../AnalyticsDatabase/InsertDedupContext": {
+    nextInsertDedupToken: () => undefined,
+  },
+  "@clickhouse/client": { ClickHouseError: class extends Error {} },
+};
+const sandbox = {
+  exports: {},
+  process,
+  setTimeout,
+  clearTimeout,
+  require: (name) => {
+    if (!(name in overrides)) {
+      throw new Error(`Unexpected writer dependency: ${name}`);
+    }
+    return overrides[name];
+  },
+};
+vm.runInNewContext(code, sandbox, { filename: sourcePath });
+
+async function nextTurn() {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function collect() {
+  for (let i = 0; i < 3; i++) {
+    global.gc();
+    await nextTurn();
+  }
+}
+
+async function main() {
+  const producerCount = 200;
+  const chunksPerProducer = 3;
+  const rowsPerChunk = 100;
+  const rowBodyBytes = 512;
+  const maxPendingRows = 1000;
+  const writer = new sandbox.exports.TelemetryFanInWriter({
+    maxBatchRows: 500,
+    maxPendingRows,
+    maxConcurrentInserts: 4,
+    maxWaitMs: 60_000,
+    retryMaxAttempts: 1,
+    retryBaseDelayMs: 1,
+    retryMaxDelayMs: 1,
+  });
+  let release;
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  let insertedRows = 0;
+  const target = {
+    model: { tableName: "CapacityBenchmark" },
+    insertJsonRows: async (rows) => {
+      await gate;
+      insertedRows += rows.length;
+    },
+  };
+
+  await collect();
+  const heapBefore = process.memoryUsage().heapUsed;
+  let createdRows = 0;
+  let acceptedSubmissions = 0;
+  const producers = Array.from(
+    { length: producerCount },
+    async (_, producer) => {
+      const acks = [];
+      for (let chunk = 0; chunk < chunksPerProducer; chunk++) {
+        const rows = Array.from({ length: rowsPerChunk }, (_, row) => {
+          createdRows++;
+          return {
+            producer,
+            chunk,
+            row,
+            // A flat, separately allocated body for each row.
+            body: Buffer.alloc(rowBodyBytes / 2, row % 256).toString("hex"),
+          };
+        });
+        const { flushed } = await writer.submit(target, rows);
+        acceptedSubmissions++;
+        acks.push(flushed);
+      }
+      await Promise.all(acks);
+    },
+  );
+
+  try {
+    await nextTurn();
+    await collect();
+    const heapDeltaMiB =
+      (process.memoryUsage().heapUsed - heapBefore) / 1024 / 1024;
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          node: process.version,
+          sourcePath,
+          producerCount,
+          chunksPerProducer,
+          rowsPerChunk,
+          rowBodyBytes,
+          maxPendingRows,
+          createdRows,
+          acceptedSubmissions,
+          ...writer.getStats(),
+          heapDeltaMiB: Number(heapDeltaMiB.toFixed(2)),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } finally {
+    release();
+    await writer.flushAll();
+    await Promise.all(producers);
+    if (insertedRows !== producerCount * chunksPerProducer * rowsPerChunk) {
+      throw new Error(`Writer lost rows: inserted ${insertedRows}.`);
+    }
+    if (writer.getStats().pendingRows !== 0) {
+      throw new Error("Writer retained pending rows after drain.");
+    }
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error}\n`);
+  process.exitCode = 1;
+});

--- a/Common/Server/Types/Database/QueryHelper.ts
+++ b/Common/Server/Types/Database/QueryHelper.ts
@@ -10,6 +10,8 @@ import { toLikePattern } from "../../../Types/BaseDatabase/WildcardPattern";
 import CaptureSpan from "../../Utils/Telemetry/CaptureSpan";
 import buildJSONColumnQuery, { JSONColumnQuery } from "./JSONColumnQuery";
 
+export type { FindOperator };
+
 export default class QueryHelper {
   @CaptureSpan()
   public static modulo(

--- a/Common/Server/Utils/Telemetry/TelemetryFanInWriter.ts
+++ b/Common/Server/Utils/Telemetry/TelemetryFanInWriter.ts
@@ -125,7 +125,10 @@ export interface FanInWriterOptions {
   maxWaitMs: number;
   /** Per-pod cap on concurrent ClickHouse inserts across all tables. */
   maxConcurrentInserts: number;
-  /** High-water mark of buffered+in-flight rows; submit() blocks above it. */
+  /**
+   * High-water mark of reserved+buffered+in-flight rows. A whole submission
+   * may cross it once; later submit() calls wait for capacity to be released.
+   */
   maxPendingRows: number;
   retryMaxAttempts: number;
   retryBaseDelayMs: number;
@@ -195,6 +198,11 @@ type TableBuffer = {
   submissions: Array<PendingSubmission>;
   rowCount: number;
   timer: NodeJS.Timeout | null;
+};
+
+type CapacityWaiter = {
+  rowCount: number;
+  resolve: () => void;
 };
 
 /*
@@ -328,7 +336,7 @@ export class TelemetryFanInWriter {
   private options: FanInWriterOptions;
   private buffers: Map<string, TableBuffer> = new Map();
   private pendingRows: number = 0;
-  private capacityWaiters: Array<() => void> = [];
+  private capacityWaiters: Set<CapacityWaiter> = new Set();
   private activeInserts: number = 0;
   private insertSlotWaiters: Array<() => void> = [];
   private inFlightDispatches: Set<Promise<void>> = new Set();
@@ -428,7 +436,7 @@ export class TelemetryFanInWriter {
 
     this.acceptingSubmits++;
     try {
-      await this.waitForCapacity();
+      await this.waitForCapacity(rows.length);
 
       let buffer: TableBuffer | undefined = this.buffers.get(tableName);
       if (!buffer) {
@@ -458,7 +466,6 @@ export class TelemetryFanInWriter {
         rejectAck,
       });
       buffer.rowCount += rows.length;
-      this.pendingRows += rows.length;
 
       if (buffer.rowCount >= this.getMaxBatchRows(tableName)) {
         this.cutAndDispatch(tableName, false);
@@ -532,24 +539,39 @@ export class TelemetryFanInWriter {
     );
   }
 
-  private async waitForCapacity(): Promise<void> {
-    while (this.pendingRows >= this.options.maxPendingRows) {
-      await new Promise<void>((resolve: () => void) => {
-        this.capacityWaiters.push(resolve);
-      });
+  private async waitForCapacity(rowCount: number): Promise<void> {
+    /*
+     * Reserve before yielding: concurrent submitters otherwise all observe
+     * the same available capacity and buffer their rows after the await,
+     * multiplying the memory limit by the number of submitters. Keep whole
+     * submissions intact: one submission may cross the high-water mark,
+     * but every later submission waits until pending rows fall below it.
+     */
+    if (this.pendingRows < this.options.maxPendingRows) {
+      this.pendingRows += rowCount;
+      return;
     }
+
+    await new Promise<void>((resolve: () => void) => {
+      this.capacityWaiters.add({ rowCount, resolve });
+    });
   }
 
   private releaseCapacity(): void {
     /*
-     * Wake all waiters; each re-checks the high-water mark in its
-     * waitForCapacity loop, so overshoot stays bounded to one submission
-     * per waiter.
+     * Transfer capacity to FIFO waiters before waking them. Only admitted
+     * callers resume, so completing an insert does not wake the entire
+     * backlog to compete for the same capacity again.
+     * Set keeps FIFO order and releases each waiter without shifting the
+     * remaining queue or retaining consumed entries.
      */
-    const waiters: Array<() => void> = this.capacityWaiters;
-    this.capacityWaiters = [];
-    for (const wake of waiters) {
-      wake();
+    for (const waiter of this.capacityWaiters) {
+      if (this.pendingRows >= this.options.maxPendingRows) {
+        break;
+      }
+      this.pendingRows += waiter.rowCount;
+      this.capacityWaiters.delete(waiter);
+      waiter.resolve();
     }
   }
 

--- a/Common/Tests/Server/Utils/Telemetry/TelemetryFanInWriterCapacity.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/TelemetryFanInWriterCapacity.test.ts
@@ -1,0 +1,458 @@
+import {
+  FanInInsertError,
+  FanInInsertTarget,
+  FanInSubmitResult,
+  FanInWriterOptions,
+  TelemetryFanInWriter,
+  TransientInsertError,
+} from "../../../../Server/Utils/Telemetry/TelemetryFanInWriter";
+import { runWithInsertDedup } from "../../../../Server/Utils/AnalyticsDatabase/InsertDedupContext";
+import { JSONObject } from "../../../../Types/JSON";
+import { setImmediate } from "timers";
+
+jest.mock("../../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+function deferred(): Deferred {
+  let resolve: () => void = () => {};
+  let reject: (error: Error) => void = () => {};
+  const promise: Promise<void> = new Promise<void>(
+    (res: () => void, rej: (error: Error) => void) => {
+      resolve = res;
+      reject = rej;
+    },
+  );
+  return { promise, resolve, reject };
+}
+
+function options(
+  overrides: Partial<FanInWriterOptions> = {},
+): FanInWriterOptions {
+  return {
+    maxBatchRows: 1,
+    maxPendingRows: 4,
+    maxConcurrentInserts: 1,
+    maxWaitMs: 60_000,
+    retryMaxAttempts: 2,
+    retryBaseDelayMs: 1,
+    retryMaxDelayMs: 1,
+    ...overrides,
+  };
+}
+
+function rows(count: number, seq: number = 0): Array<JSONObject> {
+  return Array.from({ length: count }, () => {
+    return { seq };
+  });
+}
+
+// Complete the current microtask queue without waiting for the flush timer.
+async function settle(): Promise<void> {
+  await new Promise<void>((resolve: () => void) => {
+    setImmediate(resolve);
+  });
+}
+
+function gatedTarget(): {
+  target: FanInInsertTarget;
+  gates: Array<Deferred>;
+  inserted: Array<Array<JSONObject>>;
+} {
+  const gates: Array<Deferred> = [];
+  const inserted: Array<Array<JSONObject>> = [];
+  return {
+    gates,
+    inserted,
+    target: {
+      model: { tableName: "CapacityTable" },
+      insertJsonRows: async (batch: Array<JSONObject>): Promise<void> => {
+        inserted.push(batch);
+        const gate: Deferred = deferred();
+        gates.push(gate);
+        await gate.promise;
+      },
+    },
+  };
+}
+
+async function drainGated(
+  writer: TelemetryFanInWriter,
+  gates: Array<Deferred>,
+  submissions: Array<Promise<FanInSubmitResult>>,
+): Promise<void> {
+  let resolvedGates: number = 0;
+  let drained: boolean = false;
+  const drain: Promise<void> = writer.flushAll().then(() => {
+    drained = true;
+  });
+  while (!drained) {
+    while (resolvedGates < gates.length) {
+      gates[resolvedGates++]!.resolve();
+    }
+    await settle();
+  }
+  await drain;
+  const accepted: Array<FanInSubmitResult> = await Promise.all(submissions);
+  await Promise.all(
+    accepted.map((result: FanInSubmitResult) => {
+      return result.flushed;
+    }),
+  );
+  expect(writer.getStats()).toEqual({
+    bufferedRows: 0,
+    pendingRows: 0,
+    activeInserts: 0,
+  });
+}
+
+describe("TelemetryFanInWriter capacity reservations", () => {
+  test.each([1, 4])(
+    "a simultaneous burst respects the row limit with %i insert slots",
+    async (maxConcurrentInserts: number) => {
+      const { target, gates, inserted } = gatedTarget();
+      const writer: TelemetryFanInWriter = new TelemetryFanInWriter(
+        options({ maxPendingRows: 8, maxConcurrentInserts }),
+      );
+      let accepted: number = 0;
+      const submissions: Array<Promise<FanInSubmitResult>> = Array.from(
+        { length: 100 },
+        (_: unknown, seq: number) => {
+          return writer
+            .submit(target, rows(2, seq))
+            .then((result: FanInSubmitResult) => {
+              accepted++;
+              return result;
+            });
+        },
+      );
+
+      // Reservations must exist before any submit continuation has resumed.
+      expect(writer.getStats().pendingRows).toBe(8);
+      await settle();
+      expect(accepted).toBe(4);
+      expect(writer.getStats().pendingRows).toBe(8);
+      expect(gates).toHaveLength(maxConcurrentInserts);
+
+      await drainGated(writer, gates, submissions);
+      expect(accepted).toBe(100);
+      expect(
+        inserted.map((batch: Array<JSONObject>) => {
+          return batch[0]!["seq"];
+        }),
+      ).toEqual(
+        Array.from({ length: 100 }, (_: unknown, seq: number) => {
+          return seq;
+        }),
+      );
+    },
+  );
+
+  test("each released slot admits only the rows it reserved, in FIFO order", async () => {
+    const { target, gates, inserted } = gatedTarget();
+    const writer: TelemetryFanInWriter = new TelemetryFanInWriter(options());
+    const accepted: Array<number> = [];
+    const submissions: Array<Promise<FanInSubmitResult>> = [];
+    for (let seq: number = 0; seq < 10; seq++) {
+      submissions.push(
+        writer
+          .submit(target, rows(4, seq))
+          .then((result: FanInSubmitResult) => {
+            accepted.push(seq);
+            return result;
+          }),
+      );
+    }
+    await settle();
+    expect(accepted).toEqual([0]);
+
+    for (let seq: number = 1; seq < 10; seq++) {
+      gates[seq - 1]!.resolve();
+      await settle();
+      expect(accepted).toEqual(
+        Array.from({ length: seq + 1 }, (_: unknown, i: number) => {
+          return i;
+        }),
+      );
+      expect(writer.getStats().pendingRows).toBe(4);
+      expect(inserted).toHaveLength(seq + 1);
+    }
+    await drainGated(writer, gates, submissions);
+  });
+
+  test("an insert completion admits several small submissions that fit", async () => {
+    const { target, gates } = gatedTarget();
+    const writer: TelemetryFanInWriter = new TelemetryFanInWriter(options());
+    const submissions: Array<Promise<FanInSubmitResult>> = [
+      writer.submit(target, rows(4)),
+    ];
+    let accepted: number = 0;
+    const recordAcceptance: (result: FanInSubmitResult) => FanInSubmitResult = (
+      result: FanInSubmitResult,
+    ): FanInSubmitResult => {
+      accepted++;
+      return result;
+    };
+    for (let seq: number = 1; seq <= 20; seq++) {
+      submissions.push(
+        writer.submit(target, rows(1, seq)).then(recordAcceptance),
+      );
+    }
+    await settle();
+    expect(accepted).toBe(0);
+    gates[0]!.resolve();
+    await settle();
+    expect(accepted).toBe(4);
+    expect(writer.getStats().pendingRows).toBe(4);
+    await drainGated(writer, gates, submissions);
+  });
+
+  test("new submissions cannot steal capacity already granted to queued callers", async () => {
+    const { target, gates, inserted } = gatedTarget();
+    const writer: TelemetryFanInWriter = new TelemetryFanInWriter(options());
+    const first: Promise<FanInSubmitResult> = writer.submit(target, rows(4, 0));
+    const second: Promise<FanInSubmitResult> = writer.submit(
+      target,
+      rows(4, 1),
+    );
+    await settle();
+    gates[0]!.resolve();
+    const third: Promise<FanInSubmitResult> = (await first).flushed.then(() => {
+      return writer.submit(target, rows(4, 2));
+    });
+    await settle();
+    expect(writer.getStats().pendingRows).toBe(4);
+    expect(
+      inserted.map((batch: Array<JSONObject>) => {
+        return batch[0]!["seq"];
+      }),
+    ).toEqual([0, 1]);
+    await drainGated(writer, gates, [first, second, third]);
+    expect(
+      inserted.map((batch: Array<JSONObject>) => {
+        return batch[0]!["seq"];
+      }),
+    ).toEqual([0, 1, 2]);
+  });
+
+  test.each([0, 3])(
+    "a whole oversized submission makes progress with %i existing rows and bounds overshoot",
+    async (initialRows: number) => {
+      const { target, gates, inserted } = gatedTarget();
+      const writer: TelemetryFanInWriter = new TelemetryFanInWriter(options());
+      const submissions: Array<Promise<FanInSubmitResult>> = [];
+      if (initialRows) {
+        submissions.push(writer.submit(target, rows(initialRows, 0)));
+      }
+      let oversizedAccepted: number = 0;
+      const recordAcceptance: (
+        result: FanInSubmitResult,
+      ) => FanInSubmitResult = (
+        result: FanInSubmitResult,
+      ): FanInSubmitResult => {
+        oversizedAccepted++;
+        return result;
+      };
+      for (let seq: number = 1; seq <= 20; seq++) {
+        submissions.push(
+          writer.submit(target, rows(10, seq)).then(recordAcceptance),
+        );
+      }
+      await settle();
+      expect(oversizedAccepted).toBe(1);
+      expect(writer.getStats().pendingRows).toBe(initialRows + 10);
+      await drainGated(writer, gates, submissions);
+      expect(
+        inserted.filter((batch: Array<JSONObject>) => {
+          return batch.length === 10;
+        }),
+      ).toHaveLength(20);
+    },
+  );
+
+  test("definitive insert failure releases its reservation for the next submission", async () => {
+    const { target, gates } = gatedTarget();
+    const writer: TelemetryFanInWriter = new TelemetryFanInWriter(options());
+    const first: FanInSubmitResult = await writer.submit(target, rows(4));
+    const failed: Promise<unknown> = first.flushed.catch((error: unknown) => {
+      return error;
+    });
+    const second: Promise<FanInSubmitResult> = writer.submit(
+      target,
+      rows(4, 1),
+    );
+    const third: Promise<FanInSubmitResult> = writer.submit(target, rows(4, 2));
+    await settle();
+    gates[0]!.reject(new Error("Definitive insert failure"));
+    expect(await failed).toBeInstanceOf(FanInInsertError);
+    await settle();
+    expect(writer.getStats().pendingRows).toBe(4);
+    expect(gates).toHaveLength(2);
+    await drainGated(writer, gates, [second, third]);
+  });
+
+  test("retry backoff holds its reservation until success and preserves the dedup token", async () => {
+    const backoff: Deferred = deferred();
+    const writer: TelemetryFanInWriter = new TelemetryFanInWriter(
+      options({
+        sleep: async (): Promise<void> => {
+          await backoff.promise;
+        },
+      }),
+    );
+    const insertJsonRows: jest.MockedFunction<
+      FanInInsertTarget["insertJsonRows"]
+    > = jest
+      .fn<Promise<void>, Parameters<FanInInsertTarget["insertJsonRows"]>>()
+      .mockRejectedValueOnce(new TransientInsertError("overloaded"))
+      .mockResolvedValue(undefined);
+    const target: FanInInsertTarget = {
+      model: { tableName: "CapacityTable" },
+      insertJsonRows,
+    };
+    const first: FanInSubmitResult = await writer.submit(target, rows(4), {
+      dedupToken: "first-job",
+    });
+    let secondAccepted: boolean = false;
+    const second: Promise<FanInSubmitResult> = writer
+      .submit(target, rows(4, 1), {
+        dedupToken: "second-job",
+      })
+      .then((result: FanInSubmitResult) => {
+        secondAccepted = true;
+        return result;
+      });
+    await settle();
+    expect(secondAccepted).toBe(false);
+    expect(writer.getStats().pendingRows).toBe(4);
+    expect(insertJsonRows).toHaveBeenCalledTimes(1);
+    backoff.resolve();
+    await writer.flushAll();
+    await first.flushed;
+    await (
+      await second
+    ).flushed;
+    expect(
+      insertJsonRows.mock.calls.map(
+        (call: Parameters<FanInInsertTarget["insertJsonRows"]>) => {
+          return call[1]?.dedupToken;
+        },
+      ),
+    ).toEqual(["first-job", "first-job", "second-job"]);
+    expect(writer.getStats().pendingRows).toBe(0);
+  });
+
+  test("empty submissions bypass a full writer without reserving rows", async () => {
+    const { target, gates } = gatedTarget();
+    const writer: TelemetryFanInWriter = new TelemetryFanInWriter(options());
+    const full: Promise<FanInSubmitResult> = writer.submit(target, rows(4));
+    await (
+      await writer.submit(target, [])
+    ).flushed;
+    expect(writer.getStats().pendingRows).toBe(4);
+    await drainGated(writer, gates, [full]);
+  });
+
+  test("shutdown drains thousands of concurrent submissions across tables with no lost rows or tokens", async () => {
+    const totalSubmissions: number = 2000;
+    const maxPendingRows: number = 23;
+    const largestSubmission: number = 7;
+    const writer: TelemetryFanInWriter = new TelemetryFanInWriter(
+      options({
+        maxBatchRows: 11,
+        maxPendingRows,
+        maxConcurrentInserts: 3,
+      }),
+    );
+    const seen: Map<number, number> = new Map();
+    const tokens: Set<string> = new Set();
+    let peakPending: number = 0;
+    const checkCapacity: () => void = () => {
+      peakPending = Math.max(peakPending, writer.getStats().pendingRows);
+      expect(writer.getStats().pendingRows).toBeLessThanOrEqual(
+        maxPendingRows + largestSubmission - 1,
+      );
+    };
+    const targets: Array<FanInInsertTarget> = Array.from(
+      { length: 3 },
+      (_: unknown, i: number) => {
+        return {
+          model: { tableName: `CapacityTable${i}` },
+          insertJsonRows: async (
+            batch: Array<JSONObject>,
+            insertOptions?: { dedupToken?: string | undefined },
+          ): Promise<void> => {
+            checkCapacity();
+            expect(insertOptions?.dedupToken).toBeTruthy();
+            expect(tokens.has(insertOptions!.dedupToken!)).toBe(false);
+            tokens.add(insertOptions!.dedupToken!);
+            const seq: number = batch[0]!["seq"] as number;
+            expect(insertOptions!.dedupToken).toBe(
+              `capacity-scale-job:CapacityTable${i}:${Math.floor(seq / 3)}`,
+            );
+            expect(seen.has(seq)).toBe(false);
+            expect(
+              batch.every((row: JSONObject) => {
+                return row["seq"] === seq;
+              }),
+            ).toBe(true);
+            seen.set(seq, batch.length);
+            await Promise.resolve();
+          },
+        };
+      },
+    );
+    const submissions: Array<Promise<FanInSubmitResult>> = [];
+    await runWithInsertDedup("capacity-scale-job", async () => {
+      for (let seq: number = 0; seq < totalSubmissions; seq++) {
+        submissions.push(
+          writer
+            .submit(
+              targets[seq % targets.length]!,
+              rows((seq % largestSubmission) + 1, seq),
+            )
+            .then((result: FanInSubmitResult) => {
+              checkCapacity();
+              return result;
+            }),
+        );
+        checkCapacity();
+      }
+    });
+    /*
+     * flushAll must also wait for rows whose capacity is reserved before their
+     * submit continuation buffers them, including every later admission wave.
+     */
+    await writer.flushAll();
+    await Promise.all(
+      (await Promise.all(submissions)).map((result: FanInSubmitResult) => {
+        return result.flushed;
+      }),
+    );
+    expect(seen.size).toBe(totalSubmissions);
+    expect(tokens.size).toBe(totalSubmissions);
+    for (let seq: number = 0; seq < totalSubmissions; seq++) {
+      expect(seen.get(seq)).toBe((seq % largestSubmission) + 1);
+    }
+    expect(peakPending).toBeGreaterThanOrEqual(maxPendingRows);
+    expect(writer.getStats()).toEqual({
+      bufferedRows: 0,
+      pendingRows: 0,
+      activeInserts: 0,
+    });
+  });
+});

--- a/Internal/Performance/ConcurrentIngestResourceUsage.md
+++ b/Internal/Performance/ConcurrentIngestResourceUsage.md
@@ -85,7 +85,7 @@ over wall-clock comparisons. Heap deltas vary with V8 and collection timing.
 | Same burst: distinct retained configuration graphs | 1,000 | 1 |
 | Same burst: sampled retained JS heap | 19.89 MiB | 0.10 MiB |
 | Same burst: process CPU in recorded run | 325.63 ms | 3.05 ms |
-| 2,000 services, 4 metrics, 24,000 observations: catalog median CPU | 2,069.12 ms | 4.08 ms |
+| 2,000 services, 4 metrics, 24,000 observations: catalog median CPU | 1,743.25 ms | 4.17 ms |
 | Same catalog: existing-service ID reads during membership scans | 39,996,000 | 0 |
 | 200 writer producers, 100-row chunks, 1,000-row limit: admitted rows while inserts stall | 20,000 | 1,000 |
 | Same writer workload: sampled live JS heap increase | 23.20 MiB | 12.35 MiB |
@@ -129,9 +129,9 @@ node --require ts-node/register/transpile-only scripts/benchmark-metric-catalog.
 
 ## Regression coverage
 
-The focused run passes 356 tests across 16 suites, including 142 new regression
-and scale cases: 124 pipeline/cache tests, 45 metric-ingestion tests, 86 writer
-tests, and 101 probe tests. Tests assert work counts and behavior rather than
+The focused run passes 393 tests across 19 suites, including 143 new regression
+and scale cases: 124 pipeline/cache tests, 46 metric-ingestion tests, 86 writer
+tests, 101 probe tests, and 36 existing monitor-sweep tests. Tests assert work counts and behavior rather than
 machine-dependent timing thresholds.
 
 - Pipeline cache unit tests exercise 10,000 overlapping callers, empty values,

--- a/Internal/Performance/ConcurrentIngestResourceUsage.md
+++ b/Internal/Performance/ConcurrentIngestResourceUsage.md
@@ -22,6 +22,7 @@ retry. Results for different projects and signals remain independent.
 Pending entries are also capped at 10,000 per signal. Overflow requests still
 load, but do not share or cache their result without an ownership slot. A pending
 load older than 60 seconds stops attracting new callers; it is not cancelled.
+At capacity, an expired oldest slot is reclaimed for a new project.
 Its original callers receive its outcome, but a superseded load cannot overwrite
 newer configuration or remove a replacement's pending entry. No cleanup timers
 are added.
@@ -128,8 +129,8 @@ node --require ts-node/register/transpile-only scripts/benchmark-metric-catalog.
 
 ## Regression coverage
 
-The focused run passes 354 tests across 16 suites, including 140 new regression
-and scale cases: 122 pipeline/cache tests, 45 metric-ingestion tests, 86 writer
+The focused run passes 356 tests across 16 suites, including 142 new regression
+and scale cases: 124 pipeline/cache tests, 45 metric-ingestion tests, 86 writer
 tests, and 101 probe tests. Tests assert work counts and behavior rather than
 machine-dependent timing thresholds.
 

--- a/Internal/Performance/ConcurrentIngestResourceUsage.md
+++ b/Internal/Performance/ConcurrentIngestResourceUsage.md
@@ -1,0 +1,165 @@
+# Concurrent ingestion CPU and memory improvements
+
+This follow-up starts from master `0b23baed11`, after the improvements documented
+in [RuntimeResourceUsage.md](./RuntimeResourceUsage.md). It removes repeated work
+and excess buffering when many requests or monitors run together. No schema
+migration, dependency update, or deployment configuration change is required.
+
+## Changes
+
+### Share concurrent pipeline loads
+
+Log and trace pipeline loaders now share a pending load for the same project and
+signal. A burst of cold requests previously repeated every pipeline/processor
+query, filter compilation, and configuration allocation before the first load
+populated the existing cache. All callers now receive the same loaded graph.
+
+The existing 60-second result TTL, 10,000-project limit per signal, enabled
+predicates, query limits, and database sort order are preserved. The TTL starts
+when loading completes. Failures reach every waiter and release the slot for
+retry. Results for different projects and signals remain independent.
+
+Pending entries are also capped at 10,000 per signal. Overflow requests still
+load, but do not share or cache their result without an ownership slot. A pending
+load older than 60 seconds stops attracting new callers; it is not cancelled.
+Its original callers receive its outcome, but a superseded load cannot overwrite
+newer configuration or remove a replacement's pending entry. No cleanup timers
+are added.
+
+### Index metric catalog service membership
+
+A collector export can contain the same metric from thousands of services. The
+catalog formerly scanned the growing service array for every observation. Each
+scan also created an array and read Service.id, whose getter constructs an
+ObjectID. The new request-local index makes membership checks constant time.
+
+Catalog entries retain first-observation metadata and first-seen service order.
+Host and other infrastructure IDs are still excluded from Service relationships.
+Heartbeat metrics, aggregation temporality, monotonic counters, chunk flushes,
+and best-effort catalog persistence keep their existing behavior. A Set is
+allocated only when a metric encounters a second distinct service; the usual
+single-service export stores its first ID directly. This index adds linear
+request-local memory and is released with the request.
+
+### Reserve writer capacity before yielding
+
+TelemetryFanInWriter previously checked its pending-row limit before an await,
+then incremented the count afterward. Concurrent submitters could all pass the
+same check, multiplying the intended buffer limit. Row reservations now happen
+synchronously before yielding. Completing inserts transfer capacity to queued
+callers in FIFO order before waking them, avoiding repeated wakeups of the whole
+queue.
+
+Whole submissions remain intact. One submission can cross the high-water mark,
+including a submission larger than the configured limit. Every subsequent
+submission waits until admitted rows fall below that mark. This bounds accepted
+buffering, not rows already held by callers waiting to submit, request-body
+memory, or total process RSS. Existing acknowledgements, deduplication tokens,
+retry semantics, insert concurrency, and shutdown drains are unchanged.
+
+### Share probe connectivity checks
+
+Simultaneously failing monitors on a SaaS probe now share overlapping reference
+connectivity checks independently for HTTP, ICMP, and TCP. Settled results are
+immediately discarded so a subsequent monitor checks current connectivity.
+Self-hosted probes retain their existing public-connectivity bypass.
+
+A five-minute sharing limit prevents an unusually old operation from attracting
+new callers indefinitely. This allows the existing TCP fallback budget of about
+145 seconds. Original callers still receive their original outcome; late
+settlement cannot remove a newer operation. Sharing uses at most three map
+entries and adds no timers or result cache.
+
+## Isolated measurements
+
+Measured with Node 26.6.0. These are reproducible workload-specific measurements,
+not estimates of deployment-wide savings. Concurrent unrelated development
+processes were running; prefer operation counts and retained-object invariants
+over wall-clock comparisons. Heap deltas vary with V8 and collection timing.
+
+| Workload / measurement | Before | After |
+| --- | ---: | ---: |
+| 1,000 cold pipeline callers, 20 pipelines: database calls | 21,000 | 21 |
+| Same burst: filter compilations | 20,000 | 20 |
+| Same burst: distinct retained configuration graphs | 1,000 | 1 |
+| Same burst: sampled retained JS heap | 19.89 MiB | 0.10 MiB |
+| Same burst: process CPU in recorded run | 325.63 ms | 3.05 ms |
+| 2,000 services, 4 metrics, 24,000 observations: catalog median CPU | 2,069.12 ms | 4.08 ms |
+| Same catalog: existing-service ID reads during membership scans | 39,996,000 | 0 |
+| 200 writer producers, 100-row chunks, 1,000-row limit: admitted rows while inserts stall | 20,000 | 1,000 |
+| Same writer workload: sampled live JS heap increase | 23.20 MiB | 12.35 MiB |
+| 10,000 simultaneous offline probe callers: reference checks | 50,000 | 5 |
+| Same probe burst: simultaneously pending references | 10,000 | 1 |
+| Same probe burst: sampled pending JS heap | 10.60 MiB | 2.54 MiB |
+
+The pipeline, writer, and probe harnesses execute the selected source with I/O
+stubbed. Pipeline measurements exclude actual Postgres/network latency. The
+writer harness holds ClickHouse inserts pending, then verifies both versions
+ultimately insert all 60,000 rows. Its heap includes rows retained by blocked
+callers. The probe heap includes deferred stub promises and caller promises,
+not actual sockets. The catalog benchmark uses real models and the new helper,
+compared with the previous scan algorithm; it excludes row processing and
+persistence. It also measures one-service and 500-service cases and checks output
+counts and service order.
+
+## Reproduce
+
+Use the supported Node runtime. From the repository root:
+
+```sh
+git show 0b23baed11:App/FeatureSet/Telemetry/Services/LogPipelineService.ts > /tmp/oneuptime-log-pipeline-before.ts
+node --expose-gc App/scripts/benchmark-pipeline-loads.js /tmp/oneuptime-log-pipeline-before.ts
+node --expose-gc App/scripts/benchmark-pipeline-loads.js
+
+git show 0b23baed11:Common/Server/Utils/Telemetry/TelemetryFanInWriter.ts > /tmp/oneuptime-fanin-before.ts
+node --expose-gc Common/Scripts/benchmark-fanin-capacity.js /tmp/oneuptime-fanin-before.ts
+node --expose-gc Common/Scripts/benchmark-fanin-capacity.js
+
+git show 0b23baed11:Probe/Utils/OnlineCheck.ts > /tmp/oneuptime-online-check-before.ts
+node --expose-gc Probe/scripts/benchmark-online-check.js /tmp/oneuptime-online-check-before.ts
+node --expose-gc Probe/scripts/benchmark-online-check.js
+```
+
+From `App`:
+
+```sh
+node --require ts-node/register/transpile-only scripts/benchmark-metric-catalog.ts
+```
+
+## Regression coverage
+
+The focused run passes 354 tests across 16 suites, including 140 new regression
+and scale cases: 122 pipeline/cache tests, 45 metric-ingestion tests, 86 writer
+tests, and 101 probe tests. Tests assert work counts and behavior rather than
+machine-dependent timing thresholds.
+
+- Pipeline cache unit tests exercise 10,000 overlapping callers, empty values,
+  rejection/synchronous failure, expiry, refresh, slow-load replacement, backward
+  clock changes, bounded completed/pending entries, overflow, late completion,
+  and project/signal isolation. Service integration tests exercise real loaders
+  and filter compilation with database I/O stubbed, including 1,000 callers
+  loading 20 ordered pipelines, partial failures, metadata edits, and late joiners.
+- Metric catalog tests cover service-ID value equality, metadata/service order,
+  every non-Service entity type, repeated and independent exports, large service
+  lists, heartbeat overlap, row/chunk counts, counter semantics, and failed
+  catalog persistence. Existing IoT rule and ingestion-stamp suites also run.
+- Writer tests hold inserts pending to inspect synchronous reservations, bounded
+  resumed waves, FIFO admission, multiple insert slots, oversized submissions,
+  retries and terminal failures. A 2,000-submission multi-table shutdown test
+  verifies every row and its deduplication token. The existing writer suite runs
+  alongside these regressions.
+- Probe tests cover 10,000 simultaneous callers, all three protocols, fallback
+  order, late joiners, self-hosted bypass, failures, immediate rechecks after
+  recovery, sharing expiry, and late settlement. Existing ICMP/TCP monitor
+  regression suites also run.
+
+These service integration tests isolate database/network I/O. They do not replace
+a sustained deployment test against real Postgres and ClickHouse. The local
+Compose stack mounts the original checkout, not this worktree, and its endpoint
+returned HTTP 502 during inspection. It is not used as branch validation.
+
+For a deployment comparison, hold workload, role split, concurrency, and database
+capacity constant. Measure CPU, live heap/RSS, queue depth, accepted/dropped rows,
+ingestion latency, and monitor detection delay during steady traffic and bursts.
+Writer backpressure can increase the time submitters wait when storage is slow;
+that is the intended tradeoff for limiting accepted work.

--- a/Internal/Performance/RuntimeResourceUsage.md
+++ b/Internal/Performance/RuntimeResourceUsage.md
@@ -85,6 +85,10 @@ active ingestion request.
   unrelated timers, late settlement, and 10,000 completed jobs without lingering
   deadline handles.
 
+The follow-up [ConcurrentIngestResourceUsage.md](./ConcurrentIngestResourceUsage.md)
+covers concurrent log/trace cache loads, metric catalog construction, writer
+admission, and shared probe connectivity checks.
+
 ## Next recommendations
 
 1. **Measure each production role under the same workload.** The existing

--- a/Internal/Performance/RuntimeResourceUsage.md
+++ b/Internal/Performance/RuntimeResourceUsage.md
@@ -98,11 +98,12 @@ admission, and shared probe connectivity checks.
    equal traffic, fleet size, and deployment settings, including bursts and a
    sustained run. The local Docker development app also runs five frontend build
    watchers, so its container memory is not a production API-process baseline.
-2. **Coalesce concurrent telemetry cache misses and batch processor reads.**
-   The log/trace pipeline loaders cache projects for 60 seconds but still load
-   processor lists per pipeline. Concurrent cold loads can repeat the same
-   database work. A follow-up should share in-flight loads and fetch processors
-   in batches, with rejection/retry, tenant-isolation, and invalidation tests.
+2. **Batch remaining processor reads.**
+   Concurrent log/trace cache misses now share a load, as documented in
+   [ConcurrentIngestResourceUsage.md](./ConcurrentIngestResourceUsage.md).
+   Each pipeline still reads its own processor list. A batching follow-up must
+   preserve per-pipeline query limits and processor order while reducing those
+   remaining database round trips.
 3. **Bound the remaining on-call backlog sweeps.**
    `UserOnCallLog/ExecutePendingExecutions.ts` and
    `OnCallDutyPolicyExecutionLog/ExecutePendingExecutions.ts` still collect whole

--- a/Probe/Tests/Utils/OnlineCheck.test.ts
+++ b/Probe/Tests/Utils/OnlineCheck.test.ts
@@ -1,0 +1,471 @@
+import OnlineCheck, {
+  ONLINE_CHECK_MAX_SHARING_AGE_IN_MS,
+} from "../../Utils/OnlineCheck";
+import WebsiteMonitor from "../../Utils/Monitors/MonitorTypes/WebsiteMonitor";
+import PingMonitor from "../../Utils/Monitors/MonitorTypes/PingMonitor";
+import PortMonitor from "../../Utils/Monitors/MonitorTypes/PortMonitor";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const mockEnvironment: { billingEnabled: boolean } = { billingEnabled: true };
+
+jest.mock("Common/Server/EnvironmentConfig", () => {
+  return {
+    get IsBillingEnabled(): boolean {
+      return mockEnvironment.billingEnabled;
+    },
+  };
+});
+
+jest.mock("../../Utils/Monitors/MonitorTypes/WebsiteMonitor", () => {
+  return { __esModule: true, default: { ping: jest.fn() } };
+});
+
+jest.mock("../../Utils/Monitors/MonitorTypes/PingMonitor", () => {
+  return { __esModule: true, default: { ping: jest.fn() } };
+});
+
+jest.mock("../../Utils/Monitors/MonitorTypes/PortMonitor", () => {
+  return { __esModule: true, default: { ping: jest.fn() } };
+});
+
+interface ReferenceResponse {
+  isOnline: boolean;
+}
+
+type ReferenceResult = ReferenceResponse | null;
+type ReferenceMock = jest.Mock<Promise<ReferenceResult>, Array<unknown>>;
+
+interface ProtocolCase {
+  name: string;
+  run: () => Promise<boolean>;
+  probe: ReferenceMock;
+  targets: Array<string>;
+}
+
+const DOMAINS: Array<string> = [
+  "google.com",
+  "facebook.com",
+  "microsoft.com",
+  "youtube.com",
+  "apple.com",
+];
+
+const protocolCases: Array<ProtocolCase> = [
+  {
+    name: "website",
+    run: () => {
+      return OnlineCheck.canProbeMonitorWebsiteMonitors();
+    },
+    probe: WebsiteMonitor.ping as unknown as ReferenceMock,
+    targets: DOMAINS.map((domain: string) => {
+      return `https://${domain}/`;
+    }),
+  },
+  {
+    name: "ping",
+    run: () => {
+      return OnlineCheck.canProbeMonitorPingMonitors();
+    },
+    probe: PingMonitor.ping as unknown as ReferenceMock,
+    targets: DOMAINS,
+  },
+  {
+    name: "port",
+    run: () => {
+      return OnlineCheck.canProbeMonitorPortMonitors();
+    },
+    probe: PortMonitor.ping as unknown as ReferenceMock,
+    targets: DOMAINS,
+  },
+];
+
+interface DeferredReference {
+  promise: Promise<ReferenceResult>;
+  resolve: (value: ReferenceResult) => void;
+  reject: (error: Error) => void;
+}
+
+const deferredReferences: Array<DeferredReference> = [];
+
+function deferReference(): DeferredReference {
+  let resolve!: (value: ReferenceResult) => void;
+  let reject!: (error: Error) => void;
+  const promise: Promise<ReferenceResult> = new Promise(
+    (
+      resolvePromise: (value: ReferenceResult) => void,
+      rejectPromise: (error: Error) => void,
+    ) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    },
+  );
+  const deferred: DeferredReference = { promise, resolve, reject };
+  deferredReferences.push(deferred);
+  return deferred;
+}
+
+async function nextTurn(): Promise<void> {
+  await new Promise<void>((resolve: () => void) => {
+    setImmediate(resolve);
+  });
+}
+
+function getCalledTargets(probe: ReferenceMock): Array<string> {
+  return probe.mock.calls.map((call: Array<unknown>) => {
+    return String(call[0]);
+  });
+}
+
+beforeEach(() => {
+  mockEnvironment.billingEnabled = true;
+  for (const protocol of protocolCases) {
+    protocol.probe.mockReset();
+    protocol.probe.mockResolvedValue({ isOnline: true });
+  }
+});
+
+afterEach(async () => {
+  /*
+   * Release reference probes even if an intermediate assertion fails, so a
+   * pending shared operation cannot cascade into later test timeouts.
+   */
+  for (const reference of deferredReferences) {
+    reference.resolve({ isOnline: false });
+  }
+  deferredReferences.length = 0;
+  await nextTurn();
+  jest.restoreAllMocks();
+});
+
+for (const protocol of protocolCases) {
+  describe(`OnlineCheck ${protocol.name}`, () => {
+    it("bypasses public reference probes on self-hosted installations", async () => {
+      mockEnvironment.billingEnabled = false;
+
+      const results: Array<boolean> = await Promise.all(
+        Array.from({ length: 1000 }, protocol.run),
+      );
+
+      expect(
+        results.every((result: boolean) => {
+          return result;
+        }),
+      ).toBe(true);
+      expect(protocol.probe).not.toHaveBeenCalled();
+    });
+
+    it("stops after the first reachable reference and preserves its options", async () => {
+      expect(await protocol.run()).toBe(true);
+      expect(getCalledTargets(protocol.probe)).toEqual([protocol.targets[0]]);
+      const call: Array<unknown> = protocol.probe.mock.calls[0]!;
+      expect(call[call.length - 1]).toEqual({ isOnlineCheckRequest: true });
+      if (protocol.name === "port") {
+        expect(String(call[1])).toBe("80");
+      }
+    });
+
+    it("tries references sequentially and stops on fallback success", async () => {
+      const fallback: DeferredReference = deferReference();
+      protocol.probe
+        .mockResolvedValueOnce({ isOnline: false })
+        .mockImplementationOnce(() => {
+          return fallback.promise;
+        });
+
+      const result: Promise<boolean> = protocol.run();
+      await nextTurn();
+
+      expect(getCalledTargets(protocol.probe)).toEqual(
+        protocol.targets.slice(0, 2),
+      );
+      fallback.resolve({ isOnline: true });
+      expect(await result).toBe(true);
+      expect(protocol.probe).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns false only after all five references are offline", async () => {
+      protocol.probe.mockResolvedValue({ isOnline: false });
+      expect(await protocol.run()).toBe(false);
+      expect(getCalledTargets(protocol.probe)).toEqual(protocol.targets);
+    });
+
+    it("continues through empty reference responses", async () => {
+      protocol.probe
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ isOnline: false })
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ isOnline: true });
+
+      expect(await protocol.run()).toBe(true);
+      expect(getCalledTargets(protocol.probe)).toEqual(
+        protocol.targets.slice(0, 4),
+      );
+    });
+
+    it.each([true, false, null])(
+      "shares one reference sequence across 10000 callers with response %s",
+      async (online: boolean | null) => {
+        const reference: DeferredReference = deferReference();
+        protocol.probe.mockImplementation(() => {
+          return reference.promise;
+        });
+
+        const checks: Array<Promise<boolean>> = Array.from(
+          { length: 10000 },
+          protocol.run,
+        );
+        await Promise.resolve();
+        expect(protocol.probe).toHaveBeenCalledTimes(1);
+        expect(new Set(checks).size).toBe(1);
+
+        reference.resolve(online === null ? null : { isOnline: online });
+        const results: Array<boolean> = await Promise.all(checks);
+
+        expect(results).toEqual(Array<boolean>(10000).fill(online === true));
+        expect(protocol.probe).toHaveBeenCalledTimes(online ? 1 : 5);
+      },
+    );
+
+    it("lets callers arriving during a fallback join the same sequence", async () => {
+      const fallback: DeferredReference = deferReference();
+      protocol.probe
+        .mockResolvedValueOnce({ isOnline: false })
+        .mockImplementationOnce(() => {
+          return fallback.promise;
+        });
+
+      const first: Promise<boolean> = protocol.run();
+      await nextTurn();
+      const late: Promise<boolean> = protocol.run();
+
+      expect(late).toBe(first);
+      expect(protocol.probe).toHaveBeenCalledTimes(2);
+      fallback.resolve({ isOnline: true });
+      expect(await Promise.all([first, late])).toEqual([true, true]);
+      expect(protocol.probe).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([true, false])(
+      "rechecks immediately after a completed %s result",
+      async (online: boolean) => {
+        protocol.probe.mockResolvedValue({ isOnline: online });
+        expect(await protocol.run()).toBe(online);
+        const completedCallCount: number = protocol.probe.mock.calls.length;
+        protocol.probe.mockResolvedValue({ isOnline: !online });
+
+        expect(await protocol.run()).toBe(!online);
+        expect(protocol.probe.mock.calls.length).toBe(
+          completedCallCount + (online ? 5 : 1),
+        );
+      },
+    );
+
+    it("releases the shared operation after an asynchronous rejection", async () => {
+      const reference: DeferredReference = deferReference();
+      const error: Error = new Error("Reference probe failed");
+      protocol.probe.mockImplementationOnce(() => {
+        return reference.promise;
+      });
+      const results: Promise<Array<PromiseSettledResult<boolean>>> =
+        Promise.allSettled(Array.from({ length: 1000 }, protocol.run));
+      await Promise.resolve();
+      reference.reject(error);
+
+      expect(await results).toEqual(
+        Array<PromiseSettledResult<boolean>>(1000).fill({
+          status: "rejected",
+          reason: error,
+        }),
+      );
+      expect(protocol.probe).toHaveBeenCalledTimes(1);
+      expect(await protocol.run()).toBe(true);
+      expect(protocol.probe).toHaveBeenCalledTimes(2);
+    });
+
+    it("releases the shared operation after a synchronous probe exception", async () => {
+      const error: Error = new Error("Cannot start reference probe");
+      protocol.probe.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      const results: Array<PromiseSettledResult<boolean>> =
+        await Promise.allSettled([protocol.run(), protocol.run()]);
+      expect(results).toEqual([
+        { status: "rejected", reason: error },
+        { status: "rejected", reason: error },
+      ]);
+      expect(protocol.probe).toHaveBeenCalledTimes(1);
+      expect(await protocol.run()).toBe(true);
+      expect(protocol.probe).toHaveBeenCalledTimes(2);
+    });
+
+    it("releases a rejected fallback and starts again at the first reference", async () => {
+      const error: Error = new Error("Fallback failed");
+      protocol.probe
+        .mockResolvedValueOnce({ isOnline: false })
+        .mockRejectedValueOnce(error);
+
+      await expect(protocol.run()).rejects.toBe(error);
+      expect(await protocol.run()).toBe(true);
+      expect(getCalledTargets(protocol.probe)).toEqual([
+        ...protocol.targets.slice(0, 2),
+        protocol.targets[0],
+      ]);
+    });
+
+    it.each(["resolve", "reject"])(
+      "replaces expired work without letting a late %s clear its replacement",
+      async (settlement: string) => {
+        let currentTimeInMs: number = 0;
+        jest.spyOn(Date, "now").mockImplementation(() => {
+          return currentTimeInMs;
+        });
+        const originalReference: DeferredReference = deferReference();
+        const replacementReference: DeferredReference = deferReference();
+        protocol.probe
+          .mockResolvedValue({ isOnline: false })
+          .mockImplementationOnce(() => {
+            return originalReference.promise;
+          })
+          .mockImplementationOnce(() => {
+            return replacementReference.promise;
+          });
+
+        const original: Promise<boolean> = protocol.run();
+        const originalResult: Promise<Array<PromiseSettledResult<boolean>>> =
+          Promise.allSettled([original]);
+        await nextTurn();
+        currentTimeInMs = ONLINE_CHECK_MAX_SHARING_AGE_IN_MS - 1;
+        expect(protocol.run()).toBe(original);
+        expect(protocol.probe).toHaveBeenCalledTimes(1);
+
+        currentTimeInMs = ONLINE_CHECK_MAX_SHARING_AGE_IN_MS;
+        const replacement: Promise<boolean> = protocol.run();
+        expect(replacement).not.toBe(original);
+        await nextTurn();
+        expect(protocol.probe).toHaveBeenCalledTimes(2);
+
+        const error: Error = new Error("Old reference failed late");
+        if (settlement === "resolve") {
+          originalReference.resolve({ isOnline: true });
+        } else {
+          originalReference.reject(error);
+        }
+        expect(await originalResult).toEqual([
+          settlement === "resolve"
+            ? { status: "fulfilled", value: true }
+            : { status: "rejected", reason: error },
+        ]);
+        expect(protocol.run()).toBe(replacement);
+        expect(protocol.probe).toHaveBeenCalledTimes(2);
+
+        replacementReference.resolve({ isOnline: false });
+        expect(await replacement).toBe(false);
+        protocol.probe.mockResolvedValue({ isOnline: true });
+        expect(await protocol.run()).toBe(true);
+      },
+    );
+
+    it("starts fresh after the wall clock moves backward", async () => {
+      let currentTimeInMs: number = 1000;
+      jest.spyOn(Date, "now").mockImplementation(() => {
+        return currentTimeInMs;
+      });
+      const reference: DeferredReference = deferReference();
+      protocol.probe.mockImplementationOnce(() => {
+        return reference.promise;
+      });
+      const original: Promise<boolean> = protocol.run();
+      await nextTurn();
+
+      currentTimeInMs = 999;
+      expect(await protocol.run()).toBe(true);
+      expect(protocol.probe).toHaveBeenCalledTimes(2);
+      reference.resolve({ isOnline: true });
+      expect(await original).toBe(true);
+    });
+
+    it("handles repeated outage and recovery bursts without retaining verdicts", async () => {
+      for (let cycle: number = 0; cycle < 20; cycle++) {
+        const online: boolean = cycle % 2 === 0;
+        const previousCallCount: number = protocol.probe.mock.calls.length;
+        protocol.probe.mockResolvedValue({ isOnline: online });
+
+        const results: Array<boolean> = await Promise.all(
+          Array.from({ length: 500 }, protocol.run),
+        );
+
+        expect(results).toEqual(Array<boolean>(500).fill(online));
+        expect(protocol.probe.mock.calls.length - previousCallCount).toBe(
+          online ? 1 : 5,
+        );
+      }
+    });
+  });
+}
+
+describe("OnlineCheck protocol isolation", () => {
+  it("allows HTTP and TCP checks to complete while ICMP remains pending", async () => {
+    const reference: DeferredReference = deferReference();
+    const ping: ProtocolCase = protocolCases[1]!;
+    ping.probe.mockImplementation(() => {
+      return reference.promise;
+    });
+    const pingCheck: Promise<boolean> = ping.run();
+
+    expect(
+      await Promise.all([
+        OnlineCheck.canProbeMonitorWebsiteMonitors(),
+        OnlineCheck.canProbeMonitorPortMonitors(),
+      ]),
+    ).toEqual([true, true]);
+    expect(ping.run()).toBe(pingCheck);
+    expect(ping.probe).toHaveBeenCalledTimes(1);
+    reference.resolve({ isOnline: false });
+    expect(await pingCheck).toBe(false);
+  });
+
+  it("keeps concurrent protocol verdicts independent across a large burst", async () => {
+    protocolCases[0]!.probe.mockResolvedValue({ isOnline: true });
+    protocolCases[1]!.probe.mockResolvedValue({ isOnline: false });
+    protocolCases[2]!.probe.mockResolvedValue(null);
+
+    const results: Array<Array<boolean>> = await Promise.all(
+      protocolCases.map((protocol: ProtocolCase) => {
+        return Promise.all(Array.from({ length: 1000 }, protocol.run));
+      }),
+    );
+
+    expect(results[0]).toEqual(Array<boolean>(1000).fill(true));
+    expect(results[1]).toEqual(Array<boolean>(1000).fill(false));
+    expect(results[2]).toEqual(Array<boolean>(1000).fill(false));
+    expect(protocolCases[0]!.probe).toHaveBeenCalledTimes(1);
+    expect(protocolCases[1]!.probe).toHaveBeenCalledTimes(5);
+    expect(protocolCases[2]!.probe).toHaveBeenCalledTimes(5);
+  });
+
+  it("isolates a protocol rejection from the other protocols", async () => {
+    const error: Error = new Error("HTTP reference check failed");
+    protocolCases[0]!.probe.mockRejectedValueOnce(error);
+
+    expect(
+      await Promise.allSettled(
+        protocolCases.map((protocol: ProtocolCase) => {
+          return protocol.run();
+        }),
+      ),
+    ).toEqual([
+      { status: "rejected", reason: error },
+      { status: "fulfilled", value: true },
+      { status: "fulfilled", value: true },
+    ]);
+    expect(await OnlineCheck.canProbeMonitorWebsiteMonitors()).toBe(true);
+  });
+});

--- a/Probe/Utils/OnlineCheck.ts
+++ b/Probe/Utils/OnlineCheck.ts
@@ -6,101 +6,111 @@ import URL from "Common/Types/API/URL";
 import Port from "Common/Types/Port";
 import { IsBillingEnabled } from "Common/Server/EnvironmentConfig";
 
+const REFERENCE_DOMAINS: Array<string> = [
+  "google.com",
+  "facebook.com",
+  "microsoft.com",
+  "youtube.com",
+  "apple.com",
+];
+
+/*
+ * Five TCP references can each take five 5-second attempts plus retry waits
+ * (about 145 seconds total). Allow five minutes before new callers stop sharing
+ * unusually old work. Original callers still receive their original verdict.
+ */
+export const ONLINE_CHECK_MAX_SHARING_AGE_IN_MS: number = 5 * 60 * 1000;
+
+interface InProgressCheck {
+  promise: Promise<boolean>;
+  startedAt: number;
+}
+
+type OnlineCheckProtocol = "website" | "ping" | "port";
+type ReferenceProbe = (domain: string) => Promise<{ isOnline: boolean } | null>;
+
 export default class OnlineCheck {
-  // burn domain names into the code to see if this probe is online.
-  public static async canProbeMonitorWebsiteMonitors(): Promise<boolean> {
-    if (!IsBillingEnabled) {
-      /*
-       * if the billing is not enabled which means its non on SaaS but self-hosted.
-       * in this case return true as we don't need to check for online status.
-       */
-      return true;
-    }
+  /*
+   * A probe outage can fail hundreds of monitors together. They all need the
+   * same connectivity verdict: share the reference checks already in flight
+   * instead of starting up to five extra network requests per failed monitor.
+   * Keep protocols independent, since HTTP connectivity does not prove that
+   * ICMP or TCP checks work. Settled results are immediately released so the
+   * next monitor checks current connectivity, including after recovery.
+   */
+  private static checksInProgress: Map<OnlineCheckProtocol, InProgressCheck> =
+    new Map();
 
-    const websiteNames: Array<string> = [
-      "https://google.com",
-      "https://facebook.com",
-      "https://microsoft.com",
-      "https://youtube.com",
-      "https://apple.com",
-    ];
-
-    for (const websiteName of websiteNames) {
-      if (
-        (
-          await WebsiteMonitor.ping(URL.fromString(websiteName), {
-            isOnlineCheckRequest: true,
-          })
-        )?.isOnline
-      ) {
-        return true;
-      }
-    }
-
-    return false;
+  public static canProbeMonitorWebsiteMonitors(): Promise<boolean> {
+    return OnlineCheck.checkOnline("website", (domain: string) => {
+      return WebsiteMonitor.ping(URL.fromString(`https://${domain}`), {
+        isOnlineCheckRequest: true,
+      });
+    });
   }
 
-  public static async canProbeMonitorPingMonitors(): Promise<boolean> {
-    if (!IsBillingEnabled) {
-      /*
-       * if the billing is not enabled which means its non on SaaS but self-hosted.
-       * in this case return true as we don't need to check for online status.
-       */
-      return true;
-    }
-
-    const domains: Array<string> = [
-      "google.com",
-      "facebook.com",
-      "microsoft.com",
-      "youtube.com",
-      "apple.com",
-    ];
-
-    for (const domain of domains) {
-      if (
-        (
-          await PingMonitor.ping(new Hostname(domain), {
-            isOnlineCheckRequest: true,
-          })
-        )?.isOnline
-      ) {
-        return true;
-      }
-    }
-
-    return false;
+  public static canProbeMonitorPingMonitors(): Promise<boolean> {
+    return OnlineCheck.checkOnline("ping", (domain: string) => {
+      return PingMonitor.ping(new Hostname(domain), {
+        isOnlineCheckRequest: true,
+      });
+    });
   }
 
-  public static async canProbeMonitorPortMonitors(): Promise<boolean> {
+  public static canProbeMonitorPortMonitors(): Promise<boolean> {
+    return OnlineCheck.checkOnline("port", (domain: string) => {
+      return PortMonitor.ping(new Hostname(domain), new Port(80), {
+        isOnlineCheckRequest: true,
+      });
+    });
+  }
+
+  private static checkOnline(
+    protocol: OnlineCheckProtocol,
+    probe: ReferenceProbe,
+  ): Promise<boolean> {
     if (!IsBillingEnabled) {
-      /*
-       * if the billing is not enabled which means its non on SaaS but self-hosted.
-       * in this case return true as we don't need to check for online status.
-       */
-      return true;
+      // Self-hosted probes do not require public internet connectivity.
+      return Promise.resolve(true);
     }
 
-    const domains: Array<string> = [
-      "google.com",
-      "facebook.com",
-      "microsoft.com",
-      "youtube.com",
-      "apple.com",
-    ];
+    const now: number = Date.now();
+    const inProgress: InProgressCheck | undefined =
+      OnlineCheck.checksInProgress.get(protocol);
 
-    for (const domain of domains) {
-      if (
-        (
-          await PortMonitor.ping(new Hostname(domain), new Port(80), {
-            isOnlineCheckRequest: true,
-          })
-        )?.isOnline
-      ) {
-        return true;
-      }
+    if (
+      inProgress &&
+      now >= inProgress.startedAt &&
+      now - inProgress.startedAt < ONLINE_CHECK_MAX_SHARING_AGE_IN_MS
+    ) {
+      return inProgress.promise;
     }
 
-    return false;
+    /*
+     * Defer execution until the shared promise is registered. Synchronous
+     * errors also become rejections, and finally releases either outcome.
+     */
+    const check: Promise<boolean> = Promise.resolve()
+      .then(async (): Promise<boolean> => {
+        for (const domain of REFERENCE_DOMAINS) {
+          if ((await probe(domain))?.isOnline) {
+            return true;
+          }
+        }
+
+        return false;
+      })
+      .finally(() => {
+        // An older operation can finish after its replacement has started.
+        if (OnlineCheck.checksInProgress.get(protocol)?.promise === check) {
+          OnlineCheck.checksInProgress.delete(protocol);
+        }
+      });
+
+    OnlineCheck.checksInProgress.set(protocol, {
+      promise: check,
+      startedAt: now,
+    });
+    return check;
   }
 }

--- a/Probe/scripts/benchmark-online-check.js
+++ b/Probe/scripts/benchmark-online-check.js
@@ -1,0 +1,129 @@
+/*
+ * Benchmark simultaneous failed monitors asking whether their probe is online.
+ * Run from the repository root:
+ *
+ *   node --expose-gc Probe/scripts/benchmark-online-check.js
+ *
+ * Compare against an earlier revision in a separate process:
+ *
+ *   git show 0b23baed11:Probe/Utils/OnlineCheck.ts > /tmp/oneuptime-online-check-before.ts
+ *   node --expose-gc Probe/scripts/benchmark-online-check.js /tmp/oneuptime-online-check-before.ts
+ *
+ * The selected OnlineCheck.ts is transpiled and executed unchanged. Reference
+ * probes are deferred stubs that all return offline; no network traffic or
+ * operating-system ping processes are created. The heap measurement includes
+ * these stub promises, their resolver queue and the caller promises, not real
+ * sockets or response bodies. It illustrates pending JavaScript work for this
+ * workload and is not an estimate of total production memory savings.
+ */
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const ts = require("typescript");
+
+if (typeof global.gc !== "function") {
+  throw new Error("Run this benchmark with node --expose-gc.");
+}
+
+const callerCount = 10000;
+const sourcePath = path.resolve(
+  process.argv[2] || path.join(__dirname, "../Utils/OnlineCheck.ts"),
+);
+const code = ts.transpileModule(fs.readFileSync(sourcePath, "utf8"), {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2020,
+    esModuleInterop: true,
+  },
+}).outputText;
+
+let referenceChecks = 0;
+let pendingReferences = [];
+const referenceProbe = {
+  ping: () => {
+    referenceChecks++;
+    return new Promise((resolve) => {
+      pendingReferences.push(resolve);
+    });
+  },
+};
+const overrides = {
+  "./Monitors/MonitorTypes/PingMonitor": referenceProbe,
+  "./Monitors/MonitorTypes/PortMonitor": referenceProbe,
+  "./Monitors/MonitorTypes/WebsiteMonitor": referenceProbe,
+  "Common/Server/EnvironmentConfig": { IsBillingEnabled: true },
+  "Common/Types/API/URL": { fromString: (value) => value },
+  "Common/Types/API/Hostname": class Hostname {},
+  "Common/Types/Port": class Port {},
+};
+const sandbox = {
+  exports: {},
+  require: (name) => {
+    if (!(name in overrides)) {
+      throw new Error(`Unexpected import: ${name}`);
+    }
+    return overrides[name];
+  },
+};
+vm.runInNewContext(code, sandbox, { filename: sourcePath });
+const OnlineCheck = sandbox.exports.default;
+
+async function nextTurn() {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function collectGarbage() {
+  for (let round = 0; round < 3; round++) {
+    global.gc();
+    await nextTurn();
+  }
+}
+
+async function main() {
+  await collectGarbage();
+  const heapBefore = process.memoryUsage().heapUsed;
+  const checks = Array.from({ length: callerCount }, () => {
+    return OnlineCheck.canProbeMonitorWebsiteMonitors();
+  });
+  const resultsPromise = Promise.all(checks);
+  await nextTurn();
+  await collectGarbage();
+  const pendingHeapMiB =
+    (process.memoryUsage().heapUsed - heapBefore) / 1024 / 1024;
+  const peakPendingReferences = pendingReferences.length;
+
+  for (let fallback = 0; fallback < 5; fallback++) {
+    const references = pendingReferences;
+    pendingReferences = [];
+    if (references.length === 0) {
+      throw new Error("Reference sequence ended earlier than expected.");
+    }
+    for (const resolve of references) {
+      resolve({ isOnline: false });
+    }
+    await nextTurn();
+  }
+  if (pendingReferences.length !== 0) {
+    throw new Error("Reference sequence exceeded the five fallback domains.");
+  }
+  const results = await resultsPromise;
+  if (results.length !== callerCount || results.some(Boolean)) {
+    throw new Error("Not all callers received the expected offline verdict.");
+  }
+
+  console.log(
+    JSON.stringify({
+      sourcePath,
+      callerCount,
+      referenceChecks,
+      peakPendingReferences,
+      pendingHeapMiB: Number(pendingHeapMiB.toFixed(2)),
+      offlineVerdicts: results.length,
+    }),
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -237,6 +237,8 @@ export default tseslint.config(
         exports: true,
         NodeJS: true,
         PromiseSettledResult: true,
+        AsyncIterable: true,
+        AsyncIterator: true,
       },
       parserOptions: {
         projectService: true,


### PR DESCRIPTION
Concurrent ingestion and shared probe outages repeat expensive work and can admit much more buffered telemetry than configured. This change reduces that overhead while preserving pipeline order, metric metadata, write acknowledgements, retry/deduplication behavior, and probe verdicts.

- Share overlapping log/trace pipeline loads by project, with bounded pending state, retry after failure, and protection against stale completions.
- Replace quadratic metric-to-service catalog scans with a request-local membership index; allocate a Set only for metrics spanning multiple services.
- Reserve telemetry writer rows before yielding and admit queued submissions in FIFO order. Whole submissions remain intact, so one submission can cross the high-water mark.
- Share simultaneous HTTP/ICMP/TCP connectivity checks per protocol on SaaS probes. Settled results are discarded; unusually old operations stop attracting new callers.

### Measured examples

| Isolated workload | Before | After |
| --- | ---: | ---: |
| 1,000 cold pipeline callers / 20 pipelines: database calls | 21,000 | 21 |
| Same pipeline workload: distinct configuration graphs | 1,000 | 1 |
| 2,000-service metric catalog: median CPU | 1,743.25 ms | 4.17 ms |
| 200 writer producers / 1,000-row cap: admitted rows while storage stalls | 20,000 | 1,000 |
| Same writer workload: sampled retained JS heap | 23.20 MiB | 12.35 MiB |
| 10,000 concurrent offline probe callers: reference checks | 50,000 | 5 |

These are workload-specific measurements on Node 26.6.0, not deployment-wide savings. The pipeline/writer/probe harnesses execute actual source with I/O stubbed; the metric benchmark compares the real helper/models with the previous scan algorithm. Both writer versions ultimately insert every row. Scripts, measured heap figures, methodology, and reproduction commands are in `Internal/Performance/ConcurrentIngestResourceUsage.md`.

### Validation

- 393 passing tests across 19 focused suites, including 143 new regression/scale tests.
- Pipeline/cache: 124; metric ingestion: 46; writer: 86; probes: 101; existing monitor sweeps: 36.
- Coverage includes large simultaneous bursts, per-project/signal isolation, bounded cache overflow, late/stale completions, retries, FIFO ordering, oversized submissions, multi-table shutdown drains, preserved deduplication tokens, metric counter metadata, and probe recovery.
- Four reproducible before/after benchmarks pass.
- Full repository lint passes in CI.
- `npm run compile` passes for Common, App, and Probe in CI; App and Probe also pass locally.
- Include standard iterator type globals for ESLint and route three existing type-only test imports through Common, correcting missing-type/dependency errors without changing runtime behavior.

The integration tests isolate database/network I/O; sustained testing against real Postgres/ClickHouse remains a deployment validation step. The local Compose stack mounts a different checkout and returned HTTP 502 during inspection, so it is not evidence for this branch. Writer backpressure can increase submit wait time when storage is slow. No migration, dependency, or deployment configuration change is required.
