### PR TITLE
Make workflow steps easier to add, configure, and find

### DIFF
--- a/Common/Tests/UI/Components/ComponentsModal.test.tsx
+++ b/Common/Tests/UI/Components/ComponentsModal.test.tsx
@@ -1031,10 +1031,18 @@ describe("ComponentsModal", () => {
         },
       );
 
-      expect(screen.getByText("Create One Monitor")).toBeInTheDocument();
-      expect(screen.getByText("Create Many Monitors")).toBeInTheDocument();
-      expect(screen.queryByText("Find One Monitor")).not.toBeInTheDocument();
-      expect(screen.queryByText("Create One Team")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Create One Monitor" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Create Many Monitors" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Find One Monitor" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Create One Team" }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/Common/Tests/UI/Components/ComponentsModalUsability.test.tsx
+++ b/Common/Tests/UI/Components/ComponentsModalUsability.test.tsx
@@ -1,0 +1,518 @@
+import ComponentsModal, {
+  ComponentProps,
+} from "../../../UI/Components/Workflow/ComponentsModal";
+import ComponentMetadata, {
+  ComponentCategory,
+  ComponentType,
+} from "../../../Types/Workflow/Component";
+import IconProp from "../../../Types/Icon/IconProp";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import { describe, expect, it } from "@jest/globals";
+import "@testing-library/jest-dom";
+import {
+  fireEvent,
+  render,
+  RenderResult,
+  screen,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+type UserEventController = ReturnType<typeof userEvent.setup>;
+
+type MakeComponentFunction = (
+  overrides: Partial<ComponentMetadata>,
+) => ComponentMetadata;
+
+const makeComponent: MakeComponentFunction = (
+  overrides: Partial<ComponentMetadata>,
+): ComponentMetadata => {
+  return {
+    id: "create-monitor",
+    title: "Create One Monitor",
+    description: "Database query to create one Monitor",
+    category: "Monitor",
+    componentType: ComponentType.Component,
+    iconProp: IconProp.Activity,
+    arguments: [],
+    returnValues: [],
+    inPorts: [],
+    outPorts: [],
+    ...overrides,
+  };
+};
+
+const createMonitor: ComponentMetadata = makeComponent({});
+const updateMonitor: ComponentMetadata = makeComponent({
+  id: "update-monitor",
+  title: "Update One Monitor",
+  description: "Database query to update one Monitor",
+});
+const customCode: ComponentMetadata = makeComponent({
+  id: "custom-code",
+  title: "Run Custom JavaScript",
+  description: "Run custom JavaScript in your workflow",
+  category: "Custom Code",
+});
+const manualTrigger: ComponentMetadata = makeComponent({
+  id: "manual",
+  title: "Manual",
+  description: "Run this workflow manually",
+  category: "Utils",
+  componentType: ComponentType.Trigger,
+});
+const monitorTrigger: ComponentMetadata = makeComponent({
+  id: "monitor-created",
+  title: "Monitor Created",
+  description: "Run when a Monitor is created",
+  componentType: ComponentType.Trigger,
+});
+const components: Array<ComponentMetadata> = [
+  updateMonitor,
+  customCode,
+  manualTrigger,
+  createMonitor,
+  monitorTrigger,
+];
+const categories: Array<ComponentCategory> = [
+  { name: "Utils", description: "Utilities", icon: IconProp.Activity },
+  { name: "Monitor", description: "Monitoring", icon: IconProp.Activity },
+  { name: "Custom Code", description: "Code", icon: IconProp.Code },
+  { name: "Unused", description: "Unused", icon: IconProp.Activity },
+];
+
+type RenderPickerFunction = (
+  overrides?: Partial<ComponentProps>,
+) => RenderResult;
+
+const renderPicker: RenderPickerFunction = (
+  overrides: Partial<ComponentProps> = {},
+): RenderResult => {
+  return render(
+    <ComponentsModal
+      componentsType={ComponentType.Component}
+      components={components}
+      categories={categories}
+      onCloseModal={getJestMockFunction()}
+      onComponentClick={getJestMockFunction()}
+      {...overrides}
+    />,
+  );
+};
+
+type SearchFunction = (value: string) => void;
+const search: SearchFunction = (value: string): void => {
+  fireEvent.change(screen.getByRole("textbox"), { target: { value } });
+};
+
+type GetAddButtonFunction = () => HTMLElement;
+const getAddButton: GetAddButtonFunction = (): HTMLElement => {
+  return screen.getByRole("button", { name: "Add to Workflow" });
+};
+
+type GetCardFunction = (component: ComponentMetadata) => HTMLElement;
+const getCard: GetCardFunction = (
+  component: ComponentMetadata,
+): HTMLElement => {
+  return screen.getByRole("button", { name: component.title });
+};
+
+describe("Workflow picker availability and quick filters", () => {
+  it("counts only components and suggests only categories with components", () => {
+    renderPicker();
+
+    expect(screen.getByText("3 available")).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: "Search components" }),
+    ).toHaveFocus();
+    expect(getCard(createMonitor)).toBeInTheDocument();
+    expect(getCard(customCode)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Manual" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Monitor Created" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Monitor" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Custom Code" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Utils" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Unused" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("counts triggers separately and excludes categories containing only components", () => {
+    renderPicker({ componentsType: ComponentType.Trigger });
+
+    expect(screen.getByText("2 available")).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: "Search triggers" }),
+    ).toBeInTheDocument();
+    expect(getCard(manualTrigger)).toBeInTheDocument();
+    expect(getCard(monitorTrigger)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Utils" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Custom Code" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: createMonitor.title }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows singular labels when one matching type exists in a mixed catalog", () => {
+    renderPicker({
+      components: [manualTrigger, createMonitor],
+      componentsType: ComponentType.Trigger,
+    });
+
+    expect(screen.getByText("1 available")).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: "Search trigger" }),
+    ).toBeInTheDocument();
+    search("manual");
+    expect(screen.getByText("1 match")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 1 trigger.")).toBeInTheDocument();
+  });
+
+  it("uses the current type total when a search has one, several, or no matches", () => {
+    renderPicker();
+
+    search("monitor");
+    expect(screen.getByText("2 matches")).toBeInTheDocument();
+    expect(screen.getByText("Showing 2 of 3 components.")).toBeInTheDocument();
+    search("create monitor");
+    expect(screen.getByText("1 match")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 3 components.")).toBeInTheDocument();
+    search("nothing exists");
+    expect(screen.getByText("0 matches")).toBeInTheDocument();
+    expect(screen.getByText("Showing 0 of 3 components.")).toBeInTheDocument();
+  });
+
+  it("shows no available items or quick filters when the catalog contains only the other type", () => {
+    renderPicker({ components: [manualTrigger, monitorTrigger] });
+
+    expect(screen.getByText("0 available")).toBeInTheDocument();
+    expect(screen.getByText("No components to show.")).toBeInTheDocument();
+    expect(screen.queryByText("Quick filters:")).not.toBeInTheDocument();
+    expect(getAddButton()).toBeDisabled();
+  });
+
+  it("activates a multiword quick filter and restores all items when cleared", () => {
+    renderPicker();
+
+    fireEvent.click(screen.getByRole("button", { name: "Custom Code" }));
+    expect(screen.getByRole("textbox")).toHaveValue("Custom Code");
+    expect(screen.getByRole("textbox")).toHaveFocus();
+    expect(screen.getByRole("button", { name: "Custom Code" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(getCard(customCode)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: createMonitor.title }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear", exact: true }));
+    expect(screen.getByRole("textbox")).toHaveValue("");
+    expect(screen.getByRole("textbox")).toHaveFocus();
+    expect(screen.getByRole("button", { name: "Custom Code" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(getCard(createMonitor)).toBeInTheDocument();
+    expect(screen.getByText("3 available")).toBeInTheDocument();
+  });
+});
+
+describe("Workflow picker selection follows visible results", () => {
+  it("disables Add when search hides the selected card and requires deliberate reselection", () => {
+    const onComponentClick: MockFunction = getJestMockFunction();
+    renderPicker({ onComponentClick });
+
+    fireEvent.click(getCard(createMonitor));
+    expect(getAddButton()).toBeEnabled();
+    search("update monitor");
+    expect(getAddButton()).toBeDisabled();
+    fireEvent.click(getAddButton());
+    expect(onComponentClick).not.toHaveBeenCalled();
+
+    search("");
+    expect(getAddButton()).toBeDisabled();
+    expect(getCard(createMonitor)).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(getCard(updateMonitor));
+    fireEvent.click(getAddButton());
+    expect(onComponentClick).toHaveBeenCalledTimes(1);
+    expect(onComponentClick).toHaveBeenCalledWith(updateMonitor);
+  });
+
+  it("preserves selection while all search words still match the selected card", () => {
+    const onComponentClick: MockFunction = getJestMockFunction();
+    renderPicker({ onComponentClick });
+
+    fireEvent.click(getCard(createMonitor));
+    search("  CrEaTe   MONITOR  ");
+    expect(getCard(createMonitor)).toHaveAttribute("aria-pressed", "true");
+    expect(getAddButton()).toBeEnabled();
+    fireEvent.click(getAddButton());
+    expect(onComponentClick).toHaveBeenCalledWith(createMonitor);
+  });
+
+  it("clears selection when a quick filter hides it", () => {
+    renderPicker();
+
+    fireEvent.click(getCard(createMonitor));
+    fireEvent.click(screen.getByRole("button", { name: "Custom Code" }));
+    expect(getAddButton()).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Monitor" }));
+    expect(getCard(createMonitor)).toHaveAttribute("aria-pressed", "false");
+    expect(getAddButton()).toBeDisabled();
+  });
+
+  it("does not restore a stale selection after resetting a search with no results", () => {
+    renderPicker();
+    fireEvent.click(getCard(createMonitor));
+    search("no matching component");
+    expect(getAddButton()).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset search" }));
+    expect(screen.getByRole("textbox")).toHaveFocus();
+    expect(getCard(createMonitor)).toHaveAttribute("aria-pressed", "false");
+    expect(getAddButton()).toBeDisabled();
+  });
+
+  it("switches type without carrying over selection, counts, or irrelevant quick filters", () => {
+    const onComponentClick: MockFunction = getJestMockFunction();
+    const props: ComponentProps = {
+      components,
+      categories,
+      componentsType: ComponentType.Component,
+      onComponentClick,
+      onCloseModal: getJestMockFunction(),
+    };
+    const view: RenderResult = renderPicker(props);
+    fireEvent.click(getCard(createMonitor));
+
+    view.rerender(
+      <ComponentsModal {...props} componentsType={ComponentType.Trigger} />,
+    );
+    expect(screen.getByText("2 available")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Utils" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Custom Code" }),
+    ).not.toBeInTheDocument();
+    expect(getAddButton()).toBeDisabled();
+    fireEvent.click(getCard(manualTrigger));
+    fireEvent.click(getAddButton());
+    expect(onComponentClick).toHaveBeenCalledWith(manualTrigger);
+
+    view.rerender(<ComponentsModal {...props} />);
+    expect(screen.getByText("3 available")).toBeInTheDocument();
+    expect(getCard(createMonitor)).toHaveAttribute("aria-pressed", "false");
+    expect(getAddButton()).toBeDisabled();
+  });
+
+  it("drops a selection removed from the catalog and does not restore it when reintroduced", () => {
+    const props: ComponentProps = {
+      components,
+      categories,
+      componentsType: ComponentType.Component,
+      onComponentClick: getJestMockFunction(),
+      onCloseModal: getJestMockFunction(),
+    };
+    const view: RenderResult = renderPicker(props);
+    fireEvent.click(getCard(createMonitor));
+
+    view.rerender(<ComponentsModal {...props} components={[customCode]} />);
+    expect(screen.getByText("1 available")).toBeInTheDocument();
+    expect(getAddButton()).toBeDisabled();
+    view.rerender(<ComponentsModal {...props} />);
+    expect(getCard(createMonitor)).toHaveAttribute("aria-pressed", "false");
+    expect(getAddButton()).toBeDisabled();
+  });
+
+  it("submits the latest metadata for a selected component after the catalog updates", () => {
+    const onComponentClick: MockFunction = getJestMockFunction();
+    const props: ComponentProps = {
+      components,
+      categories,
+      componentsType: ComponentType.Component,
+      onComponentClick,
+      onCloseModal: getJestMockFunction(),
+    };
+    const view: RenderResult = renderPicker(props);
+    fireEvent.click(getCard(createMonitor));
+    const updatedComponent: ComponentMetadata = {
+      ...createMonitor,
+      description: "Create a monitor with updated defaults",
+    };
+
+    view.rerender(
+      <ComponentsModal
+        {...props}
+        components={[updatedComponent, customCode]}
+      />,
+    );
+    expect(getCard(updatedComponent)).toHaveAttribute("aria-pressed", "true");
+    fireEvent.click(getAddButton());
+    expect(onComponentClick).toHaveBeenCalledWith(updatedComponent);
+  });
+});
+
+describe("Workflow picker keyboard access", () => {
+  it.each(["{Enter}", " "])(
+    "selects a focused card using %s without adding it before confirmation",
+    async (key: string) => {
+      const user: UserEventController = userEvent.setup();
+      const onComponentClick: MockFunction = getJestMockFunction();
+      renderPicker({ onComponentClick });
+      const card: HTMLElement = getCard(createMonitor);
+
+      // Reach the card through the actual tab order, starting at the focused search.
+      await user.tab();
+      expect(screen.getByRole("button", { name: "Monitor" })).toHaveFocus();
+      await user.tab();
+      expect(screen.getByRole("button", { name: "Custom Code" })).toHaveFocus();
+      await user.tab();
+      expect(card).toHaveFocus();
+      expect(card.tagName).toBe("BUTTON");
+      expect(card).toHaveAttribute("type", "button");
+      expect(card).toHaveAccessibleDescription(createMonitor.description);
+      expect(card).toHaveAttribute("aria-pressed", "false");
+
+      await user.keyboard(key);
+      expect(card).toHaveAttribute("aria-pressed", "true");
+      expect(getAddButton()).toBeEnabled();
+      expect(onComponentClick).not.toHaveBeenCalled();
+      await user.click(getAddButton());
+      expect(onComponentClick).toHaveBeenCalledWith(createMonitor);
+    },
+  );
+
+  it("announces only the most recently selected card as selected", async () => {
+    const user: UserEventController = userEvent.setup();
+    renderPicker();
+    await user.click(getCard(createMonitor));
+    await user.tab();
+    expect(getCard(updateMonitor)).toHaveFocus();
+    await user.keyboard("{Enter}");
+
+    expect(getCard(createMonitor)).toHaveAttribute("aria-pressed", "false");
+    expect(getCard(updateMonitor)).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("returns focus from a card to search with slash and clears search with Escape", async () => {
+    const user: UserEventController = userEvent.setup();
+    const onCloseModal: MockFunction = getJestMockFunction();
+    renderPicker({ onCloseModal });
+    await user.click(getCard(createMonitor));
+    await user.keyboard("/");
+    expect(screen.getByRole("textbox")).toHaveFocus();
+    expect(screen.getByRole("textbox")).toHaveValue("");
+    await user.type(screen.getByRole("textbox"), "update monitor");
+    expect(getAddButton()).toBeDisabled();
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("textbox")).toHaveValue("");
+    expect(screen.getByRole("textbox")).toHaveFocus();
+    expect(getAddButton()).toBeDisabled();
+    expect(onCloseModal).not.toHaveBeenCalled();
+  });
+
+  it("leaves slash available as input text", async () => {
+    const user: UserEventController = userEvent.setup();
+    renderPicker();
+    await user.keyboard("/");
+    expect(screen.getByRole("textbox")).toHaveValue("/");
+  });
+});
+
+describe("Workflow picker search highlighting", () => {
+  it("highlights each non-adjacent word with original capitalization", () => {
+    renderPicker();
+    search("  CrEaTe  MONITOR ");
+    const card: HTMLElement = getCard(createMonitor);
+    const marks: Array<string | null> = Array.from(
+      card.querySelectorAll("mark"),
+    ).map((mark: HTMLElement) => {
+      return mark.textContent;
+    });
+
+    expect(marks).toEqual([
+      "Create",
+      "Monitor",
+      "Monitor",
+      "create",
+      "Monitor",
+    ]);
+    expect(card).toHaveAccessibleName("Create One Monitor");
+    expect(card).toHaveAccessibleDescription(createMonitor.description);
+  });
+
+  it("highlights tokens spread across title, category, and description", () => {
+    renderPicker();
+    search("javascript code workflow");
+    const card: HTMLElement = getCard(customCode);
+    const marks: Array<string | null> = Array.from(
+      card.querySelectorAll("mark"),
+    ).map((mark: HTMLElement) => {
+      return mark.textContent;
+    });
+
+    expect(marks).toEqual(["JavaScript", "Code", "JavaScript", "workflow"]);
+    expect(
+      screen.queryByRole("button", { name: createMonitor.title }),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each([".", "[", "(", "*", "+", "?", "$", "^", "|", "\\"])(
+    "treats regex metacharacter %s as literal text",
+    (token: string) => {
+      const literalComponent: ComponentMetadata = makeComponent({
+        id: "literal",
+        title: `Literal ${token} operation`,
+        description: "A component with punctuation",
+      });
+      renderPicker({ components: [literalComponent, createMonitor] });
+      search(`${token} operation`);
+      const card: HTMLElement = getCard(literalComponent);
+      const marks: Array<string | null> = Array.from(
+        card.querySelectorAll("mark"),
+      ).map((mark: HTMLElement) => {
+        return mark.textContent;
+      });
+
+      expect(marks).toEqual([token, "operation"]);
+      expect(screen.getByText("1 match")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: createMonitor.title }),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it("highlights the longest token when search words overlap and repeat", () => {
+    renderPicker();
+    search("mon monitor MONITOR");
+    const marks: Array<string | null> = Array.from(
+      getCard(createMonitor).querySelectorAll("mark"),
+    ).map((mark: HTMLElement) => {
+      return mark.textContent;
+    });
+
+    expect(marks).toEqual(["Monitor", "Monitor", "Monitor"]);
+  });
+
+  it("renders whitespace-only searches without highlights or a reset action", () => {
+    renderPicker();
+    search("    ");
+
+    expect(getCard(createMonitor).querySelectorAll("mark")).toHaveLength(0);
+    expect(screen.getByText("3 available")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Clear", exact: true }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/NodePlacement.test.ts
+++ b/Common/Tests/UI/Components/Workflow/NodePlacement.test.ts
@@ -1,0 +1,148 @@
+import { getNewWorkflowNodePosition } from "../../../../UI/Components/Workflow/NodePlacement";
+import { ComponentType, NodeType } from "../../../../Types/Workflow/Component";
+import { describe, expect, test } from "@jest/globals";
+import { Node } from "reactflow";
+
+type MakeNodeFunction = (
+  id: string,
+  x: number,
+  y: number,
+  height?: number,
+) => Node;
+
+const makeNode: MakeNodeFunction = (
+  id: string,
+  x: number,
+  y: number,
+  height?: number,
+): Node => {
+  return {
+    id,
+    position: { x, y },
+    ...(height === undefined ? {} : { height }),
+    data: {
+      nodeType: NodeType.Node,
+      componentType: ComponentType.Component,
+    },
+  };
+};
+
+describe("Workflow node placement", () => {
+  test.each([ComponentType.Trigger, ComponentType.Component])(
+    "places a first %s on an empty canvas",
+    (componentType: ComponentType) => {
+      expect(getNewWorkflowNodePosition([], componentType)).toEqual({
+        x: 100,
+        y: 100,
+      });
+    },
+  );
+
+  test("places a component below the measured height of the existing card", () => {
+    expect(
+      getNewWorkflowNodePosition(
+        [makeNode("first", 320, 100, 360)],
+        ComponentType.Component,
+      ),
+    ).toEqual({ x: 320, y: 540 });
+  });
+
+  test.each([undefined, 0])(
+    "reserves room when a card's height is %s during its first render",
+    (height: number | undefined) => {
+      expect(
+        getNewWorkflowNodePosition(
+          [makeNode("first", 200, 200, height)],
+          ComponentType.Component,
+        ),
+      ).toEqual({ x: 200, y: 480 });
+    },
+  );
+
+  test("uses the lowest bottom edge, not insertion order or the lowest top edge", () => {
+    const nodes: Array<Node> = [
+      makeNode("short-low", 400, 400, 100),
+      makeNode("tall-high", 100, 200, 500),
+      makeNode("last", 800, 100, 100),
+    ];
+
+    expect(getNewWorkflowNodePosition(nodes, ComponentType.Component)).toEqual({
+      x: 100,
+      y: 780,
+    });
+  });
+
+  test("keeps spacing when the canvas contains negative coordinates", () => {
+    expect(
+      getNewWorkflowNodePosition(
+        [makeNode("first", -800, -600, 100)],
+        ComponentType.Component,
+      ),
+    ).toEqual({ x: -800, y: -420 });
+  });
+
+  test("successive additions do not stack even before React Flow measures them", () => {
+    const nodes: Array<Node> = [makeNode("existing", 100, 100)];
+
+    for (let index: number = 0; index < 5; index++) {
+      const position: { x: number; y: number } = getNewWorkflowNodePosition(
+        nodes,
+        ComponentType.Component,
+      );
+
+      for (const node of nodes) {
+        expect(position.y).toBeGreaterThanOrEqual(node.position.y + 280);
+      }
+
+      nodes.push(makeNode(`new-${index}`, position.x, position.y));
+    }
+  });
+
+  test.each([NodeType.PlaceholderNode, NodeType.Node])(
+    "replaces a %s trigger in place without moving the other steps",
+    (nodeType: NodeType) => {
+      const trigger: Node = makeNode("trigger", 432, -180);
+      trigger.data.nodeType = nodeType;
+      if (nodeType === NodeType.Node) {
+        trigger.data.componentType = ComponentType.Trigger;
+      }
+      const nodes: Array<Node> = [makeNode("action", 100, 500), trigger];
+
+      const position: { x: number; y: number } = getNewWorkflowNodePosition(
+        nodes,
+        ComponentType.Trigger,
+      );
+
+      expect(position).toEqual({ x: 432, y: -180 });
+      expect(position).not.toBe(trigger.position);
+      expect(nodes[0]?.position).toEqual({ x: 100, y: 500 });
+    },
+  );
+
+  test("places a missing trigger above the first existing component", () => {
+    expect(
+      getNewWorkflowNodePosition(
+        [makeNode("last", 800, 1000), makeNode("first", 432, -180)],
+        ComponentType.Trigger,
+      ),
+    ).toEqual({ x: 432, y: -460 });
+  });
+
+  test("does not mutate the caller's nodes or their order", () => {
+    const nodes: Array<Node> = [
+      makeNode("last", 400, 1000),
+      makeNode("first", 100, 100),
+    ];
+    const before: string = JSON.stringify(nodes);
+    Object.freeze(nodes);
+    nodes.forEach((node: Node) => {
+      Object.freeze(node);
+      Object.freeze(node.position);
+    });
+
+    getNewWorkflowNodePosition(nodes, ComponentType.Trigger);
+    getNewWorkflowNodePosition(nodes, ComponentType.Component);
+
+    expect(JSON.stringify(nodes)).toBe(before);
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/Workflow.test.tsx
+++ b/Common/Tests/UI/Components/Workflow/Workflow.test.tsx
@@ -1,0 +1,981 @@
+import Workflow, {
+  ComponentProps as WorkflowProps,
+  getPlaceholderTriggerNode,
+} from "../../../../UI/Components/Workflow/Workflow";
+import { ComponentProps as PickerProps } from "../../../../UI/Components/Workflow/ComponentsModal";
+import { ComponentProps as SettingsProps } from "../../../../UI/Components/Workflow/ComponentSettingsModal";
+import { ComponentProps as RunProps } from "../../../../UI/Components/Workflow/RunModal";
+import ComponentMetadata, {
+  ComponentInputType,
+  ComponentType,
+  NodeDataProp,
+  NodeType,
+} from "../../../../Types/Workflow/Component";
+import IconProp from "../../../../Types/Icon/IconProp";
+import ObjectID from "../../../../Types/ObjectID";
+import getJestMockFunction, { MockFunction } from "../../../MockType";
+import React, { ReactElement } from "react";
+import { Edge, Node, ReactFlowInstance, ReactFlowProps } from "reactflow";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  RenderResult,
+  screen,
+} from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * These tests exercise the builder's wiring, including ReactFlow's real state
+ * hooks and graph helpers. Only its browser renderer and the three modal
+ * boundaries are replaced: jsdom cannot measure the canvas, and form field
+ * validation is covered in the modal suites. Clicks travel through ReactFlow's
+ * node-click event, matching the production canvas's settings entry point.
+ */
+let mockFlowProps: ReactFlowProps | null = null;
+let mockSettingsProps: SettingsProps | null = null;
+const mockSetCenter: MockFunction = getJestMockFunction();
+const mockGetZoom: MockFunction = getJestMockFunction();
+
+jest.mock("reactflow", () => {
+  const actual: typeof import("reactflow") = jest.requireActual(
+    "reactflow",
+  ) as typeof import("reactflow");
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: (props: ReactFlowProps): ReactElement => {
+      mockFlowProps = props;
+
+      React.useEffect(() => {
+        props.onInit?.({
+          setCenter: mockSetCenter,
+          getZoom: mockGetZoom,
+        } as unknown as ReactFlowInstance);
+      }, []);
+
+      return (
+        <div data-testid="workflow-canvas">
+          {(props.nodes || []).map((node: Node): ReactElement => {
+            const data: NodeDataProp = node.data as NodeDataProp;
+
+            return (
+              <button
+                type="button"
+                key={node.id}
+                data-testid={`workflow-node-${node.id}`}
+                onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+                  props.onNodeClick?.(event, node);
+                }}
+              >
+                {data.id || "Add trigger"}
+              </button>
+            );
+          })}
+        </div>
+      );
+    },
+    Background: (): null => {
+      return null;
+    },
+    Controls: (): null => {
+      return null;
+    },
+    MiniMap: (): null => {
+      return null;
+    },
+  };
+});
+
+jest.mock("../../../../UI/Components/Workflow/Component", () => {
+  return {
+    __esModule: true,
+    default: (): null => {
+      return null;
+    },
+  };
+});
+
+jest.mock("../../../../UI/Components/Workflow/Utils", () => {
+  return {
+    loadComponentsAndCategories: () => {
+      return {
+        components: [ACTION_METADATA, TRIGGER_METADATA],
+        categories: [
+          {
+            name: "General",
+            description: "Workflow building blocks",
+            icon: IconProp.Bolt,
+          },
+        ],
+      };
+    },
+  };
+});
+
+jest.mock("../../../../UI/Components/Workflow/ComponentsModal", () => {
+  return {
+    __esModule: true,
+    default: (props: PickerProps): ReactElement => {
+      return (
+        <div data-testid={`picker-${props.componentsType}`}>
+          {props.components.map((metadata: ComponentMetadata): ReactElement => {
+            return (
+              <button
+                type="button"
+                key={metadata.id}
+                onClick={() => {
+                  props.onComponentClick(metadata);
+                }}
+              >
+                Choose {metadata.title}
+              </button>
+            );
+          })}
+          <button type="button" onClick={props.onCloseModal}>
+            Close picker
+          </button>
+        </div>
+      );
+    },
+  };
+});
+
+jest.mock("../../../../UI/Components/Workflow/ComponentSettingsModal", () => {
+  return {
+    __esModule: true,
+    default: (props: SettingsProps): ReactElement => {
+      mockSettingsProps = props;
+      const [draft, setDraft] = React.useState<NodeDataProp>(props.component);
+
+      return (
+        <div data-testid="step-settings">
+          <span data-testid="settings-step-id">{props.component.id}</span>
+          <input
+            aria-label="Step message"
+            value={String(draft.arguments?.["message"] || "")}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              setDraft({
+                ...draft,
+                arguments: {
+                  ...draft.arguments,
+                  message: event.target.value,
+                },
+              });
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => {
+              props.onSave(draft);
+            }}
+          >
+            Save settings
+          </button>
+          <button type="button" onClick={props.onClose}>
+            Close settings
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              props.onDelete(props.component);
+              props.onClose();
+            }}
+          >
+            Delete step
+          </button>
+          {props.onRunStep && (
+            <button
+              type="button"
+              onClick={() => {
+                props.onRunStep?.(draft);
+              }}
+            >
+              Run this step
+            </button>
+          )}
+        </div>
+      );
+    },
+  };
+});
+
+jest.mock("../../../../UI/Components/Workflow/RunModal", () => {
+  return {
+    __esModule: true,
+    default: (props: RunProps): ReactElement => {
+      return (
+        <div data-testid="run-workflow-modal">
+          <span data-testid="run-trigger-id">{props.trigger.id}</span>
+          <button type="button" onClick={props.onClose}>
+            Close run
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              props.onRun(props.trigger);
+            }}
+          >
+            Confirm run
+          </button>
+        </div>
+      );
+    },
+  };
+});
+
+const ACTION_METADATA: ComponentMetadata = {
+  id: "write-log",
+  title: "Write a log message",
+  description: "Write a message to the workflow log.",
+  category: "General",
+  iconProp: IconProp.Bolt,
+  componentType: ComponentType.Component,
+  arguments: [
+    {
+      id: "message",
+      name: "Message",
+      description: "The message to log.",
+      required: true,
+      type: ComponentInputType.Text,
+    },
+  ],
+  returnValues: [],
+  inPorts: [{ id: "in", title: "In", description: "Start this step." }],
+  outPorts: [{ id: "out", title: "Out", description: "Continue." }],
+};
+
+const TRIGGER_METADATA: ComponentMetadata = {
+  ...ACTION_METADATA,
+  id: "manual-trigger",
+  title: "Manual trigger",
+  description: "Start this workflow manually.",
+  componentType: ComponentType.Trigger,
+  arguments: [],
+  inPorts: [],
+};
+
+type MakeNodeFunction = (
+  metadata: ComponentMetadata,
+  number?: number,
+) => Node<NodeDataProp>;
+
+const makeNode: MakeNodeFunction = (
+  metadata: ComponentMetadata,
+  number: number = 1,
+): Node<NodeDataProp> => {
+  return {
+    id: `canvas-${metadata.id}-${number}`,
+    type: "node",
+    position: { x: 160, y: number * 240 },
+    data: {
+      id: `${metadata.id}-${number}`,
+      internalId: `runner-${metadata.id}-${number}`,
+      nodeType: NodeType.Node,
+      componentType: metadata.componentType,
+      metadataId: metadata.id,
+      metadata: metadata,
+      error: "",
+      arguments: {},
+      returnValues: {},
+    },
+  };
+};
+
+interface BuilderHarness {
+  view: RenderResult;
+  props: WorkflowProps;
+  onUpdated: MockFunction;
+  onPickerUpdate: MockFunction;
+  onRunUpdate: MockFunction;
+  onRun: MockFunction;
+  onLint: MockFunction;
+}
+
+type RenderBuilderFunction = (
+  overrides?: Partial<WorkflowProps>,
+) => BuilderHarness;
+
+const renderBuilder: RenderBuilderFunction = (
+  overrides: Partial<WorkflowProps> = {},
+): BuilderHarness => {
+  const onUpdated: MockFunction = getJestMockFunction();
+  const onPickerUpdate: MockFunction = getJestMockFunction();
+  const onRunUpdate: MockFunction = getJestMockFunction();
+  const onRun: MockFunction = getJestMockFunction();
+  const onLint: MockFunction = getJestMockFunction();
+  const props: WorkflowProps = {
+    initialNodes: [makeNode(TRIGGER_METADATA)],
+    initialEdges: [],
+    workflowId: new ObjectID("11111111-1111-4111-8111-111111111111"),
+    showComponentsPickerModal: false,
+    showRunModal: false,
+    onWorkflowUpdated: onUpdated,
+    onComponentPickerModalUpdate: onPickerUpdate,
+    onRunModalUpdate: onRunUpdate,
+    onRun: onRun,
+    onLintResultChange: onLint,
+    ...overrides,
+  };
+
+  return {
+    view: render(<Workflow {...props} />),
+    props: props,
+    onUpdated: onUpdated,
+    onPickerUpdate: onPickerUpdate,
+    onRunUpdate: onRunUpdate,
+    onRun: onRun,
+    onLint: onLint,
+  };
+};
+
+type GetRenderedNodesFunction = () => Array<Node<NodeDataProp>>;
+
+const getRenderedNodes: GetRenderedNodesFunction = (): Array<
+  Node<NodeDataProp>
+> => {
+  return (mockFlowProps?.nodes || []) as Array<Node<NodeDataProp>>;
+};
+
+type GetStoredNodesFunction = (
+  harness: BuilderHarness,
+) => Array<Node<NodeDataProp>>;
+
+const getStoredNodes: GetStoredNodesFunction = (
+  harness: BuilderHarness,
+): Array<Node<NodeDataProp>> => {
+  const calls: Array<Array<unknown>> = harness.onUpdated.mock.calls;
+  return calls[calls.length - 1]?.[0] as Array<Node<NodeDataProp>>;
+};
+
+type FindRenderedNodeFunction = (componentId: string) => Node<NodeDataProp>;
+
+const findRenderedNode: FindRenderedNodeFunction = (
+  componentId: string,
+): Node<NodeDataProp> => {
+  const node: Node<NodeDataProp> | undefined = getRenderedNodes().find(
+    (candidate: Node<NodeDataProp>) => {
+      return candidate.data.id === componentId;
+    },
+  );
+
+  if (!node) {
+    throw new Error(`Expected ${componentId} on the workflow canvas.`);
+  }
+
+  return node;
+};
+
+type GetSettingsPropsFunction = () => SettingsProps;
+
+const getSettingsProps: GetSettingsPropsFunction = (): SettingsProps => {
+  if (!mockSettingsProps) {
+    throw new Error("Expected step settings to have opened.");
+  }
+
+  return mockSettingsProps;
+};
+
+type OpenPickerFunction = (harness: BuilderHarness) => void;
+
+const openPicker: OpenPickerFunction = (harness: BuilderHarness): void => {
+  harness.view.rerender(
+    <Workflow {...harness.props} showComponentsPickerModal={false} />,
+  );
+  harness.view.rerender(
+    <Workflow {...harness.props} showComponentsPickerModal={true} />,
+  );
+};
+
+type ChooseActionFunction = () => void;
+
+const chooseAction: ChooseActionFunction = (): void => {
+  fireEvent.click(
+    screen.getByRole("button", { name: `Choose ${ACTION_METADATA.title}` }),
+  );
+};
+
+beforeEach(() => {
+  mockFlowProps = null;
+  mockSettingsProps = null;
+  mockSetCenter.mockReset();
+  mockSetCenter.mockResolvedValue(true);
+  mockGetZoom.mockReset();
+  mockGetZoom.mockReturnValue(1);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Workflow builder: adding and configuring steps", () => {
+  test("opens settings immediately after choosing a component and closes the picker", () => {
+    const harness: BuilderHarness = renderBuilder();
+    openPicker(harness);
+    chooseAction();
+
+    expect(screen.queryByTestId("picker-Component")).not.toBeInTheDocument();
+    expect(screen.getByTestId("settings-step-id")).toHaveTextContent(
+      "write-log-1",
+    );
+    expect(harness.onPickerUpdate).toHaveBeenLastCalledWith(false);
+    expect(getRenderedNodes()).toHaveLength(2);
+    expect(findRenderedNode("write-log-1").selected).toBe(true);
+    expect(getSettingsProps().workflowId).toEqual(harness.props.workflowId);
+  });
+
+  test("a newly added component can be reopened after its settings are closed", () => {
+    const harness: BuilderHarness = renderBuilder();
+    openPicker(harness);
+    chooseAction();
+    fireEvent.click(screen.getByRole("button", { name: "Close settings" }));
+
+    const added: Node<NodeDataProp> = findRenderedNode("write-log-1");
+    expect(added.data.onClick).toBeUndefined();
+    fireEvent.click(screen.getByTestId(`workflow-node-${added.id}`));
+
+    expect(screen.getByTestId("settings-step-id")).toHaveTextContent(
+      "write-log-1",
+    );
+  });
+
+  test("brings an added step into view after the canvas has initialized", () => {
+    const harness: BuilderHarness = renderBuilder();
+    expect(mockSetCenter).not.toHaveBeenCalled();
+    openPicker(harness);
+    chooseAction();
+
+    const added: Node<NodeDataProp> = findRenderedNode("write-log-1");
+    expect(mockSetCenter).toHaveBeenCalledTimes(1);
+    const call: Array<unknown> = mockSetCenter.mock.calls[0] as Array<unknown>;
+    expect(call[0]).toBeGreaterThan(added.position.x);
+    expect(call[1]).toBeGreaterThan(added.position.y);
+    expect(call[2]).toEqual(expect.objectContaining({ zoom: 1 }));
+  });
+
+  test("saving arguments updates the graph and reopening shows the saved values", () => {
+    const harness: BuilderHarness = renderBuilder();
+    openPicker(harness);
+    chooseAction();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Step message" }), {
+      target: { value: "Deployment finished" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    expect(screen.queryByTestId("step-settings")).not.toBeInTheDocument();
+    const stored: Node<NodeDataProp> | undefined = getStoredNodes(harness).find(
+      (node: Node<NodeDataProp>) => {
+        return node.data.id === "write-log-1";
+      },
+    );
+    expect(stored?.data.arguments).toEqual({ message: "Deployment finished" });
+
+    const added: Node<NodeDataProp> = findRenderedNode("write-log-1");
+    fireEvent.click(screen.getByTestId(`workflow-node-${added.id}`));
+    expect(screen.getByRole("textbox", { name: "Step message" })).toHaveValue(
+      "Deployment finished",
+    );
+  });
+
+  test("adding the same component twice keeps every identity unique and only the newest selected", () => {
+    const harness: BuilderHarness = renderBuilder();
+    openPicker(harness);
+    chooseAction();
+    fireEvent.click(screen.getByRole("button", { name: "Close settings" }));
+    openPicker(harness);
+    chooseAction();
+
+    const nodes: Array<Node<NodeDataProp>> = getRenderedNodes();
+    expect(nodes).toHaveLength(3);
+    expect(
+      new Set(
+        nodes.map((node: Node) => {
+          return node.id;
+        }),
+      ).size,
+    ).toBe(3);
+    expect(
+      new Set(
+        nodes.map((node: Node<NodeDataProp>) => {
+          return node.data.internalId;
+        }),
+      ).size,
+    ).toBe(3);
+    expect(findRenderedNode("write-log-1").selected).toBe(false);
+    expect(findRenderedNode("manual-trigger-1").selected).toBe(false);
+    expect(findRenderedNode("write-log-2").selected).toBe(true);
+    expect(screen.getByTestId("settings-step-id")).toHaveTextContent(
+      "write-log-2",
+    );
+  });
+
+  test("allocates the next free component id without overwriting an existing step", () => {
+    const existing: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    existing.data.arguments = { message: "Keep this message" };
+    const harness: BuilderHarness = renderBuilder({
+      initialNodes: [makeNode(TRIGGER_METADATA), existing],
+    });
+    openPicker(harness);
+    chooseAction();
+
+    expect(findRenderedNode("write-log-1").data.arguments).toEqual({
+      message: "Keep this message",
+    });
+    expect(findRenderedNode("write-log-2").data.internalId).not.toBe(
+      existing.data.internalId,
+    );
+  });
+
+  test("places successive additions below existing steps instead of stacking them", () => {
+    const existing: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    existing.position = { x: 400, y: 900 };
+    existing.height = 180;
+    const harness: BuilderHarness = renderBuilder({
+      initialNodes: [makeNode(TRIGGER_METADATA), existing],
+    });
+    openPicker(harness);
+    chooseAction();
+    const first: Node<NodeDataProp> = findRenderedNode("write-log-2");
+    expect(first.position.y).toBeGreaterThan(1080);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close settings" }));
+    openPicker(harness);
+    chooseAction();
+    expect(findRenderedNode("write-log-3").position.y).toBeGreaterThan(
+      first.position.y,
+    );
+  });
+
+  test("adding a step preserves existing connections and does not invent a new one", () => {
+    const trigger: Node<NodeDataProp> = makeNode(TRIGGER_METADATA);
+    const existing: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    const edge: Edge = {
+      id: "existing-connection",
+      source: trigger.id,
+      target: existing.id,
+    };
+    const harness: BuilderHarness = renderBuilder({
+      initialNodes: [trigger, existing],
+      initialEdges: [edge],
+    });
+    openPicker(harness);
+    chooseAction();
+
+    expect(mockFlowProps?.edges).toHaveLength(1);
+    expect(mockFlowProps?.edges?.[0]).toEqual(expect.objectContaining(edge));
+    expect(harness.onUpdated).toHaveBeenLastCalledWith(expect.any(Array), [
+      expect.objectContaining(edge),
+    ]);
+  });
+
+  test("closing configuration leaves the newly added step available for later editing", () => {
+    const harness: BuilderHarness = renderBuilder();
+    openPicker(harness);
+    chooseAction();
+    fireEvent.change(screen.getByRole("textbox", { name: "Step message" }), {
+      target: { value: "Unsaved draft" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Close settings" }));
+
+    const added: Node<NodeDataProp> = findRenderedNode("write-log-1");
+    expect(added.data.arguments?.["message"]).toBeUndefined();
+    fireEvent.click(screen.getByTestId(`workflow-node-${added.id}`));
+    expect(screen.getByRole("textbox", { name: "Step message" })).toHaveValue(
+      "",
+    );
+  });
+});
+
+describe("Workflow builder: trigger setup and deletion", () => {
+  test("the placeholder opens the trigger picker, and the chosen trigger opens settings", () => {
+    const placeholder: Node = getPlaceholderTriggerNode();
+    const harness: BuilderHarness = renderBuilder({
+      initialNodes: [placeholder],
+    });
+    fireEvent.click(screen.getByTestId(`workflow-node-${placeholder.id}`));
+
+    expect(screen.getByTestId("picker-Trigger")).toBeInTheDocument();
+    expect(screen.queryByTestId("step-settings")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(`Choose ${ACTION_METADATA.title}`),
+    ).not.toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: `Choose ${TRIGGER_METADATA.title}` }),
+    );
+
+    expect(screen.queryByTestId("picker-Trigger")).not.toBeInTheDocument();
+    expect(screen.getByTestId("settings-step-id")).toHaveTextContent(
+      "manual-trigger-1",
+    );
+    expect(getStoredNodes(harness)).toHaveLength(1);
+    expect(getRenderedNodes()[0]?.data.nodeType).toBe(NodeType.Node);
+  });
+
+  test("replacing a placeholder preserves existing components and selects only the new trigger", () => {
+    const placeholder: Node = getPlaceholderTriggerNode();
+    const existing: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    existing.selected = true;
+    existing.data.arguments = { message: "Existing work" };
+    renderBuilder({ initialNodes: [placeholder, existing] });
+
+    fireEvent.click(screen.getByTestId(`workflow-node-${placeholder.id}`));
+    fireEvent.click(
+      screen.getByRole("button", { name: `Choose ${TRIGGER_METADATA.title}` }),
+    );
+
+    expect(getRenderedNodes()).toHaveLength(2);
+    expect(findRenderedNode("write-log-1").data.arguments).toEqual({
+      message: "Existing work",
+    });
+    expect(findRenderedNode("write-log-1").selected).toBe(false);
+    expect(findRenderedNode("manual-trigger-1").selected).toBe(true);
+    expect(
+      getRenderedNodes().some((node: Node<NodeDataProp>) => {
+        return node.data.nodeType === NodeType.PlaceholderNode;
+      }),
+    ).toBe(false);
+    expect(mockFlowProps?.edges).toEqual([]);
+  });
+
+  test("deleting a trigger restores a clickable placeholder and removes only its connections", () => {
+    const trigger: Node<NodeDataProp> = makeNode(TRIGGER_METADATA);
+    const first: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    const second: Node<NodeDataProp> = makeNode(ACTION_METADATA, 2);
+    const retained: Edge = {
+      id: "between-components",
+      source: first.id,
+      target: second.id,
+    };
+    renderBuilder({
+      initialNodes: [trigger, first, second],
+      initialEdges: [
+        { id: "from-trigger", source: trigger.id, target: first.id },
+        retained,
+      ],
+    });
+
+    fireEvent.click(screen.getByTestId(`workflow-node-${trigger.id}`));
+    fireEvent.click(screen.getByRole("button", { name: "Delete step" }));
+
+    const placeholder: Node<NodeDataProp> | undefined = getRenderedNodes().find(
+      (node: Node<NodeDataProp>) => {
+        return node.data.nodeType === NodeType.PlaceholderNode;
+      },
+    );
+    expect(placeholder?.data.onClick).toBeUndefined();
+    expect(getRenderedNodes()).toHaveLength(3);
+    expect(mockFlowProps?.edges).toEqual([expect.objectContaining(retained)]);
+    fireEvent.click(screen.getByTestId(`workflow-node-${placeholder?.id}`));
+    expect(screen.getByTestId("picker-Trigger")).toBeInTheDocument();
+  });
+
+  test("deleting an ordinary component keeps its trigger and other nodes interactive", () => {
+    const trigger: Node<NodeDataProp> = makeNode(TRIGGER_METADATA);
+    const action: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    renderBuilder({ initialNodes: [trigger, action] });
+
+    fireEvent.click(screen.getByTestId(`workflow-node-${action.id}`));
+    fireEvent.click(screen.getByRole("button", { name: "Delete step" }));
+
+    expect(getRenderedNodes()).toHaveLength(1);
+    expect(getRenderedNodes()[0]?.data.nodeType).toBe(NodeType.Node);
+    fireEvent.click(screen.getByTestId(`workflow-node-${trigger.id}`));
+    expect(screen.getByTestId("settings-step-id")).toHaveTextContent(
+      "manual-trigger-1",
+    );
+  });
+
+  test("deleting a component before a trigger is configured keeps exactly one usable placeholder", () => {
+    const placeholder: Node = getPlaceholderTriggerNode();
+    const action: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    const other: Node<NodeDataProp> = makeNode(ACTION_METADATA, 2);
+    renderBuilder({ initialNodes: [placeholder, action, other] });
+    fireEvent.click(screen.getByTestId(`workflow-node-${action.id}`));
+    fireEvent.click(screen.getByRole("button", { name: "Delete step" }));
+
+    const placeholders: Array<Node<NodeDataProp>> = getRenderedNodes().filter(
+      (node: Node<NodeDataProp>) => {
+        return node.data.nodeType === NodeType.PlaceholderNode;
+      },
+    );
+    expect(placeholders).toHaveLength(1);
+    expect(getRenderedNodes()).toHaveLength(2);
+    expect(placeholders[0]?.id).toBe(placeholder.id);
+    fireEvent.click(screen.getByTestId(`workflow-node-${placeholder.id}`));
+    expect(screen.getByTestId("picker-Trigger")).toBeInTheDocument();
+  });
+});
+
+describe("Workflow builder: rendering and persistence boundaries", () => {
+  test("existing nodes open settings without mutating the initial graph to attach callbacks", () => {
+    const action: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    const originalData: NodeDataProp = action.data;
+    const original: string = JSON.stringify(action);
+    renderBuilder({ initialNodes: [action] });
+
+    expect(action.data).toBe(originalData);
+    expect(action.data.onClick).toBeUndefined();
+    expect(JSON.stringify(action)).toBe(original);
+    expect(findRenderedNode("write-log-1").data.onClick).toBeUndefined();
+    fireEvent.click(screen.getByTestId(`workflow-node-${action.id}`));
+    expect(screen.getByTestId("settings-step-id")).toHaveTextContent(
+      "write-log-1",
+    );
+  });
+
+  test("lint messages remain render-only and click callbacks are never sent for persistence", () => {
+    const trigger: Node<NodeDataProp> = makeNode(TRIGGER_METADATA);
+    const action: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    const harness: BuilderHarness = renderBuilder({
+      initialNodes: [trigger, action],
+      initialEdges: [
+        { id: "connected", source: trigger.id, target: action.id },
+      ],
+    });
+
+    expect(findRenderedNode("write-log-1").data.error).toContain("Message");
+    for (const node of getStoredNodes(harness)) {
+      expect(node.data.error).toBe("");
+      expect(node.data.onClick).toBeUndefined();
+    }
+    expect(harness.onLint).toHaveBeenLastCalledWith(
+      expect.objectContaining({ errorCount: 1 }),
+    );
+
+    fireEvent.click(screen.getByTestId(`workflow-node-${action.id}`));
+    fireEvent.change(screen.getByRole("textbox", { name: "Step message" }), {
+      target: { value: "Configured" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    expect(findRenderedNode("write-log-1").data.error).toBe("");
+    expect(harness.onLint).toHaveBeenLastCalledWith(
+      expect.objectContaining({ errorCount: 0 }),
+    );
+    for (const node of getStoredNodes(harness)) {
+      expect(node.data.error).toBe("");
+      expect(node.data.onClick).toBeUndefined();
+    }
+  });
+
+  test("editing an existing step does not modify the node objects supplied by its caller", () => {
+    const action: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    action.data.arguments = { message: "Original" };
+    renderBuilder({ initialNodes: [action] });
+    fireEvent.click(screen.getByTestId(`workflow-node-${action.id}`));
+    fireEvent.change(screen.getByRole("textbox", { name: "Step message" }), {
+      target: { value: "Changed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    expect(action.data.arguments).toEqual({ message: "Original" });
+    expect(findRenderedNode("write-log-1").data.arguments).toEqual({
+      message: "Changed",
+    });
+  });
+
+  test("renaming a step updates its existing node by internal identity and keeps it clickable", () => {
+    const action: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    const harness: BuilderHarness = renderBuilder({ initialNodes: [action] });
+    fireEvent.click(screen.getByTestId(`workflow-node-${action.id}`));
+    act(() => {
+      const settings: SettingsProps = getSettingsProps();
+      settings.onSave({ ...settings.component, id: "deployment-log" });
+    });
+
+    expect(getStoredNodes(harness)).toHaveLength(1);
+    const renamed: Node<NodeDataProp> = findRenderedNode("deployment-log");
+    expect(renamed.id).toBe(action.id);
+    expect(renamed.data.internalId).toBe(action.data.internalId);
+    fireEvent.click(screen.getByTestId(`workflow-node-${renamed.id}`));
+    expect(screen.getByTestId("settings-step-id")).toHaveTextContent(
+      "deployment-log",
+    );
+  });
+
+  test("the settings value picker receives only real graph steps", () => {
+    const placeholder: Node = getPlaceholderTriggerNode();
+    const action: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    renderBuilder({ initialNodes: [placeholder, action] });
+    fireEvent.click(screen.getByTestId(`workflow-node-${action.id}`));
+
+    expect(getSettingsProps().graphComponents).toHaveLength(1);
+    expect(getSettingsProps().graphComponents[0]?.id).toBe("write-log-1");
+  });
+
+  test("an issue-panel request opens the matching step and acknowledges missing steps", () => {
+    const action: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    const onStepOpened: MockFunction = getJestMockFunction();
+    const harness: BuilderHarness = renderBuilder({
+      initialNodes: [action],
+      openStepForNodeId: action.id,
+      onStepOpened: onStepOpened,
+    });
+
+    expect(screen.getByTestId("settings-step-id")).toHaveTextContent(
+      "write-log-1",
+    );
+    expect(onStepOpened).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: "Close settings" }));
+    harness.view.rerender(
+      <Workflow {...harness.props} openStepForNodeId="removed-node" />,
+    );
+
+    expect(screen.queryByTestId("step-settings")).not.toBeInTheDocument();
+    expect(onStepOpened).toHaveBeenCalledTimes(2);
+  });
+
+  test("dragging a step through ReactFlow updates its saved position and preserves edit access", () => {
+    const action: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    const harness: BuilderHarness = renderBuilder({ initialNodes: [action] });
+    act(() => {
+      mockFlowProps?.onNodesChange?.([
+        {
+          id: action.id,
+          type: "position",
+          position: { x: 720, y: 480 },
+          dragging: false,
+        },
+      ]);
+    });
+
+    expect(getStoredNodes(harness)[0]?.position).toEqual({ x: 720, y: 480 });
+    fireEvent.click(screen.getByTestId(`workflow-node-${action.id}`));
+    expect(screen.getByTestId("settings-step-id")).toHaveTextContent(
+      "write-log-1",
+    );
+  });
+});
+
+describe("Workflow builder: running and modal state", () => {
+  test.each(["component picker", "trigger picker", "settings", "run"])(
+    "%s suspends canvas keyboard shortcuts until it closes",
+    (modal: string) => {
+      const placeholder: Node = getPlaceholderTriggerNode();
+      const action: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+      const harness: BuilderHarness = renderBuilder({
+        initialNodes: [placeholder, action],
+      });
+
+      expect(mockFlowProps).toEqual(
+        expect.objectContaining({
+          panActivationKeyCode: "Space",
+          deleteKeyCode: "Backspace",
+          selectionKeyCode: "Shift",
+        }),
+      );
+
+      let closeButton: string = "Close picker";
+
+      if (modal === "component picker") {
+        openPicker(harness);
+      } else if (modal === "trigger picker") {
+        fireEvent.click(screen.getByTestId(`workflow-node-${placeholder.id}`));
+      } else if (modal === "settings") {
+        closeButton = "Close settings";
+        fireEvent.click(screen.getByTestId(`workflow-node-${action.id}`));
+      } else {
+        closeButton = "Close run";
+        harness.view.rerender(
+          <Workflow {...harness.props} showRunModal={true} />,
+        );
+      }
+
+      expect(mockFlowProps).toEqual(
+        expect.objectContaining({
+          panActivationKeyCode: null,
+          deleteKeyCode: null,
+          selectionKeyCode: null,
+        }),
+      );
+      fireEvent.click(screen.getByRole("button", { name: closeButton }));
+      expect(mockFlowProps).toEqual(
+        expect.objectContaining({
+          panActivationKeyCode: "Space",
+          deleteKeyCode: "Backspace",
+          selectionKeyCode: "Shift",
+        }),
+      );
+      expect(getStoredNodes(harness)).toHaveLength(2);
+    },
+  );
+
+  test("turning the external run flag off closes the run modal without closing the component picker", () => {
+    const harness: BuilderHarness = renderBuilder({
+      showRunModal: true,
+      showComponentsPickerModal: true,
+    });
+    expect(screen.getByTestId("run-workflow-modal")).toBeInTheDocument();
+    expect(screen.getByTestId("picker-Component")).toBeInTheDocument();
+    harness.view.rerender(<Workflow {...harness.props} showRunModal={false} />);
+
+    expect(screen.queryByTestId("run-workflow-modal")).not.toBeInTheDocument();
+    expect(screen.getByTestId("picker-Component")).toBeInTheDocument();
+    expect(harness.onRunUpdate).toHaveBeenLastCalledWith(false);
+  });
+
+  test("an initially closed run modal does not suppress an explicitly opened component picker", () => {
+    renderBuilder({ showRunModal: false, showComponentsPickerModal: true });
+    expect(screen.getByTestId("picker-Component")).toBeInTheDocument();
+    expect(screen.queryByTestId("run-workflow-modal")).not.toBeInTheDocument();
+  });
+
+  test("the run modal receives the actual trigger and forwards the run request", () => {
+    const trigger: Node<NodeDataProp> = makeNode(TRIGGER_METADATA);
+    const harness: BuilderHarness = renderBuilder({
+      initialNodes: [makeNode(ACTION_METADATA), trigger],
+      showRunModal: true,
+    });
+
+    expect(screen.getByTestId("run-trigger-id")).toHaveTextContent(
+      "manual-trigger-1",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Confirm run" }));
+    expect(harness.onRun).toHaveBeenCalledWith(
+      expect.objectContaining({ internalId: trigger.data.internalId }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Close run" }));
+    expect(screen.queryByTestId("run-workflow-modal")).not.toBeInTheDocument();
+    expect(harness.onRunUpdate).toHaveBeenLastCalledWith(false);
+  });
+
+  test("only action settings offer running a single step", () => {
+    const trigger: Node<NodeDataProp> = makeNode(TRIGGER_METADATA);
+    const action: Node<NodeDataProp> = makeNode(ACTION_METADATA);
+    const onRunStep: MockFunction = getJestMockFunction();
+    renderBuilder({ initialNodes: [trigger, action], onRunStep: onRunStep });
+    fireEvent.click(screen.getByTestId(`workflow-node-${trigger.id}`));
+    expect(
+      screen.queryByRole("button", { name: "Run this step" }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Close settings" }));
+    fireEvent.click(screen.getByTestId(`workflow-node-${action.id}`));
+    fireEvent.click(screen.getByRole("button", { name: "Run this step" }));
+
+    expect(onRunStep).toHaveBeenCalledWith(
+      expect.objectContaining({ internalId: action.data.internalId }),
+    );
+  });
+
+  test("closing the picker reports its state without changing the graph", () => {
+    const harness: BuilderHarness = renderBuilder();
+    const initialNodes: Array<Node<NodeDataProp>> = getStoredNodes(harness);
+    openPicker(harness);
+    fireEvent.click(screen.getByRole("button", { name: "Close picker" }));
+
+    expect(harness.onPickerUpdate).toHaveBeenLastCalledWith(false);
+    expect(getStoredNodes(harness)).toEqual(initialNodes);
+    expect(screen.queryByTestId("step-settings")).not.toBeInTheDocument();
+  });
+});

--- a/Common/UI/Components/Workflow/ComponentsModal.tsx
+++ b/Common/UI/Components/Workflow/ComponentsModal.tsx
@@ -146,38 +146,31 @@ const ComponentsModal: FunctionComponent<ComponentProps> = (
   const searchInputRef: React.RefObject<HTMLInputElement> =
     useRef<HTMLInputElement>(null);
 
-  const [components, setComponents] = useState<Array<ComponentMetadata>>([]);
-  const [categories, setCategories] = useState<Array<ComponentCategory>>([]);
-  const [componentsToShow, setComponentsToShow] = useState<
-    Array<ComponentMetadata>
-  >([]);
-  const [selectedComponentMetadata, setSelectedComponentMetadata] =
-    useState<ComponentMetadata | null>(null);
-
-  useEffect(() => {
-    setComponents(props.components);
-    setComponentsToShow([...props.components]);
-    setCategories(props.categories);
-  }, [props.categories, props.components]);
-
-  useEffect(() => {
-    const tokens: Array<string> = getSearchTokens(search);
-
-    const filteredComponents: Array<ComponentMetadata> = components
+  const [selectedComponentId, setSelectedComponentId] = useState<string | null>(
+    null,
+  );
+  const categories: Array<ComponentCategory> = props.categories;
+  const searchTokens: Array<string> = useMemo(() => {
+    return getSearchTokens(search);
+  }, [search]);
+  const components: Array<ComponentMetadata> = useMemo(() => {
+    return props.components.filter((componentMetadata: ComponentMetadata) => {
+      return componentMetadata.componentType === props.componentsType;
+    });
+  }, [props.components, props.componentsType]);
+  const componentsToShow: Array<ComponentMetadata> = useMemo(() => {
+    return components
       .filter((componentMetadata: ComponentMetadata) => {
-        return componentMetadata.componentType === props.componentsType;
-      })
-      .filter((componentMetadata: ComponentMetadata) => {
-        return matchesSearch(componentMetadata, tokens);
+        return matchesSearch(componentMetadata, searchTokens);
       })
       .sort((componentA: ComponentMetadata, componentB: ComponentMetadata) => {
-        if (tokens.length === 0) {
+        if (searchTokens.length === 0) {
           return componentA.title.localeCompare(componentB.title);
         }
 
         const scoreDifference: number =
-          getSearchScore(componentB, tokens) -
-          getSearchScore(componentA, tokens);
+          getSearchScore(componentB, searchTokens) -
+          getSearchScore(componentA, searchTokens);
 
         if (scoreDifference !== 0) {
           return scoreDifference;
@@ -185,9 +178,33 @@ const ComponentsModal: FunctionComponent<ComponentProps> = (
 
         return componentA.title.localeCompare(componentB.title);
       });
+  }, [components, searchTokens]);
+  const selectedComponentMetadata: ComponentMetadata | undefined =
+    componentsToShow.find((componentMetadata: ComponentMetadata) => {
+      return componentMetadata.id === selectedComponentId;
+    });
 
-    setComponentsToShow(filteredComponents);
-  }, [components, props.componentsType, search]);
+  useEffect(() => {
+    // A hidden selection must not be submitted or reappear when search clears.
+    if (!selectedComponentMetadata) {
+      setSelectedComponentId(null);
+    }
+  }, [selectedComponentMetadata]);
+
+  const searchHighlightPattern: RegExp | null = useMemo(() => {
+    if (searchTokens.length === 0) {
+      return null;
+    }
+
+    const alternatives: string = [...new Set(searchTokens)]
+      .sort((tokenA: string, tokenB: string) => {
+        return tokenB.length - tokenA.length;
+      })
+      .map(escapeRegExp)
+      .join("|");
+
+    return new RegExp(`(${alternatives})`, "ig");
+  }, [searchTokens]);
 
   /*
    * Grouped once per search rather than re-filtered inside the render loop.
@@ -270,18 +287,16 @@ const ComponentsModal: FunctionComponent<ComponentProps> = (
     text: string,
     markClassName?: string,
   ): React.ReactNode => {
-    if (!hasSearchTerm) {
+    if (!searchHighlightPattern) {
       return text;
     }
 
-    const highlightedParts: Array<string> = text.split(
-      new RegExp(`(${escapeRegExp(search.trim())})`, "ig"),
-    );
+    const highlightedParts: Array<string> = text.split(searchHighlightPattern);
 
     return (
       <>
         {highlightedParts.map((part: string, index: number) => {
-          if (part.toLowerCase() === normalizedSearch) {
+          if (searchTokens.includes(part.toLowerCase())) {
             return (
               <mark
                 key={`${part}-${index}`}
@@ -424,6 +439,7 @@ const ComponentsModal: FunctionComponent<ComponentProps> = (
                       <button
                         key={category.name}
                         type="button"
+                        aria-pressed={isActive}
                         onClick={() => {
                           setSearch(category.name);
                           searchInputRef.current?.focus();
@@ -520,19 +536,23 @@ const ComponentsModal: FunctionComponent<ComponentProps> = (
                     {/* Component cards grid */}
                     <div className="grid grid-cols-1 gap-2">
                       {categoryComponents.map(
-                        (componentMetadata: ComponentMetadata, j: number) => {
+                        (componentMetadata: ComponentMetadata) => {
                           const isSelected: boolean =
-                            selectedComponentMetadata !== null &&
+                            selectedComponentMetadata !== undefined &&
                             selectedComponentMetadata.id ===
                               componentMetadata.id;
 
                           return (
-                            <div
-                              key={j}
+                            <button
+                              key={componentMetadata.id}
+                              type="button"
+                              aria-label={componentMetadata.title}
+                              aria-describedby={`workflow-component-description-${componentMetadata.id}`}
+                              aria-pressed={isSelected}
                               onClick={() => {
-                                setSelectedComponentMetadata(componentMetadata);
+                                setSelectedComponentId(componentMetadata.id);
                               }}
-                              className="cursor-pointer transition-all duration-150"
+                              className="w-full cursor-pointer text-left transition-all duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
                               style={{
                                 padding: "0.75rem",
                                 borderRadius: "10px",
@@ -618,6 +638,7 @@ const ComponentsModal: FunctionComponent<ComponentProps> = (
                                   )}
                                 </div>
                                 <p
+                                  id={`workflow-component-description-${componentMetadata.id}`}
                                   style={{
                                     fontSize: "0.75rem",
                                     color: isSelected
@@ -666,7 +687,7 @@ const ComponentsModal: FunctionComponent<ComponentProps> = (
                                   />
                                 </div>
                               )}
-                            </div>
+                            </button>
                           );
                         },
                       )}

--- a/Common/UI/Components/Workflow/NodePlacement.ts
+++ b/Common/UI/Components/Workflow/NodePlacement.ts
@@ -1,0 +1,57 @@
+import { ComponentType, NodeType } from "../../../Types/Workflow/Component";
+import { Node, XYPosition } from "reactflow";
+
+const DEFAULT_NODE_HEIGHT: number = 200;
+const NODE_GAP: number = 80;
+
+type GetNewWorkflowNodePositionFunction = (
+  nodes: Array<Node>,
+  componentType: ComponentType,
+) => XYPosition;
+
+/** Keep new steps clear of existing cards, including cards resized by content. */
+export const getNewWorkflowNodePosition: GetNewWorkflowNodePositionFunction = (
+  nodes: Array<Node>,
+  componentType: ComponentType,
+): XYPosition => {
+  if (componentType === ComponentType.Trigger) {
+    const trigger: Node | undefined = nodes.find((node: Node) => {
+      return (
+        node.data.nodeType === NodeType.PlaceholderNode ||
+        node.data.componentType === ComponentType.Trigger
+      );
+    });
+
+    if (trigger) {
+      return { ...trigger.position };
+    }
+
+    const firstNode: Node | undefined = [...nodes].sort((a: Node, b: Node) => {
+      return a.position.y - b.position.y;
+    })[0];
+
+    return firstNode
+      ? {
+          x: firstNode.position.x,
+          y: firstNode.position.y - DEFAULT_NODE_HEIGHT - NODE_GAP,
+        }
+      : { x: 100, y: 100 };
+  }
+
+  let lastNode: Node | undefined;
+  let lowestBottom: number = -Infinity;
+
+  for (const node of nodes) {
+    const bottom: number =
+      node.position.y + (node.height || DEFAULT_NODE_HEIGHT);
+
+    if (bottom > lowestBottom) {
+      lowestBottom = bottom;
+      lastNode = node;
+    }
+  }
+
+  return lastNode
+    ? { x: lastNode.position.x, y: lowestBottom + NODE_GAP }
+    : { x: 100, y: 100 };
+};

--- a/Common/UI/Components/Workflow/Workflow.tsx
+++ b/Common/UI/Components/Workflow/Workflow.tsx
@@ -2,6 +2,7 @@ import WorkflowComponent from "./Component";
 import ComponentSettingsModal from "./ComponentSettingsModal";
 import ComponentsModal from "./ComponentsModal";
 import RunModal from "./RunModal";
+import { getNewWorkflowNodePosition } from "./NodePlacement";
 import {
   LintGraphEdge,
   LintGraphNode,
@@ -40,6 +41,7 @@ import ReactFlow, {
   NodeTypes,
   OnConnect,
   ProOptions,
+  ReactFlowInstance,
   addEdge,
   getConnectedEdges,
   updateEdge,
@@ -62,7 +64,7 @@ export const getPlaceholderTriggerNode: GetPlaceholderTriggerNodeFunction =
           iconProp: IconProp.Bolt,
           componentType: ComponentType.Trigger,
           title: "Trigger",
-          description: "Please click here to add trigger",
+          description: "Choose what starts this workflow",
         },
         metadataId: "",
         internalId: "",
@@ -159,6 +161,8 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
   }, []);
 
   const edgeUpdateSuccessful: any = useRef(true);
+  const flowInstance: React.MutableRefObject<ReactFlowInstance | null> =
+    useRef<ReactFlowInstance | null>(null);
   const [showComponentSettingsModal, setShowComponentSettingsModal] =
     useState<boolean>(false);
   const [selectedNodeData, setSelectedNodeData] = useState<NodeDataProp | null>(
@@ -167,7 +171,7 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
 
   type OnNodeClickFunction = (data: NodeDataProp) => void;
 
-  const onNodeClick: OnNodeClickFunction = (data: NodeDataProp) => {
+  const onNodeClick: OnNodeClickFunction = useCallback((data: NodeDataProp) => {
     // if placeholder node is clicked then show modal.
 
     if (data.nodeType === NodeType.PlaceholderNode) {
@@ -180,7 +184,7 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
       setShowComponentSettingsModal(true);
       setSelectedNodeData(data);
     }
-  };
+  }, []);
 
   useEffect(() => {
     if (props.showComponentsPickerModal) {
@@ -194,7 +198,7 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
     if (props.showRunModal) {
       setShowRunModal(true);
     } else {
-      setShowComponentsModal(false);
+      setShowRunModal(false);
     }
   }, [props.showRunModal]);
 
@@ -214,12 +218,12 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
       });
 
       if (
-        nodeToUpdate.filter((n: Node) => {
+        !nodeToUpdate.some((n: Node) => {
           return (
-            (n.data as NodeDataProp).componentType === ComponentType.Trigger &&
-            (n.data as NodeDataProp).nodeType === NodeType.Node
+            (n.data as NodeDataProp).componentType === ComponentType.Trigger ||
+            (n.data as NodeDataProp).nodeType === NodeType.PlaceholderNode
           );
-        }).length === 0
+        })
       ) {
         nodeToUpdate = nodeToUpdate.concat(getPlaceholderTriggerNode());
       }
@@ -244,12 +248,7 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
     });
   };
 
-  const [nodes, setNodes, onNodesChange] = useNodesState(
-    props.initialNodes.map((node: Node) => {
-      node.data.onClick = onNodeClick;
-      return node;
-    }),
-  );
+  const [nodes, setNodes, onNodesChange] = useNodesState(props.initialNodes);
 
   const [edges, setEdges, onEdgesChange] = useEdgesState(
     props.initialEdges.map((edge: Edge) => {
@@ -410,6 +409,11 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
   const [showTriggersModal, setShowTriggersModal] = useState<boolean>(false);
 
   const [showRunModal, setShowRunModal] = useState<boolean>(false);
+  const isModalOpen: boolean =
+    showComponentsModal ||
+    showTriggersModal ||
+    showComponentSettingsModal ||
+    showRunModal;
 
   useEffect(() => {
     props.onComponentPickerModalUpdate(showComponentsModal);
@@ -457,7 +461,10 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
     const compToAdd: Node = {
       id: ObjectID.generate().toString(), // react-flow id
       type: "node",
-      position: { x: 200, y: 200 },
+      position: getNewWorkflowNodePosition(
+        nodes,
+        componentMetadata.componentType,
+      ),
       selected: true,
       data: {
         nodeType: NodeType.Node,
@@ -491,13 +498,21 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
           .concat({ ...compToAdd } as any);
       });
     }
+
+    setSelectedNodeData(compToAdd.data as NodeDataProp);
+    setShowComponentSettingsModal(true);
+    flowInstance.current?.setCenter(
+      compToAdd.position.x + 128,
+      compToAdd.position.y + 100,
+      { zoom: 1, duration: 200 },
+    );
   };
 
   return (
     <div
       style={{
         height: "calc(100vh - 220px)",
-        minHeight: "600px",
+        minHeight: "400px",
         borderRadius: "8px",
         overflow: "hidden",
         border: "1px solid var(--ou-border-default, #e2e8f0)",
@@ -556,20 +571,33 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
         `}
       </style>
       <ReactFlow
+        onInit={(instance: ReactFlowInstance) => {
+          flowInstance.current = instance;
+        }}
         nodes={nodesToRender}
         edges={edges}
         fitView={true}
+        fitViewOptions={{ maxZoom: 1 }}
         onEdgeClick={() => {
           refreshEdges();
         }}
-        onNodeClick={() => {
+        onNodeClick={(_event: React.MouseEvent, node: Node) => {
           refreshEdges();
+          /*
+           * Handle every node through the canvas, including newly added steps
+           * and replacement trigger placeholders, without persisting callbacks.
+           */
+          onNodeClick(node.data as NodeDataProp);
         }}
         proOptions={proOptions}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
         multiSelectionKeyCode={null}
+        // React Flow listens on document, even while a dialog has focus.
+        panActivationKeyCode={isModalOpen ? null : "Space"}
+        deleteKeyCode={isModalOpen ? null : "Backspace"}
+        selectionKeyCode={isModalOpen ? null : "Shift"}
         onEdgeUpdate={onEdgeUpdate}
         nodeTypes={nodeTypes}
         onEdgeUpdateStart={onEdgeUpdateStart}
@@ -704,11 +732,12 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
               ...componentData,
               error: "",
             };
+            delete dataToStore.onClick;
 
             setNodes((nds: Array<Node>) => {
               return nds.map((n: Node) => {
                 if (n.data.internalId === dataToStore.internalId) {
-                  n.data = dataToStore;
+                  return { ...n, data: dataToStore };
                 }
 
                 return n;


### PR DESCRIPTION
### Title of this pull request?

Make workflow steps easier to add, configure, and find

### Small Description?

New workflow steps were stacked at the same canvas position and could not open their settings until the builder reloaded. Adding a step now opens its settings immediately, places it below existing cards, and brings it into view. Initial and replacement trigger cards remain editable through the canvas's normal click event.

The component picker now supports native keyboard selection, highlights every search word, and clears selections hidden by a search or catalog change. Counts and quick filters reflect the selected component type. Canvas shortcuts pause while its picker, settings, or run dialog is open, so Space selects a card and Backspace cannot delete a step behind the dialog. The canvas also fits smaller laptop windows and avoids over-zooming an empty workflow.

### Pull Request Checklist:

- [ ] CI jobs pass before requesting review.
- [x] Root formatting/lint checks completed for the seven changed workflow files.
- [x] Added 74 unit and component-integration regression cases, alongside the existing 30 picker tests.

### Validation

- 104 focused tests passed: 30 existing picker tests, 32 picker usability cases, 30 builder integration cases, and 12 placement cases. Tests run with the normal TypeScript checking configuration.
- `npm run compile` in Common passed.
- The isolated preview build passed.
- `npm run fix` with the repository rules scoped to the seven modified workflow files passed; the full-repository pass was stopped while analyzing unrelated projects.
- `git diff --check` passed.

Browser checks used the actual worktree components at 1440×1000 and 900×760. Verified Enter/Space selection, slash-to-search, Escape/reset recovery, hidden-selection protection, automatic settings, saved values after reopening, repeated additions, issue-to-step navigation, manual connections, and viewport fit. No browser errors or horizontal overflow were observed.

The shared Docker app was repeatedly restarting and returned HTTP 502, so these screenshots come from an isolated component preview. Graph changes stayed in browser state, and the workflow-variable list returned an empty fixture. Live backend persistence and execution were not exercised.

### Related Issue?

None.

### Screenshots

Screenshots are stored on a separate evidence branch, keeping binaries out of this product PR.

**Keyboard selection and individual search-word highlights**

![Keyboard selection and search results](https://raw.githubusercontent.com/OneUptime/oneuptime/5709f1d16d2f7108f551b7c10415e6493c3ff9d0/screenshots/keyboard-search.png)

**New step settings open immediately; saved values can be reopened**

![Step settings](https://raw.githubusercontent.com/OneUptime/oneuptime/5709f1d16d2f7108f551b7c10415e6493c3ff9d0/screenshots/step-settings.png)

**Repeated steps are spaced apart; connections were added manually**

![Separated workflow steps](https://raw.githubusercontent.com/OneUptime/oneuptime/5709f1d16d2f7108f551b7c10415e6493c3ff9d0/screenshots/spaced-steps.png)

<details>
<summary>Smaller window and empty-search recovery</summary>

![Canvas at 900 by 760](https://raw.githubusercontent.com/OneUptime/oneuptime/5709f1d16d2f7108f551b7c10415e6493c3ff9d0/screenshots/canvas-small.png)

![Empty search disables Add](https://raw.githubusercontent.com/OneUptime/oneuptime/5709f1d16d2f7108f551b7c10415e6493c3ff9d0/screenshots/empty-search-small.png)

</details>
