### PR TITLE
Reduce routine notification email noise

### DIFF
--- a/App/FeatureSet/BaseAPI/Index.ts
+++ b/App/FeatureSet/BaseAPI/Index.ts
@@ -1010,9 +1010,7 @@ import TelemetryUsageBillingService, {
 import UserNotificationRuleService, {
   Service as UserNotificationRuleServiceType,
 } from "Common/Server/Services/UserNotificationRuleService";
-import UserNotificationSettingService, {
-  Service as UserNotificationSettingServiceType,
-} from "Common/Server/Services/UserNotificationSettingService";
+import UserNotificationSettingAPI from "Common/Server/API/UserNotificationSettingAPI";
 import UserOnCallLogService, {
   Service as UserNotificationLogServiceType,
 } from "Common/Server/Services/UserOnCallLogService";
@@ -1356,7 +1354,6 @@ import TeamPermission from "Common/Models/DatabaseModels/TeamPermission";
 import TeamComplianceSetting from "Common/Models/DatabaseModels/TeamComplianceSetting";
 import TelemetryUsageBilling from "Common/Models/DatabaseModels/TelemetryUsageBilling";
 import UserNotificationRule from "Common/Models/DatabaseModels/UserNotificationRule";
-import UserNotificationSetting from "Common/Models/DatabaseModels/UserNotificationSetting";
 import UserOnCallLog from "Common/Models/DatabaseModels/UserOnCallLog";
 import Workflow from "Common/Models/DatabaseModels/Workflow";
 import WorkflowLog from "Common/Models/DatabaseModels/WorkflowLog";
@@ -4431,10 +4428,7 @@ const BaseAPIFeatureSet: FeatureSet = {
 
     app.use(
       `/${APP_NAME.toLocaleLowerCase()}`,
-      new BaseAPI<UserNotificationSetting, UserNotificationSettingServiceType>(
-        UserNotificationSetting,
-        UserNotificationSettingService,
-      ).getRouter(),
+      new UserNotificationSettingAPI().getRouter(),
     );
 
     app.use(

--- a/App/FeatureSet/Dashboard/src/Components/NotificationMethods/EmailNoiseCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NotificationMethods/EmailNoiseCard.tsx
@@ -1,0 +1,95 @@
+import Card from "Common/UI/Components/Card/Card";
+import API from "Common/UI/Utils/API/API";
+import useTranslateValue from "Common/UI/Utils/Translation";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useRef,
+  useState,
+} from "react";
+
+interface ComponentProps {
+  onApply: () => Promise<void>;
+  disabled?: boolean;
+}
+
+const EmailNoiseCard: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const { translateString } = useTranslateValue();
+  const applying: React.MutableRefObject<boolean> = useRef<boolean>(false);
+  const [isBusy, setIsBusy] = useState<boolean>(false);
+  const [isApplied, setIsApplied] = useState<boolean>(false);
+  const [error, setError] = useState<string>("");
+
+  const apply: () => Promise<void> = async (): Promise<void> => {
+    if (applying.current || props.disabled) {
+      return;
+    }
+
+    applying.current = true;
+    setIsBusy(true);
+    setIsApplied(false);
+    setError("");
+
+    try {
+      await props.onApply();
+      setIsApplied(true);
+    } catch (err) {
+      setError(API.getFriendlyMessage(err));
+    } finally {
+      applying.current = false;
+      setIsBusy(false);
+    }
+  };
+
+  return (
+    <Card
+      title="Fewer routine emails"
+      description="Keep the updates that need your attention."
+      bodyClassName="mt-5"
+    >
+      <React.Fragment>
+        <p className="max-w-3xl text-sm text-gray-600">
+          {translateString(
+            "Turn off emails about notes, being added as an owner, new monitors and status pages, items added to episodes, and on-call policy membership changes.",
+          )}
+        </p>
+        <p className="mt-2 max-w-3xl text-sm text-gray-600">
+          {translateString(
+            "Your choices for incident and alert creation, state changes, reminders, assignments, monitor health, and on-call shifts stay as they are. Other notification channels, paging, account and billing emails are unaffected.",
+          )}
+        </p>
+        <p className="mt-2 text-sm text-gray-600">
+          {translateString(
+            "Applies to you in this project. You can turn individual emails back on below.",
+          )}
+        </p>
+        <button
+          type="button"
+          onClick={apply}
+          disabled={isBusy || props.disabled}
+          className="mt-4 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-60"
+        >
+          {translateString(
+            isBusy ? "Saving email preferences…" : "Reduce routine emails",
+          )}
+        </button>
+        {isApplied ? (
+          <p role="status" className="mt-3 text-sm text-emerald-700">
+            {translateString(
+              "Routine emails turned off. Review or change individual preferences below.",
+            )}
+          </p>
+        ) : null}
+        {error ? (
+          <p role="alert" className="mt-3 text-sm text-red-700">
+            {error}
+          </p>
+        ) : null}
+      </React.Fragment>
+    </Card>
+  );
+};
+
+export default EmailNoiseCard;

--- a/App/FeatureSet/Dashboard/src/Pages/UserSettings/NotificationSettings.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/UserSettings/NotificationSettings.tsx
@@ -1,4 +1,10 @@
 import ProjectUtil from "Common/UI/Utils/Project";
+import EmailNoiseCard from "../../Components/NotificationMethods/EmailNoiseCard";
+import { APP_API_URL } from "Common/UI/Config";
+import URL from "Common/Types/API/URL";
+import Route from "Common/Types/API/Route";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import PageComponentProps from "../PageComponentProps";
 import NotificationSettingEventType from "Common/Types/NotificationSetting/NotificationSettingEventType";
 import User from "Common/UI/Utils/User";
@@ -371,6 +377,7 @@ const buildSection: SectionFactory = (
 interface ChannelCellProps {
   channel: ChannelDef;
   enabled: boolean;
+  disabled: boolean;
   onChange: (next: boolean) => Promise<void>;
 }
 
@@ -380,7 +387,7 @@ const ChannelCell: FunctionComponent<ChannelCellProps> = (
   const [isBusy, setIsBusy] = useState<boolean>(false);
 
   const handleClick: () => Promise<void> = async (): Promise<void> => {
-    if (isBusy) {
+    if (isBusy || props.disabled) {
       return;
     }
     setIsBusy(true);
@@ -402,7 +409,7 @@ const ChannelCell: FunctionComponent<ChannelCellProps> = (
       aria-checked={props.enabled}
       aria-label={`${props.channel.label}: ${props.enabled ? "On" : "Off"}. Click to ${props.enabled ? "disable" : "enable"}.`}
       onClick={handleClick}
-      disabled={isBusy}
+      disabled={isBusy || props.disabled}
       className={`inline-flex h-9 w-9 items-center justify-center rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 disabled:opacity-60 ${stateClasses}`}
     >
       {props.enabled ? (
@@ -416,6 +423,8 @@ const ChannelCell: FunctionComponent<ChannelCellProps> = (
 
 interface NotificationMatrixProps {
   section: SectionDef;
+  disabled: boolean;
+  onSavingChange: (isSaving: boolean) => void;
 }
 
 const NotificationMatrix: FunctionComponent<NotificationMatrixProps> = (
@@ -650,12 +659,20 @@ const NotificationMatrix: FunctionComponent<NotificationMatrixProps> = (
                             <ChannelCell
                               channel={channel}
                               enabled={enabled}
-                              onChange={(nextValue: boolean) => {
-                                return persistToggle(
-                                  event.type,
-                                  channel.key,
-                                  nextValue,
-                                );
+                              disabled={props.disabled}
+                              onChange={async (
+                                nextValue: boolean,
+                              ): Promise<void> => {
+                                props.onSavingChange(true);
+                                try {
+                                  await persistToggle(
+                                    event.type,
+                                    channel.key,
+                                    nextValue,
+                                  );
+                                } finally {
+                                  props.onSavingChange(false);
+                                }
                               }}
                             />
                           </td>
@@ -872,7 +889,7 @@ const EmailRollupCard: FunctionComponent = (): ReactElement => {
               </div>
               <p className="mt-1 text-sm text-gray-500 max-w-2xl">
                 {isEnabled
-                  ? "When a burst of notifications about the resources you own lands at once, the first few are still emailed one by one as they happen. The rest are gathered up and delivered together as a single email a few minutes later. Nothing is dropped - every one of them is in that email."
+                  ? "When a burst of notifications about the resources you own lands at once, the first few are still emailed one by one as they happen. The rest are delivered together a few minutes later. The summary includes the notifications you are still subscribed to when it is sent."
                   : "Nothing is held back or combined, ever. This is exactly how OneUptime delivered owner notifications before rollup existed, and it is the right choice if you file, filter or forward mail one event at a time."}
               </p>
               <p className="mt-3 text-xs text-gray-500 max-w-2xl">
@@ -894,104 +911,146 @@ const EmailRollupCard: FunctionComponent = (): ReactElement => {
   );
 };
 
+const incidents: Array<SectionDef> = [
+  buildSection("Incidents", "Notify me about incidents on resources I own.", [
+    NotificationSettingEventType.SEND_INCIDENT_CREATED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_STATE_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_REMINDER_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_NOTE_POSTED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_OWNER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_MEMBER_ADDED_NOTIFICATION,
+  ]),
+  buildSection(
+    "Incident Episodes",
+    "Notify me about activity on incident episodes I own.",
+    [
+      NotificationSettingEventType.SEND_INCIDENT_EPISODE_CREATED_OWNER_NOTIFICATION,
+      NotificationSettingEventType.SEND_INCIDENT_EPISODE_STATE_CHANGED_OWNER_NOTIFICATION,
+      NotificationSettingEventType.SEND_INCIDENT_EPISODE_NOTE_POSTED_OWNER_NOTIFICATION,
+      NotificationSettingEventType.SEND_INCIDENT_EPISODE_OWNER_ADDED_NOTIFICATION,
+      NotificationSettingEventType.SEND_INCIDENT_ADDED_TO_EPISODE_OWNER_NOTIFICATION,
+    ],
+  ),
+];
+
+const alerts: Array<SectionDef> = [
+  buildSection("Alerts", "Notify me about alerts on resources I own.", [
+    NotificationSettingEventType.SEND_ALERT_CREATED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_STATE_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_REMINDER_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_NOTE_POSTED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_OWNER_ADDED_NOTIFICATION,
+  ]),
+  buildSection(
+    "Alert Episodes",
+    "Notify me about activity on alert episodes I own.",
+    [
+      NotificationSettingEventType.SEND_ALERT_EPISODE_CREATED_OWNER_NOTIFICATION,
+      NotificationSettingEventType.SEND_ALERT_EPISODE_STATE_CHANGED_OWNER_NOTIFICATION,
+      NotificationSettingEventType.SEND_ALERT_EPISODE_NOTE_POSTED_OWNER_NOTIFICATION,
+      NotificationSettingEventType.SEND_ALERT_EPISODE_OWNER_ADDED_NOTIFICATION,
+      NotificationSettingEventType.SEND_ALERT_ADDED_TO_EPISODE_OWNER_NOTIFICATION,
+    ],
+  ),
+];
+
+const monitoring: Array<SectionDef> = [
+  buildSection("Monitors", "Notify me about monitors I own.", [
+    NotificationSettingEventType.SEND_MONITOR_CREATED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_MONITOR_STATUS_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_MONITOR_OWNER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_MONITOR_NOTIFICATION_WHEN_PORBE_STATUS_CHANGES,
+    NotificationSettingEventType.SEND_MONITOR_NOTIFICATION_WHEN_NO_PROBES_ARE_MONITORING_THE_MONITOR,
+  ]),
+  buildSection("SLOs", "Notify me about SLOs I own.", [
+    NotificationSettingEventType.SEND_SLO_OWNER_STATUS_CHANGE_NOTIFICATION,
+    NotificationSettingEventType.SEND_SLO_OWNER_ADDED_NOTIFICATION,
+  ]),
+  buildSection("Probes", "Notify me about custom probes I own.", [
+    NotificationSettingEventType.SEND_PROBE_STATUS_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_PROBE_OWNER_ADDED_NOTIFICATION,
+  ]),
+  buildSection("AI Agents", "Notify me about AI agents I own.", [
+    NotificationSettingEventType.SEND_AI_AGENT_STATUS_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_AI_AGENT_OWNER_ADDED_NOTIFICATION,
+  ]),
+];
+
+const statusPages: Array<SectionDef> = [
+  buildSection("Status Pages", "Notify me about status pages I own.", [
+    NotificationSettingEventType.SEND_STATUS_PAGE_CREATED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_STATUS_PAGE_ANNOUNCEMENT_CREATED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_STATUS_PAGE_OWNER_ADDED_NOTIFICATION,
+  ]),
+];
+
+const scheduledMaintenance: Array<SectionDef> = [
+  buildSection(
+    "Scheduled Maintenance",
+    "Notify me about scheduled maintenance events I own.",
+    [
+      NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_CREATED_OWNER_NOTIFICATION,
+      NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_STATE_CHANGED_OWNER_NOTIFICATION,
+      NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_REMINDER_OWNER_NOTIFICATION,
+      NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_NOTE_POSTED_OWNER_NOTIFICATION,
+      NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_OWNER_ADDED_NOTIFICATION,
+    ],
+  ),
+];
+
+const onCall: Array<SectionDef> = [
+  buildSection(
+    "On-Call",
+    "Notify me about my on-call schedule and policy membership.",
+    [
+      NotificationSettingEventType.SEND_WHEN_USER_IS_ON_CALL_ROSTER,
+      NotificationSettingEventType.SEND_WHEN_USER_IS_NEXT_ON_CALL_ROSTER,
+      NotificationSettingEventType.SEND_WHEN_USER_IS_NO_LONGER_ACTIVE_ON_ON_CALL_ROSTER,
+      NotificationSettingEventType.SEND_WHEN_USER_IS_ADDED_TO_ON_CALL_POLICY,
+      NotificationSettingEventType.SEND_WHEN_USER_IS_REMOVED_FROM_ON_CALL_POLICY,
+      NotificationSettingEventType.SEND_BEFORE_USER_ON_CALL_SHIFT_STARTS,
+      NotificationSettingEventType.SEND_WHEN_USER_ON_CALL_SHIFT_IS_REASSIGNED,
+    ],
+  ),
+];
+
 const Settings: FunctionComponent<PageComponentProps> = (): ReactElement => {
-  const incidents: Array<SectionDef> = [
-    buildSection("Incidents", "Notify me about incidents on resources I own.", [
-      NotificationSettingEventType.SEND_INCIDENT_CREATED_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_INCIDENT_STATE_CHANGED_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_INCIDENT_REMINDER_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_INCIDENT_NOTE_POSTED_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_INCIDENT_OWNER_ADDED_NOTIFICATION,
-    ]),
-    buildSection(
-      "Incident Episodes",
-      "Notify me about activity on incident episodes I own.",
-      [
-        NotificationSettingEventType.SEND_INCIDENT_EPISODE_CREATED_OWNER_NOTIFICATION,
-        NotificationSettingEventType.SEND_INCIDENT_EPISODE_STATE_CHANGED_OWNER_NOTIFICATION,
-        NotificationSettingEventType.SEND_INCIDENT_EPISODE_NOTE_POSTED_OWNER_NOTIFICATION,
-        NotificationSettingEventType.SEND_INCIDENT_EPISODE_OWNER_ADDED_NOTIFICATION,
-        NotificationSettingEventType.SEND_INCIDENT_ADDED_TO_EPISODE_OWNER_NOTIFICATION,
-      ],
-    ),
-  ];
+  const projectId: string = ProjectUtil.getCurrentProjectId()?.toString() || "";
+  const [settingsVersion, setSettingsVersion] = useState<number>(0);
+  const [isApplyingPreset, setIsApplyingPreset] = useState<boolean>(false);
+  const [pendingSaves, setPendingSaves] = useState<number>(0);
+  const onSavingChange: (isSaving: boolean) => void = useCallback(
+    (isSaving: boolean): void => {
+      setPendingSaves((count: number): number => {
+        return count + (isSaving ? 1 : -1);
+      });
+    },
+    [],
+  );
 
-  const alerts: Array<SectionDef> = [
-    buildSection("Alerts", "Notify me about alerts on resources I own.", [
-      NotificationSettingEventType.SEND_ALERT_CREATED_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_ALERT_STATE_CHANGED_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_ALERT_REMINDER_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_ALERT_NOTE_POSTED_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_ALERT_OWNER_ADDED_NOTIFICATION,
-    ]),
-    buildSection(
-      "Alert Episodes",
-      "Notify me about activity on alert episodes I own.",
-      [
-        NotificationSettingEventType.SEND_ALERT_EPISODE_CREATED_OWNER_NOTIFICATION,
-        NotificationSettingEventType.SEND_ALERT_EPISODE_STATE_CHANGED_OWNER_NOTIFICATION,
-        NotificationSettingEventType.SEND_ALERT_EPISODE_NOTE_POSTED_OWNER_NOTIFICATION,
-        NotificationSettingEventType.SEND_ALERT_EPISODE_OWNER_ADDED_NOTIFICATION,
-        NotificationSettingEventType.SEND_ALERT_ADDED_TO_EPISODE_OWNER_NOTIFICATION,
-      ],
-    ),
-  ];
+  const reduceRoutineEmails: () => Promise<void> = async (): Promise<void> => {
+    setIsApplyingPreset(true);
+    try {
+      const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+        await API.post<JSONObject>({
+          url: URL.fromURL(APP_API_URL).addRoute(
+            new Route("/user-notification-setting/reduce-routine-emails"),
+          ),
+          data: {},
+          headers: ModelAPI.getCommonHeaders(),
+        });
 
-  const monitoring: Array<SectionDef> = [
-    buildSection("Monitors", "Notify me about monitors I own.", [
-      NotificationSettingEventType.SEND_MONITOR_CREATED_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_MONITOR_STATUS_CHANGED_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_MONITOR_OWNER_ADDED_NOTIFICATION,
-      NotificationSettingEventType.SEND_MONITOR_NOTIFICATION_WHEN_PORBE_STATUS_CHANGES,
-      NotificationSettingEventType.SEND_MONITOR_NOTIFICATION_WHEN_NO_PROBES_ARE_MONITORING_THE_MONITOR,
-    ]),
-    buildSection("SLOs", "Notify me about SLOs I own.", [
-      NotificationSettingEventType.SEND_SLO_OWNER_STATUS_CHANGE_NOTIFICATION,
-      NotificationSettingEventType.SEND_SLO_OWNER_ADDED_NOTIFICATION,
-    ]),
-    buildSection("Probes", "Notify me about custom probes I own.", [
-      NotificationSettingEventType.SEND_PROBE_STATUS_CHANGED_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_PROBE_OWNER_ADDED_NOTIFICATION,
-    ]),
-  ];
+      if (response instanceof HTTPErrorResponse || response.isFailure()) {
+        throw response;
+      }
 
-  const statusPages: Array<SectionDef> = [
-    buildSection("Status Pages", "Notify me about status pages I own.", [
-      NotificationSettingEventType.SEND_STATUS_PAGE_CREATED_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_STATUS_PAGE_ANNOUNCEMENT_CREATED_OWNER_NOTIFICATION,
-      NotificationSettingEventType.SEND_STATUS_PAGE_OWNER_ADDED_NOTIFICATION,
-    ]),
-  ];
-
-  const scheduledMaintenance: Array<SectionDef> = [
-    buildSection(
-      "Scheduled Maintenance",
-      "Notify me about scheduled maintenance events I own.",
-      [
-        NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_CREATED_OWNER_NOTIFICATION,
-        NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_STATE_CHANGED_OWNER_NOTIFICATION,
-        NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_REMINDER_OWNER_NOTIFICATION,
-        NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_NOTE_POSTED_OWNER_NOTIFICATION,
-        NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_OWNER_ADDED_NOTIFICATION,
-      ],
-    ),
-  ];
-
-  const onCall: Array<SectionDef> = [
-    buildSection(
-      "On-Call",
-      "Notify me about my on-call schedule and policy membership.",
-      [
-        NotificationSettingEventType.SEND_WHEN_USER_IS_ON_CALL_ROSTER,
-        NotificationSettingEventType.SEND_WHEN_USER_IS_NEXT_ON_CALL_ROSTER,
-        NotificationSettingEventType.SEND_WHEN_USER_IS_NO_LONGER_ACTIVE_ON_ON_CALL_ROSTER,
-        NotificationSettingEventType.SEND_WHEN_USER_IS_ADDED_TO_ON_CALL_POLICY,
-        NotificationSettingEventType.SEND_WHEN_USER_IS_REMOVED_FROM_ON_CALL_POLICY,
-        NotificationSettingEventType.SEND_BEFORE_USER_ON_CALL_SHIFT_STARTS,
-        NotificationSettingEventType.SEND_WHEN_USER_ON_CALL_SHIFT_IS_REASSIGNED,
-      ],
-    ),
-  ];
+      setSettingsVersion((version: number): number => {
+        return version + 1;
+      });
+    } finally {
+      setIsApplyingPreset(false);
+    }
+  };
 
   const renderSections: (sections: Array<SectionDef>) => ReactElement = (
     sections: Array<SectionDef>,
@@ -999,14 +1058,25 @@ const Settings: FunctionComponent<PageComponentProps> = (): ReactElement => {
     return (
       <div className="space-y-4">
         {sections.map((section: SectionDef) => {
-          return <NotificationMatrix key={section.title} section={section} />;
+          return (
+            <NotificationMatrix
+              key={`${section.title}-${settingsVersion}`}
+              section={section}
+              disabled={isApplyingPreset}
+              onSavingChange={onSavingChange}
+            />
+          );
         })}
       </div>
     );
   };
 
   return (
-    <Fragment>
+    <Fragment key={projectId}>
+      <EmailNoiseCard
+        onApply={reduceRoutineEmails}
+        disabled={pendingSaves > 0}
+      />
       {/* Above the tabs on purpose: it governs delivery for every tab. */}
       <EmailRollupCard />
       <Tabs

--- a/App/FeatureSet/Docs/Content/en/emails/notification-rollup.md
+++ b/App/FeatureSet/Docs/Content/en/emails/notification-rollup.md
@@ -21,11 +21,12 @@ scheduled maintenance, status pages, probes, SLOs, and so on.
 - About five minutes later, everything held back for you in that project — across all categories —
   arrives as **one** email listing what happened, newest first, with a link to each resource.
 
-Nothing is dropped. A held-back notification is delayed, never discarded, and the rollup email
-contains every one of them.
+The rollup includes notifications that you are still subscribed to when it is sent. If you turn off
+an event's email while its notifications are queued, those notifications are left out of the rollup.
+Turning email back on later does not replay those skipped updates.
 
 Below the threshold the feature does nothing at all. A project that produces three owner emails a
-day still produces three owner emails a day, and they are byte-for-byte the emails you got before.
+day still receives those three owner emails individually.
 
 ## What the rollup email looks like
 
@@ -115,11 +116,23 @@ What it does **not** touch:
 
 ## Turning it down further
 
-Rollup reduces how many emails a notification produces. It does not decide which notifications you
-get in the first place — that is still yours to set, per event type and per channel, under
-**User Settings → Notification Settings** in the dashboard. Every rollup email links straight to that
-page.
+Open **Manage notification preferences** at the bottom of an owner notification or rollup email,
+or go to **User Settings → Notification Settings** in the dashboard.
 
-If a whole class of notification is not useful to you, switching it off there is a bigger saving than
-any amount of batching — and unlike the rollup switch above, it takes the notification away rather
-than repackaging it.
+Choose **Reduce routine emails** to turn off these informational emails for yourself in the current
+project:
+
+- Notes posted on incidents, alerts, episodes, and scheduled maintenance.
+- Notices that you were added as a resource owner.
+- New monitors and status pages.
+- Incidents or alerts added to existing episodes.
+- Being added to or removed from an on-call policy.
+
+The action preserves your existing choices for incident and alert creation, state changes, reminders,
+incident assignments, monitor health, and on-call shifts. It does not enable any email you previously
+disabled. Paging, other delivery channels, account email, billing email, and status page subscriber
+email are unaffected.
+
+The changes save together. Review the per-event switches below to turn any individual email back on.
+These preferences also apply to notifications waiting for a rollup; an already-sent email cannot be
+recalled. Email rollup remains a separate setting that controls batching for the events you keep.

--- a/App/FeatureSet/Notification/Templates/AIAgentOwnerAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/AIAgentOwnerAdded.hbs
@@ -23,6 +23,8 @@
 
 {{> InfoBlock info="You will be notified when the status of this AI agent changes."}}
 
+{{> UnsubscribeOwnerEmail this }}
+
 {{> Footer this }}
 
 {{> End this}}

--- a/App/FeatureSet/Notification/Templates/AlertEpisodeOwnerAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/AlertEpisodeOwnerAdded.hbs
@@ -25,6 +25,8 @@
 
 {{> InfoBlock info="You will be notified when the status of this alert episode changes."}}
 
+{{> UnsubscribeOwnerEmail this }}
+
 {{> Footer this }}
 
 {{> End this}}

--- a/App/FeatureSet/Notification/Templates/AlertOwnerAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/AlertOwnerAdded.hbs
@@ -26,6 +26,8 @@
 
 {{> InfoBlock info="You will be notified when the status of this alert changes."}}
 
+{{> UnsubscribeOwnerEmail this }}
+
 {{> Footer this }}
 
 {{> End this}}

--- a/App/FeatureSet/Notification/Templates/IncidentEpisodeOwnerAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/IncidentEpisodeOwnerAdded.hbs
@@ -25,6 +25,8 @@
 
 {{> InfoBlock info="You will be notified when the status of this incident episode changes."}}
 
+{{> UnsubscribeOwnerEmail this }}
+
 {{> Footer this }}
 
 {{> End this}}

--- a/App/FeatureSet/Notification/Templates/IncidentMemberAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/IncidentMemberAdded.hbs
@@ -27,6 +27,8 @@
 
 {{> InfoBlock info="You will be notified when the status of this incident changes."}}
 
+{{> UnsubscribeOwnerEmail this }}
+
 {{> Footer this }}
 
 {{> End this}}

--- a/App/FeatureSet/Notification/Templates/IncidentOwnerAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/IncidentOwnerAdded.hbs
@@ -26,6 +26,8 @@
 
 {{> InfoBlock info="You will be notified when the status of this incident changes."}}
 
+{{> UnsubscribeOwnerEmail this }}
+
 {{> Footer this }}
 
 {{> End this}}

--- a/App/FeatureSet/Notification/Templates/MonitorOwnerAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/MonitorOwnerAdded.hbs
@@ -31,6 +31,8 @@
 
 {{> InfoBlock info="You will be notified when the status of this monitor changes."}}
 
+{{> UnsubscribeOwnerEmail this }}
+
 {{> Footer this }}
 
 {{> End this}}

--- a/App/FeatureSet/Notification/Templates/Partials/UnsubscribeOwnerEmail.hbs
+++ b/App/FeatureSet/Notification/Templates/Partials/UnsubscribeOwnerEmail.hbs
@@ -1,2 +1,30 @@
-{{> TitleBlock title="How do I unsubscribe from this email?"}}
-{{> InfoBlock info="You can go to OneUptime Dashboard > More > User Settings > Notification Settings to unsubscribe from this email."}}
+{{> TitleBlock title="Want fewer notification emails?"}}
+{{#if notificationPreferencesUrl}}
+<table
+  class="st-Copy st-Width st-Width--mobile"
+  border="0"
+  cellpadding="0"
+  cellspacing="0"
+  width="600"
+  style="min-width: 600px;"
+>
+  <tbody>
+    <tr>
+      <td class="st-Spacer st-Spacer--gutter" width="64"></td>
+      <td
+        class="st-Font st-Font--caption"
+        style="color: #6b7280; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Ubuntu, sans-serif; font-size: 13px; line-height: 20px; padding-bottom: 16px;"
+      >
+        Choose which notifications you receive and how emails are grouped in this project.
+        <a
+          href="{{notificationPreferencesUrl}}"
+          style="color: #1a1a2e; text-decoration: underline; font-weight: 500;"
+        >Manage notification preferences</a>
+      </td>
+      <td class="st-Spacer st-Spacer--gutter" width="64"></td>
+    </tr>
+  </tbody>
+</table>
+{{else}}
+{{> InfoBlock info="Go to OneUptime Dashboard > More > User Settings > Notification Settings to choose which notification emails you receive."}}
+{{/if}}

--- a/App/FeatureSet/Notification/Templates/ProbeOwnerAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/ProbeOwnerAdded.hbs
@@ -23,6 +23,8 @@
 
 {{> InfoBlock info="You will be notified when the status of this probe changes."}}
 
+{{> UnsubscribeOwnerEmail this }}
+
 {{> Footer this }}
 
 {{> End this}}

--- a/App/FeatureSet/Notification/Templates/ScheduledMaintenanceOwnerAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/ScheduledMaintenanceOwnerAdded.hbs
@@ -24,6 +24,8 @@
 
 {{> InfoBlock info="You will be notified when the status of this scheduled maintenance changes."}}
 
+{{> UnsubscribeOwnerEmail this }}
+
 {{> Footer this }}
 
 {{> End this}}

--- a/App/FeatureSet/Notification/Templates/StatusPageOwnerAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/StatusPageOwnerAdded.hbs
@@ -23,8 +23,7 @@
 
 {{> InfoBlock info="You will be notified when new announcements are posted on the status page."}}
 
-{{> TitleBlock title="How do I unsubscribe from this email?"}}
-{{> InfoBlock info="You can go to OneUptime Dashboard > More > User Settings > Notification Settings to unsubscribe from this email."}}
+{{> UnsubscribeOwnerEmail this }}
 
 
 {{> Footer this }}

--- a/App/Tests/Notification/OwnerNotificationPreferencesTemplate.test.ts
+++ b/App/Tests/Notification/OwnerNotificationPreferencesTemplate.test.ts
@@ -1,0 +1,190 @@
+import Handlebars from "handlebars";
+import fs from "fs";
+import Path from "path";
+import EmailTemplateType from "Common/Types/Email/EmailTemplateType";
+import { beforeAll, describe, expect, test } from "@jest/globals";
+
+const TEMPLATES_DIR: string = Path.resolve(
+  __dirname,
+  "../../FeatureSet/Notification/Templates",
+);
+const handlebars: typeof Handlebars = Handlebars.create();
+const PREFERENCES_URL: string =
+  "https://oneuptime.example.com/dashboard/11111111-1111-4111-8111-111111111111/user-settings/notification-settings";
+const FALLBACK: string =
+  "Dashboard > More > User Settings > Notification Settings";
+
+function readTemplate(name: string): string {
+  return fs.readFileSync(Path.join(TEMPLATES_DIR, name), "utf8");
+}
+
+function render(name: string, vars: Record<string, string> = {}): string {
+  return handlebars.compile(readTemplate(name))({
+    homeURL: "https://oneuptime.example.com",
+    year: "2026",
+    incidentTitle: "Checkout unavailable",
+    alertTitle: "High latency",
+    statusPageName: "Customer status",
+    statusPageViewLink:
+      "https://oneuptime.example.com/dashboard/project/status-pages/page",
+    unsubscribeUrl: "https://status.example.com/manage-subscription/recipient",
+    ...vars,
+  });
+}
+
+const ownerTemplates: Array<EmailTemplateType> = [
+  EmailTemplateType.AIAgentOwnerAdded,
+  EmailTemplateType.ProbeOwnerAdded,
+  EmailTemplateType.MonitorOwnerAdded,
+  EmailTemplateType.IncidentOwnerAdded,
+  EmailTemplateType.IncidentMemberAdded,
+  EmailTemplateType.AlertOwnerAdded,
+  EmailTemplateType.AlertEpisodeOwnerAdded,
+  EmailTemplateType.IncidentEpisodeOwnerAdded,
+  EmailTemplateType.ScheduledMaintenanceOwnerAdded,
+  EmailTemplateType.AIAgentConnectionStatusChange,
+  EmailTemplateType.AlertEpisodeOwnerAlertAdded,
+  EmailTemplateType.AlertEpisodeOwnerNotePosted,
+  EmailTemplateType.AlertEpisodeOwnerResourceCreated,
+  EmailTemplateType.AlertEpisodeOwnerStateChanged,
+  EmailTemplateType.AlertOwnerNotePosted,
+  EmailTemplateType.AlertOwnerResourceCreated,
+  EmailTemplateType.AlertOwnerStateChanged,
+  EmailTemplateType.AlertOwnerUnresolvedReminder,
+  EmailTemplateType.IncidentEpisodeOwnerIncidentAdded,
+  EmailTemplateType.IncidentEpisodeOwnerNotePosted,
+  EmailTemplateType.IncidentEpisodeOwnerResourceCreated,
+  EmailTemplateType.IncidentEpisodeOwnerStateChanged,
+  EmailTemplateType.IncidentOwnerNotePosted,
+  EmailTemplateType.IncidentOwnerResourceCreated,
+  EmailTemplateType.IncidentOwnerStateChanged,
+  EmailTemplateType.IncidentOwnerUnresolvedReminder,
+  EmailTemplateType.MonitorOwnerResourceCreated,
+  EmailTemplateType.MonitorOwnerStatusChanged,
+  EmailTemplateType.MonitorProbesStatus,
+  EmailTemplateType.ProbeConnectionStatusChange,
+  EmailTemplateType.ScheduledMaintenanceOwnerNotePosted,
+  EmailTemplateType.ScheduledMaintenanceOwnerResourceCreated,
+  EmailTemplateType.ScheduledMaintenanceOwnerStateChanged,
+  EmailTemplateType.ScheduledMaintenanceOwnerUnresolvedReminder,
+  EmailTemplateType.SloOwnerStatusChanged,
+  EmailTemplateType.StatusPageOwnerAdded,
+  EmailTemplateType.StatusPageOwnerAnnouncementPosted,
+  EmailTemplateType.StatusPageOwnerResourceCreated,
+  EmailTemplateType.UserAddedToOnCallPolicy,
+  EmailTemplateType.UserCurrentlyOnOnCallRoster,
+  EmailTemplateType.UserNextOnOnCallRoster,
+  EmailTemplateType.UserNoLongerActiveOnOnCallRoster,
+  EmailTemplateType.UserOnCallShiftReassigned,
+  EmailTemplateType.UserOnCallShiftReminder,
+  EmailTemplateType.UserRemovedFromOnCallPolicy,
+];
+
+beforeAll(() => {
+  const partialsDir: string = Path.join(TEMPLATES_DIR, "Partials");
+  for (const name of fs.readdirSync(partialsDir)) {
+    if (name.endsWith(".hbs")) {
+      handlebars.registerPartial(
+        name.slice(0, -4),
+        fs.readFileSync(Path.join(partialsDir, name), "utf8"),
+      );
+    }
+  }
+
+  handlebars.registerHelper(
+    "concat",
+    (first: string, second: string): string => {
+      return first + second;
+    },
+  );
+  handlebars.registerHelper(
+    "ifCond",
+    function (
+      this: unknown,
+      first: unknown,
+      second: unknown,
+      options: Handlebars.HelperOptions,
+    ): string {
+      return first === second ? options.fn(this) : options.inverse(this);
+    },
+  );
+  handlebars.registerHelper(
+    "ifNotCond",
+    function (
+      this: unknown,
+      first: unknown,
+      second: unknown,
+      options: Handlebars.HelperOptions,
+    ): string {
+      return first !== second ? options.fn(this) : options.inverse(this);
+    },
+  );
+});
+
+describe("owner notification preferences footer", () => {
+  test.each(ownerTemplates)(
+    "%s has one direct preferences link",
+    (name: string) => {
+      const html: string = render(name, {
+        notificationPreferencesUrl: PREFERENCES_URL,
+      });
+
+      expect(html).toContain(`href="${PREFERENCES_URL}"`);
+      expect(html.match(/Manage notification preferences/g)).toHaveLength(1);
+      expect(html).toContain(
+        "Choose which notifications you receive and how emails are grouped in this project.",
+      );
+      expect(html).not.toContain(FALLBACK);
+    },
+  );
+
+  test.each<Record<string, string>>([{}, { notificationPreferencesUrl: "" }])(
+    "keeps useful directions when no URL is provided: %j",
+    (vars: Record<string, string>) => {
+      const html: string = render("Partials/UnsubscribeOwnerEmail.hbs", vars);
+
+      expect(html).toContain(FALLBACK);
+      expect(html).toContain("choose which notification emails you receive");
+      expect(html).not.toContain("href=");
+      expect(html).not.toContain("Manage notification preferences");
+    },
+  );
+
+  test("escapes the URL once inside a quoted href", () => {
+    const url: string = `${PREFERENCES_URL}?source=email&label="preferences"`;
+    const html: string = render("Partials/UnsubscribeOwnerEmail.hbs", {
+      notificationPreferencesUrl: url,
+    });
+
+    expect(html).toContain(`href="${Handlebars.escapeExpression(url)}"`);
+    expect(html).not.toContain(`href="${url}"`);
+    expect(html).not.toContain("&amp;quot;");
+  });
+
+  test.each([
+    EmailTemplateType.AcknowledgeIncident,
+    EmailTemplateType.AcknowledgeAlert,
+    EmailTemplateType.AcknowledgeIncidentEpisode,
+    EmailTemplateType.AcknowledgeAlertEpisode,
+    EmailTemplateType.VerificationCode,
+    EmailTemplateType.ForgotPassword,
+    EmailTemplateType.PasswordChanged,
+    EmailTemplateType.Invoice,
+    EmailTemplateType.ProjectSubscriptionOverdue,
+    EmailTemplateType.SubscriberIncidentCreated,
+    EmailTemplateType.SubscribedToStatusPage,
+    EmailTemplateType.ConfirmStatusPageSubscription,
+    EmailTemplateType.NotificationRollup,
+  ])(
+    "does not alter the separate settings or actions in %s",
+    (name: EmailTemplateType) => {
+      const original: string = render(name);
+      const withOwnerPreferences: string = render(name, {
+        notificationPreferencesUrl: PREFERENCES_URL,
+      });
+
+      expect(withOwnerPreferences).toBe(original);
+      expect(withOwnerPreferences).not.toContain(PREFERENCES_URL);
+    },
+  );
+});

--- a/Common/Server/API/UserNotificationSettingAPI.ts
+++ b/Common/Server/API/UserNotificationSettingAPI.ts
@@ -1,0 +1,55 @@
+import BaseAPI from "./BaseAPI";
+import CommonAPI from "./CommonAPI";
+import UserMiddleware from "../Middleware/UserAuthorization";
+import RoutineEmailSettingsService from "../Services/RoutineEmailSettingsService";
+import UserNotificationSettingService, {
+  Service as UserNotificationSettingServiceType,
+} from "../Services/UserNotificationSettingService";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../Utils/Express";
+import Response from "../Utils/Response";
+import UserNotificationSetting from "../../Models/DatabaseModels/UserNotificationSetting";
+import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import { ROUTINE_EMAIL_EVENT_TYPES } from "../../Types/NotificationSetting/RoutineEmailEvents";
+import ObjectID from "../../Types/ObjectID";
+
+export default class UserNotificationSettingAPI extends BaseAPI<
+  UserNotificationSetting,
+  UserNotificationSettingServiceType
+> {
+  public constructor() {
+    super(UserNotificationSetting, UserNotificationSettingService);
+
+    this.router.post(
+      "/user-notification-setting/reduce-routine-emails",
+      UserMiddleware.getUserMiddleware,
+      async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+        try {
+          const props: DatabaseCommonInteractionProps =
+            await CommonAPI.getDatabaseCommonInteractionProps(req);
+          const projectId: ObjectID =
+            CommonAPI.assertAuthenticatedProjectMember(props);
+
+          /*
+           * The model grants CurrentUser access. A member may change their own
+           * settings, regardless of role, and may never select another user.
+           */
+          await RoutineEmailSettingsService.reduceRoutineEmails({
+            userId: props.userId!,
+            projectId: projectId,
+          });
+
+          return Response.sendJsonObjectResponse(req, res, {
+            success: true,
+            routineEventTypeCount: ROUTINE_EMAIL_EVENT_TYPES.length,
+          });
+        } catch (err) {
+          next(err);
+        }
+      },
+    );
+  }
+}

--- a/Common/Server/Services/RoutineEmailSettingsService.ts
+++ b/Common/Server/Services/RoutineEmailSettingsService.ts
@@ -1,0 +1,73 @@
+import DatabaseService, { EntityManager } from "./DatabaseService";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import UserNotificationSetting from "../../Models/DatabaseModels/UserNotificationSetting";
+import { ROUTINE_EMAIL_EVENT_TYPES } from "../../Types/NotificationSetting/RoutineEmailEvents";
+import ObjectID from "../../Types/ObjectID";
+
+export class Service extends DatabaseService<UserNotificationSetting> {
+  public constructor() {
+    super(UserNotificationSetting);
+  }
+
+  /*
+   * The API authorizes the authenticated user's own settings before calling
+   * this method. Every statement remains scoped to that user and project.
+   */
+  @CaptureSpan()
+  public async reduceRoutineEmails(data: {
+    userId: ObjectID;
+    projectId: ObjectID;
+  }): Promise<void> {
+    await this.executeTransaction(async (manager: EntityManager) => {
+      /*
+       * There is no unique constraint on (user, project, event). Serializing
+       * preset requests also protects the missing-row insert on a double click.
+       */
+      await manager.query(
+        "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+        [
+          `routine-email-settings:${data.projectId.toString()}:${data.userId.toString()}`,
+        ],
+      );
+
+      const parameters: [string, string, ReadonlyArray<string>] = [
+        data.userId.toString(),
+        data.projectId.toString(),
+        ROUTINE_EMAIL_EVENT_TYPES,
+      ];
+
+      /*
+       * Update every matching row, including historical duplicates. Changing
+       * only email avoids overwriting another channel edited concurrently.
+       */
+      await manager.query(
+        `UPDATE "UserNotificationSetting"
+         SET "alertByEmail" = false, "updatedAt" = now(), "version" = "version" + 1
+         WHERE "userId" = $1 AND "projectId" = $2
+           AND "eventType" = ANY($3::text[])
+           AND "deletedAt" IS NULL AND "alertByEmail" = true`,
+        parameters,
+      );
+
+      /*
+       * Persist an explicit opt-out for missing events so later default
+       * seeding sees the user's choice. Other channels keep their false defaults.
+       */
+      await manager.query(
+        `INSERT INTO "UserNotificationSetting"
+           ("userId", "projectId", "eventType", "alertByEmail", "createdByUserId", "version")
+         SELECT $1::uuid, $2::uuid, event."eventType", false, $1::uuid, 1
+         FROM unnest($3::text[]) AS event("eventType")
+         WHERE NOT EXISTS (
+           SELECT 1 FROM "UserNotificationSetting" setting
+           WHERE setting."userId" = $1 AND setting."projectId" = $2
+             AND setting."eventType" = event."eventType"
+             AND setting."deletedAt" IS NULL
+         )`,
+        parameters,
+      );
+    });
+  }
+}
+
+export default new Service();

--- a/Common/Server/Services/UserNotificationSettingService.ts
+++ b/Common/Server/Services/UserNotificationSettingService.ts
@@ -53,6 +53,8 @@ import {
 import EmailRollupWriter from "../Utils/EmailRollup/EmailRollupWriter";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import { appendRecipientToWhatsAppMessage } from "../Utils/WhatsAppTemplateUtil";
+import DatabaseConfig from "../DatabaseConfig";
+import URL from "../../Types/API/URL";
 
 export class Service extends DatabaseService<UserNotificationSetting> {
   public constructor() {
@@ -149,18 +151,44 @@ export class Service extends DatabaseService<UserNotificationSetting> {
           },
         });
 
+        const emailEnvelope: EmailEnvelope = {
+          ...data.emailEnvelope,
+          vars: { ...data.emailEnvelope.vars },
+        };
+
+        if (userEmails.length > 0) {
+          try {
+            const dashboardUrl: URL = await DatabaseConfig.getDashboardUrl();
+            /*
+             * Keep this out of the producer's envelope and the other channels.
+             * A *Link variable would be mistaken for a resource by the rollup writer.
+             */
+            emailEnvelope.vars["notificationPreferencesUrl"] = URL.fromString(
+              dashboardUrl.toString(),
+            )
+              .addRoute(
+                `/${data.projectId.toString()}/user-settings/notification-settings`,
+              )
+              .toString();
+          } catch (err) {
+            // The footer retains navigation instructions if a URL is unavailable.
+            logger.error(err);
+          }
+        }
+
         for (const userEmail of userEmails) {
           /*
            * The one seam where an owner email can be held back. Below the
-           * burst threshold this is byte-for-byte the send that was here
-           * before - same envelope, same correlation ids, still
-           * fire-and-forget inside the writer - and above it the message is
+           * burst threshold the email is sent immediately with its original
+           * subject, template and correlation ids, plus the preferences URL
+           * above. Delivery is fire-and-forget inside the writer; above the
+           * threshold the message is
            * queued for a rollup instead of dropped. Awaited, unlike the raw
            * send it replaces, because the queue row has to exist before this
            * method returns; the writer itself never awaits MailService.
            *
-           * data.emailEnvelope is passed by reference and is never mutated by
-           * the writer, which the Telegram fallback below and the Slack /
+           * The email-only envelope copy is never mutated by the writer.
+           * The original remains unchanged, which the Telegram fallback and Slack /
            * Microsoft Teams bodies further down depend on: all three
            * synthesise their message from data.emailEnvelope.subject.
            *
@@ -177,7 +205,7 @@ export class Service extends DatabaseService<UserNotificationSetting> {
               userId: data.userId,
               toEmail: userEmail.email!,
               eventType: data.eventType,
-              emailEnvelope: data.emailEnvelope,
+              emailEnvelope: emailEnvelope,
               mailOptions: {
                 projectId: data.projectId,
                 incidentId: data.incidentId,

--- a/Common/Server/Utils/EmailRollup/EmailRollupFlushRunner.ts
+++ b/Common/Server/Utils/EmailRollup/EmailRollupFlushRunner.ts
@@ -5,6 +5,7 @@ import ProjectService from "../../Services/ProjectService";
 import UserEmailService from "../../Services/UserEmailService";
 import UserNotificationEmailRollupBatchService from "../../Services/UserNotificationEmailRollupBatchService";
 import UserNotificationEmailRollupItemService from "../../Services/UserNotificationEmailRollupItemService";
+import UserNotificationSettingService from "../../Services/UserNotificationSettingService";
 import QueryHelper from "../../Types/Database/QueryHelper";
 import PostgresErrorTranslator from "../Database/PostgresErrorTranslator";
 import logger from "../Logger";
@@ -29,6 +30,7 @@ import UserNotificationEmailRollupBatch, {
   RollupBatchStatus,
 } from "../../../Models/DatabaseModels/UserNotificationEmailRollupBatch";
 import UserNotificationEmailRollupItem from "../../../Models/DatabaseModels/UserNotificationEmailRollupItem";
+import UserNotificationSetting from "../../../Models/DatabaseModels/UserNotificationSetting";
 import URL from "../../../Types/API/URL";
 import SortOrder from "../../../Types/BaseDatabase/SortOrder";
 import ColumnLength from "../../../Types/Database/ColumnLength";
@@ -37,6 +39,7 @@ import PartialEntity from "../../../Types/Database/PartialEntity";
 import OneUptimeDate from "../../../Types/Date";
 import Email from "../../../Types/Email";
 import EmailTemplateType from "../../../Types/Email/EmailTemplateType";
+import NotificationSettingEventType from "../../../Types/NotificationSetting/NotificationSettingEventType";
 import ObjectID from "../../../Types/ObjectID";
 import PositiveNumber from "../../../Types/PositiveNumber";
 import Text from "../../../Types/Text";
@@ -52,8 +55,9 @@ import Text from "../../../Types/Text";
  * WHAT ONE TICK DOES. Find every rollup item that is still pending and old
  * enough to be due, group them by (project, user, address), and for each such
  * bucket send ONE email carrying everything still pending for that address -
- * across every category. Nothing is suppressed and nothing is summarised
- * away; the recipient gets the same information in one message instead of N.
+ * across every category, excluding events the user has since unsubscribed
+ * from. The recipient gets their subscribed updates in one message instead
+ * of N.
  *
  * THE EXACTLY-ONCE ARGUMENT, IN THE ORDER THE LAYERS ACTUALLY MATTER.
  *
@@ -550,6 +554,38 @@ export default class EmailRollupFlushRunner {
       return RollupFlushOutcome.Empty;
     }
 
+    /*
+     * Read current preferences before consuming any queued items. A user may
+     * have turned an event's email off, or removed its setting, while this
+     * batch was waiting. Both mean no email, just as they do on the immediate
+     * send path. If this lookup fails, the items stay pending so a later epoch
+     * can retry instead of discarding them or mailing against unknown choices.
+     */
+    const settings: Array<UserNotificationSetting> =
+      await UserNotificationSettingService.findBy({
+        query: {
+          projectId: bucket.projectId,
+          userId: bucket.userId,
+          alertByEmail: true,
+        },
+        select: {
+          eventType: true,
+        },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+    const enabledEventTypes: Set<NotificationSettingEventType> =
+      new Set<NotificationSettingEventType>();
+
+    for (const setting of settings) {
+      if (setting.eventType) {
+        enabledEventTypes.add(setting.eventType);
+      }
+    }
+
     const stamped: number =
       await UserNotificationEmailRollupItemService.updateBy({
         query: {
@@ -591,7 +627,7 @@ export default class EmailRollupFlushRunner {
      * READ BACK BY BATCH, never by "still pending for this bucket": this is
      * what guarantees the email describes exactly the rows this attempt owns.
      */
-    const items: Array<UserNotificationEmailRollupItem> =
+    const claimedItems: Array<UserNotificationEmailRollupItem> =
       await UserNotificationEmailRollupItemService.findBy({
         query: {
           rollupBatchId: batchId,
@@ -613,7 +649,7 @@ export default class EmailRollupFlushRunner {
         },
       });
 
-    if (items.length === 0) {
+    if (claimedItems.length === 0) {
       await EmailRollupFlushRunner.finish({
         batchId: batchId,
         status: RollupBatchStatus.Empty,
@@ -621,6 +657,23 @@ export default class EmailRollupFlushRunner {
         now: now,
       });
       return RollupFlushOutcome.Empty;
+    }
+
+    const items: Array<UserNotificationEmailRollupItem> = claimedItems.filter(
+      (item: UserNotificationEmailRollupItem): boolean => {
+        return Boolean(item.eventType && enabledEventTypes.has(item.eventType));
+      },
+    );
+
+    if (items.length === 0) {
+      await EmailRollupFlushRunner.finish({
+        batchId: batchId,
+        status: RollupBatchStatus.Skipped,
+        itemCount: 0,
+        now: now,
+        message: "email notifications are no longer enabled for these events",
+      });
+      return RollupFlushOutcome.Skipped;
     }
 
     /*

--- a/Common/Tests/App/Dashboard/NotificationEmailPreferences.test.tsx
+++ b/Common/Tests/App/Dashboard/NotificationEmailPreferences.test.tsx
@@ -1,0 +1,399 @@
+import "@testing-library/jest-dom";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import React from "react";
+import NotificationSettings from "../../../../App/FeatureSet/Dashboard/src/Pages/UserSettings/NotificationSettings";
+import EmailNoiseCard from "../../../../App/FeatureSet/Dashboard/src/Components/NotificationMethods/EmailNoiseCard";
+import UserNotificationSetting from "../../../Models/DatabaseModels/UserNotificationSetting";
+import UserNotificationEmailRollupSetting from "../../../Models/DatabaseModels/UserNotificationEmailRollupSetting";
+import Route from "../../../Types/API/Route";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import Query from "../../../Types/BaseDatabase/Query";
+import NotificationSettingEventType from "../../../Types/NotificationSetting/NotificationSettingEventType";
+import { ROUTINE_EMAIL_EVENT_TYPES } from "../../../Types/NotificationSetting/RoutineEmailEvents";
+import ObjectID from "../../../Types/ObjectID";
+import API from "../../../UI/Utils/API/API";
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "../../../UI/Utils/Project";
+import User from "../../../UI/Utils/User";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const USER_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+
+describe("notification email preferences", () => {
+  let rows: Array<UserNotificationSetting>;
+  let post: jest.SpyInstance;
+  let getList: jest.SpyInstance;
+
+  beforeEach(() => {
+    rows = Object.values(NotificationSettingEventType).map(
+      (
+        eventType: NotificationSettingEventType,
+        index: number,
+      ): UserNotificationSetting => {
+        const row: UserNotificationSetting = new UserNotificationSetting();
+        row._id = `33333333-3333-4333-8333-${String(index).padStart(12, "0")}`;
+        row.projectId = PROJECT_ID;
+        row.userId = USER_ID;
+        row.eventType = eventType;
+        row.alertByEmail = true;
+        row.alertBySMS = true;
+        return row;
+      },
+    );
+    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(PROJECT_ID);
+    jest.spyOn(User, "getUserId").mockReturnValue(USER_ID);
+    jest
+      .spyOn(ModelAPI, "getCommonHeaders")
+      .mockReturnValue({ tenantid: PROJECT_ID.toString() });
+    jest
+      .spyOn(API, "getFriendlyMessage")
+      .mockImplementation((err: unknown): string => {
+        return err instanceof Error || err instanceof HTTPErrorResponse
+          ? err.message
+          : "Request failed";
+      });
+    getList = jest
+      .spyOn(ModelAPI, "getList")
+      .mockImplementation(
+        async (data: Parameters<typeof ModelAPI.getList>[0]): Promise<any> => {
+          if (data.modelType === UserNotificationEmailRollupSetting) {
+            return { data: [], count: 0 };
+          }
+          const query: Query<UserNotificationSetting> = data.query;
+          const eventTypes: Array<string> = (query.eventType as Includes)
+            .values as Array<string>;
+          const settings: Array<UserNotificationSetting> = rows.filter(
+            (row: UserNotificationSetting): boolean => {
+              return (
+                eventTypes.includes(row.eventType!) &&
+                row.projectId?.toString() ===
+                  (query.projectId as ObjectID).toString() &&
+                row.userId?.toString() === (query.userId as ObjectID).toString()
+              );
+            },
+          );
+          return {
+            data: settings,
+            count: settings.length,
+          };
+        },
+      );
+    post = jest
+      .spyOn(API, "post")
+      .mockImplementation(async (): Promise<any> => {
+        rows = rows.map(
+          (row: UserNotificationSetting): UserNotificationSetting => {
+            const copy: UserNotificationSetting = Object.assign(
+              new UserNotificationSetting(),
+              row,
+            );
+            if (ROUTINE_EMAIL_EVENT_TYPES.includes(copy.eventType!)) {
+              copy.alertByEmail = false;
+            }
+            return copy;
+          },
+        );
+        return new HTTPResponse(200, { success: true }, {});
+      });
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  function renderPage(): void {
+    render(
+      <NotificationSettings
+        pageRoute={new Route("/user-settings/notification-settings")}
+        currentProject={null}
+        hasPaymentMethod={true}
+      />,
+    );
+  }
+
+  async function findEventRow(label: string): Promise<HTMLElement> {
+    return (await screen.findByText(label)).closest("tr")!;
+  }
+
+  test("offers reduction without changing preferences on page load", async () => {
+    renderPage();
+    await findEventRow("Incident created");
+    expect(
+      screen.getByRole("button", { name: "Reduce routine emails" }),
+    ).toBeEnabled();
+    expect(screen.getByText(/Applies to you in this project/)).toBeVisible();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  test("reloads preferences and clears the old success message when switching projects", async () => {
+    const { rerender } = render(
+      <NotificationSettings
+        pageRoute={new Route("/user-settings/notification-settings")}
+        currentProject={null}
+        hasPaymentMethod={true}
+      />,
+    );
+    await findEventRow("Incident created");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reduce routine emails" }),
+    );
+    await screen.findByRole("status");
+    const otherProjectId: ObjectID = new ObjectID(
+      "44444444-4444-4444-8444-444444444444",
+    );
+    jest
+      .spyOn(ProjectUtil, "getCurrentProjectId")
+      .mockReturnValue(otherProjectId);
+    getList.mockClear();
+    rerender(
+      <NotificationSettings
+        pageRoute={new Route("/user-settings/notification-settings")}
+        currentProject={null}
+        hasPaymentMethod={true}
+      />,
+    );
+    const row: HTMLElement = await findEventRow("Incident created");
+    expect(
+      within(row).getByRole("switch", { name: /^Email:/ }),
+    ).toHaveAttribute("aria-checked", "false");
+    expect(
+      screen.queryByText(
+        "Routine emails turned off. Review or change individual preferences below.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(getList.mock.calls.length).toBeGreaterThan(0);
+    for (const call of getList.mock.calls) {
+      expect(call[0].query.projectId).toEqual(otherProjectId);
+      expect(call[0].query.userId).toEqual(USER_ID);
+    }
+  });
+
+  test("applies once, refreshes visible settings, and preserves urgent emails and SMS", async () => {
+    renderPage();
+    const before: HTMLElement = await findEventRow("Incident note posted");
+    expect(
+      within(before).getByRole("switch", { name: /^Email:/ }),
+    ).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reduce routine emails" }),
+    );
+    await screen.findByRole("status");
+    await waitFor(() => {
+      const after: HTMLElement = screen
+        .getByText("Incident note posted")
+        .closest("tr")!;
+      expect(
+        within(after).getByRole("switch", { name: /^Email:/ }),
+      ).toHaveAttribute("aria-checked", "false");
+      expect(
+        within(after).getByRole("switch", { name: /^SMS:/ }),
+      ).toHaveAttribute("aria-checked", "true");
+    });
+    const urgent: HTMLElement = await findEventRow("Incident created");
+    expect(
+      within(urgent).getByRole("switch", { name: /^Email:/ }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post.mock.calls[0][0].url.toString()).toContain(
+      "/user-notification-setting/reduce-routine-emails",
+    );
+    expect(post.mock.calls[0][0].data).toEqual({});
+    expect(post.mock.calls[0][0].headers).toEqual({
+      tenantid: PROJECT_ID.toString(),
+    });
+  });
+
+  test("does not reenable an urgent email the user had already disabled", async () => {
+    rows.find((row: UserNotificationSetting): boolean => {
+      return (
+        row.eventType ===
+        NotificationSettingEventType.SEND_INCIDENT_CREATED_OWNER_NOTIFICATION
+      );
+    })!.alertByEmail = false;
+    renderPage();
+    await findEventRow("Incident created");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reduce routine emails" }),
+    );
+    await screen.findByRole("status");
+    const urgent: HTMLElement = await findEventRow("Incident created");
+    expect(
+      within(urgent).getByRole("switch", { name: /^Email:/ }),
+    ).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("disables repeated submission and channel edits while the action is pending", async () => {
+    let resolveRequest!: (response: HTTPResponse<any>) => void;
+    post.mockReturnValue(
+      new Promise<HTTPResponse<any>>(
+        (resolve: (response: HTTPResponse<any>) => void): void => {
+          resolveRequest = resolve;
+        },
+      ),
+    );
+    renderPage();
+    const row: HTMLElement = await findEventRow("Incident note posted");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reduce routine emails" }),
+    );
+    const saving: HTMLElement = screen.getByRole("button", {
+      name: "Saving email preferences…",
+    });
+    expect(saving).toBeDisabled();
+    fireEvent.click(saving);
+    expect(within(row).getByRole("switch", { name: /^Email:/ })).toBeDisabled();
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    await act(async () => {
+      resolveRequest(new HTTPResponse(200, { success: true }, {}));
+    });
+    await screen.findByRole("status");
+  });
+
+  test("waits for an earlier individual save before allowing the routine preset", async () => {
+    rows.find((row: UserNotificationSetting): boolean => {
+      return (
+        row.eventType ===
+        NotificationSettingEventType.SEND_INCIDENT_NOTE_POSTED_OWNER_NOTIFICATION
+      );
+    })!.alertByEmail = false;
+    let finishSave!: (response: HTTPResponse<any>) => void;
+    const save: jest.SpyInstance = jest
+      .spyOn(ModelAPI, "updateById")
+      .mockReturnValue(
+        new Promise<HTTPResponse<any>>(
+          (resolve: (response: HTTPResponse<any>) => void): void => {
+            finishSave = resolve;
+          },
+        ),
+      );
+    renderPage();
+    const row: HTMLElement = await findEventRow("Incident note posted");
+    fireEvent.click(within(row).getByRole("switch", { name: /^Email:/ }));
+    expect(save).toHaveBeenCalledTimes(1);
+    const reduce: HTMLElement = screen.getByRole("button", {
+      name: "Reduce routine emails",
+    });
+    expect(reduce).toBeDisabled();
+    fireEvent.click(reduce);
+    expect(post).not.toHaveBeenCalled();
+    await act(async () => {
+      finishSave(new HTTPResponse(200, {}, {}));
+    });
+    await waitFor(() => {
+      expect(reduce).toBeEnabled();
+    });
+    fireEvent.click(reduce);
+    await screen.findByRole("status");
+    const updated: HTMLElement = await findEventRow("Incident note posted");
+    expect(
+      within(updated).getByRole("switch", { name: /^Email:/ }),
+    ).toHaveAttribute("aria-checked", "false");
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["resolved HTTP error", "network rejection"])(
+    "shows %s, keeps settings, and allows retry",
+    async (kind: string) => {
+      if (kind === "resolved HTTP error") {
+        post.mockResolvedValueOnce(
+          new HTTPErrorResponse(
+            503,
+            { message: "Preferences could not be saved" },
+            {},
+          ),
+        );
+      } else {
+        post.mockRejectedValueOnce(new Error("Preferences could not be saved"));
+      }
+      renderPage();
+      await findEventRow("Incident note posted");
+      const readsBefore: number = getList.mock.calls.length;
+      fireEvent.click(
+        screen.getByRole("button", { name: "Reduce routine emails" }),
+      );
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        "Preferences could not be saved",
+      );
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      expect(getList).toHaveBeenCalledTimes(readsBefore);
+      const row: HTMLElement = await findEventRow("Incident note posted");
+      expect(
+        within(row).getByRole("switch", { name: /^Email:/ }),
+      ).toHaveAttribute("aria-checked", "true");
+      fireEvent.click(
+        screen.getByRole("button", { name: "Reduce routine emails" }),
+      );
+      await screen.findByRole("status");
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    },
+  );
+
+  test("every event has one reachable preference and reads are scoped to the current member", async () => {
+    renderPage();
+    await findEventRow("Assigned to an incident");
+    for (const tabName of [
+      "Alerts",
+      "Monitoring",
+      "Status Pages",
+      "Scheduled Maintenance",
+      "On-Call",
+    ]) {
+      fireEvent.click(screen.getByRole("tab", { name: tabName }));
+      await waitFor(() => {
+        expect(screen.getAllByRole("switch").length).toBeGreaterThan(1);
+      });
+      if (tabName === "Monitoring") {
+        await screen.findByText("AI agent status changed");
+        await screen.findByText("Added as AI agent owner");
+      }
+    }
+    const eventReads: Array<any> = getList.mock.calls
+      .map((call: Array<any>): any => {
+        return call[0];
+      })
+      .filter((call: any): boolean => {
+        return call.modelType === UserNotificationSetting;
+      });
+    const queriedTypes: Array<string> = eventReads.flatMap(
+      (call: any): Array<string> => {
+        return call.query.eventType.values;
+      },
+    );
+    expect(queriedTypes.sort()).toEqual(
+      Object.values(NotificationSettingEventType).sort(),
+    );
+    for (const call of eventReads) {
+      expect(call.query.projectId).toEqual(PROJECT_ID);
+      expect(call.query.userId).toEqual(USER_ID);
+    }
+  });
+
+  test("the reduction card can be used again after an individual preference change", async () => {
+    const apply: jest.Mock = jest.fn().mockResolvedValue(undefined);
+    render(<EmailNoiseCard onApply={apply} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reduce routine emails" }),
+    );
+    await screen.findByRole("status");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reduce routine emails" }),
+    );
+    await waitFor(() => {
+      expect(apply).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/Common/Tests/Server/API/UserNotificationSettingAPI.test.ts
+++ b/Common/Tests/Server/API/UserNotificationSettingAPI.test.ts
@@ -1,0 +1,186 @@
+import { mockRouter } from "./Helpers";
+import CommonAPI from "../../../Server/API/CommonAPI";
+import UserNotificationSettingAPI from "../../../Server/API/UserNotificationSettingAPI";
+import UserMiddleware from "../../../Server/Middleware/UserAuthorization";
+import RoutineEmailSettingsService from "../../../Server/Services/RoutineEmailSettingsService";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import NotAuthorizedException from "../../../Types/Exception/NotAuthorizedException";
+import { ROUTINE_EMAIL_EVENT_TYPES } from "../../../Types/NotificationSetting/RoutineEmailEvents";
+import ObjectID from "../../../Types/ObjectID";
+import Permission from "../../../Types/Permission";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+const ROUTE: string = "/user-notification-setting/reduce-routine-emails";
+const USER_ID: ObjectID = ObjectID.generate();
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const OTHER_PROJECT_ID: ObjectID = ObjectID.generate();
+
+describe("POST reduce routine emails", () => {
+  let props: DatabaseCommonInteractionProps;
+  let reduceSpy: jest.SpyInstance;
+  let responseSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    props = {
+      userId: USER_ID,
+      tenantId: PROJECT_ID,
+      userTenantAccessPermission: {
+        [PROJECT_ID.toString()]: {
+          _type: "UserTenantAccessPermission",
+          projectId: PROJECT_ID,
+          permissions: [
+            {
+              _type: "UserPermission",
+              permission: Permission.ProjectMember,
+              labelIds: [],
+              isBlockPermission: false,
+            },
+          ],
+        },
+      },
+    };
+    jest
+      .spyOn(CommonAPI, "getDatabaseCommonInteractionProps")
+      .mockImplementation(async () => {
+        return props;
+      });
+    reduceSpy = jest
+      .spyOn(RoutineEmailSettingsService, "reduceRoutineEmails")
+      .mockResolvedValue(undefined);
+    responseSpy = jest
+      .spyOn(Response, "sendJsonObjectResponse")
+      .mockImplementation(jest.fn());
+    mockRouter.routes = [];
+    new UserNotificationSettingAPI();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  async function call(body?: unknown): Promise<jest.Mock> {
+    const next: jest.Mock = jest.fn();
+    await mockRouter
+      .match("POST", ROUTE)
+      .handlerFunction(
+        { body, headers: {} } as ExpressRequest,
+        {} as ExpressResponse,
+        next as NextFunction,
+      );
+    return next;
+  }
+
+  test("requires user middleware and retains the existing settings CRUD routes", () => {
+    expect(mockRouter.match("POST", ROUTE).middleware).toBe(
+      UserMiddleware.getUserMiddleware,
+    );
+    expect(
+      mockRouter.match("POST", "/user-notification-setting"),
+    ).toBeDefined();
+    expect(
+      mockRouter.match("POST", "/user-notification-setting/get-list"),
+    ).toBeDefined();
+  });
+
+  test("lets a project member change their own preferences and returns the covered event count", async () => {
+    const next: jest.Mock = await call();
+    expect(next).not.toHaveBeenCalled();
+    expect(reduceSpy).toHaveBeenCalledWith({
+      userId: USER_ID,
+      projectId: PROJECT_ID,
+    });
+    expect(responseSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      {
+        success: true,
+        routineEventTypeCount: ROUTINE_EMAIL_EVENT_TYPES.length,
+      },
+    );
+  });
+
+  test("ignores client-selected users, projects, channels and event lists", async () => {
+    await call({
+      userId: ObjectID.generate().toString(),
+      projectId: OTHER_PROJECT_ID.toString(),
+      tenantId: OTHER_PROJECT_ID.toString(),
+      alertByCall: false,
+      eventTypes: ["arbitrary event"],
+    });
+    expect(reduceSpy).toHaveBeenCalledTimes(1);
+    expect(reduceSpy).toHaveBeenCalledWith({
+      userId: USER_ID,
+      projectId: PROJECT_ID,
+    });
+  });
+
+  test.each(["anonymous", "project API key"])(
+    "rejects a %s without an authenticated user",
+    async () => {
+      props.userId = undefined;
+      const next: jest.Mock = await call({ userId: USER_ID.toString() });
+      expect(next).toHaveBeenCalledWith(expect.any(NotAuthorizedException));
+      expect(reduceSpy).not.toHaveBeenCalled();
+      expect(responseSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  test("rejects missing project context before changing preferences", async () => {
+    props.tenantId = undefined;
+    const next: jest.Mock = await call({ projectId: PROJECT_ID.toString() });
+    expect(next).toHaveBeenCalledWith(expect.any(BadDataException));
+    expect(reduceSpy).not.toHaveBeenCalled();
+  });
+
+  test("rejects a logged-in user without project membership", async () => {
+    props.userTenantAccessPermission = undefined;
+    const next: jest.Mock = await call();
+    expect(next).toHaveBeenCalledWith(expect.any(NotAuthorizedException));
+    expect(reduceSpy).not.toHaveBeenCalled();
+  });
+
+  test("rejects membership in a different project", async () => {
+    props.tenantId = OTHER_PROJECT_ID;
+    const next: jest.Mock = await call();
+    expect(next).toHaveBeenCalledWith(expect.any(NotAuthorizedException));
+    expect(reduceSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not report success when the transaction fails", async () => {
+    const error: Error = new Error("transaction failed");
+    reduceSpy.mockRejectedValue(error);
+    const next: jest.Mock = await call();
+    expect(next).toHaveBeenCalledWith(error);
+    expect(responseSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not report success until the entire transaction commits", async () => {
+    let resolveTransaction: (() => void) | undefined;
+    reduceSpy.mockImplementation(() => {
+      return new Promise<void>((resolve: () => void) => {
+        resolveTransaction = resolve;
+      });
+    });
+    const request: Promise<jest.Mock> = call();
+    await Promise.resolve();
+    expect(reduceSpy).toHaveBeenCalledTimes(1);
+    expect(responseSpy).not.toHaveBeenCalled();
+    resolveTransaction!();
+    await request;
+    expect(responseSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/Server/Services/RoutineEmailSettingsPostgres.test.ts
+++ b/Common/Tests/Server/Services/RoutineEmailSettingsPostgres.test.ts
@@ -1,0 +1,329 @@
+import RoutineEmailSettingsService from "../../../Server/Services/RoutineEmailSettingsService";
+import UserNotificationSettingService from "../../../Server/Services/UserNotificationSettingService";
+import PostgresAppInstance from "../../../Server/Infrastructure/PostgresDatabase";
+import Entities from "../../../Models/DatabaseModels/Index";
+import NotificationSettingEventType from "../../../Types/NotificationSetting/NotificationSettingEventType";
+import { ROUTINE_EMAIL_EVENT_TYPES } from "../../../Types/NotificationSetting/RoutineEmailEvents";
+import ObjectID from "../../../Types/ObjectID";
+import { DataSource } from "typeorm";
+
+/*
+ * Opt in with RUN_POSTGRES_NOTIFICATION_TESTS=true and the normal database
+ * credentials. Uses the local development Postgres port unless overridden by
+ * NOTIFICATION_TEST_DATABASE_HOST / NOTIFICATION_TEST_DATABASE_PORT.
+ * All writes go to a uniquely named schema; no project data is modified.
+ * Cloning the production table also verifies the statements against its actual
+ * defaults and column types rather than a hand-maintained test schema.
+ */
+const describePostgres: typeof describe =
+  process.env["RUN_POSTGRES_NOTIFICATION_TESTS"] === "true"
+    ? describe
+    : describe.skip;
+
+const USER_ID: ObjectID = ObjectID.generate();
+const OTHER_USER_ID: ObjectID = ObjectID.generate();
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const OTHER_PROJECT_ID: ObjectID = ObjectID.generate();
+const ROUTINE_EVENT: NotificationSettingEventType =
+  NotificationSettingEventType.SEND_INCIDENT_NOTE_POSTED_OWNER_NOTIFICATION;
+const CHANNELS: Array<string> = [
+  "alertBySMS",
+  "alertByCall",
+  "alertByPush",
+  "alertByWhatsApp",
+  "alertByTelegram",
+  "alertBySlack",
+  "alertByMicrosoftTeams",
+  "alertByWebhook",
+];
+
+interface StoredSetting {
+  _id: string;
+  userId: string;
+  projectId: string;
+  eventType: NotificationSettingEventType;
+  alertByEmail: boolean;
+  version: number;
+  deletedAt: Date | null;
+  [key: string]: unknown;
+}
+
+describePostgres("reduce routine emails against Postgres", () => {
+  const schema: string = `routine_email_test_${ObjectID.generate().toString().replace(/-/g, "")}`;
+  let database: DataSource;
+
+  beforeAll(async () => {
+    database = new DataSource({
+      type: "postgres",
+      host: process.env["NOTIFICATION_TEST_DATABASE_HOST"] || "localhost",
+      port: Number(process.env["NOTIFICATION_TEST_DATABASE_PORT"] || "5400"),
+      username: process.env["DATABASE_USERNAME"] || "postgres",
+      password: process.env["DATABASE_PASSWORD"] || "password",
+      database: process.env["DATABASE_NAME"] || "oneuptimedb",
+      entities: Entities,
+      schema: schema,
+      synchronize: false,
+      extra: { options: `-c search_path=${schema},public` },
+    });
+    await database.initialize();
+    await database.query(`CREATE SCHEMA "${schema}"`);
+    await database.query(
+      `CREATE TABLE "${schema}"."UserNotificationSetting" (LIKE public."UserNotificationSetting" INCLUDING ALL)`,
+    );
+    const currentSchema: Array<{ current_schema: string }> =
+      await database.query("SELECT current_schema()");
+    expect(currentSchema[0]?.current_schema).toBe(schema);
+    jest.spyOn(PostgresAppInstance, "isConnected").mockReturnValue(true);
+    jest.spyOn(PostgresAppInstance, "getDataSource").mockReturnValue(database);
+  });
+
+  beforeEach(async () => {
+    await database.query(`TRUNCATE "${schema}"."UserNotificationSetting"`);
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    if (database?.isInitialized) {
+      await database.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+      await database.destroy();
+    }
+  });
+
+  async function seed(data: {
+    eventType: NotificationSettingEventType;
+    email?: boolean;
+    userId?: ObjectID;
+    projectId?: ObjectID;
+    deleted?: boolean;
+  }): Promise<StoredSetting> {
+    const rows: Array<StoredSetting> = await database.query(
+      `INSERT INTO "UserNotificationSetting"
+       ("userId", "projectId", "eventType", "alertByEmail", "version", "deletedAt", ${CHANNELS.map(
+         (channel: string) => {
+           return `"${channel}"`;
+         },
+       ).join(", ")})
+       VALUES ($1, $2, $3, $4, 1, $5, ${CHANNELS.map(() => {
+         return "true";
+       }).join(", ")})
+       RETURNING *`,
+      [
+        (data.userId || USER_ID).toString(),
+        (data.projectId || PROJECT_ID).toString(),
+        data.eventType,
+        data.email ?? true,
+        data.deleted ? new Date() : null,
+      ],
+    );
+    return rows[0]!;
+  }
+
+  async function rows(): Promise<Array<StoredSetting>> {
+    return await database.query(
+      'SELECT * FROM "UserNotificationSetting" ORDER BY "_id"',
+    );
+  }
+
+  async function apply(): Promise<void> {
+    await RoutineEmailSettingsService.reduceRoutineEmails({
+      userId: USER_ID,
+      projectId: PROJECT_ID,
+    });
+  }
+
+  test("creates a persisted opt-out for every missing routine event", async () => {
+    await apply();
+    const settings: Array<StoredSetting> = await rows();
+    expect(settings).toHaveLength(ROUTINE_EMAIL_EVENT_TYPES.length);
+    expect(
+      new Set(
+        settings.map((setting: StoredSetting) => {
+          return setting.eventType;
+        }),
+      ),
+    ).toEqual(new Set(ROUTINE_EMAIL_EVENT_TYPES));
+    for (const setting of settings) {
+      expect(setting.userId).toBe(USER_ID.toString());
+      expect(setting.projectId).toBe(PROJECT_ID.toString());
+      expect(setting["createdByUserId"]).toBe(USER_ID.toString());
+      expect(setting.alertByEmail).toBe(false);
+      expect(setting.version).toBe(1);
+      for (const channel of CHANNELS) {
+        expect(setting[channel]).toBe(false);
+      }
+    }
+  });
+
+  test("disables only email while preserving every other channel on existing rows", async () => {
+    for (const eventType of ROUTINE_EMAIL_EVENT_TYPES) {
+      await seed({ eventType });
+    }
+    await apply();
+    const settings: Array<StoredSetting> = await rows();
+    expect(settings).toHaveLength(ROUTINE_EMAIL_EVENT_TYPES.length);
+    for (const setting of settings) {
+      expect(setting.alertByEmail).toBe(false);
+      expect(setting.version).toBe(2);
+      for (const channel of CHANNELS) {
+        expect(setting[channel]).toBe(true);
+      }
+    }
+  });
+
+  test("preserves every non-routine event, including existing opt-outs", async () => {
+    const preserved: Array<StoredSetting> = [];
+    for (const eventType of Object.values(NotificationSettingEventType)) {
+      if (!ROUTINE_EMAIL_EVENT_TYPES.includes(eventType)) {
+        preserved.push(await seed({ eventType }));
+        preserved.push(await seed({ eventType, email: false }));
+      }
+    }
+    await apply();
+    const settings: Array<StoredSetting> = await rows();
+    for (const before of preserved) {
+      expect(
+        settings.find((setting: StoredSetting) => {
+          return setting._id === before._id;
+        }),
+      ).toEqual(before);
+    }
+  });
+
+  test("does not create missing incident, alert or on-call preferences", async () => {
+    await apply();
+    for (const setting of await rows()) {
+      expect(ROUTINE_EMAIL_EVENT_TYPES).toContain(setting.eventType);
+    }
+  });
+
+  test("preserves an event introduced after this preset was defined", async () => {
+    const futureEvent: StoredSetting = await seed({
+      eventType: "Future notification event" as NotificationSettingEventType,
+    });
+    await apply();
+    expect(
+      (await rows()).find((setting: StoredSetting) => {
+        return setting._id === futureEvent._id;
+      }),
+    ).toEqual(futureEvent);
+  });
+
+  test("leaves other users and projects unchanged", async () => {
+    const preserved: Array<StoredSetting> = [
+      await seed({ eventType: ROUTINE_EVENT, userId: OTHER_USER_ID }),
+      await seed({ eventType: ROUTINE_EVENT, projectId: OTHER_PROJECT_ID }),
+      await seed({
+        eventType: ROUTINE_EVENT,
+        userId: OTHER_USER_ID,
+        projectId: OTHER_PROJECT_ID,
+      }),
+    ];
+    await apply();
+    const settings: Array<StoredSetting> = await rows();
+    for (const before of preserved) {
+      expect(
+        settings.find((setting: StoredSetting) => {
+          return setting._id === before._id;
+        }),
+      ).toEqual(before);
+    }
+  });
+
+  test("repeated requests do not create duplicates or change row versions and timestamps", async () => {
+    await seed({ eventType: ROUTINE_EVENT });
+    await apply();
+    const first: Array<StoredSetting> = await rows();
+    await apply();
+    expect(await rows()).toEqual(first);
+  });
+
+  test("later default seeding respects every persisted opt-out", async () => {
+    await apply();
+    const before: Array<StoredSetting> = await rows();
+    for (const eventType of ROUTINE_EMAIL_EVENT_TYPES) {
+      await UserNotificationSettingService.ensureSettingExistsForUser({
+        userId: USER_ID,
+        projectId: PROJECT_ID,
+        eventType: eventType,
+      });
+    }
+    expect(await rows()).toEqual(before);
+  });
+
+  test("simultaneous requests create only one live row per routine event", async () => {
+    await Promise.all(
+      Array.from({ length: 8 }, async () => {
+        return apply();
+      }),
+    );
+    const settings: Array<StoredSetting> = await rows();
+    expect(settings).toHaveLength(ROUTINE_EMAIL_EVENT_TYPES.length);
+    expect(
+      new Set(
+        settings.map((setting: StoredSetting) => {
+          return setting.eventType;
+        }),
+      ).size,
+    ).toBe(ROUTINE_EMAIL_EVENT_TYPES.length);
+    expect(
+      settings.every((setting: StoredSetting) => {
+        return setting.alertByEmail === false;
+      }),
+    ).toBe(true);
+  });
+
+  test("disables all live historical duplicates for the same event", async () => {
+    const first: StoredSetting = await seed({ eventType: ROUTINE_EVENT });
+    const second: StoredSetting = await seed({ eventType: ROUTINE_EVENT });
+    await apply();
+    const settings: Array<StoredSetting> = await rows();
+    for (const id of [first._id, second._id]) {
+      expect(
+        settings.find((setting: StoredSetting) => {
+          return setting._id === id;
+        })?.alertByEmail,
+      ).toBe(false);
+    }
+    expect(settings).toHaveLength(ROUTINE_EMAIL_EVENT_TYPES.length + 1);
+  });
+
+  test("retains deleted history and creates a new live opt-out", async () => {
+    const deleted: StoredSetting = await seed({
+      eventType: ROUTINE_EVENT,
+      deleted: true,
+    });
+    await apply();
+    const settings: Array<StoredSetting> = await rows();
+    expect(
+      settings.find((setting: StoredSetting) => {
+        return setting._id === deleted._id;
+      }),
+    ).toEqual(deleted);
+    expect(
+      settings.filter((setting: StoredSetting) => {
+        return (
+          setting.eventType === ROUTINE_EVENT && setting.deletedAt === null
+        );
+      }),
+    ).toEqual([expect.objectContaining({ alertByEmail: false })]);
+  });
+
+  test("rolls back existing changes when inserting a missing preference fails", async () => {
+    const original: StoredSetting = await seed({ eventType: ROUTINE_EVENT });
+    // A database constraint supplies a real statement failure after UPDATE.
+    await database.query(
+      'ALTER TABLE "UserNotificationSetting" ADD CONSTRAINT "fail_missing_preferences" CHECK ("eventType" = \'Send incident note posted notification when I am the owner of the incident\')',
+    );
+    try {
+      await expect(apply()).rejects.toThrow();
+      expect(await rows()).toEqual([original]);
+    } finally {
+      await database.query(
+        'ALTER TABLE "UserNotificationSetting" DROP CONSTRAINT "fail_missing_preferences"',
+      );
+    }
+    // The failed transaction also releases the advisory lock, so retry works.
+    await apply();
+    expect(await rows()).toHaveLength(ROUTINE_EMAIL_EVENT_TYPES.length);
+  });
+});

--- a/Common/Tests/Server/Services/UserNotificationSettingRollupRouting.test.ts
+++ b/Common/Tests/Server/Services/UserNotificationSettingRollupRouting.test.ts
@@ -52,6 +52,8 @@ import {
 import fs from "fs";
 import path from "path";
 import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+import DatabaseConfig from "../../../Server/DatabaseConfig";
+import URL from "../../../Types/API/URL";
 
 /*
  * sendUserNotification's email branch now runs through EmailRollupWriter
@@ -513,6 +515,145 @@ describe("UserNotificationSettingService.sendUserNotification - rollup routing",
    */
 
   describe("the email envelope", () => {
+    test.each([
+      "11111111-1111-4111-8111-111111111111",
+      "44444444-4444-4444-8444-444444444444",
+    ])(
+      "links directly to the sending project's preferences: %s",
+      async (projectId: string) => {
+        const dashboardUrl: URL = URL.fromString(
+          "https://self-hosted.example.com/dashboard",
+        );
+        jest
+          .spyOn(DatabaseConfig, "getDashboardUrl")
+          .mockResolvedValue(dashboardUrl);
+        const data: SendUserNotificationData = notificationData({
+          projectId: new ObjectID(projectId),
+        });
+        Object.freeze(data.emailEnvelope.vars);
+        Object.freeze(data.emailEnvelope);
+
+        await UserNotificationSettingService.sendUserNotification(data);
+
+        const sent: EmailEnvelope = sendMail.mock
+          .calls[0]?.[0] as EmailEnvelope;
+        expect(sent.vars["notificationPreferencesUrl"]).toBe(
+          `https://self-hosted.example.com/dashboard/${projectId}/user-settings/notification-settings`,
+        );
+        expect(sent.subject).toBe(data.emailEnvelope.subject);
+        expect(sent.templateType).toBe(data.emailEnvelope.templateType);
+        expect(sent.vars["incidentViewLink"]).toBe(
+          data.emailEnvelope.vars["incidentViewLink"],
+        );
+        expect(data.emailEnvelope.vars).not.toHaveProperty(
+          "notificationPreferencesUrl",
+        );
+        expect(dashboardUrl.toString()).toBe(
+          "https://self-hosted.example.com/dashboard",
+        );
+        expect(JSON.stringify(sendWebhook.mock.calls)).not.toContain(
+          "notificationPreferencesUrl",
+        );
+        expect(JSON.stringify(sendDm.mock.calls)).not.toContain(
+          "notificationPreferencesUrl",
+        );
+      },
+    );
+
+    test("replaces a stale preferences URL without modifying the producer's variables", async () => {
+      const data: SendUserNotificationData = notificationData();
+      data.emailEnvelope.vars["notificationPreferencesUrl"] =
+        "https://old.example.com/other-project";
+      jest
+        .spyOn(DatabaseConfig, "getDashboardUrl")
+        .mockResolvedValue(
+          URL.fromString("https://current.example.com/dashboard"),
+        );
+
+      await UserNotificationSettingService.sendUserNotification(data);
+
+      const sent: EmailEnvelope = sendMail.mock.calls[0]?.[0] as EmailEnvelope;
+      expect(sent.vars["notificationPreferencesUrl"]).toBe(
+        `https://current.example.com/dashboard/${PROJECT_ID.toString()}/user-settings/notification-settings`,
+      );
+      expect(data.emailEnvelope.vars["notificationPreferencesUrl"]).toBe(
+        "https://old.example.com/other-project",
+      );
+    });
+
+    test("does not mistake the preferences URL for the resource link in a rollup", async () => {
+      deferEveryEmail();
+      const data: SendUserNotificationData = notificationData();
+      data.emailEnvelope.vars = {};
+
+      await UserNotificationSettingService.sendUserNotification(data);
+
+      const item: UserNotificationEmailRollupItem = (
+        createItem.mock.calls[0]?.[0] as {
+          data: UserNotificationEmailRollupItem;
+        }
+      ).data;
+      expect(item.viewLink).toBeUndefined();
+      expect(sendMail).not.toHaveBeenCalled();
+    });
+
+    test("keeps every delivery channel working if the preferences URL cannot be built", async () => {
+      jest
+        .spyOn(DatabaseConfig, "getDashboardUrl")
+        .mockRejectedValue(new Error("URL unavailable"));
+
+      await UserNotificationSettingService.sendUserNotification(
+        notificationData(),
+      );
+
+      const sent: EmailEnvelope = sendMail.mock.calls[0]?.[0] as EmailEnvelope;
+      expect(sent.vars).not.toHaveProperty("notificationPreferencesUrl");
+      expect(sendMail).toHaveBeenCalledTimes(1);
+      expect(sendSms).toHaveBeenCalledTimes(1);
+      expect(makeCall).toHaveBeenCalledTimes(1);
+      expect(sendPush).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+      expect(sendDm).toHaveBeenCalledTimes(2);
+      expect(sendWebhook).toHaveBeenCalledTimes(1);
+      expect(loggerError).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not build email preferences when email is disabled", async () => {
+      findSettings.mockResolvedValue({
+        ...allChannelsOn(),
+        alertByEmail: false,
+      } as never);
+      const getDashboardUrl: jest.SpyInstance = jest.spyOn(
+        DatabaseConfig,
+        "getDashboardUrl",
+      );
+
+      await UserNotificationSettingService.sendUserNotification(
+        notificationData(),
+      );
+
+      expect(getDashboardUrl).not.toHaveBeenCalled();
+      expect(sendMail).not.toHaveBeenCalled();
+      expect(sendSms).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not build email preferences without a verified email address", async () => {
+      findEmails.mockResolvedValue([] as never);
+      const getDashboardUrl: jest.SpyInstance = jest.spyOn(
+        DatabaseConfig,
+        "getDashboardUrl",
+      );
+
+      await UserNotificationSettingService.sendUserNotification(
+        notificationData(),
+      );
+
+      expect(getDashboardUrl).not.toHaveBeenCalled();
+      expect(sendMail).not.toHaveBeenCalled();
+      expect(sendSms).toHaveBeenCalledTimes(1);
+    });
+
     test("is deep-equal before and after the call, whether the email is deferred", async () => {
       deferEveryEmail();
 

--- a/Common/Tests/Server/Services/UserNotificationSettingWorkspaceChannels.test.ts
+++ b/Common/Tests/Server/Services/UserNotificationSettingWorkspaceChannels.test.ts
@@ -6,12 +6,14 @@ import ProjectCallSMSConfigService from "../../../Server/Services/ProjectCallSMS
 import MailService from "../../../Server/Services/MailService";
 import UserEmailService from "../../../Server/Services/UserEmailService";
 import UserNotificationEmailRollupItemService from "../../../Server/Services/UserNotificationEmailRollupItemService";
+import DatabaseConfig from "../../../Server/DatabaseConfig";
 import logger from "../../../Server/Utils/Logger";
 import UserNotificationSetting from "../../../Models/DatabaseModels/UserNotificationSetting";
 import UserSlack from "../../../Models/DatabaseModels/UserSlack";
 import UserMicrosoftTeams from "../../../Models/DatabaseModels/UserMicrosoftTeams";
 import UserEmail from "../../../Models/DatabaseModels/UserEmail";
 import UserNotificationEmailRollupItem from "../../../Models/DatabaseModels/UserNotificationEmailRollupItem";
+import URL from "../../../Types/API/URL";
 import { CallRequestMessage } from "../../../Types/Call/CallRequest";
 import { EmailEnvelope } from "../../../Types/Email/EmailMessage";
 import EmailTemplateType from "../../../Types/Email/EmailTemplateType";
@@ -451,36 +453,42 @@ describe("UserNotificationSettingService.sendUserNotification - workspace channe
 
   /*
    * ----------------------------------------------------------------------- *
-   * (D) The email hand-off is unchanged by the rollup seam.
+   * (D) The email hand-off preserves content and correlation ids.
    * -----------------------------------------------------------------------
    */
 
   describe("the email hand-off", () => {
     /*
      * Owner emails now pass through EmailRollupWriter on their way to
-     * MailService. Below the burst threshold that has to be invisible, and
-     * "invisible" means these two exact arguments - not merely an email that
-     * arrives. The second argument is the correlation-id bag every downstream
-     * log line joins on, so a field silently dropped in the hand-off would
+     * MailService. Below the burst threshold the email keeps its content and
+     * gains a direct preferences link. The second argument is the correlation-id
+     * bag every downstream log line joins on, so a field silently dropped in the hand-off would
      * detach incident emails from their incident with nothing failing.
      */
-    test("MailService receives the identical envelope and correlation-id options it received before rollup existed", async () => {
+    test("MailService receives the original content and correlation ids with a direct preferences link", async () => {
       findSettings.mockResolvedValue(
         settingsRow({ alertByEmail: true }) as never,
       );
+      jest
+        .spyOn(DatabaseConfig, "getDashboardUrl")
+        .mockResolvedValue(
+          URL.fromString("https://oneuptime.example.com/dashboard"),
+        );
 
-      await UserNotificationSettingService.sendUserNotification(
-        notificationData(),
-      );
+      const data: SendUserNotificationData = notificationData();
+      await UserNotificationSettingService.sendUserNotification(data);
 
       expect(sendMail).toHaveBeenCalledTimes(1);
 
       expect(sendMail.mock.calls[0]?.[0]).toEqual({
         subject: "Incident created: Checkout is down",
         templateType: EmailTemplateType.BlankTemplate,
-        vars: {},
+        vars: {
+          notificationPreferencesUrl: `https://oneuptime.example.com/dashboard/${PROJECT_ID.toString()}/user-settings/notification-settings`,
+        },
         toEmail: "user@example.com",
       });
+      expect(data.emailEnvelope.vars).toEqual({});
 
       expect(sendMail.mock.calls[0]?.[1]).toEqual({
         projectId: PROJECT_ID,

--- a/Common/Tests/Server/Utils/EmailRollup/EmailRollupFlushRunnerBehaviour.test.ts
+++ b/Common/Tests/Server/Utils/EmailRollup/EmailRollupFlushRunnerBehaviour.test.ts
@@ -236,7 +236,7 @@ describe("EmailRollupFlushRunner - one flush", () => {
 
       await EmailRollupFlushRunner.runSweep({ now: NOW });
 
-      expect(harness.callLog).toEqual(["stamp", "send"]);
+      expect(harness.callLog).toEqual(["preferences", "stamp", "send"]);
     });
 
     test("a throwing send leaves the items stamped, so a broken mailer cannot re-spam every epoch", async () => {

--- a/Common/Tests/Server/Utils/EmailRollup/EmailRollupFlushRunnerPreferences.test.ts
+++ b/Common/Tests/Server/Utils/EmailRollup/EmailRollupFlushRunnerPreferences.test.ts
@@ -1,0 +1,362 @@
+import UserNotificationSettingService from "../../../../Server/Services/UserNotificationSettingService";
+import EmailRollupFlushRunner, {
+  RollupSweepStats,
+} from "../../../../Server/Utils/EmailRollup/EmailRollupFlushRunner";
+import { CLAIM_EPOCH_MINUTES } from "../../../../Server/Utils/EmailRollup/EmailRollupConstants";
+import { RollupBatchStatus } from "../../../../Models/DatabaseModels/UserNotificationEmailRollupBatch";
+import OneUptimeDate from "../../../../Types/Date";
+import Email from "../../../../Types/Email";
+import RollupCategory from "../../../../Types/NotificationSetting/NotificationEmailRollupCategory";
+import NotificationSettingEventType from "../../../../Types/NotificationSetting/NotificationSettingEventType";
+import ObjectID from "../../../../Types/ObjectID";
+import {
+  FakeItemRow,
+  FakeRow,
+  RollupHarness,
+  SentRollupMail,
+  emptyRollupHarness,
+  installRollupHarness,
+  pendingItems,
+  seedItem,
+  seedNotificationSetting,
+  seedProject,
+  seedVerifiedEmail,
+} from "./EmailRollupTestHarness";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const USER_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const OTHER_USER_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const TO_EMAIL: Email = new Email("owner@example.com");
+const OTHER_EMAIL: Email = new Email("second-owner@example.com");
+const NOW: Date = OneUptimeDate.fromString("2026-09-03T17:07:30.000Z");
+const CREATED_EVENT: NotificationSettingEventType =
+  NotificationSettingEventType.SEND_INCIDENT_CREATED_OWNER_NOTIFICATION;
+const STATE_CHANGED_EVENT: NotificationSettingEventType =
+  NotificationSettingEventType.SEND_INCIDENT_STATE_CHANGED_OWNER_NOTIFICATION;
+const ALERT_EVENT: NotificationSettingEventType =
+  NotificationSettingEventType.SEND_ALERT_CREATED_OWNER_NOTIFICATION;
+
+describe("EmailRollupFlushRunner - preferences changed while email is queued", () => {
+  let harness: RollupHarness;
+
+  beforeEach(() => {
+    harness = emptyRollupHarness();
+    installRollupHarness(harness);
+    seedProject(harness, { projectId: PROJECT_ID, name: "Acme" });
+    seedVerifiedEmail(harness, {
+      projectId: PROJECT_ID,
+      userId: USER_ID,
+      email: TO_EMAIL,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function seedDue(
+    data: {
+      subject?: string | undefined;
+      eventType?: NotificationSettingEventType | undefined;
+      rollupCategory?: RollupCategory | undefined;
+      projectId?: ObjectID | undefined;
+      userId?: ObjectID | undefined;
+      toEmail?: Email | undefined;
+    } = {},
+  ): FakeItemRow {
+    return seedItem(harness, {
+      projectId: data.projectId ?? PROJECT_ID,
+      userId: data.userId ?? USER_ID,
+      toEmail: data.toEmail ?? TO_EMAIL,
+      createdAt: OneUptimeDate.addRemoveMinutes(NOW, -12),
+      subject: data.subject,
+      eventType: data.eventType,
+      rollupCategory: data.rollupCategory,
+    });
+  }
+
+  function getSetting(eventType: NotificationSettingEventType): FakeRow {
+    return harness.notificationSettings.find((row: FakeRow): boolean => {
+      return (
+        row["eventType"] === eventType &&
+        String(row["projectId"]) === PROJECT_ID.toString() &&
+        String(row["userId"]) === USER_ID.toString()
+      );
+    })!;
+  }
+
+  test("a mixed batch omits muted events and reports only delivered notifications", async () => {
+    seedDue({ subject: "Checkout is down" });
+    seedDue({
+      subject: "Muted incident state change",
+      eventType: STATE_CHANGED_EVENT,
+    });
+    seedDue({
+      subject: "CPU is high",
+      eventType: ALERT_EVENT,
+      rollupCategory: RollupCategory.Alerts,
+    });
+    getSetting(STATE_CHANGED_EVENT)["alertByEmail"] = false;
+
+    const stats: RollupSweepStats = await EmailRollupFlushRunner.runSweep({
+      now: NOW,
+    });
+
+    expect(stats.sent).toBe(1);
+    expect(harness.sent).toHaveLength(1);
+    const mail: SentRollupMail = harness.sent[0]!;
+    expect(mail.subject).toBe("[Acme] 2 notifications: 1 Alerts, 1 Incidents");
+    expect(mail.vars["summaryCount"]).toBe("2 notifications");
+    expect(JSON.stringify(mail.vars)).toContain("Checkout is down");
+    expect(JSON.stringify(mail.vars)).toContain("CPU is high");
+    expect(JSON.stringify(mail.vars)).not.toContain(
+      "Muted incident state change",
+    );
+    expect(harness.batches[0]!.itemCount).toBe(2);
+    expect(pendingItems(harness)).toHaveLength(0);
+    expect(harness.items).toHaveLength(3);
+    expect(harness.callLog).toEqual(["preferences", "stamp", "send"]);
+  });
+
+  test.each([false, null, undefined])(
+    "an event whose email preference is %s is skipped even if other channels remain enabled",
+    async (alertByEmail: boolean | null | undefined) => {
+      seedDue();
+      const setting: FakeRow = getSetting(CREATED_EVENT);
+      setting["alertByEmail"] = alertByEmail;
+      setting["alertByPush"] = true;
+      setting["alertBySMS"] = true;
+
+      const stats: RollupSweepStats = await EmailRollupFlushRunner.runSweep({
+        now: NOW,
+      });
+
+      expect(stats.skipped).toBe(1);
+      expect(stats.sent).toBe(0);
+      expect(harness.sendAttempts).toHaveLength(0);
+      expect(harness.batches[0]!.status).toBe(RollupBatchStatus.Skipped);
+      expect(harness.batches[0]!.itemCount).toBe(0);
+      expect(harness.batches[0]!.sentAt).toBeNull();
+      expect(harness.batches[0]!.statusMessage).toContain("no longer enabled");
+      expect(pendingItems(harness)).toHaveLength(0);
+      expect(setting["alertByPush"]).toBe(true);
+      expect(setting["alertBySMS"]).toBe(true);
+    },
+  );
+
+  test("deleting a preference removes that event from an otherwise enabled batch", async () => {
+    seedDue({ subject: "Deleted subscription" });
+    seedDue({
+      subject: "Still subscribed",
+      eventType: STATE_CHANGED_EVENT,
+    });
+    harness.notificationSettings = harness.notificationSettings.filter(
+      (row: FakeRow): boolean => {
+        return row["eventType"] !== CREATED_EVENT;
+      },
+    );
+
+    await EmailRollupFlushRunner.runSweep({ now: NOW });
+
+    expect(harness.sent).toHaveLength(1);
+    expect(harness.sent[0]!.subject).toContain("Still subscribed");
+    expect(JSON.stringify(harness.sent[0]!.vars)).not.toContain(
+      "Deleted subscription",
+    );
+    expect(harness.batches[0]!.itemCount).toBe(1);
+  });
+
+  test("an absent preference is not replaced by another user's or project's enabled preference", async () => {
+    seedDue();
+    harness.notificationSettings = [];
+    seedNotificationSetting(harness, {
+      projectId: OTHER_PROJECT_ID,
+      userId: USER_ID,
+      eventType: CREATED_EVENT,
+    });
+    seedNotificationSetting(harness, {
+      projectId: PROJECT_ID,
+      userId: OTHER_USER_ID,
+      eventType: CREATED_EVENT,
+    });
+
+    const stats: RollupSweepStats = await EmailRollupFlushRunner.runSweep({
+      now: NOW,
+    });
+
+    expect(stats.skipped).toBe(1);
+    expect(harness.sendAttempts).toHaveLength(0);
+    expect(UserNotificationSettingService.findBy).toHaveBeenCalledWith({
+      query: {
+        projectId: PROJECT_ID,
+        userId: USER_ID,
+        alertByEmail: true,
+      },
+      select: { eventType: true },
+      limit: expect.any(Number),
+      skip: 0,
+      props: { isRoot: true },
+    });
+  });
+
+  test("muting one recipient leaves other users and other projects subscribed", async () => {
+    seedProject(harness, { projectId: OTHER_PROJECT_ID, name: "Beta" });
+    seedVerifiedEmail(harness, {
+      projectId: OTHER_PROJECT_ID,
+      userId: USER_ID,
+      email: TO_EMAIL,
+    });
+    seedVerifiedEmail(harness, {
+      projectId: PROJECT_ID,
+      userId: OTHER_USER_ID,
+      email: OTHER_EMAIL,
+    });
+    seedDue({ subject: "Muted in Acme" });
+    seedDue({ subject: "Enabled in Beta", projectId: OTHER_PROJECT_ID });
+    seedDue({
+      subject: "Enabled for another user",
+      userId: OTHER_USER_ID,
+      toEmail: OTHER_EMAIL,
+    });
+    getSetting(CREATED_EVENT)["alertByEmail"] = false;
+
+    const stats: RollupSweepStats = await EmailRollupFlushRunner.runSweep({
+      now: NOW,
+    });
+
+    expect(stats.skipped).toBe(1);
+    expect(stats.sent).toBe(2);
+    expect(
+      harness.sent.map((mail: SentRollupMail): string => {
+        return mail.subject;
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Enabled in Beta"),
+        expect.stringContaining("Enabled for another user"),
+      ]),
+    );
+    expect(JSON.stringify(harness.sent)).not.toContain("Muted in Acme");
+  });
+
+  test("a fully muted batch stays consumed after email is enabled again", async () => {
+    seedDue();
+    getSetting(CREATED_EVENT)["alertByEmail"] = false;
+    await EmailRollupFlushRunner.runSweep({ now: NOW });
+    getSetting(CREATED_EVENT)["alertByEmail"] = true;
+
+    const later: RollupSweepStats = await EmailRollupFlushRunner.runSweep({
+      now: OneUptimeDate.addRemoveMinutes(NOW, CLAIM_EPOCH_MINUTES),
+    });
+
+    expect(later.bucketsDue).toBe(0);
+    expect(harness.batches).toHaveLength(1);
+    expect(harness.sendAttempts).toHaveLength(0);
+  });
+
+  test("the most recent preference is used when email is enabled again before the flush", async () => {
+    seedDue();
+    getSetting(CREATED_EVENT)["alertByEmail"] = false;
+    getSetting(CREATED_EVENT)["alertByEmail"] = true;
+
+    await EmailRollupFlushRunner.runSweep({ now: NOW });
+
+    expect(harness.sent).toHaveLength(1);
+    expect(harness.batches[0]!.itemCount).toBe(1);
+  });
+
+  test("a preference lookup failure preserves pending items and retries once in the next epoch", async () => {
+    seedDue({ subject: "Keep for retry" });
+    seedDue({ subject: "Also keep for retry" });
+    jest
+      .spyOn(UserNotificationSettingService, "findBy")
+      .mockRejectedValueOnce(new Error("preferences read timed out"));
+
+    const failed: RollupSweepStats = await EmailRollupFlushRunner.runSweep({
+      now: NOW,
+    });
+
+    expect(failed.failed).toBe(1);
+    expect(harness.batches[0]!.status).toBe(RollupBatchStatus.Failed);
+    expect(harness.batches[0]!.itemCount).toBe(0);
+    expect(harness.batches[0]!.statusMessage).toBe(
+      "preferences read timed out",
+    );
+    expect(pendingItems(harness)).toHaveLength(2);
+    expect(
+      harness.items.every((item: FakeItemRow): boolean => {
+        return item.rollupBatchId === null;
+      }),
+    ).toBe(true);
+    expect(harness.itemUpdateByCalls).toBe(0);
+    expect(harness.sendAttempts).toHaveLength(0);
+
+    const sameEpoch: RollupSweepStats = await EmailRollupFlushRunner.runSweep({
+      now: NOW,
+    });
+    expect(sameEpoch.claimCollisions).toBe(1);
+    expect(UserNotificationSettingService.findBy).toHaveBeenCalledTimes(1);
+
+    await EmailRollupFlushRunner.runSweep({
+      now: OneUptimeDate.addRemoveMinutes(NOW, CLAIM_EPOCH_MINUTES),
+    });
+
+    expect(harness.batches).toHaveLength(2);
+    expect(harness.batches[1]!.status).toBe(RollupBatchStatus.Sent);
+    expect(harness.batches[1]!.itemCount).toBe(2);
+    expect(harness.sent).toHaveLength(1);
+    expect(pendingItems(harness)).toHaveLength(0);
+  });
+
+  test("a preference lookup failure does not prevent another recipient's delivery", async () => {
+    seedDue();
+    seedVerifiedEmail(harness, {
+      projectId: PROJECT_ID,
+      userId: OTHER_USER_ID,
+      email: OTHER_EMAIL,
+    });
+    seedDue({ userId: OTHER_USER_ID, toEmail: OTHER_EMAIL });
+    jest
+      .spyOn(UserNotificationSettingService, "findBy")
+      .mockRejectedValueOnce(new Error("preferences read timed out"));
+
+    const stats: RollupSweepStats = await EmailRollupFlushRunner.runSweep({
+      now: NOW,
+    });
+
+    expect(stats.failed).toBe(1);
+    expect(stats.sent).toBe(1);
+    expect(harness.sent[0]!.toEmail).toBe(OTHER_EMAIL.toString());
+    expect(pendingItems(harness)).toHaveLength(1);
+    expect(pendingItems(harness)[0]!.userId).toBe(USER_ID);
+  });
+
+  test("a failed send records only the enabled items that were attempted", async () => {
+    seedDue();
+    seedDue({ eventType: STATE_CHANGED_EVENT });
+    getSetting(STATE_CHANGED_EVENT)["alertByEmail"] = false;
+    harness.failSend = (): Error => {
+      return new Error("mail transport unavailable");
+    };
+
+    const stats: RollupSweepStats = await EmailRollupFlushRunner.runSweep({
+      now: NOW,
+    });
+
+    expect(stats.failed).toBe(1);
+    expect(harness.batches[0]!.status).toBe(RollupBatchStatus.Failed);
+    expect(harness.batches[0]!.itemCount).toBe(1);
+    expect(harness.sendAttempts[0]!.vars["summaryCount"]).toBe(
+      "1 notification",
+    );
+    expect(pendingItems(harness)).toHaveLength(0);
+  });
+});

--- a/Common/Tests/Server/Utils/EmailRollup/EmailRollupTestHarness.ts
+++ b/Common/Tests/Server/Utils/EmailRollup/EmailRollupTestHarness.ts
@@ -7,6 +7,7 @@ import ProjectService from "../../../../Server/Services/ProjectService";
 import UserEmailService from "../../../../Server/Services/UserEmailService";
 import UserNotificationEmailRollupBatchService from "../../../../Server/Services/UserNotificationEmailRollupBatchService";
 import UserNotificationEmailRollupItemService from "../../../../Server/Services/UserNotificationEmailRollupItemService";
+import UserNotificationSettingService from "../../../../Server/Services/UserNotificationSettingService";
 import logger from "../../../../Server/Utils/Logger";
 import UserNotificationEmailRollupBatch, {
   RollupBatchStatus,
@@ -102,6 +103,8 @@ export interface RollupHarness {
   batches: Array<FakeBatchRow>;
   // UserEmail rows: { _id, id, userId, projectId, isVerified, email }.
   userEmails: Array<FakeRow>;
+  // Current event preferences; queued events start enabled at enqueue time.
+  notificationSettings: Array<FakeRow>;
   // Project rows: { _id, id, name }.
   projects: Array<FakeRow>;
 
@@ -114,7 +117,8 @@ export interface RollupHarness {
 
   /*
    * An ordered trace of the collaborator calls whose ORDER is load-bearing.
-   * "stamp" is pushed by the item updateBy, "send" by MailService.sendMail:
+   * "preferences" is pushed by the settings read, "stamp" by the item
+   * updateBy, and "send" by MailService.sendMail:
    * stamp-before-send is the property that stops a permanently failing send
    * re-spamming an address every epoch, and it is only observable as an
    * ordering.
@@ -165,6 +169,7 @@ export function emptyRollupHarness(): RollupHarness {
     items: [],
     batches: [],
     userEmails: [],
+    notificationSettings: [],
     projects: [],
     sendAttempts: [],
     sent: [],
@@ -367,7 +372,53 @@ export function seedItem(
 
   harness.items.push(row);
 
+  /*
+   * An owner email only enters the queue when its event is enabled. Seed that
+   * initial preference once; tests can then disable or remove it before the
+   * flush to exercise changes made while the email was waiting.
+   */
+  const hasSetting: boolean = harness.notificationSettings.some(
+    (setting: FakeRow): boolean => {
+      return (
+        toKey(setting["projectId"]) === toKey(row.projectId) &&
+        toKey(setting["userId"]) === toKey(row.userId) &&
+        setting["eventType"] === row.eventType
+      );
+    },
+  );
+
+  if (!hasSetting) {
+    seedNotificationSetting(harness, {
+      projectId: row.projectId,
+      userId: row.userId,
+      eventType: row.eventType,
+    });
+  }
+
   return row;
+}
+
+export function seedNotificationSetting(
+  harness: RollupHarness,
+  data: {
+    projectId: ObjectID;
+    userId: ObjectID;
+    eventType: NotificationSettingEventType;
+    alertByEmail?: boolean | undefined;
+  },
+): FakeRow {
+  const id: ObjectID = ObjectID.generate();
+  const setting: FakeRow = {
+    _id: id,
+    id: id,
+    projectId: data.projectId,
+    userId: data.userId,
+    eventType: data.eventType,
+    alertByEmail: data.alertByEmail ?? true,
+  };
+
+  harness.notificationSettings.push(setting);
+  return setting;
 }
 
 export function seedVerifiedEmail(
@@ -648,6 +699,31 @@ export function installRollupHarness(harness: RollupHarness): void {
     }) as never);
 
   // -- The recipient re-validation ----------------------------------------
+
+  jest
+    .spyOn(UserNotificationSettingService, "findBy")
+    .mockImplementation(((args: {
+      query?: Record<string, unknown>;
+      select?: Record<string, unknown>;
+      limit?: unknown;
+      skip?: number;
+    }) => {
+      harness.callLog.push("preferences");
+      const matched: Array<FakeRow> = harness.notificationSettings.filter(
+        (row: FakeRow): boolean => {
+          return matchesQuery(args.query, row);
+        },
+      );
+      const skip: number = args.skip ?? 0;
+
+      return Promise.resolve(
+        matched
+          .slice(skip, skip + toLimit(args.limit, matched.length))
+          .map((row: FakeRow): FakeRow => {
+            return applySelect(row, args.select);
+          }),
+      );
+    }) as never);
 
   jest.spyOn(UserEmailService, "findBy").mockImplementation(((args: {
     query?: Record<string, unknown>;

--- a/Common/Tests/Types/NotificationSetting/RoutineEmailEvents.test.ts
+++ b/Common/Tests/Types/NotificationSetting/RoutineEmailEvents.test.ts
@@ -1,0 +1,47 @@
+import NotificationSettingEventType from "../../../Types/NotificationSetting/NotificationSettingEventType";
+import { ROUTINE_EMAIL_EVENT_TYPES } from "../../../Types/NotificationSetting/RoutineEmailEvents";
+
+describe("routine email preset allowlist", () => {
+  test("contains only known, unique event types and cannot be mutated", () => {
+    expect(ROUTINE_EMAIL_EVENT_TYPES).toHaveLength(21);
+    expect(new Set(ROUTINE_EMAIL_EVENT_TYPES).size).toBe(21);
+    expect(Object.isFrozen(ROUTINE_EMAIL_EVENT_TYPES)).toBe(true);
+    for (const eventType of ROUTINE_EMAIL_EVENT_TYPES) {
+      expect(Object.values(NotificationSettingEventType)).toContain(eventType);
+    }
+  });
+
+  test.each([
+    NotificationSettingEventType.SEND_INCIDENT_CREATED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_STATE_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_REMINDER_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_MEMBER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_CREATED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_STATE_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_REMINDER_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_EPISODE_CREATED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_EPISODE_STATE_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_EPISODE_CREATED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_EPISODE_STATE_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_MONITOR_STATUS_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_MONITOR_NOTIFICATION_WHEN_PORBE_STATUS_CHANGES,
+    NotificationSettingEventType.SEND_MONITOR_NOTIFICATION_WHEN_NO_PROBES_ARE_MONITORING_THE_MONITOR,
+    NotificationSettingEventType.SEND_PROBE_STATUS_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_AI_AGENT_STATUS_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_SLO_OWNER_STATUS_CHANGE_NOTIFICATION,
+    NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_CREATED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_STATE_CHANGED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_REMINDER_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_WHEN_USER_IS_ON_CALL_ROSTER,
+    NotificationSettingEventType.SEND_WHEN_USER_IS_NEXT_ON_CALL_ROSTER,
+    NotificationSettingEventType.SEND_WHEN_USER_IS_NO_LONGER_ACTIVE_ON_ON_CALL_ROSTER,
+    NotificationSettingEventType.SEND_BEFORE_USER_ON_CALL_SHIFT_STARTS,
+    NotificationSettingEventType.SEND_WHEN_USER_ON_CALL_SHIFT_IS_REASSIGNED,
+    NotificationSettingEventType.SEND_STATUS_PAGE_ANNOUNCEMENT_CREATED_OWNER_NOTIFICATION,
+  ])(
+    "preserves email preferences for %s",
+    (eventType: NotificationSettingEventType) => {
+      expect(ROUTINE_EMAIL_EVENT_TYPES).not.toContain(eventType);
+    },
+  );
+});

--- a/Common/Types/NotificationSetting/RoutineEmailEvents.ts
+++ b/Common/Types/NotificationSetting/RoutineEmailEvents.ts
@@ -1,0 +1,30 @@
+import NotificationSettingEventType from "./NotificationSettingEventType";
+
+/*
+ * Keep this an explicit allowlist: newly introduced events retain their existing
+ * email preference until someone deliberately classifies them as routine.
+ */
+export const ROUTINE_EMAIL_EVENT_TYPES: ReadonlyArray<NotificationSettingEventType> =
+  Object.freeze([
+    NotificationSettingEventType.SEND_INCIDENT_NOTE_POSTED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_NOTE_POSTED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_EPISODE_NOTE_POSTED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_EPISODE_NOTE_POSTED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_NOTE_POSTED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_OWNER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_OWNER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_EPISODE_OWNER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_EPISODE_OWNER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_MONITOR_OWNER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_SLO_OWNER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_PROBE_OWNER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_AI_AGENT_OWNER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_STATUS_PAGE_OWNER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_SCHEDULED_MAINTENANCE_OWNER_ADDED_NOTIFICATION,
+    NotificationSettingEventType.SEND_INCIDENT_ADDED_TO_EPISODE_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_ALERT_ADDED_TO_EPISODE_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_WHEN_USER_IS_ADDED_TO_ON_CALL_POLICY,
+    NotificationSettingEventType.SEND_WHEN_USER_IS_REMOVED_FROM_ON_CALL_POLICY,
+    NotificationSettingEventType.SEND_MONITOR_CREATED_OWNER_NOTIFICATION,
+    NotificationSettingEventType.SEND_STATUS_PAGE_CREATED_OWNER_NOTIFICATION,
+  ]);

--- a/Internal/Roadmap/EmailExperience.md
+++ b/Internal/Roadmap/EmailExperience.md
@@ -1,0 +1,56 @@
+# Email experience
+
+Customers report too much email. The code review found that owner notifications default to email,
+burst batching is already enabled, and the settings page requires individual choices across many
+event types. This is an implementation audit, not a measurement of customer inbox volume.
+
+## Implemented in this change
+
+1. **Make reducing routine updates easy.** A personal, per-project **Reduce routine emails** action
+   turns off 21 informational event types in one transaction. It covers notes, ownership notices,
+   monitor/status-page creation, episode membership, and on-call policy membership. It preserves
+   existing incident/alert creation, state changes, reminders, assignments, health updates, and
+   shift preferences. Other channels and on-call paging are unchanged. Missing routine settings get
+   explicit opt-outs so later normal default seeding preserves the choice.
+2. **Put preferences within reach.** Owner emails link directly to the relevant project's settings.
+   Incident assignment and AI agent preferences, previously missing from the page, are visible.
+3. **Honor the latest choice before sending a summary.** Queued events whose email setting was
+   disabled or removed are excluded. Entirely unsubscribed batches send no email. A preference
+   lookup failure leaves queued items available for a later attempt.
+
+These changes do not reset existing preferences automatically and do not introduce a new delivery
+delay. The existing burst rollup remains enabled by default and independently configurable.
+
+## Recommended next steps
+
+| Priority | Improvement | Why / validation |
+| --- | --- | --- |
+| Next | Measure email volume by project, event type, and recipient | Establish the leading sources of noise and compare emails per active recipient before and after adoption. Use aggregate counts; retain existing notification content policies. |
+| Next | Debounce flapping health notifications and consolidate related incidents | Preserve the first actionable outage and meaningful recovery while reducing repeated transitions. Verify with outage/recovery timelines and on-call delivery latency. |
+| Next | Offer configurable summaries for routine updates | Let people choose immediate, short summary, or daily summary for informational email. Keep paging, urgent health signals, account and billing email outside this setting. |
+| Later | Resource-level subscriptions and temporary muting | People can follow the services they operate without turning off a whole event category. Show scope and expiry clearly, and keep paging governed by on-call rules. |
+| Later | Explain why each email was received and show noisy sources | Include ownership/team/subscription context and a relevant preference link so customers can address the source. |
+
+Track preset adoption, routine emails per recipient, summary size, repeated transitions, and support
+complaints. Check acknowledgement latency and paging delivery alongside volume so improvement is
+not inferred from fewer emails alone.
+
+Grouping and actionable, personalized notifications are established approaches: see
+[PagerDuty's noise reduction guidance](https://www.pagerduty.com/ops-guides/ops-practices/reduce-noise/)
+and [Atlassian's alert fatigue guidance](https://www.atlassian.com/blog/blog/opsgenie/5-ways-to-reduce-alert-fatigue).
+The exact choices above come from OneUptime's current code and should be refined with customer data.
+
+## Validation and limits
+
+Coverage includes rendered settings interactions, real email templates, authenticated API scope,
+the event allowlist, queue delivery preferences, and opt-in Postgres integration tests for atomic
+updates, rollback, repeated/concurrent requests, and other-channel preservation.
+
+Run the Postgres suite with `RUN_POSTGRES_NOTIFICATION_TESTS=true`, normal database credentials, and
+optional `NOTIFICATION_TEST_DATABASE_HOST` / `NOTIFICATION_TEST_DATABASE_PORT`. It creates and removes
+an isolated schema using the existing settings table's structure. It does not change customer rows.
+
+Already-sent email cannot be recalled. Delivery uses preferences read immediately before consuming
+the queued batch; a change after that read can race with that send. Concurrent preset requests are
+serialized. Existing default seeding still has a separate count-then-create race because the settings
+table lacks a unique user/project/event constraint; repairing that general constraint is separate work.

--- a/Internal/Roadmap/README.md
+++ b/Internal/Roadmap/README.md
@@ -2,6 +2,7 @@
 
 | Doc | What it is | Update cadence |
 |---|---|---|
+| [EmailExperience.md](./EmailExperience.md) | Implemented email noise controls, delivery-time preferences, and recommendations for grouping, summaries, and measurement | When an email experience improvement ships or customer volume data changes priorities |
 | [CodeFixSandboxDesign.md](./CodeFixSandboxDesign.md) | Design: the two-tier code-fix verification & sandbox plan (B4) — Tier 0 metered in-house agent, Tier 1 customer-CI verify, Tier 2 ephemeral sandbox | Frozen once implemented; revisit at Tier 2 |
 | [CodeFixHarnessAudit.md](./CodeFixHarnessAudit.md) | Audit: end-to-end review of the clone → agent → verify → commit → push → PR harness. What was fixed, what is deliberately left (server-side token scoping and run binding, PR dedup, handler duplication), and where the tests are | When a "Not fixed here" item ships, or the harness changes shape |
 | [NetworkObservability.md](./NetworkObservability.md) | Roadmap: shipped network-monitoring baseline + the remaining epics (NCM, IPAM, wireless, forecasting, sFlow/IPFIX, topology history, flap detection, maintenance/status-page relations, sensor tables, flow retention) with design sketches, sizes, and open questions | When an epic starts (spin its section into a design doc) or the shipped baseline changes |


### PR DESCRIPTION
Customers receiving routine owner updates must currently change many individual settings, ordinary owner emails provide manual navigation instructions, and already queued summaries ignore later email opt-outs.

This adds a personal **Reduce routine emails** action that disables 21 informational event types together. For example, an incident note email turns off while that person's incident-created and SMS choices remain unchanged. It also links owner emails directly to project preferences and excludes unsubscribed events from queued summaries.

## Changes

- Apply the email-only preset atomically for the authenticated user/project, including explicit opt-outs for missing settings; preserve other channels and event types. Concurrent preset requests are serialized.
- Wait for pending individual preference saves before applying the preset, prevent repeated submissions, handle failed responses, and refresh settings after a successful save.
- Expose incident assignment and both AI agent preferences that were missing from the page.
- Add a direct preferences footer to all 45 owner/assignment/schedule templates without changing other-channel payloads or rollup resource grouping.
- Recheck current event preferences before consuming a queued batch. Muted events are skipped; a failed preference lookup keeps items pending for a later attempt.
- Document the behavior and recommendations in `Internal/Roadmap/EmailExperience.md`: measure noisy sources, debounce flapping, offer configurable routine summaries, and add resource-level controls.

No schema migration or automatic reset of customer preferences. On-call paging, account and billing email, other channels, and existing burst-rollup thresholds remain unchanged.

## Validation

- 388 distinct tests passed across 17 focused suites: rendered settings interactions (including project switching) and existing rollup controls; owner and rollup templates; routing/channel/default behavior; writer, renderer, queue claims and delivery preferences; API authorization; allowlist policy; and real Postgres integration.
- The 12 Postgres cases cover channel/event/user/project preservation, missing rows, duplicate rows, soft deletion, repeated and concurrent requests, transaction rollback, future events, and later default seeding.
- All nine changed test files also passed strict TypeScript diagnostics.
- `npm run compile` passed in Common, App, and Dashboard (Dashboard also checked the final edit using incremental compilation).
- Root `npm run fix` passed.

The real Postgres suite uses an isolated temporary schema and removes it afterward. Reproduce from `Common` with normal database credentials in `config.env`:

```sh
RUN_POSTGRES_NOTIFICATION_TESTS=true node --env-file=../config.env node_modules/jest/bin/jest.js --runInBand Tests/Server/Services/RoutineEmailSettingsPostgres.test.ts --globals '{"ts-jest":{"isolatedModules":true}}' --forceExit
```

## Limits

Already-sent mail cannot be recalled. Preferences are checked just before consuming a summary, so a change after that read can race with delivery. Existing default seeding has a separate count-then-insert race; the preset preserves later seeded defaults but does not add a general user/project/event uniqueness migration.
