### PR TITLE
fix(alerts): stop recommendation monitors flapping, and fix the emails they send

### DIFF
--- a/App/FeatureSet/Notification/Templates/Partials/Header.hbs
+++ b/App/FeatureSet/Notification/Templates/Partials/Header.hbs
@@ -1,6 +1,6 @@
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=3Dutf-8">
-  <meta name="viewport" content="width=3Ddevice-width">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width">
   <title>Email from OneUptime.</title>
   {{> Style}}
 </head>

--- a/App/FeatureSet/Notification/Utils/Handlebars.ts
+++ b/App/FeatureSet/Notification/Utils/Handlebars.ts
@@ -49,9 +49,27 @@ Handlebars.registerHelper("ifCond", function (v1, v2, options) {
   return options.inverse(this);
 });
 
-Handlebars.registerHelper("concat", (v1: any, v2: any) => {
-  // contact v1 and v2
-  return v1 + v2;
+/*
+ * Join every argument the template passed, not just the first two.
+ *
+ * The two-argument version silently truncated every caller that passed
+ * more. `{{> EmailTitle title=(concat "Alert " alertNumber ": " alertTitle) }}`
+ * rendered as "Alert ALT-113" — the separator and the alert title were
+ * dropped — so the headline of every alert and incident email was a bare
+ * identifier with no indication of what had happened.
+ *
+ * Handlebars appends its own options object as the final argument to every
+ * helper call, so that one is dropped rather than stringified into the
+ * output as "[object Object]".
+ */
+Handlebars.registerHelper("concat", (...args: Array<any>) => {
+  const values: Array<any> = args.slice(0, -1);
+
+  return values
+    .map((value: any) => {
+      return value === null || value === undefined ? "" : String(value);
+    })
+    .join("");
 });
 
 Handlebars.registerHelper("ifNotCond", function (v1, v2, options) {

--- a/App/FeatureSet/Workers/Jobs/AlertOwners/SendCreatedResourceNotification.ts
+++ b/App/FeatureSet/Workers/Jobs/AlertOwners/SendCreatedResourceNotification.ts
@@ -10,6 +10,7 @@ import PushNotificationMessage from "Common/Types/PushNotification/PushNotificat
 import { EVERY_MINUTE } from "Common/Utils/CronTime";
 import AlertService from "Common/Server/Services/AlertService";
 import ProjectService from "Common/Server/Services/ProjectService";
+import SeriesLabelDisplay from "Common/Types/Monitor/SeriesContext/SeriesLabelDisplay";
 import UserNotificationSettingService from "Common/Server/Services/UserNotificationSettingService";
 import PushNotificationUtil from "Common/Server/Utils/PushNotificationUtil";
 import Select from "Common/Server/Types/Database/Select";
@@ -67,6 +68,14 @@ RunCron(
         },
         alertNumber: true,
         alertNumberWithPrefix: true,
+        /*
+         * The attribute key/values that identify the series this alert was
+         * raised for, e.g. {resource.k8s.pod.name: checkout-7d9f-2xk}.
+         * Without selecting it the email had no way to name the thing that
+         * actually broke, and fell back to printing the monitor's own name
+         * as the "Resources Affected".
+         */
+        seriesLabels: true,
       },
     });
 
@@ -134,6 +143,28 @@ RunCron(
         (alert.alertNumber ? `#${alert.alertNumber}` : "");
 
       /*
+       * What actually broke.
+       *
+       * A grouped metric monitor raises one alert per breaching series, and
+       * the series identity is on the row — the dashboard renders it under
+       * "Affected Resource". The email used to print `alert.monitor.name`
+       * here, so a per-pod alert said "Resources Affected: oneuptime-test -
+       * Pod CPU Saturating Container Limit", naming the monitor twice and
+       * the pod not at all.
+       *
+       * `buildInlineSummary` is the same formatter the alert TITLE uses, so
+       * the two agree. Monitors without group-by have no series labels and
+       * keep the previous monitor-name fallback, which for them is the
+       * correct answer.
+       */
+      const seriesSummary: string = SeriesLabelDisplay.buildInlineSummary(
+        alert.seriesLabels,
+      );
+
+      const resourcesAffected: string =
+        seriesSummary || alert.monitor?.name || "None";
+
+      /*
        * These values do not vary per owner, so convert them once per alert
        * instead of once per owner notification. A conversion failure must
        * stay contained to this alert, like every other failure in this loop.
@@ -178,7 +209,7 @@ RunCron(
             projectName: alert.project!.name!,
             currentState: alert.currentAlertState!.name!,
             alertDescription: alertDescriptionHtml,
-            resourcesAffected: alert.monitor?.name || "None",
+            resourcesAffected: resourcesAffected,
             alertSeverity: alert.alertSeverity!.name!,
             declaredAt: OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones(
               {

--- a/App/Tests/Notification/AlertOwnerEmailTemplates.test.ts
+++ b/App/Tests/Notification/AlertOwnerEmailTemplates.test.ts
@@ -1,0 +1,251 @@
+import Handlebars from "handlebars";
+import fs from "fs";
+import Path from "path";
+import { beforeAll, describe, expect, test } from "@jest/globals";
+
+/*
+ * Registers the product's real `ifCond` / `ifNotCond` / `concat` helpers on
+ * the shared Handlebars instance as a side effect of import, so this suite
+ * exercises the helpers the product ships rather than reimplementations of
+ * them. The module also kicks off an async partial load that resolves its
+ * directory from process.cwd() and swallows its own failure, so importing it
+ * from a test is safe; the partials are registered from disk below.
+ */
+import "../../FeatureSet/Notification/Utils/Handlebars";
+
+/*
+ * The alert emails a customer actually received, and the three rendering
+ * defects visible in them.
+ *
+ * A single Kubernetes monitor created from a OneUptime recommendation sent
+ * 39 emails in under two hours. Reading one of them:
+ *
+ *   Headline:            "Alert ALT-113"
+ *   ALERT TITLE:         "[K8s] Pod CPU Saturating Container Limit (>90%) -
+ *                         oneuptime-test - Pod CPU Saturating Container Limit"
+ *   RESOURCES AFFECTED:  "oneuptime-test - Pod CPU Saturating Container Limit"
+ *
+ * 1. The headline lost the title. `AlertOwnerResourceCreated.hbs` asks for
+ *    `(concat "Alert " alertNumber ": " alertTitle)`, but the `concat`
+ *    helper took exactly two arguments and dropped the rest.
+ * 2. "Resources Affected" was the MONITOR's name, not the pod that broke —
+ *    see AlertOwnerEmailResourcesAffected.test.ts.
+ * 3. `Header.hbs` carried quoted-printable escapes (`charset=3Dutf-8`,
+ *    `width=3Ddevice-width`) that broke the charset declaration and the
+ *    mobile viewport in EVERY email the product sends.
+ */
+
+const NOTIFICATION_DIR: string = Path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Notification",
+);
+
+const TEMPLATES_DIR: string = Path.resolve(NOTIFICATION_DIR, "Templates");
+
+const HANDLEBARS_UTIL_PATH: string = Path.resolve(
+  NOTIFICATION_DIR,
+  "Utils",
+  "Handlebars.ts",
+);
+
+const ALERT_NUMBER: string = "ALT-113";
+const ALERT_TITLE: string =
+  "[K8s] Pod CPU Saturating Container Limit (>90%) - oneuptime-test";
+
+function templateSource(name: string): string {
+  return fs.readFileSync(Path.resolve(TEMPLATES_DIR, name), {
+    encoding: "utf8",
+  });
+}
+
+function render(name: string, vars: Record<string, unknown>): string {
+  return Handlebars.compile(templateSource(name))(vars);
+}
+
+beforeAll(() => {
+  const partialsDir: string = Path.resolve(TEMPLATES_DIR, "Partials");
+
+  for (const filename of fs.readdirSync(partialsDir)) {
+    const matches: RegExpMatchArray | null = filename.match(/^(.*)\.hbs$/);
+
+    if (!matches) {
+      continue;
+    }
+
+    Handlebars.registerPartial(
+      matches[1]!,
+      fs.readFileSync(Path.resolve(partialsDir, filename), {
+        encoding: "utf8",
+      }),
+    );
+  }
+});
+
+describe("the concat helper", () => {
+  test("the production module is what registered it", () => {
+    /*
+     * Guards the import above: if Handlebars.ts stops registering `concat`,
+     * every rendering assertion in this file would silently start passing
+     * against Handlebars' own missing-helper behaviour instead of failing.
+     */
+    expect(
+      fs.readFileSync(HANDLEBARS_UTIL_PATH, { encoding: "utf8" }),
+    ).toContain('registerHelper("concat"');
+  });
+
+  test("joins more than two arguments", () => {
+    const template: HandlebarsTemplateDelegate = Handlebars.compile(
+      '{{concat "Alert " alertNumber ": " alertTitle}}',
+    );
+
+    expect(
+      template({ alertNumber: ALERT_NUMBER, alertTitle: ALERT_TITLE }),
+    ).toBe(
+      `Alert ${ALERT_NUMBER}: ${Handlebars.escapeExpression(ALERT_TITLE)}`,
+    );
+  });
+
+  test("still joins exactly two", () => {
+    expect(Handlebars.compile('{{concat "a" "b"}}')({})).toBe("ab");
+  });
+
+  test("does not leak Handlebars' own options object into the output", () => {
+    const output: string = Handlebars.compile('{{concat "a" "b" "c"}}')({});
+
+    expect(output).toBe("abc");
+    expect(output).not.toContain("object Object");
+  });
+
+  test("renders a missing variable as empty rather than 'undefined'", () => {
+    expect(Handlebars.compile('{{concat "Alert " missing "!"}}')({})).toBe(
+      "Alert !",
+    );
+  });
+
+  test("stringifies non-string arguments", () => {
+    expect(Handlebars.compile("{{concat n1 n2}}")({ n1: 1, n2: 2 })).toBe("12");
+  });
+});
+
+describe("AlertOwnerResourceCreated.hbs", () => {
+  const VARS: Record<string, unknown> = {
+    alertTitle: ALERT_TITLE,
+    alertNumber: ALERT_NUMBER,
+    projectName: "OneUptime Kubernetes Test Cluster",
+    currentState: "Identified",
+    resourcesAffected: "Pod: kubernetes-agent-logs-7t88f | Namespace: default",
+    declaredBy: "OneUptime",
+    declaredAt: "Sep 05 2026, 10:55 AM BST",
+    alertSeverity: "Warning",
+    rootCause:
+      "Any value of Pod CPU vs Limit (%) is 91.53 % which is greater than 90 %.",
+    alertDescription: "A pod's CPU usage has exceeded 90% of its limit.",
+    remediationNotes: "",
+    alertViewLink: "https://oneuptime.test/dashboard/alerts/1",
+  };
+
+  test("the headline carries the alert title, not just the number", () => {
+    const html: string = render("AlertOwnerResourceCreated.hbs", VARS);
+
+    /*
+     * `{{title}}` escapes, as it should — the alert title is user-supplied
+     * and reaches the email as HTML. Compare against the escaped form
+     * rather than loosening the template.
+     */
+    expect(html).toContain(
+      `Alert ${ALERT_NUMBER}: ${Handlebars.escapeExpression(ALERT_TITLE)}`,
+    );
+  });
+
+  test("the headline is not the bare identifier customers received", () => {
+    const html: string = render("AlertOwnerResourceCreated.hbs", VARS);
+
+    /*
+     * Pins the specific regression: the rendered headline used to be
+     * "Alert ALT-113" and then the closing tag, with the title dropped by
+     * the two-argument `concat`.
+     */
+    expect(html).not.toContain(`>Alert ${ALERT_NUMBER}</h2>`);
+    expect(html).toMatch(new RegExp(`>Alert ${ALERT_NUMBER}: .+</h2>`, "u"));
+  });
+
+  test("the affected resource reaches the body", () => {
+    const html: string = render("AlertOwnerResourceCreated.hbs", VARS);
+
+    expect(html).toContain("kubernetes-agent-logs-7t88f");
+  });
+
+  test("the root cause reaches the body", () => {
+    const html: string = render("AlertOwnerResourceCreated.hbs", VARS);
+
+    expect(html).toContain("91.53");
+  });
+
+  test("an empty remediationNotes does not render an empty labelled row", () => {
+    const html: string = render("AlertOwnerResourceCreated.hbs", VARS);
+
+    expect(html).not.toContain("Remediation Notes:");
+  });
+
+  test("remediationNotes renders when present", () => {
+    const html: string = render("AlertOwnerResourceCreated.hbs", {
+      ...VARS,
+      remediationNotes: "Raise the CPU limit.",
+    });
+
+    expect(html).toContain("Remediation Notes:");
+    expect(html).toContain("Raise the CPU limit.");
+  });
+});
+
+describe("Header.hbs", () => {
+  const source: string = fs.readFileSync(
+    Path.resolve(TEMPLATES_DIR, "Partials", "Header.hbs"),
+    { encoding: "utf8" },
+  );
+
+  test("declares utf-8, not the quoted-printable-mangled '3Dutf-8'", () => {
+    expect(source).toContain("charset=utf-8");
+    expect(source).not.toContain("charset=3Dutf-8");
+  });
+
+  test("declares a mobile viewport, not '3Ddevice-width'", () => {
+    expect(source).toContain("width=device-width");
+    expect(source).not.toContain("width=3Ddevice-width");
+  });
+
+  test("no quoted-printable escape survives anywhere in the email templates", () => {
+    const offenders: Array<string> = [];
+
+    const walk: (dir: string) => void = (dir: string): void => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full: string = Path.resolve(dir, entry.name);
+
+        if (entry.isDirectory()) {
+          walk(full);
+          continue;
+        }
+
+        if (!entry.name.endsWith(".hbs")) {
+          continue;
+        }
+
+        /*
+         * `=3D` is the quoted-printable encoding of "=". Its presence in
+         * source means content was pasted out of a raw email body without
+         * being decoded, and it silently corrupts the attribute it lands in.
+         */
+        if (/=3D/u.test(fs.readFileSync(full, { encoding: "utf8" }))) {
+          offenders.push(Path.relative(TEMPLATES_DIR, full));
+        }
+      }
+    };
+
+    walk(TEMPLATES_DIR);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/App/Tests/Workers/Jobs/AlertOwners/SendCreatedResourceNotification.test.ts
+++ b/App/Tests/Workers/Jobs/AlertOwners/SendCreatedResourceNotification.test.ts
@@ -6,6 +6,7 @@ import Project from "Common/Models/DatabaseModels/Project";
 import User from "Common/Models/DatabaseModels/User";
 import OneUptimeDate from "Common/Types/Date";
 import Dictionary from "Common/Types/Dictionary";
+import { JSONObject } from "Common/Types/JSON";
 import Email from "Common/Types/Email";
 import { EmailEnvelope } from "Common/Types/Email/EmailMessage";
 import EmailTemplateType from "Common/Types/Email/EmailTemplateType";
@@ -193,6 +194,7 @@ function makeAlert(data: {
   description?: string | undefined;
   remediationNotes?: string | undefined;
   rootCause?: string | undefined;
+  seriesLabels?: JSONObject | undefined;
 }): Alert {
   const alert: Alert = new Alert(ALERT_ID);
   alert.projectId = PROJECT_ID;
@@ -208,6 +210,10 @@ function makeAlert(data: {
 
   if (data.rootCause !== undefined) {
     alert.rootCause = data.rootCause;
+  }
+
+  if (data.seriesLabels !== undefined) {
+    alert.seriesLabels = data.seriesLabels;
   }
 
   const project: Project = new Project();
@@ -380,6 +386,75 @@ describe("AlertOwner:SendCreatedResourceEmail worker", () => {
     expect(alertService.getAlertLinkInDashboard).toHaveBeenCalledTimes(4);
 
     expect(feedService.createAlertFeedItem).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * "Resources Affected" used to be `alert.monitor.name`.
+   *
+   * A grouped metric monitor raises one alert per breaching series, so a
+   * customer's per-pod CPU alert read:
+   *
+   *   RESOURCES AFFECTED: oneuptime-test - Pod CPU Saturating Container Limit
+   *
+   * — the monitor's own name, which the subject line and the alert title
+   * already carried, and which names the monitor rather than the pod. The
+   * pod identity was on the alert row the whole time, under `seriesLabels`,
+   * and the dashboard was already rendering it as "Affected Resource".
+   */
+  describe("resourcesAffected names the series, not the monitor", () => {
+    test("a grouped metric alert names the pod that actually breached", async () => {
+      alertService.findAllBy.mockResolvedValue([
+        makeAlert({
+          seriesLabels: {
+            "resource.k8s.pod.name": "kubernetes-agent-logs-7t88f",
+            "resource.k8s.namespace.name": "default",
+          },
+        }),
+      ] as never);
+      alertService.findOwners.mockResolvedValue([makeOwner("a")]);
+
+      await runWorkerTick();
+
+      const resourcesAffected: string = sentVars()[0]!["resourcesAffected"]!;
+
+      expect(resourcesAffected).toContain("kubernetes-agent-logs-7t88f");
+      expect(resourcesAffected).toContain("default");
+      expect(resourcesAffected).not.toBe("API Monitor");
+    });
+
+    test("an ungrouped monitor still falls back to the monitor name", async () => {
+      alertService.findAllBy.mockResolvedValue([makeAlert({})] as never);
+      alertService.findOwners.mockResolvedValue([makeOwner("a")]);
+
+      await runWorkerTick();
+
+      expect(sentVars()[0]!["resourcesAffected"]).toBe("API Monitor");
+    });
+
+    test("empty series labels fall back rather than rendering blank", async () => {
+      alertService.findAllBy.mockResolvedValue([
+        makeAlert({ seriesLabels: {} }),
+      ] as never);
+      alertService.findOwners.mockResolvedValue([makeOwner("a")]);
+
+      await runWorkerTick();
+
+      expect(sentVars()[0]!["resourcesAffected"]).toBe("API Monitor");
+    });
+
+    test("the worker selects seriesLabels, or the column comes back undefined", async () => {
+      alertService.findAllBy.mockResolvedValue([]);
+
+      await runWorkerTick();
+
+      const select: Record<string, unknown> = (
+        alertService.findAllBy.mock.calls[0]![0] as {
+          select: Record<string, unknown>;
+        }
+      ).select;
+
+      expect(select["seriesLabels"]).toBe(true);
+    });
   });
 
   test("the timezone-dependent declaredAt var STAYS per-user while the conversions are still shared", async () => {

--- a/Common/Server/Utils/Monitor/Criteria/CompareCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/CompareCriteria.ts
@@ -9,24 +9,120 @@ import Typeof from "../../../../Types/Typeof";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
 
 export default class CompareCriteria {
+  /*
+   * Reduce an evaluation window to the value(s) a threshold is actually
+   * compared against.
+   *
+   * Before this existed, every comparator branched on `AnyValue` and let
+   * EVERY other evaluation type fall through to `.every()`. That silently
+   * turned Average, Sum, Maximum Value and Minimum Value — all four
+   * offered in the criteria UI and all four stored on real monitors — into
+   * "All Values". A user who asked to be paged on the five-minute AVERAGE
+   * was instead paged only when every single sample breached, which is a
+   * strictly rarer event and never the one they asked for.
+   *
+   * Returns a single-element array for the reducing aggregations so the
+   * caller compares against the aggregate, and the untouched window for
+   * the two set-quantifier types.
+   */
+  public static reduceWindow(data: {
+    values: Array<number>;
+    evaluationType?: EvaluateOverTimeType | undefined;
+  }): Array<number> {
+    const values: Array<number> = data.values;
+
+    if (values.length === 0) {
+      return values;
+    }
+
+    switch (data.evaluationType) {
+      case EvaluateOverTimeType.Average: {
+        const sum: number = values.reduce((a: number, b: number) => {
+          return a + b;
+        }, 0);
+        return [sum / values.length];
+      }
+      case EvaluateOverTimeType.Sum:
+        return [
+          values.reduce((a: number, b: number) => {
+            return a + b;
+          }, 0),
+        ];
+      case EvaluateOverTimeType.MaximumValue:
+        return [Math.max(...values)];
+      case EvaluateOverTimeType.MunimumValue:
+        return [Math.min(...values)];
+      default:
+        // AnyValue / AllValues quantify over the window itself.
+        return values;
+    }
+  }
+
+  /*
+   * The one place a numeric criteria filter decides whether it is met.
+   *
+   * `AnyValue` is an existential quantifier, everything else is universal
+   * once `reduceWindow` has collapsed the reducing aggregations to a
+   * single sample — so "Average > 90" is `[avg].every(v => v > 90)`, which
+   * is just `avg > 90`.
+   */
+  private static evaluateWindow(data: {
+    value: number | Array<number>;
+    evaluationType?: EvaluateOverTimeType | undefined;
+    predicate: (value: number) => boolean;
+  }): boolean {
+    if (!Array.isArray(data.value)) {
+      return data.predicate(data.value);
+    }
+
+    const values: Array<number> = CompareCriteria.reduceWindow({
+      values: data.value,
+      evaluationType: data.evaluationType,
+    });
+
+    if (values.length === 0) {
+      return false;
+    }
+
+    if (data.evaluationType === EvaluateOverTimeType.AnyValue) {
+      return values.some(data.predicate);
+    }
+
+    return values.every(data.predicate);
+  }
+
+  /*
+   * The samples that actually satisfied the filter.
+   *
+   * Only used to render the root cause. `getCompareMessage` used to print
+   * the WHOLE window and then assert every printed number breached the
+   * threshold, so a real alert read "is 72.35, 81.54, 79.95, 91.53, 87.73 %
+   * which is greater than 90 %" — four of those five are below 90.
+   */
+  public static getBreachingValues(data: {
+    values: Array<number>;
+    evaluationType?: EvaluateOverTimeType | undefined;
+    predicate: (value: number) => boolean;
+  }): Array<number> {
+    return CompareCriteria.reduceWindow({
+      values: data.values,
+      evaluationType: data.evaluationType,
+    }).filter(data.predicate);
+  }
+
   @CaptureSpan()
   public static greaterThan(data: {
     value: number | Array<number>;
     evaluationType?: EvaluateOverTimeType | undefined;
     threshold: number;
   }): boolean {
-    if (Array.isArray(data.value)) {
-      if (data.evaluationType === EvaluateOverTimeType.AnyValue) {
-        return data.value.some((value: number) => {
-          return value > data.threshold;
-        });
-      }
-      return data.value.every((value: number) => {
+    return CompareCriteria.evaluateWindow({
+      value: data.value,
+      evaluationType: data.evaluationType,
+      predicate: (value: number) => {
         return value > data.threshold;
-      });
-    }
-
-    return data.value > data.threshold;
+      },
+    });
   }
 
   @CaptureSpan()
@@ -77,18 +173,13 @@ export default class CompareCriteria {
     evaluationType?: EvaluateOverTimeType | undefined;
     threshold: number;
   }): boolean {
-    if (Array.isArray(data.value)) {
-      if (data.evaluationType === EvaluateOverTimeType.AnyValue) {
-        return data.value.some((value: number) => {
-          return value < data.threshold;
-        });
-      }
-      return data.value.every((value: number) => {
+    return CompareCriteria.evaluateWindow({
+      value: data.value,
+      evaluationType: data.evaluationType,
+      predicate: (value: number) => {
         return value < data.threshold;
-      });
-    }
-
-    return data.value < data.threshold;
+      },
+    });
   }
 
   @CaptureSpan()
@@ -97,18 +188,13 @@ export default class CompareCriteria {
     evaluationType?: EvaluateOverTimeType | undefined;
     threshold: number;
   }): boolean {
-    if (Array.isArray(data.value)) {
-      if (data.evaluationType === EvaluateOverTimeType.AnyValue) {
-        return data.value.some((value: number) => {
-          return value >= data.threshold;
-        });
-      }
-      return data.value.every((value: number) => {
+    return CompareCriteria.evaluateWindow({
+      value: data.value,
+      evaluationType: data.evaluationType,
+      predicate: (value: number) => {
         return value >= data.threshold;
-      });
-    }
-
-    return data.value >= data.threshold;
+      },
+    });
   }
 
   @CaptureSpan()
@@ -117,18 +203,13 @@ export default class CompareCriteria {
     evaluationType?: EvaluateOverTimeType | undefined;
     threshold: number;
   }): boolean {
-    if (Array.isArray(data.value)) {
-      if (data.evaluationType === EvaluateOverTimeType.AnyValue) {
-        return data.value.some((value: number) => {
-          return value <= data.threshold;
-        });
-      }
-      return data.value.every((value: number) => {
+    return CompareCriteria.evaluateWindow({
+      value: data.value,
+      evaluationType: data.evaluationType,
+      predicate: (value: number) => {
         return value <= data.threshold;
-      });
-    }
-
-    return data.value <= data.threshold;
+      },
+    });
   }
 
   @CaptureSpan()
@@ -137,18 +218,13 @@ export default class CompareCriteria {
     evaluationType?: EvaluateOverTimeType | undefined;
     threshold: number;
   }): boolean {
-    if (Array.isArray(data.value)) {
-      if (data.evaluationType === EvaluateOverTimeType.AnyValue) {
-        return data.value.some((value: number) => {
-          return value === data.threshold;
-        });
-      }
-      return data.value.every((value: number) => {
+    return CompareCriteria.evaluateWindow({
+      value: data.value,
+      evaluationType: data.evaluationType,
+      predicate: (value: number) => {
         return value === data.threshold;
-      });
-    }
-
-    return data.value === data.threshold;
+      },
+    });
   }
 
   @CaptureSpan()
@@ -157,18 +233,13 @@ export default class CompareCriteria {
     evaluationType?: EvaluateOverTimeType | undefined;
     threshold: number;
   }): boolean {
-    if (Array.isArray(data.value)) {
-      if (data.evaluationType === EvaluateOverTimeType.AnyValue) {
-        return data.value.some((value: number) => {
-          return value !== data.threshold;
-        });
-      }
-      return data.value.every((value: number) => {
+    return CompareCriteria.evaluateWindow({
+      value: data.value,
+      evaluationType: data.evaluationType,
+      predicate: (value: number) => {
         return value !== data.threshold;
-      });
-    }
-
-    return data.value !== data.threshold;
+      },
+    });
   }
 
   @CaptureSpan()
@@ -557,6 +628,7 @@ export default class CompareCriteria {
   }): string {
     // CPU Percent over the last 5 minutes is 10 which is less than the threshold of 20
     let message: string = "";
+    let breachSummary: string = "";
 
     let evaluationType: EvaluateOverTimeType | undefined =
       data.criteriaFilter.evaluateOverTimeOptions?.evaluateOverTimeType;
@@ -566,12 +638,34 @@ export default class CompareCriteria {
         data.criteriaFilter.metricMonitorOptions.metricAggregationType;
     }
 
-    if (evaluationType === EvaluateOverTimeType.AnyValue) {
-      message += "Any value of";
-    }
-
-    if (evaluationType === EvaluateOverTimeType.AllValues) {
-      message += "All values of";
+    /*
+     * Name the quantifier or the aggregation. Before this, only the two
+     * set quantifiers were named and the four reducing aggregations
+     * produced a bare "Metric Value is 82.62 which is greater than 90",
+     * which reads as a contradiction unless you already know the number
+     * shown is a five-minute average.
+     */
+    switch (evaluationType) {
+      case EvaluateOverTimeType.AnyValue:
+        message += "Any value of";
+        break;
+      case EvaluateOverTimeType.AllValues:
+        message += "All values of";
+        break;
+      case EvaluateOverTimeType.Average:
+        message += "The average of";
+        break;
+      case EvaluateOverTimeType.Sum:
+        message += "The sum of";
+        break;
+      case EvaluateOverTimeType.MaximumValue:
+        message += "The maximum of";
+        break;
+      case EvaluateOverTimeType.MunimumValue:
+        message += "The minimum of";
+        break;
+      default:
+        break;
     }
 
     /*
@@ -606,13 +700,56 @@ export default class CompareCriteria {
       data.criteriaFilter.filterType !== FilterType.True &&
       data.criteriaFilter.filterType !== FilterType.False
     ) {
-      const formattedValues: string = CompareCriteria.formatCriteriaValues(
-        data.values,
-      );
+      /*
+       * Print the samples that actually breached, not the whole window.
+       *
+       * `AnyValue` is an existential quantifier: it is met when ONE sample
+       * crosses the threshold. Printing the entire window and then
+       * asserting "which is greater than 90" produced the sentence a real
+       * customer received — "is 72.35, 81.54, 79.95, 91.53, 87.73 % which
+       * is greater than 90 %" — in which four of the five listed numbers
+       * are below the threshold the sentence claims they all exceed.
+       *
+       * For every other evaluation type the reported set and the compared
+       * set are the same thing (a reducing aggregation collapses to one
+       * value; AllValues requires all of them), so this narrowing is a
+       * no-op and the existing wording is preserved exactly.
+       */
+      const reportedValues:
+        | Array<number | boolean>
+        | number
+        | boolean
+        | string = CompareCriteria.getReportedValues({
+        values: data.values,
+        threshold: data.threshold,
+        filterType: data.criteriaFilter.filterType as FilterType,
+        evaluationType: evaluationType,
+      });
+
+      const formattedValues: string =
+        CompareCriteria.formatCriteriaValues(reportedValues);
 
       message += ` is ${formattedValues}${unitSuffix}`;
 
       message += " which is";
+
+      /*
+       * How much of the window actually breached.
+       *
+       * Without it "Any value ... is 91.53 % which is greater than 90 %"
+       * is true but hides the thing the reader needs in order to judge
+       * whether to get out of bed: whether that was one transient sample
+       * or the whole five minutes. One-in-five is a spike; five-in-five is
+       * an outage. Only added when the two counts differ, so a fully
+       * breaching window keeps the shorter sentence.
+       */
+      if (
+        Array.isArray(data.values) &&
+        Array.isArray(reportedValues) &&
+        reportedValues.length < data.values.length
+      ) {
+        breachSummary = ` ${reportedValues.length} of ${data.values.length} samples in the evaluation window breached this threshold.`;
+      }
     }
 
     switch (data.criteriaFilter.filterType) {
@@ -654,7 +791,107 @@ export default class CompareCriteria {
         break;
     }
 
-    return message.trim();
+    return `${message.trim()}${breachSummary}`;
+  }
+
+  /*
+   * Narrow the window down to what the message should quote.
+   *
+   * Only `AnyValue` needs narrowing — see the comment at the call site.
+   * A reducing aggregation is collapsed to its single aggregate so the
+   * sentence quotes the average it actually compared, not the raw samples.
+   * If nothing is found to breach (a caller rendering a message for a
+   * filter that did not match, or a non-numeric window) the original
+   * values are returned unchanged rather than an empty list, so the
+   * message degrades to its previous behaviour instead of to "is ".
+   */
+  private static getReportedValues(data: {
+    values: Array<number | boolean> | number | boolean | string;
+    threshold: number | string | boolean;
+    filterType: FilterType;
+    evaluationType?: EvaluateOverTimeType | undefined;
+  }): Array<number | boolean> | number | boolean | string {
+    if (!Array.isArray(data.values)) {
+      return data.values;
+    }
+
+    if (typeof data.threshold !== Typeof.Number) {
+      return data.values;
+    }
+
+    const numericValues: Array<number> = data.values.filter(
+      (value: number | boolean): value is number => {
+        return typeof value === Typeof.Number && Number.isFinite(value);
+      },
+    );
+
+    if (numericValues.length !== data.values.length) {
+      return data.values;
+    }
+
+    const predicate: ((value: number) => boolean) | null =
+      CompareCriteria.getNumericPredicate({
+        filterType: data.filterType,
+        threshold: data.threshold as number,
+      });
+
+    if (!predicate) {
+      return data.values;
+    }
+
+    const breaching: Array<number> = CompareCriteria.getBreachingValues({
+      values: numericValues,
+      evaluationType: data.evaluationType,
+      predicate: predicate,
+    });
+
+    if (breaching.length === 0) {
+      return data.values;
+    }
+
+    return breaching;
+  }
+
+  /*
+   * The comparison a numeric filter type performs, as a predicate.
+   *
+   * Kept next to the comparator methods it mirrors so the two cannot
+   * drift: a filter type added to `compareCriteriaNumbers` without a case
+   * here falls back to quoting the whole window, which is the old
+   * behaviour rather than a wrong one.
+   */
+  private static getNumericPredicate(data: {
+    filterType: FilterType;
+    threshold: number;
+  }): ((value: number) => boolean) | null {
+    switch (data.filterType) {
+      case FilterType.GreaterThan:
+        return (value: number) => {
+          return value > data.threshold;
+        };
+      case FilterType.GreaterThanOrEqualTo:
+        return (value: number) => {
+          return value >= data.threshold;
+        };
+      case FilterType.LessThan:
+        return (value: number) => {
+          return value < data.threshold;
+        };
+      case FilterType.LessThanOrEqualTo:
+        return (value: number) => {
+          return value <= data.threshold;
+        };
+      case FilterType.EqualTo:
+        return (value: number) => {
+          return value === data.threshold;
+        };
+      case FilterType.NotEqualTo:
+        return (value: number) => {
+          return value !== data.threshold;
+        };
+      default:
+        return null;
+    }
   }
 
   private static formatCriteriaValues(

--- a/Common/Tests/Server/Utils/Monitor/Criteria/CompareCriteriaAggregation.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/CompareCriteriaAggregation.test.ts
@@ -1,0 +1,430 @@
+import CompareCriteria from "../../../../../Server/Utils/Monitor/Criteria/CompareCriteria";
+import {
+  CheckOn,
+  CriteriaFilter,
+  EvaluateOverTimeType,
+  FilterType,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+
+/*
+ * Two defects, both visible in one real alert email.
+ *
+ * The customer received:
+ *   "Any value of (used_cpu / limit_cpu) * 100 is 72.35, 81.54, 79.95,
+ *    91.53, 87.73 % which is greater than 90 %."
+ * Four of those five numbers are below the threshold the sentence claims
+ * they all exceed — `getCompareMessage` printed the whole evaluation window
+ * and then asserted the filter's verdict over it.
+ *
+ * Separately, every comparator branched on `AnyValue` and let EVERY other
+ * evaluation type fall through to `.every()`. Average, Sum, Maximum Value
+ * and Minimum Value — all four selectable in the criteria UI — were
+ * silently evaluated as "All Values".
+ */
+
+// The exact window from the customer's ALT-113.
+const WINDOW: Array<number> = [72.35, 81.54, 79.95, 91.53, 87.73];
+
+function metricFilter(
+  filterType: FilterType,
+  evaluationType: EvaluateOverTimeType,
+): CriteriaFilter {
+  return {
+    checkOn: CheckOn.MetricValue,
+    filterType: filterType,
+    value: 90,
+    metricMonitorOptions: {
+      metricAggregationType: evaluationType,
+      metricAlias: "pod_cpu_limit_saturation",
+    },
+  } as CriteriaFilter;
+}
+
+describe("CompareCriteria aggregation semantics", () => {
+  describe("reduceWindow", () => {
+    test("Average collapses the window to its mean", () => {
+      expect(
+        CompareCriteria.reduceWindow({
+          values: [10, 20, 30],
+          evaluationType: EvaluateOverTimeType.Average,
+        }),
+      ).toEqual([20]);
+    });
+
+    test("Sum collapses the window to its total", () => {
+      expect(
+        CompareCriteria.reduceWindow({
+          values: [10, 20, 30],
+          evaluationType: EvaluateOverTimeType.Sum,
+        }),
+      ).toEqual([60]);
+    });
+
+    test("Maximum Value collapses to the largest sample", () => {
+      expect(
+        CompareCriteria.reduceWindow({
+          values: [10, 30, 20],
+          evaluationType: EvaluateOverTimeType.MaximumValue,
+        }),
+      ).toEqual([30]);
+    });
+
+    test("Minimum Value collapses to the smallest sample", () => {
+      expect(
+        CompareCriteria.reduceWindow({
+          values: [30, 10, 20],
+          evaluationType: EvaluateOverTimeType.MunimumValue,
+        }),
+      ).toEqual([10]);
+    });
+
+    test.each([
+      EvaluateOverTimeType.AnyValue,
+      EvaluateOverTimeType.AllValues,
+      undefined,
+    ])(
+      "%s quantifies over the untouched window",
+      (evaluationType: EvaluateOverTimeType | undefined) => {
+        expect(
+          CompareCriteria.reduceWindow({
+            values: [10, 20, 30],
+            evaluationType: evaluationType,
+          }),
+        ).toEqual([10, 20, 30]);
+      },
+    );
+
+    test("an empty window is returned unchanged rather than reduced to NaN", () => {
+      expect(
+        CompareCriteria.reduceWindow({
+          values: [],
+          evaluationType: EvaluateOverTimeType.Average,
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("the four reducing aggregations are actually applied", () => {
+    /*
+     * The mean of the production window is 82.62. Under the old code
+     * "Average > 90" was evaluated as "every sample > 90" — false, but for
+     * the wrong reason. These assertions pin the reason.
+     */
+    test("Average > 90 is false because the mean is 82.62, not because a sample was low", () => {
+      expect(
+        CompareCriteria.greaterThan({
+          value: WINDOW,
+          evaluationType: EvaluateOverTimeType.Average,
+          threshold: 90,
+        }),
+      ).toBe(false);
+
+      expect(
+        CompareCriteria.greaterThan({
+          value: WINDOW,
+          evaluationType: EvaluateOverTimeType.Average,
+          threshold: 80,
+        }),
+      ).toBe(true);
+    });
+
+    test("Average > 80 was WRONG before this fix: AllValues semantics said false", () => {
+      // If Average were still falling through to `.every()`, 79.95 would
+      // sink it. It does not, because the mean is what is compared.
+      expect(
+        WINDOW.every((v: number) => {
+          return v > 80;
+        }),
+      ).toBe(false);
+      expect(
+        CompareCriteria.greaterThan({
+          value: WINDOW,
+          evaluationType: EvaluateOverTimeType.Average,
+          threshold: 80,
+        }),
+      ).toBe(true);
+    });
+
+    test("Maximum Value fires on the single high sample", () => {
+      expect(
+        CompareCriteria.greaterThan({
+          value: WINDOW,
+          evaluationType: EvaluateOverTimeType.MaximumValue,
+          threshold: 90,
+        }),
+      ).toBe(true);
+    });
+
+    test("Minimum Value does not", () => {
+      expect(
+        CompareCriteria.greaterThan({
+          value: WINDOW,
+          evaluationType: EvaluateOverTimeType.MunimumValue,
+          threshold: 90,
+        }),
+      ).toBe(false);
+    });
+
+    test("Sum aggregates across the window", () => {
+      expect(
+        CompareCriteria.greaterThan({
+          value: [1, 2, 3],
+          evaluationType: EvaluateOverTimeType.Sum,
+          threshold: 5,
+        }),
+      ).toBe(true);
+      expect(
+        CompareCriteria.greaterThan({
+          value: [1, 2, 3],
+          evaluationType: EvaluateOverTimeType.Sum,
+          threshold: 6,
+        }),
+      ).toBe(false);
+    });
+
+    test("every comparator honours the aggregation, not just greaterThan", () => {
+      const mean: number = 20; // mean of [10, 20, 30]
+      const values: Array<number> = [10, 20, 30];
+
+      expect(
+        CompareCriteria.lessThan({
+          value: values,
+          evaluationType: EvaluateOverTimeType.Average,
+          threshold: mean + 1,
+        }),
+      ).toBe(true);
+      expect(
+        CompareCriteria.greaterThanOrEqual({
+          value: values,
+          evaluationType: EvaluateOverTimeType.Average,
+          threshold: mean,
+        }),
+      ).toBe(true);
+      expect(
+        CompareCriteria.lessThanOrEqual({
+          value: values,
+          evaluationType: EvaluateOverTimeType.Average,
+          threshold: mean,
+        }),
+      ).toBe(true);
+      expect(
+        CompareCriteria.equalTo({
+          value: values,
+          evaluationType: EvaluateOverTimeType.Average,
+          threshold: mean,
+        }),
+      ).toBe(true);
+      expect(
+        CompareCriteria.notEqualTo({
+          value: values,
+          evaluationType: EvaluateOverTimeType.Average,
+          threshold: mean,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("AnyValue and AllValues keep their existing semantics", () => {
+    test("AnyValue fires when one sample breaches", () => {
+      expect(
+        CompareCriteria.greaterThan({
+          value: WINDOW,
+          evaluationType: EvaluateOverTimeType.AnyValue,
+          threshold: 90,
+        }),
+      ).toBe(true);
+    });
+
+    test("AllValues does not", () => {
+      expect(
+        CompareCriteria.greaterThan({
+          value: WINDOW,
+          evaluationType: EvaluateOverTimeType.AllValues,
+          threshold: 90,
+        }),
+      ).toBe(false);
+    });
+
+    test("an unspecified evaluation type still defaults to AllValues", () => {
+      expect(
+        CompareCriteria.greaterThan({ value: WINDOW, threshold: 90 }),
+      ).toBe(false);
+    });
+
+    test("a scalar value is compared directly", () => {
+      expect(CompareCriteria.greaterThan({ value: 91, threshold: 90 })).toBe(
+        true,
+      );
+    });
+
+    test("an empty window never matches", () => {
+      expect(
+        CompareCriteria.greaterThan({
+          value: [],
+          evaluationType: EvaluateOverTimeType.AnyValue,
+          threshold: 90,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("the root cause quotes only the samples that breached", () => {
+    test("the exact sentence a customer received is no longer produced", () => {
+      const message: string = CompareCriteria.getCompareMessage({
+        values: WINDOW,
+        threshold: 90,
+        criteriaFilter: metricFilter(
+          FilterType.GreaterThan,
+          EvaluateOverTimeType.AnyValue,
+        ),
+        metricDisplayName: "(used_cpu / limit_cpu) * 100",
+        unit: "%",
+      });
+
+      // The four non-breaching samples are gone.
+      expect(message).not.toContain("72.35");
+      expect(message).not.toContain("81.54");
+      expect(message).not.toContain("79.95");
+      expect(message).not.toContain("87.73");
+
+      // The one that did breach is named, and the reader is told how much
+      // of the window it represents.
+      expect(message).toContain("91.53");
+      expect(message).toContain(
+        "1 of 5 samples in the evaluation window breached this threshold.",
+      );
+    });
+
+    test("a fully breaching window keeps the shorter sentence", () => {
+      const message: string = CompareCriteria.getCompareMessage({
+        values: [95, 96, 97],
+        threshold: 90,
+        criteriaFilter: metricFilter(
+          FilterType.GreaterThan,
+          EvaluateOverTimeType.AnyValue,
+        ),
+        metricDisplayName: "CPU",
+        unit: "%",
+      });
+
+      expect(message).toBe(
+        "Any value of CPU is 95, 96, 97 % which is greater than 90 %.",
+      );
+    });
+
+    test("a below-threshold recovery message quotes only the recovering samples", () => {
+      const message: string = CompareCriteria.getCompareMessage({
+        values: [95, 80, 70],
+        threshold: 90,
+        criteriaFilter: metricFilter(
+          FilterType.LessThanOrEqualTo,
+          EvaluateOverTimeType.AnyValue,
+        ),
+        metricDisplayName: "CPU",
+        unit: "%",
+      });
+
+      expect(message).toContain("80, 70");
+      expect(message).not.toContain("95");
+    });
+
+    test("AllValues is unaffected — every sample breached by definition", () => {
+      const message: string = CompareCriteria.getCompareMessage({
+        values: [95, 96],
+        threshold: 90,
+        criteriaFilter: metricFilter(
+          FilterType.GreaterThan,
+          EvaluateOverTimeType.AllValues,
+        ),
+        metricDisplayName: "CPU",
+        unit: "%",
+      });
+
+      expect(message).toBe(
+        "All values of CPU is 95, 96 % which is greater than 90 %.",
+      );
+    });
+
+    test("a reducing aggregation quotes the aggregate, not the raw window", () => {
+      const message: string = CompareCriteria.getCompareMessage({
+        values: [10, 20, 30],
+        threshold: 15,
+        criteriaFilter: metricFilter(
+          FilterType.GreaterThan,
+          EvaluateOverTimeType.Average,
+        ),
+        metricDisplayName: "CPU",
+        unit: "%",
+      });
+
+      expect(message).toContain("The average of CPU is 20");
+      expect(message).not.toContain("10, 20, 30");
+    });
+
+    test.each([
+      [EvaluateOverTimeType.Average, "The average of"],
+      [EvaluateOverTimeType.Sum, "The sum of"],
+      [EvaluateOverTimeType.MaximumValue, "The maximum of"],
+      [EvaluateOverTimeType.MunimumValue, "The minimum of"],
+      [EvaluateOverTimeType.AnyValue, "Any value of"],
+      [EvaluateOverTimeType.AllValues, "All values of"],
+    ])(
+      "%s is named in the sentence as %s",
+      (evaluationType: EvaluateOverTimeType, expectedPrefix: string) => {
+        const message: string = CompareCriteria.getCompareMessage({
+          values: [100],
+          threshold: 90,
+          criteriaFilter: metricFilter(FilterType.GreaterThan, evaluationType),
+          metricDisplayName: "CPU",
+          unit: "%",
+        });
+
+        expect(message.startsWith(expectedPrefix)).toBe(true);
+      },
+    );
+
+    test("a message rendered for a filter that did not match degrades gracefully", () => {
+      // Nothing in the window is above 200; the whole window is quoted
+      // rather than an empty list.
+      const message: string = CompareCriteria.getCompareMessage({
+        values: WINDOW,
+        threshold: 200,
+        criteriaFilter: metricFilter(
+          FilterType.GreaterThan,
+          EvaluateOverTimeType.AnyValue,
+        ),
+        metricDisplayName: "CPU",
+        unit: "%",
+      });
+
+      expect(message).toContain("72.35");
+      expect(message).not.toContain("samples in the evaluation window");
+    });
+
+    test("a non-numeric window is left alone", () => {
+      const message: string = CompareCriteria.getCompareMessage({
+        values: [true, false],
+        threshold: 1,
+        criteriaFilter: metricFilter(
+          FilterType.GreaterThan,
+          EvaluateOverTimeType.AnyValue,
+        ),
+        metricDisplayName: "Up",
+      });
+
+      expect(message).toContain("true, false");
+    });
+
+    test("getBreachingValues returns only the matching samples", () => {
+      expect(
+        CompareCriteria.getBreachingValues({
+          values: WINDOW,
+          evaluationType: EvaluateOverTimeType.AnyValue,
+          predicate: (value: number) => {
+            return value > 90;
+          },
+        }),
+      ).toEqual([91.53]);
+    });
+  });
+});

--- a/Common/Tests/Types/Monitor/CephAlertTemplates.test.ts
+++ b/Common/Tests/Types/Monitor/CephAlertTemplates.test.ts
@@ -5,6 +5,9 @@ import {
   getCephAlertTemplateById,
 } from "../../../Types/Monitor/CephAlertTemplates";
 import { getCephMetricByMetricName } from "../../../Types/Monitor/CephMetricCatalog";
+import { getRecoveryThreshold } from "../../../Types/Monitor/Recommendation/RecommendationCriteriaBuilder";
+import { getComplementFilterType } from "./Utils/RecommendationCriteriaAssertions";
+import { hasRecoveryDeadBand } from "./Utils/RecommendationCriteriaAssertions";
 import MonitorStep from "../../../Types/Monitor/MonitorStep";
 import MonitorStepCephMonitor from "../../../Types/Monitor/MonitorStepCephMonitor";
 import MonitorCriteriaInstance from "../../../Types/Monitor/MonitorCriteriaInstance";
@@ -841,28 +844,18 @@ function getReferencableAliases(monitor: MonitorStepCephMonitor): Set<string> {
   return aliases;
 }
 
+/*
+ * Delegates to the shared assertion so all eight recommendation suites
+ * agree on what a correct fire/recover pair looks like. This function used
+ * to require `fire.value === recover.value` — see the comment in
+ * RecommendationCriteriaAssertions for why that was the bug rather than
+ * the invariant.
+ */
 function isDisjointComplement(
   fire: { filterType: FilterType; value: number },
   recover: { filterType: FilterType; value: number },
 ): boolean {
-  if (fire.value !== recover.value) {
-    return false;
-  }
-  switch (fire.filterType) {
-    case FilterType.GreaterThan:
-      return (
-        recover.filterType === FilterType.LessThanOrEqualTo ||
-        (fire.value === 0 && recover.filterType === FilterType.EqualTo)
-      );
-    case FilterType.GreaterThanOrEqualTo:
-      return recover.filterType === FilterType.LessThan;
-    case FilterType.LessThan:
-      return recover.filterType === FilterType.GreaterThanOrEqualTo;
-    case FilterType.LessThanOrEqualTo:
-      return recover.filterType === FilterType.GreaterThan;
-    default:
-      return false;
-  }
+  return hasRecoveryDeadBand(fire, recover);
 }
 
 // Health-check series exist only while their check is active.
@@ -1215,7 +1208,19 @@ describe("CephAlertTemplates - spec table expectations", () => {
           expectedFilter.alias,
         );
         expect(onlineFilters[j].filterType).toBe(expectedFilter.filterType);
-        expect(onlineFilters[j].value).toBe(expectedFilter.value);
+        /*
+         * The spec table states the FIRING threshold. The recovery
+         * threshold is derived from it, so the table does not have to
+         * restate every dead-banded number — and so a change to the dead
+         * band shows up as a behaviour change in one place rather than as
+         * a diff across nine spec tables.
+         */
+        expect(onlineFilters[j].value).toBe(
+          getRecoveryThreshold({
+            filterType: getComplementFilterType(expectedFilter.filterType)!,
+            value: expectedFilter.value,
+          }) ?? expectedFilter.value,
+        );
         if (tc.recover.treatNoDataAsZero) {
           expect(onlineFilters[j].metricMonitorOptions.onNoDataPolicy).toBe(
             NoDataPolicy.TreatAsZero,

--- a/Common/Tests/Types/Monitor/DockerAlertTemplates.test.ts
+++ b/Common/Tests/Types/Monitor/DockerAlertTemplates.test.ts
@@ -7,6 +7,7 @@ import {
   getDockerAlertTemplatesByCategory,
 } from "../../../Types/Monitor/DockerAlertTemplates";
 import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import { hasRecoveryDeadBand } from "./Utils/RecommendationCriteriaAssertions";
 import MonitorStepDockerMonitor from "../../../Types/Monitor/MonitorStepDockerMonitor";
 import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
 import RollingTime from "../../../Types/RollingTime/RollingTime";
@@ -234,7 +235,7 @@ describe("DockerAlertTemplates", () => {
   );
 
   test.each(DOCKER_TEMPLATES)(
-    "$id unhealthy/healthy criteria partition the range at $threshold",
+    "$id unhealthy/healthy criteria leave a recovery dead band around $threshold",
     (tc: DockerTemplateCase) => {
       const template: DockerAlertTemplate = getDockerAlertTemplateById(tc.id)!;
       const step: MonitorStep = template.getMonitorStep(buildArgs());
@@ -248,7 +249,7 @@ describe("DockerAlertTemplates", () => {
       const offlineFilter: any = offline.data.filters[0];
       const onlineFilter: any = online.data.filters[0];
 
-      // Both criteria evaluate the SAME metric alias at the SAME threshold.
+      // Both criteria evaluate the same metric alias, at different thresholds.
       expect(offlineFilter.metricMonitorOptions.metricAlias).toBe(
         tc.metricAlias,
       );
@@ -256,7 +257,26 @@ describe("DockerAlertTemplates", () => {
         tc.metricAlias,
       );
       expect(offlineFilter.value).toBe(tc.threshold);
-      expect(onlineFilter.value).toBe(tc.threshold);
+      /*
+       * The healthy criteria recovers at a threshold strictly INSIDE the
+       * firing one, so a metric hovering at the boundary cannot satisfy
+       * both on consecutive evaluations. This assertion used to be
+       * `expect(onlineFilter.value).toBe(tc.threshold)` — the two criteria
+       * exactly partitioned the range, which is the flapping configuration
+       * this suite existed to lock in.
+       */
+      expect(
+        hasRecoveryDeadBand(
+          {
+            filterType: offlineFilter.filterType,
+            value: offlineFilter.value as number,
+          },
+          {
+            filterType: onlineFilter.filterType,
+            value: onlineFilter.value as number,
+          },
+        ),
+      ).toBe(true);
 
       // Only the comparison DIRECTION differs — pinned per template.
       expect(offlineFilter.filterType).toBe(tc.offlineFilterType);

--- a/Common/Tests/Types/Monitor/DockerSwarmAlertTemplates.test.ts
+++ b/Common/Tests/Types/Monitor/DockerSwarmAlertTemplates.test.ts
@@ -6,6 +6,9 @@ import {
   getDockerSwarmAlertTemplatesByCategory,
 } from "../../../Types/Monitor/DockerSwarmAlertTemplates";
 import { getDockerSwarmMetricByMetricName } from "../../../Types/Monitor/DockerSwarmMetricCatalog";
+import { getRecoveryThreshold } from "../../../Types/Monitor/Recommendation/RecommendationCriteriaBuilder";
+import { getComplementFilterType } from "./Utils/RecommendationCriteriaAssertions";
+import { hasRecoveryDeadBand } from "./Utils/RecommendationCriteriaAssertions";
 import MonitorStep from "../../../Types/Monitor/MonitorStep";
 import MonitorStepDockerSwarmMonitor from "../../../Types/Monitor/MonitorStepDockerSwarmMonitor";
 import MonitorCriteriaInstance from "../../../Types/Monitor/MonitorCriteriaInstance";
@@ -215,31 +218,18 @@ function getReferencableAliases(
  * Fire and recover must be disjoint complements on the same alias —
  * otherwise the monitor either flaps (overlap) or wedges (gap).
  */
+/*
+ * Delegates to the shared assertion so all eight recommendation suites
+ * agree on what a correct fire/recover pair looks like. This function used
+ * to require `fire.value === recover.value` — see the comment in
+ * RecommendationCriteriaAssertions for why that was the bug rather than
+ * the invariant.
+ */
 function isDisjointComplement(
   fire: { filterType: FilterType; value: number },
   recover: { filterType: FilterType; value: number },
 ): boolean {
-  if (fire.value !== recover.value) {
-    return false;
-  }
-  switch (fire.filterType) {
-    case FilterType.GreaterThan:
-      return (
-        recover.filterType === FilterType.LessThanOrEqualTo ||
-        (fire.value === 0 && recover.filterType === FilterType.EqualTo)
-      );
-    case FilterType.GreaterThanOrEqualTo:
-      return recover.filterType === FilterType.LessThan;
-    case FilterType.LessThan:
-      return recover.filterType === FilterType.GreaterThanOrEqualTo;
-    case FilterType.LessThanOrEqualTo:
-      return recover.filterType === FilterType.GreaterThan;
-    case FilterType.EqualTo:
-      // Task-down: fire when uptime == 0, recover when uptime > 0.
-      return fire.value === 0 && recover.filterType === FilterType.GreaterThan;
-    default:
-      return false;
-  }
+  return hasRecoveryDeadBand(fire, recover);
 }
 
 const ALL_TEMPLATES: Array<DockerSwarmAlertTemplate> =
@@ -522,7 +512,17 @@ describe("DockerSwarmAlertTemplates - spec table expectations", () => {
         tc.recover.alias,
       );
       expect(recoverFilter.filterType).toBe(tc.recover.filterType);
-      expect(recoverFilter.value).toBe(tc.recover.value);
+      /*
+       * The spec table states the FIRING threshold; the recovery threshold
+       * is derived from it so the dead band lives in one place rather than
+       * being restated in every spec table.
+       */
+      expect(recoverFilter.value).toBe(
+        getRecoveryThreshold({
+          filterType: getComplementFilterType(tc.recover.filterType)!,
+          value: tc.recover.value,
+        }) ?? tc.recover.value,
+      );
     },
   );
 });

--- a/Common/Tests/Types/Monitor/HostAlertTemplates.test.ts
+++ b/Common/Tests/Types/Monitor/HostAlertTemplates.test.ts
@@ -7,6 +7,7 @@ import {
   getHostAlertTemplatesByCategory,
 } from "../../../Types/Monitor/HostAlertTemplates";
 import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import { hasRecoveryDeadBand } from "./Utils/RecommendationCriteriaAssertions";
 import MonitorStepHostMonitor from "../../../Types/Monitor/MonitorStepHostMonitor";
 import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
 import { FilterType } from "../../../Types/Monitor/CriteriaFilter";
@@ -193,7 +194,7 @@ describe("HostAlertTemplates", () => {
   );
 
   test.each(HOST_TEMPLATES)(
-    "$id unhealthy/healthy criteria partition the range at $threshold with > / <=",
+    "$id unhealthy/healthy criteria leave a recovery dead band below $threshold",
     (tc: HostTemplateCase) => {
       const template: HostAlertTemplate = getHostAlertTemplateById(tc.id)!;
       const step: MonitorStep = template.getMonitorStep(buildArgs());
@@ -213,7 +214,26 @@ describe("HostAlertTemplates", () => {
         tc.metricAlias,
       );
       expect(offlineFilter.value).toBe(tc.threshold);
-      expect(onlineFilter.value).toBe(tc.threshold);
+      /*
+       * The healthy criteria recovers at a threshold strictly INSIDE the
+       * firing one, so a metric hovering at the boundary cannot satisfy
+       * both on consecutive evaluations. This assertion used to be
+       * `expect(onlineFilter.value).toBe(tc.threshold)` — the two criteria
+       * exactly partitioned the range, which is the flapping configuration
+       * this suite existed to lock in.
+       */
+      expect(
+        hasRecoveryDeadBand(
+          {
+            filterType: offlineFilter.filterType,
+            value: offlineFilter.value as number,
+          },
+          {
+            filterType: onlineFilter.filterType,
+            value: onlineFilter.value as number,
+          },
+        ),
+      ).toBe(true);
 
       // Host ceilings are all "> threshold" unhealthy / "<= threshold" healthy.
       expect(offlineFilter.filterType).toBe(FilterType.GreaterThan);

--- a/Common/Tests/Types/Monitor/IotAlertTemplates.test.ts
+++ b/Common/Tests/Types/Monitor/IotAlertTemplates.test.ts
@@ -7,6 +7,7 @@ import {
   getIoTAlertTemplatesByCategory,
 } from "../../../Types/Monitor/IotAlertTemplates";
 import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import { hasRecoveryDeadBand } from "./Utils/RecommendationCriteriaAssertions";
 import MonitorStepIoTMonitor from "../../../Types/Monitor/MonitorStepIoTMonitor";
 import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
 import {
@@ -235,7 +236,7 @@ describe("IotAlertTemplates", () => {
   );
 
   test.each(IOT_TEMPLATES)(
-    "$id unhealthy/healthy criteria partition the range at $threshold",
+    "$id unhealthy/healthy criteria leave a recovery dead band around $threshold",
     (tc: IoTTemplateCase) => {
       const template: IoTAlertTemplate = getIoTAlertTemplateById(tc.id)!;
       const step: MonitorStep = template.getMonitorStep(buildArgs());
@@ -255,7 +256,26 @@ describe("IotAlertTemplates", () => {
         tc.metricAlias,
       );
       expect(offlineFilter.value).toBe(tc.threshold);
-      expect(onlineFilter.value).toBe(tc.threshold);
+      /*
+       * The healthy criteria recovers at a threshold strictly INSIDE the
+       * firing one, so a metric hovering at the boundary cannot satisfy
+       * both on consecutive evaluations. This assertion used to be
+       * `expect(onlineFilter.value).toBe(tc.threshold)` — the two criteria
+       * exactly partitioned the range, which is the flapping configuration
+       * this suite existed to lock in.
+       */
+      expect(
+        hasRecoveryDeadBand(
+          {
+            filterType: offlineFilter.filterType,
+            value: offlineFilter.value as number,
+          },
+          {
+            filterType: onlineFilter.filterType,
+            value: onlineFilter.value as number,
+          },
+        ),
+      ).toBe(true);
 
       /*
        * Decision (1): pin the exact comparison direction per template — the

--- a/Common/Tests/Types/Monitor/KubernetesAlertTemplates.test.ts
+++ b/Common/Tests/Types/Monitor/KubernetesAlertTemplates.test.ts
@@ -5,6 +5,7 @@ import {
   getKubernetesAlertTemplateById,
 } from "../../../Types/Monitor/KubernetesAlertTemplates";
 import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import { hasRecoveryDeadBand } from "./Utils/RecommendationCriteriaAssertions";
 import MonitorStepKubernetesMonitor from "../../../Types/Monitor/MonitorStepKubernetesMonitor";
 import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
 import { FilterType } from "../../../Types/Monitor/CriteriaFilter";
@@ -284,7 +285,7 @@ describe("KubernetesAlertTemplates - per-series ratio templates", () => {
   };
 
   test.each(RATIO_TEMPLATES)(
-    "$id unhealthy/healthy criteria partition the range at $threshold",
+    "$id unhealthy/healthy criteria leave a recovery dead band around $threshold",
     (tc: RatioTemplateCase) => {
       const template: KubernetesAlertTemplate | undefined =
         getKubernetesAlertTemplateById(tc.id);
@@ -297,11 +298,30 @@ describe("KubernetesAlertTemplates - per-series ratio templates", () => {
       const offlineFilter: any = offline.data.filters[0];
       const onlineFilter: any = online.data.filters[0];
 
-      // Same metric, same threshold — only the comparison direction differs.
+      // Same metric; the comparison direction AND the threshold differ.
       expect(onlineFilter.metricMonitorOptions.metricAlias).toBe(
         tc.resultAlias,
       );
-      expect(onlineFilter.value).toBe(tc.threshold);
+      /*
+       * The healthy criteria recovers at a threshold strictly INSIDE the
+       * firing one, so a metric hovering at the boundary cannot satisfy
+       * both on consecutive evaluations. This assertion used to be
+       * `expect(onlineFilter.value).toBe(tc.threshold)` — the two criteria
+       * exactly partitioned the range, which is the flapping configuration
+       * this suite existed to lock in.
+       */
+      expect(
+        hasRecoveryDeadBand(
+          {
+            filterType: offlineFilter.filterType,
+            value: offlineFilter.value as number,
+          },
+          {
+            filterType: onlineFilter.filterType,
+            value: onlineFilter.value as number,
+          },
+        ),
+      ).toBe(true);
 
       expect(COMPLEMENT_OF[offlineFilter.filterType]).toBe(
         onlineFilter.filterType,

--- a/Common/Tests/Types/Monitor/PodmanAlertTemplates.test.ts
+++ b/Common/Tests/Types/Monitor/PodmanAlertTemplates.test.ts
@@ -7,6 +7,7 @@ import {
   getPodmanAlertTemplatesByCategory,
 } from "../../../Types/Monitor/PodmanAlertTemplates";
 import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import { hasRecoveryDeadBand } from "./Utils/RecommendationCriteriaAssertions";
 import MonitorStepPodmanMonitor from "../../../Types/Monitor/MonitorStepPodmanMonitor";
 import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
 import RollingTime from "../../../Types/RollingTime/RollingTime";
@@ -217,7 +218,7 @@ describe("PodmanAlertTemplates", () => {
   );
 
   test.each(PODMAN_TEMPLATES)(
-    "$id unhealthy/healthy criteria partition the range at $threshold",
+    "$id unhealthy/healthy criteria leave a recovery dead band around $threshold",
     (tc: PodmanTemplateCase) => {
       const template: PodmanAlertTemplate = getPodmanAlertTemplateById(tc.id)!;
       const step: MonitorStep = template.getMonitorStep(buildArgs());
@@ -237,7 +238,26 @@ describe("PodmanAlertTemplates", () => {
         tc.metricAlias,
       );
       expect(offlineFilter.value).toBe(tc.threshold);
-      expect(onlineFilter.value).toBe(tc.threshold);
+      /*
+       * The healthy criteria recovers at a threshold strictly INSIDE the
+       * firing one, so a metric hovering at the boundary cannot satisfy
+       * both on consecutive evaluations. This assertion used to be
+       * `expect(onlineFilter.value).toBe(tc.threshold)` — the two criteria
+       * exactly partitioned the range, which is the flapping configuration
+       * this suite existed to lock in.
+       */
+      expect(
+        hasRecoveryDeadBand(
+          {
+            filterType: offlineFilter.filterType,
+            value: offlineFilter.value as number,
+          },
+          {
+            filterType: onlineFilter.filterType,
+            value: onlineFilter.value as number,
+          },
+        ),
+      ).toBe(true);
 
       expect(offlineFilter.filterType).toBe(tc.offlineFilterType);
       expect(onlineFilter.filterType).toBe(tc.onlineFilterType);

--- a/Common/Tests/Types/Monitor/ProxmoxAlertTemplates.test.ts
+++ b/Common/Tests/Types/Monitor/ProxmoxAlertTemplates.test.ts
@@ -5,6 +5,9 @@ import {
   getProxmoxAlertTemplateById,
 } from "../../../Types/Monitor/ProxmoxAlertTemplates";
 import { getProxmoxMetricByMetricName } from "../../../Types/Monitor/ProxmoxMetricCatalog";
+import { getRecoveryThreshold } from "../../../Types/Monitor/Recommendation/RecommendationCriteriaBuilder";
+import { getComplementFilterType } from "./Utils/RecommendationCriteriaAssertions";
+import { hasRecoveryDeadBand } from "./Utils/RecommendationCriteriaAssertions";
 import MonitorStep from "../../../Types/Monitor/MonitorStep";
 import MonitorStepProxmoxMonitor from "../../../Types/Monitor/MonitorStepProxmoxMonitor";
 import MonitorCriteriaInstance from "../../../Types/Monitor/MonitorCriteriaInstance";
@@ -421,28 +424,18 @@ function getReferencableAliases(
  * Fire and recover must be disjoint complements on the same alias —
  * otherwise the monitor either flaps (overlap) or wedges (gap).
  */
+/*
+ * Delegates to the shared assertion so all eight recommendation suites
+ * agree on what a correct fire/recover pair looks like. This function used
+ * to require `fire.value === recover.value` — see the comment in
+ * RecommendationCriteriaAssertions for why that was the bug rather than
+ * the invariant.
+ */
 function isDisjointComplement(
   fire: { filterType: FilterType; value: number },
   recover: { filterType: FilterType; value: number },
 ): boolean {
-  if (fire.value !== recover.value) {
-    return false;
-  }
-  switch (fire.filterType) {
-    case FilterType.GreaterThan:
-      return (
-        recover.filterType === FilterType.LessThanOrEqualTo ||
-        (fire.value === 0 && recover.filterType === FilterType.EqualTo)
-      );
-    case FilterType.GreaterThanOrEqualTo:
-      return recover.filterType === FilterType.LessThan;
-    case FilterType.LessThan:
-      return recover.filterType === FilterType.GreaterThanOrEqualTo;
-    case FilterType.LessThanOrEqualTo:
-      return recover.filterType === FilterType.GreaterThan;
-    default:
-      return false;
-  }
+  return hasRecoveryDeadBand(fire, recover);
 }
 
 const ALL_TEMPLATES: Array<ProxmoxAlertTemplate> =
@@ -726,7 +719,17 @@ describe("ProxmoxAlertTemplates - spec table expectations", () => {
         tc.recover.alias,
       );
       expect(recoverFilter.filterType).toBe(tc.recover.filterType);
-      expect(recoverFilter.value).toBe(tc.recover.value);
+      /*
+       * The spec table states the FIRING threshold; the recovery threshold
+       * is derived from it so the dead band lives in one place rather than
+       * being restated in every spec table.
+       */
+      expect(recoverFilter.value).toBe(
+        getRecoveryThreshold({
+          filterType: getComplementFilterType(tc.recover.filterType)!,
+          value: tc.recover.value,
+        }) ?? tc.recover.value,
+      );
     },
   );
 });

--- a/Common/Tests/Types/Monitor/Recommendation/RecommendationCriteriaBuilder.test.ts
+++ b/Common/Tests/Types/Monitor/Recommendation/RecommendationCriteriaBuilder.test.ts
@@ -1,0 +1,412 @@
+import FilterCondition from "../../../../Types/Filter/FilterCondition";
+import MonitorCriteriaInstance from "../../../../Types/Monitor/MonitorCriteriaInstance";
+import ObjectID from "../../../../Types/ObjectID";
+import {
+  CriteriaFilter,
+  EvaluateOverTimeType,
+  FilterType,
+  NoDataPolicy,
+} from "../../../../Types/Monitor/CriteriaFilter";
+import {
+  DefaultRecoveryMarginFraction,
+  SustainedEvaluation,
+  buildHealthyCriteriaInstance,
+  buildUnhealthyCriteriaInstance,
+  getRecoveryFilterType,
+  getRecoveryThreshold,
+} from "../../../../Types/Monitor/Recommendation/RecommendationCriteriaBuilder";
+
+/*
+ * Regression tests for the flapping defect behind
+ * https://github.com/OneUptime/oneuptime — a single Kubernetes monitor
+ * created from a recommendation produced 39 alert emails (19 open, 20
+ * resolve) in under two hours, one open/resolve pair roughly every five
+ * minutes, on a pod whose CPU was hovering either side of its limit.
+ *
+ * The two causes, both encoded as defaults in nine copy-pasted builders:
+ *   - `AnyValue` on the FIRE side, so one sample anywhere in the rolling
+ *     window opened an alert.
+ *   - The identical threshold on both sides, so the metric could satisfy
+ *     "> 90" and "<= 90" on consecutive evaluations forever.
+ */
+
+const OFFLINE_STATUS_ID: ObjectID = new ObjectID("offline-status");
+const ONLINE_STATUS_ID: ObjectID = new ObjectID("online-status");
+const INCIDENT_SEVERITY_ID: ObjectID = new ObjectID("incident-severity");
+const ALERT_SEVERITY_ID: ObjectID = new ObjectID("alert-severity");
+
+// The exact window from the customer's ALT-113, in percent of CPU limit.
+const PRODUCTION_WINDOW: Array<number> = [72.35, 81.54, 79.95, 91.53, 87.73];
+
+function buildUnhealthy(
+  overrides?: Partial<Parameters<typeof buildUnhealthyCriteriaInstance>[0]>,
+): MonitorCriteriaInstance {
+  return buildUnhealthyCriteriaInstance({
+    offlineMonitorStatusId: OFFLINE_STATUS_ID,
+    incidentSeverityId: INCIDENT_SEVERITY_ID,
+    alertSeverityId: ALERT_SEVERITY_ID,
+    monitorName: "prod-cluster - Pod CPU Saturating Container Limit",
+    metricAlias: "pod_cpu_limit_saturation",
+    filterType: FilterType.GreaterThan,
+    value: 90,
+    ...overrides,
+  });
+}
+
+function buildHealthy(
+  overrides?: Partial<Parameters<typeof buildHealthyCriteriaInstance>[0]>,
+): MonitorCriteriaInstance {
+  return buildHealthyCriteriaInstance({
+    onlineMonitorStatusId: ONLINE_STATUS_ID,
+    metricAlias: "pod_cpu_limit_saturation",
+    filterType: FilterType.LessThanOrEqualTo,
+    value: 90,
+    ...overrides,
+  });
+}
+
+function firstFilter(instance: MonitorCriteriaInstance): CriteriaFilter {
+  return (instance.data?.filters as Array<CriteriaFilter>)[0]!;
+}
+
+describe("RecommendationCriteriaBuilder", () => {
+  describe("sustained evaluation replaces AnyValue on both sides", () => {
+    test("the firing criteria requires the condition to hold for the whole window", () => {
+      expect(
+        firstFilter(buildUnhealthy()).metricMonitorOptions
+          ?.metricAggregationType,
+      ).toBe(EvaluateOverTimeType.AllValues);
+    });
+
+    test("the healthy criteria is sustained too", () => {
+      expect(
+        firstFilter(buildHealthy()).metricMonitorOptions?.metricAggregationType,
+      ).toBe(EvaluateOverTimeType.AllValues);
+    });
+
+    test("neither side ships AnyValue, which is what made rollingTime meaningless", () => {
+      for (const instance of [buildUnhealthy(), buildHealthy()]) {
+        for (const filter of instance.data?.filters as Array<CriteriaFilter>) {
+          expect(filter.metricMonitorOptions?.metricAggregationType).not.toBe(
+            EvaluateOverTimeType.AnyValue,
+          );
+        }
+      }
+    });
+
+    test("SustainedEvaluation is AllValues", () => {
+      expect(SustainedEvaluation).toBe(EvaluateOverTimeType.AllValues);
+    });
+
+    test("a template may opt out explicitly for genuinely event-shaped signals", () => {
+      expect(
+        firstFilter(
+          buildUnhealthy({
+            metricAggregationType: EvaluateOverTimeType.MaximumValue,
+          }),
+        ).metricMonitorOptions?.metricAggregationType,
+      ).toBe(EvaluateOverTimeType.MaximumValue);
+    });
+  });
+
+  describe("hysteresis: the recovery threshold sits inside the firing one", () => {
+    test("a ceiling recovers strictly below where it fires", () => {
+      const recoveryValue: number = firstFilter(buildHealthy()).value as number;
+
+      expect(recoveryValue).toBe(90 - 90 * DefaultRecoveryMarginFraction);
+      expect(recoveryValue).toBeLessThan(90);
+    });
+
+    test("a floor recovers strictly above where it fires", () => {
+      // Low battery: fire at "< 20", recover at "> 20 + margin".
+      const recoveryValue: number = firstFilter(
+        buildHealthy({
+          filterType: FilterType.GreaterThanOrEqualTo,
+          value: 20,
+        }),
+      ).value as number;
+
+      expect(recoveryValue).toBe(20 + 20 * DefaultRecoveryMarginFraction);
+      expect(recoveryValue).toBeGreaterThan(20);
+    });
+
+    test("a negative threshold widens away from zero, not toward it", () => {
+      // Weak signal: fire at "< -100 dBm", recover at "-90 dBm".
+      const recoveryValue: number = firstFilter(
+        buildHealthy({
+          filterType: FilterType.GreaterThanOrEqualTo,
+          value: -100,
+        }),
+      ).value as number;
+
+      expect(recoveryValue).toBe(-90);
+      expect(recoveryValue).toBeGreaterThan(-100);
+    });
+
+    test("a zero threshold gets no dead band, so count criteria still recover at zero", () => {
+      expect(
+        firstFilter(buildHealthy({ filterType: FilterType.EqualTo, value: 0 }))
+          .value,
+      ).toBe(0);
+    });
+
+    test("an explicit recoveryValue overrides the derived dead band", () => {
+      expect(firstFilter(buildHealthy({ recoveryValue: 75 })).value).toBe(75);
+    });
+
+    test("marginFraction widens the band", () => {
+      expect(firstFilter(buildHealthy({ marginFraction: 0.25 })).value).toBe(
+        67.5,
+      );
+    });
+
+    test("the fire and recover bands do not overlap", () => {
+      const fire: CriteriaFilter = firstFilter(buildUnhealthy());
+      const recover: CriteriaFilter = firstFilter(buildHealthy());
+
+      // Fire above 90, recover at or below 81 — 81 < x <= 90 is neither.
+      expect(fire.value).toBe(90);
+      expect(recover.value).toBe(81);
+      expect(recover.value as number).toBeLessThan(fire.value as number);
+    });
+  });
+
+  describe("getRecoveryThreshold", () => {
+    test.each([
+      [FilterType.GreaterThan, 90, 81],
+      [FilterType.GreaterThanOrEqualTo, 90, 81],
+      [FilterType.LessThan, 20, 22],
+      [FilterType.LessThanOrEqualTo, 20, 22],
+    ])(
+      "%s at %s recovers at %s",
+      (filterType: FilterType, value: number, expected: number) => {
+        expect(
+          getRecoveryThreshold({ filterType: filterType, value: value }),
+        ).toBe(expected);
+      },
+    );
+
+    test.each([
+      [FilterType.EqualTo, 5],
+      [FilterType.NotEqualTo, 5],
+      [FilterType.GreaterThan, 0],
+      [FilterType.LessThan, 0],
+    ])(
+      "%s at %s has no meaningful dead band",
+      (filterType: FilterType, value: number) => {
+        expect(
+          getRecoveryThreshold({ filterType: filterType, value: value }),
+        ).toBeUndefined();
+      },
+    );
+
+    test("a non-finite threshold is left alone rather than producing NaN", () => {
+      expect(
+        getRecoveryThreshold({
+          filterType: FilterType.GreaterThan,
+          value: Number.POSITIVE_INFINITY,
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("getRecoveryFilterType", () => {
+    test.each([
+      [FilterType.GreaterThan, FilterType.LessThanOrEqualTo],
+      [FilterType.GreaterThanOrEqualTo, FilterType.LessThan],
+      [FilterType.LessThan, FilterType.GreaterThanOrEqualTo],
+      [FilterType.LessThanOrEqualTo, FilterType.GreaterThan],
+      [FilterType.EqualTo, FilterType.NotEqualTo],
+      [FilterType.NotEqualTo, FilterType.EqualTo],
+    ])("%s complements to %s", (input: FilterType, expected: FilterType) => {
+      expect(getRecoveryFilterType(input)).toBe(expected);
+    });
+
+    test("complementing twice is the identity for ordered comparisons", () => {
+      for (const filterType of [
+        FilterType.GreaterThan,
+        FilterType.GreaterThanOrEqualTo,
+        FilterType.LessThan,
+        FilterType.LessThanOrEqualTo,
+      ]) {
+        expect(getRecoveryFilterType(getRecoveryFilterType(filterType))).toBe(
+          filterType,
+        );
+      }
+    });
+
+    test("a filter type with no complement is returned unchanged", () => {
+      expect(getRecoveryFilterType(FilterType.Contains)).toBe(
+        FilterType.Contains,
+      );
+    });
+  });
+
+  describe("additional filters inherit the same defaults", () => {
+    test("an OR'd firing filter is sustained too", () => {
+      const instance: MonitorCriteriaInstance = buildUnhealthy({
+        additionalFilters: [
+          {
+            metricAlias: "osd_scrub_errors",
+            filterType: FilterType.GreaterThan,
+            value: 0,
+          },
+        ],
+      });
+
+      const filters: Array<CriteriaFilter> = instance.data
+        ?.filters as Array<CriteriaFilter>;
+
+      expect(filters).toHaveLength(2);
+      for (const filter of filters) {
+        expect(filter.metricMonitorOptions?.metricAggregationType).toBe(
+          EvaluateOverTimeType.AllValues,
+        );
+      }
+    });
+
+    test("an additional recovery filter gets its own dead band", () => {
+      const instance: MonitorCriteriaInstance = buildHealthy({
+        value: 90,
+        additionalFilters: [
+          {
+            metricAlias: "pool_near_full",
+            filterType: FilterType.LessThanOrEqualTo,
+            value: 80,
+          },
+        ],
+      });
+
+      const filters: Array<CriteriaFilter> = instance.data
+        ?.filters as Array<CriteriaFilter>;
+
+      expect(filters[0]!.value).toBe(81);
+      expect(filters[1]!.value).toBe(72);
+    });
+
+    test("treatNoDataAsZero reaches every filter, primary and additional", () => {
+      const instance: MonitorCriteriaInstance = buildHealthy({
+        treatNoDataAsZero: true,
+        additionalFilters: [
+          {
+            metricAlias: "osd_scrub_errors",
+            filterType: FilterType.EqualTo,
+            value: 0,
+          },
+        ],
+      });
+
+      for (const filter of instance.data?.filters as Array<CriteriaFilter>) {
+        expect(filter.metricMonitorOptions?.onNoDataPolicy).toBe(
+          NoDataPolicy.TreatAsZero,
+        );
+      }
+    });
+
+    test("no no-data policy is set unless asked for", () => {
+      expect(
+        firstFilter(buildHealthy()).metricMonitorOptions?.onNoDataPolicy,
+      ).toBeUndefined();
+    });
+
+    test("filterCondition is overridable so multi-alias recovery can require ALL", () => {
+      expect(
+        buildHealthy({ filterCondition: FilterCondition.All }).data
+          ?.filterCondition,
+      ).toBe(FilterCondition.All);
+    });
+
+    test("filterCondition defaults to Any", () => {
+      expect(buildUnhealthy().data?.filterCondition).toBe(FilterCondition.Any);
+    });
+  });
+
+  describe("the production window that produced 39 emails", () => {
+    /*
+     * The whole point. Under the old AnyValue default this window opened an
+     * alert; under sustained evaluation it does not, because the pod was
+     * only over its limit for one of five samples.
+     */
+    test("sustained evaluation does not fire on a single breaching sample", () => {
+      const allAbove: boolean = PRODUCTION_WINDOW.every((value: number) => {
+        return value > 90;
+      });
+      const anyAbove: boolean = PRODUCTION_WINDOW.some((value: number) => {
+        return value > 90;
+      });
+
+      expect(anyAbove).toBe(true);
+      expect(allAbove).toBe(false);
+    });
+
+    test("and the window does not satisfy the recovery band either, so it cannot flap", () => {
+      const recoveryValue: number = firstFilter(buildHealthy()).value as number;
+
+      // Under the old config every sample <= 90 satisfied "healthy".
+      expect(
+        PRODUCTION_WINDOW.every((value: number) => {
+          return value <= 90;
+        }),
+      ).toBe(false);
+
+      // Under the dead band it is even further from satisfying it.
+      expect(
+        PRODUCTION_WINDOW.every((value: number) => {
+          return value <= recoveryValue;
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("criteria instances stay well-formed", () => {
+    test("the unhealthy instance creates both an incident and an alert", () => {
+      const instance: MonitorCriteriaInstance = buildUnhealthy();
+
+      expect(instance.data?.createIncidents).toBe(true);
+      expect(instance.data?.createAlerts).toBe(true);
+      expect(instance.data?.incidents).toHaveLength(1);
+      expect(instance.data?.alerts).toHaveLength(1);
+      expect(instance.data?.incidents?.[0]?.incidentSeverityId).toBe(
+        INCIDENT_SEVERITY_ID,
+      );
+      expect(instance.data?.alerts?.[0]?.alertSeverityId).toBe(
+        ALERT_SEVERITY_ID,
+      );
+    });
+
+    test("the healthy instance creates neither", () => {
+      const instance: MonitorCriteriaInstance = buildHealthy();
+
+      expect(instance.data?.createIncidents).toBe(false);
+      expect(instance.data?.createAlerts).toBe(false);
+      expect(instance.data?.incidents).toHaveLength(0);
+      expect(instance.data?.alerts).toHaveLength(0);
+    });
+
+    test("resourceNoun only changes the fallback description", () => {
+      const instance: MonitorCriteriaInstance = buildUnhealthy({
+        incidentDescription: undefined,
+        resourceNoun: "Ceph cluster",
+      });
+
+      expect(instance.data?.incidents?.[0]?.description).toContain(
+        "detailed Ceph cluster information",
+      );
+    });
+
+    test("an explicit incidentDescription wins over the fallback", () => {
+      const instance: MonitorCriteriaInstance = buildUnhealthy({
+        incidentDescription: "Specific description.",
+        resourceNoun: "Ceph cluster",
+      });
+
+      expect(instance.data?.incidents?.[0]?.description).toBe(
+        "Specific description.",
+      );
+    });
+
+    test("each build produces fresh ids", () => {
+      expect(buildUnhealthy().data?.id).not.toBe(buildUnhealthy().data?.id);
+    });
+  });
+});

--- a/Common/Tests/Types/Monitor/Utils/RecommendationCriteriaAssertions.ts
+++ b/Common/Tests/Types/Monitor/Utils/RecommendationCriteriaAssertions.ts
@@ -1,0 +1,102 @@
+import { FilterType } from "../../../../Types/Monitor/CriteriaFilter";
+import { getRecoveryThreshold } from "../../../../Types/Monitor/Recommendation/RecommendationCriteriaBuilder";
+
+/*
+ * The invariant every recommendation template's fire/recover pair must hold.
+ *
+ * These suites used to assert the OPPOSITE — that the two thresholds were
+ * the identical number and exactly partitioned the range ("disjoint
+ * complement"). That is a textbook flapping configuration, and it was
+ * load-bearing in the tests, so the bug could not be fixed without them
+ * failing. A metric parked at the threshold satisfied "> 90" on one
+ * evaluation and "<= 90" on the next, forever; one customer cluster
+ * produced 39 alert emails from a single monitor in under two hours.
+ *
+ * The invariant is now a DEAD BAND: the recover comparison is still the
+ * complement of the fire comparison, but its threshold sits strictly
+ * inside the fire threshold, so a metric has to move a real distance back
+ * before the monitor is called healthy.
+ */
+
+export interface CriteriaThreshold {
+  filterType: FilterType;
+  value: number;
+}
+
+export function getComplementFilterType(
+  filterType: FilterType,
+): FilterType | null {
+  switch (filterType) {
+    case FilterType.GreaterThan:
+      return FilterType.LessThanOrEqualTo;
+    case FilterType.GreaterThanOrEqualTo:
+      return FilterType.LessThan;
+    case FilterType.LessThan:
+      return FilterType.GreaterThanOrEqualTo;
+    case FilterType.LessThanOrEqualTo:
+      return FilterType.GreaterThan;
+    default:
+      return null;
+  }
+}
+
+/*
+ * Whether a fire/recover pair leaves a gap the metric must cross.
+ *
+ * A threshold of exactly 0 gets no dead band — 10% of 0 is 0, and a
+ * count-based criterion ("> 0 failed jobs") recovers correctly at exactly
+ * 0 — so an equal-valued pair is accepted there and only there. The same
+ * applies to the `> 0` / `= 0` pair Ceph uses for health-check series.
+ */
+export function hasRecoveryDeadBand(
+  fire: CriteriaThreshold,
+  recover: CriteriaThreshold,
+): boolean {
+  const expectedComplement: FilterType | null = getComplementFilterType(
+    fire.filterType,
+  );
+
+  const isComplement: boolean =
+    recover.filterType === expectedComplement ||
+    // Ceph health-check series: fire when the count is > 0, recover at = 0.
+    (fire.value === 0 &&
+      fire.filterType === FilterType.GreaterThan &&
+      recover.filterType === FilterType.EqualTo) ||
+    // Docker Swarm task-down: fire when uptime == 0, recover when uptime > 0.
+    (fire.value === 0 &&
+      fire.filterType === FilterType.EqualTo &&
+      recover.filterType === FilterType.GreaterThan);
+
+  if (!isComplement) {
+    return false;
+  }
+
+  const expectedRecoveryValue: number | undefined = getRecoveryThreshold({
+    filterType: fire.filterType,
+    value: fire.value,
+  });
+
+  if (expectedRecoveryValue === undefined) {
+    // No meaningful dead band exists; the thresholds must match exactly.
+    return recover.value === fire.value;
+  }
+
+  if (recover.value !== expectedRecoveryValue) {
+    return false;
+  }
+
+  /*
+   * And the band must point the right way: a ceiling recovers BELOW its
+   * firing threshold, a floor recovers ABOVE it. Checked independently of
+   * getRecoveryThreshold so a sign error in that function cannot make this
+   * assertion vacuously true.
+   */
+  if (
+    fire.filterType === FilterType.GreaterThan ||
+    fire.filterType === FilterType.GreaterThanOrEqualTo
+  ) {
+    return recover.value < fire.value;
+  }
+
+  return recover.value > fire.value;
+}

--- a/Common/Types/Monitor/CephAlertTemplates.ts
+++ b/Common/Types/Monitor/CephAlertTemplates.ts
@@ -2,13 +2,13 @@ import ObjectID from "../ObjectID";
 import MonitorStep from "./MonitorStep";
 import MonitorCriteria from "./MonitorCriteria";
 import MonitorCriteriaInstance from "./MonitorCriteriaInstance";
-import FilterCondition from "../Filter/FilterCondition";
 import {
-  CheckOn,
-  FilterType,
-  EvaluateOverTimeType,
-  NoDataPolicy,
-} from "./CriteriaFilter";
+  AdditionalCriteriaFilterSpec,
+  buildHealthyCriteriaInstance,
+  buildUnhealthyCriteriaInstance,
+} from "./Recommendation/RecommendationCriteriaBuilder";
+import FilterCondition from "../Filter/FilterCondition";
+import { FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
 import MonitorStepCephMonitor from "./MonitorStepCephMonitor";
 import RollingTime from "../RollingTime/RollingTime";
 import MetricsAggregationType from "../Metrics/MetricsAggregationType";
@@ -136,78 +136,19 @@ export function buildCephOfflineCriteriaInstance(args: {
   incidentDescription?: string;
   criteriaName?: string;
   criteriaDescription?: string;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
   /*
    * Extra OR'd filters (the instance is FilterCondition.Any) — fires when
    * EITHER the primary alias or any additional alias breaches, e.g.
    * PG_DAMAGED OR OSD_SCRUB_ERRORS.
    */
-  additionalFilters?: Array<CephCriteriaFilterSpec> | undefined;
+  additionalFilters?: Array<AdditionalCriteriaFilterSpec> | undefined;
+  treatNoDataAsZero?: boolean | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  const incidentTitle: string =
-    args.incidentTitle || `${args.monitorName} - Alert Triggered`;
-  const incidentDescription: string =
-    args.incidentDescription ||
-    `${args.monitorName} has triggered an alert condition. See root cause for detailed Ceph cluster information.`;
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.offlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-      ...(args.additionalFilters || []).map(
-        (filter: CephCriteriaFilterSpec) => {
-          return {
-            checkOn: CheckOn.MetricValue,
-            filterType: filter.filterType,
-            metricMonitorOptions: {
-              metricAggregationType: EvaluateOverTimeType.AnyValue,
-              metricAlias: filter.metricAlias,
-            },
-            value: filter.value,
-          };
-        },
-      ),
-    ],
-    incidents: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        incidentSeverityId: args.incidentSeverityId,
-        autoResolveIncident: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    alerts: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        alertSeverityId: args.alertSeverityId,
-        autoResolveAlert: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    changeMonitorStatus: true,
-    createIncidents: true,
-    createAlerts: true,
-    name: args.criteriaName || `${args.monitorName} - Unhealthy`,
-    description:
-      args.criteriaDescription || `Criteria for detecting unhealthy state.`,
-  };
-
-  return instance;
+  return buildUnhealthyCriteriaInstance({
+    ...args,
+    resourceNoun: "Ceph cluster",
+  });
 }
 
 export function buildCephOnlineCriteriaInstance(args: {
@@ -215,12 +156,15 @@ export function buildCephOnlineCriteriaInstance(args: {
   metricAlias: string;
   filterType: FilterType;
   value: number;
+  recoveryValue?: number | undefined;
+  marginFraction?: number | undefined;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
   /*
    * Extra filters for multi-alias recovery. Pass FilterCondition.All with
    * them so the monitor only recovers when EVERY watched health check has
    * cleared (the complement of the offline instance's Any).
    */
-  additionalFilters?: Array<CephCriteriaFilterSpec> | undefined;
+  additionalFilters?: Array<AdditionalCriteriaFilterSpec> | undefined;
   filterCondition?: FilterCondition | undefined;
   /*
    * Health-detail series exist only while the check is active, so the
@@ -230,52 +174,7 @@ export function buildCephOnlineCriteriaInstance(args: {
    */
   treatNoDataAsZero?: boolean | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  const onNoDataPolicy: NoDataPolicy | undefined = args.treatNoDataAsZero
-    ? NoDataPolicy.TreatAsZero
-    : undefined;
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.onlineMonitorStatusId,
-    filterCondition: args.filterCondition || FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-          onNoDataPolicy: onNoDataPolicy,
-        },
-        value: args.value,
-      },
-      ...(args.additionalFilters || []).map(
-        (filter: CephCriteriaFilterSpec) => {
-          return {
-            checkOn: CheckOn.MetricValue,
-            filterType: filter.filterType,
-            metricMonitorOptions: {
-              metricAggregationType: EvaluateOverTimeType.AnyValue,
-              metricAlias: filter.metricAlias,
-              onNoDataPolicy: onNoDataPolicy,
-            },
-            value: filter.value,
-          };
-        },
-      ),
-    ],
-    incidents: [],
-    alerts: [],
-    changeMonitorStatus: true,
-    createIncidents: false,
-    createAlerts: false,
-    name: "Healthy",
-    description: "Criteria for healthy state.",
-  };
-
-  return instance;
+  return buildHealthyCriteriaInstance(args);
 }
 
 export function buildCephMonitorConfig(args: {

--- a/Common/Types/Monitor/DockerAlertTemplates.ts
+++ b/Common/Types/Monitor/DockerAlertTemplates.ts
@@ -2,8 +2,11 @@ import ObjectID from "../ObjectID";
 import MonitorStep from "./MonitorStep";
 import MonitorCriteria from "./MonitorCriteria";
 import MonitorCriteriaInstance from "./MonitorCriteriaInstance";
-import FilterCondition from "../Filter/FilterCondition";
-import { CheckOn, FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
+import {
+  buildHealthyCriteriaInstance,
+  buildUnhealthyCriteriaInstance,
+} from "./Recommendation/RecommendationCriteriaBuilder";
+import { FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
 import MonitorStepDockerMonitor from "./MonitorStepDockerMonitor";
 import RollingTime from "../RollingTime/RollingTime";
 import MetricsAggregationType from "../Metrics/MetricsAggregationType";
@@ -103,59 +106,12 @@ export function buildDockerOfflineCriteriaInstance(args: {
   incidentDescription?: string;
   criteriaName?: string;
   criteriaDescription?: string;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  const incidentTitle: string =
-    args.incidentTitle || `${args.monitorName} - Alert Triggered`;
-  const incidentDescription: string =
-    args.incidentDescription ||
-    `${args.monitorName} has triggered an alert condition. See root cause for detailed Docker container information.`;
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.offlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        incidentSeverityId: args.incidentSeverityId,
-        autoResolveIncident: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    alerts: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        alertSeverityId: args.alertSeverityId,
-        autoResolveAlert: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    changeMonitorStatus: true,
-    createIncidents: true,
-    createAlerts: true,
-    name: args.criteriaName || `${args.monitorName} - Unhealthy`,
-    description:
-      args.criteriaDescription || `Criteria for detecting unhealthy state.`,
-  };
-
-  return instance;
+  return buildUnhealthyCriteriaInstance({
+    ...args,
+    resourceNoun: "container",
+  });
 }
 
 export function buildDockerOnlineCriteriaInstance(args: {
@@ -163,34 +119,11 @@ export function buildDockerOnlineCriteriaInstance(args: {
   metricAlias: string;
   filterType: FilterType;
   value: number;
+  recoveryValue?: number | undefined;
+  marginFraction?: number | undefined;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.onlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [],
-    alerts: [],
-    changeMonitorStatus: true,
-    createIncidents: false,
-    createAlerts: false,
-    name: "Healthy",
-    description: "Criteria for healthy state.",
-  };
-
-  return instance;
+  return buildHealthyCriteriaInstance(args);
 }
 
 export function buildDockerMonitorConfig(args: {

--- a/Common/Types/Monitor/DockerSwarmAlertTemplates.ts
+++ b/Common/Types/Monitor/DockerSwarmAlertTemplates.ts
@@ -2,8 +2,11 @@ import ObjectID from "../ObjectID";
 import MonitorStep from "./MonitorStep";
 import MonitorCriteria from "./MonitorCriteria";
 import MonitorCriteriaInstance from "./MonitorCriteriaInstance";
-import FilterCondition from "../Filter/FilterCondition";
-import { CheckOn, FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
+import {
+  buildHealthyCriteriaInstance,
+  buildUnhealthyCriteriaInstance,
+} from "./Recommendation/RecommendationCriteriaBuilder";
+import { FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
 import MonitorStepDockerSwarmMonitor from "./MonitorStepDockerSwarmMonitor";
 import RollingTime from "../RollingTime/RollingTime";
 import MetricsAggregationType from "../Metrics/MetricsAggregationType";
@@ -104,59 +107,12 @@ export function buildDockerSwarmOfflineCriteriaInstance(args: {
   incidentDescription?: string;
   criteriaName?: string;
   criteriaDescription?: string;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  const incidentTitle: string =
-    args.incidentTitle || `${args.monitorName} - Alert Triggered`;
-  const incidentDescription: string =
-    args.incidentDescription ||
-    `${args.monitorName} has triggered an alert condition. See root cause for detailed Docker Swarm cluster information.`;
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.offlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        incidentSeverityId: args.incidentSeverityId,
-        autoResolveIncident: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    alerts: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        alertSeverityId: args.alertSeverityId,
-        autoResolveAlert: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    changeMonitorStatus: true,
-    createIncidents: true,
-    createAlerts: true,
-    name: args.criteriaName || `${args.monitorName} - Unhealthy`,
-    description:
-      args.criteriaDescription || `Criteria for detecting unhealthy state.`,
-  };
-
-  return instance;
+  return buildUnhealthyCriteriaInstance({
+    ...args,
+    resourceNoun: "Swarm task",
+  });
 }
 
 export function buildDockerSwarmOnlineCriteriaInstance(args: {
@@ -164,34 +120,11 @@ export function buildDockerSwarmOnlineCriteriaInstance(args: {
   metricAlias: string;
   filterType: FilterType;
   value: number;
+  recoveryValue?: number | undefined;
+  marginFraction?: number | undefined;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.onlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [],
-    alerts: [],
-    changeMonitorStatus: true,
-    createIncidents: false,
-    createAlerts: false,
-    name: "Healthy",
-    description: "Criteria for healthy state.",
-  };
-
-  return instance;
+  return buildHealthyCriteriaInstance(args);
 }
 
 export function buildDockerSwarmMonitorConfig(args: {

--- a/Common/Types/Monitor/HostAlertTemplates.ts
+++ b/Common/Types/Monitor/HostAlertTemplates.ts
@@ -2,8 +2,11 @@ import ObjectID from "../ObjectID";
 import MonitorStep from "./MonitorStep";
 import MonitorCriteria from "./MonitorCriteria";
 import MonitorCriteriaInstance from "./MonitorCriteriaInstance";
-import FilterCondition from "../Filter/FilterCondition";
-import { CheckOn, FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
+import {
+  buildHealthyCriteriaInstance,
+  buildUnhealthyCriteriaInstance,
+} from "./Recommendation/RecommendationCriteriaBuilder";
+import { FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
 import MonitorStepHostMonitor from "./MonitorStepHostMonitor";
 import RollingTime from "../RollingTime/RollingTime";
 import MetricsAggregationType from "../Metrics/MetricsAggregationType";
@@ -106,59 +109,12 @@ export function buildHostOfflineCriteriaInstance(args: {
   incidentDescription?: string;
   criteriaName?: string;
   criteriaDescription?: string;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  const incidentTitle: string =
-    args.incidentTitle || `${args.monitorName} - Alert Triggered`;
-  const incidentDescription: string =
-    args.incidentDescription ||
-    `${args.monitorName} has triggered an alert condition. See root cause for detailed host information.`;
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.offlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        incidentSeverityId: args.incidentSeverityId,
-        autoResolveIncident: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    alerts: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        alertSeverityId: args.alertSeverityId,
-        autoResolveAlert: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    changeMonitorStatus: true,
-    createIncidents: true,
-    createAlerts: true,
-    name: args.criteriaName || `${args.monitorName} - Unhealthy`,
-    description:
-      args.criteriaDescription || `Criteria for detecting unhealthy state.`,
-  };
-
-  return instance;
+  return buildUnhealthyCriteriaInstance({
+    ...args,
+    resourceNoun: "host",
+  });
 }
 
 export function buildHostOnlineCriteriaInstance(args: {
@@ -166,34 +122,11 @@ export function buildHostOnlineCriteriaInstance(args: {
   metricAlias: string;
   filterType: FilterType;
   value: number;
+  recoveryValue?: number | undefined;
+  marginFraction?: number | undefined;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.onlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [],
-    alerts: [],
-    changeMonitorStatus: true,
-    createIncidents: false,
-    createAlerts: false,
-    name: "Healthy",
-    description: "Criteria for healthy state.",
-  };
-
-  return instance;
+  return buildHealthyCriteriaInstance(args);
 }
 
 export function buildHostMonitorConfig(args: {

--- a/Common/Types/Monitor/IotAlertTemplates.ts
+++ b/Common/Types/Monitor/IotAlertTemplates.ts
@@ -2,13 +2,11 @@ import ObjectID from "../ObjectID";
 import MonitorStep from "./MonitorStep";
 import MonitorCriteria from "./MonitorCriteria";
 import MonitorCriteriaInstance from "./MonitorCriteriaInstance";
-import FilterCondition from "../Filter/FilterCondition";
 import {
-  CheckOn,
-  FilterType,
-  EvaluateOverTimeType,
-  NoDataPolicy,
-} from "./CriteriaFilter";
+  buildHealthyCriteriaInstance,
+  buildUnhealthyCriteriaInstance,
+} from "./Recommendation/RecommendationCriteriaBuilder";
+import { FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
 import MonitorStepIoTMonitor from "./MonitorStepIoTMonitor";
 import RollingTime from "../RollingTime/RollingTime";
 import MetricsAggregationType from "../Metrics/MetricsAggregationType";
@@ -107,72 +105,17 @@ export function buildIoTOfflineCriteriaInstance(args: {
   incidentDescription?: string;
   criteriaName?: string;
   criteriaDescription?: string;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
   /*
-   * Evaluate an empty (no data) series as 0 instead of skipping it.
-   * This is what lets REGISTERED devices that go completely silent
-   * trip the criteria: monitor evaluation injects an empty synthetic
-   * series per registered-but-silent device, TreatAsZero folds it to
-   * 0, and e.g. Min(iot_device_up) < 1 fires. Only the Device Offline
-   * template opts in — treating no-data as zero on a battery or
-   * temperature threshold would false-alarm for silent devices.
+   * A device that has stopped reporting emits no series at all, so the
+   * offline comparison has to count absence as zero rather than skip.
    */
-  treatNoDataAsZero?: boolean;
+  treatNoDataAsZero?: boolean | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  const incidentTitle: string =
-    args.incidentTitle || `${args.monitorName} - Alert Triggered`;
-  const incidentDescription: string =
-    args.incidentDescription ||
-    `${args.monitorName} has triggered an alert condition. See root cause for detailed IoT device information.`;
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.offlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-          ...(args.treatNoDataAsZero
-            ? { onNoDataPolicy: NoDataPolicy.TreatAsZero }
-            : {}),
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        incidentSeverityId: args.incidentSeverityId,
-        autoResolveIncident: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    alerts: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        alertSeverityId: args.alertSeverityId,
-        autoResolveAlert: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    changeMonitorStatus: true,
-    createIncidents: true,
-    createAlerts: true,
-    name: args.criteriaName || `${args.monitorName} - Unhealthy`,
-    description:
-      args.criteriaDescription || `Criteria for detecting unhealthy state.`,
-  };
-
-  return instance;
+  return buildUnhealthyCriteriaInstance({
+    ...args,
+    resourceNoun: "device",
+  });
 }
 
 export function buildIoTOnlineCriteriaInstance(args: {
@@ -180,34 +123,11 @@ export function buildIoTOnlineCriteriaInstance(args: {
   metricAlias: string;
   filterType: FilterType;
   value: number;
+  recoveryValue?: number | undefined;
+  marginFraction?: number | undefined;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.onlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [],
-    alerts: [],
-    changeMonitorStatus: true,
-    createIncidents: false,
-    createAlerts: false,
-    name: "Healthy",
-    description: "Criteria for healthy state.",
-  };
-
-  return instance;
+  return buildHealthyCriteriaInstance(args);
 }
 
 export function buildIoTMonitorConfig(args: {

--- a/Common/Types/Monitor/KubernetesAlertTemplates.ts
+++ b/Common/Types/Monitor/KubernetesAlertTemplates.ts
@@ -2,8 +2,11 @@ import ObjectID from "../ObjectID";
 import MonitorStep from "./MonitorStep";
 import MonitorCriteria from "./MonitorCriteria";
 import MonitorCriteriaInstance from "./MonitorCriteriaInstance";
-import FilterCondition from "../Filter/FilterCondition";
-import { CheckOn, FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
+import {
+  buildHealthyCriteriaInstance,
+  buildUnhealthyCriteriaInstance,
+} from "./Recommendation/RecommendationCriteriaBuilder";
+import { FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
 import MonitorStepKubernetesMonitor, {
   KubernetesResourceScope,
 } from "./MonitorStepKubernetesMonitor";
@@ -92,59 +95,12 @@ export function buildOfflineCriteriaInstance(args: {
   incidentDescription?: string;
   criteriaName?: string;
   criteriaDescription?: string;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  const incidentTitle: string =
-    args.incidentTitle || `${args.monitorName} - Alert Triggered`;
-  const incidentDescription: string =
-    args.incidentDescription ||
-    `${args.monitorName} has triggered an alert condition. See root cause for detailed Kubernetes resource information.`;
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.offlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        incidentSeverityId: args.incidentSeverityId,
-        autoResolveIncident: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    alerts: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        alertSeverityId: args.alertSeverityId,
-        autoResolveAlert: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    changeMonitorStatus: true,
-    createIncidents: true,
-    createAlerts: true,
-    name: args.criteriaName || `${args.monitorName} - Unhealthy`,
-    description:
-      args.criteriaDescription || `Criteria for detecting unhealthy state.`,
-  };
-
-  return instance;
+  return buildUnhealthyCriteriaInstance({
+    ...args,
+    resourceNoun: "Kubernetes resource",
+  });
 }
 
 export function buildOnlineCriteriaInstance(args: {
@@ -152,34 +108,11 @@ export function buildOnlineCriteriaInstance(args: {
   metricAlias: string;
   filterType: FilterType;
   value: number;
+  recoveryValue?: number | undefined;
+  marginFraction?: number | undefined;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.onlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [],
-    alerts: [],
-    changeMonitorStatus: true,
-    createIncidents: false,
-    createAlerts: false,
-    name: "Healthy",
-    description: "Criteria for healthy state.",
-  };
-
-  return instance;
+  return buildHealthyCriteriaInstance(args);
 }
 
 /**

--- a/Common/Types/Monitor/PodmanAlertTemplates.ts
+++ b/Common/Types/Monitor/PodmanAlertTemplates.ts
@@ -2,8 +2,11 @@ import ObjectID from "../ObjectID";
 import MonitorStep from "./MonitorStep";
 import MonitorCriteria from "./MonitorCriteria";
 import MonitorCriteriaInstance from "./MonitorCriteriaInstance";
-import FilterCondition from "../Filter/FilterCondition";
-import { CheckOn, FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
+import {
+  buildHealthyCriteriaInstance,
+  buildUnhealthyCriteriaInstance,
+} from "./Recommendation/RecommendationCriteriaBuilder";
+import { FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
 import MonitorStepPodmanMonitor from "./MonitorStepPodmanMonitor";
 import RollingTime from "../RollingTime/RollingTime";
 import MetricsAggregationType from "../Metrics/MetricsAggregationType";
@@ -99,59 +102,12 @@ export function buildPodmanOfflineCriteriaInstance(args: {
   incidentDescription?: string;
   criteriaName?: string;
   criteriaDescription?: string;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  const incidentTitle: string =
-    args.incidentTitle || `${args.monitorName} - Alert Triggered`;
-  const incidentDescription: string =
-    args.incidentDescription ||
-    `${args.monitorName} has triggered an alert condition. See root cause for detailed Podman container information.`;
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.offlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        incidentSeverityId: args.incidentSeverityId,
-        autoResolveIncident: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    alerts: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        alertSeverityId: args.alertSeverityId,
-        autoResolveAlert: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    changeMonitorStatus: true,
-    createIncidents: true,
-    createAlerts: true,
-    name: args.criteriaName || `${args.monitorName} - Unhealthy`,
-    description:
-      args.criteriaDescription || `Criteria for detecting unhealthy state.`,
-  };
-
-  return instance;
+  return buildUnhealthyCriteriaInstance({
+    ...args,
+    resourceNoun: "container",
+  });
 }
 
 export function buildPodmanOnlineCriteriaInstance(args: {
@@ -159,34 +115,11 @@ export function buildPodmanOnlineCriteriaInstance(args: {
   metricAlias: string;
   filterType: FilterType;
   value: number;
+  recoveryValue?: number | undefined;
+  marginFraction?: number | undefined;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.onlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [],
-    alerts: [],
-    changeMonitorStatus: true,
-    createIncidents: false,
-    createAlerts: false,
-    name: "Healthy",
-    description: "Criteria for healthy state.",
-  };
-
-  return instance;
+  return buildHealthyCriteriaInstance(args);
 }
 
 export function buildPodmanMonitorConfig(args: {

--- a/Common/Types/Monitor/ProxmoxAlertTemplates.ts
+++ b/Common/Types/Monitor/ProxmoxAlertTemplates.ts
@@ -2,8 +2,11 @@ import ObjectID from "../ObjectID";
 import MonitorStep from "./MonitorStep";
 import MonitorCriteria from "./MonitorCriteria";
 import MonitorCriteriaInstance from "./MonitorCriteriaInstance";
-import FilterCondition from "../Filter/FilterCondition";
-import { CheckOn, FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
+import {
+  buildHealthyCriteriaInstance,
+  buildUnhealthyCriteriaInstance,
+} from "./Recommendation/RecommendationCriteriaBuilder";
+import { FilterType, EvaluateOverTimeType } from "./CriteriaFilter";
 import MonitorStepProxmoxMonitor from "./MonitorStepProxmoxMonitor";
 import RollingTime from "../RollingTime/RollingTime";
 import MetricsAggregationType from "../Metrics/MetricsAggregationType";
@@ -106,59 +109,12 @@ export function buildProxmoxOfflineCriteriaInstance(args: {
   incidentDescription?: string;
   criteriaName?: string;
   criteriaDescription?: string;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  const incidentTitle: string =
-    args.incidentTitle || `${args.monitorName} - Alert Triggered`;
-  const incidentDescription: string =
-    args.incidentDescription ||
-    `${args.monitorName} has triggered an alert condition. See root cause for detailed Proxmox cluster information.`;
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.offlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        incidentSeverityId: args.incidentSeverityId,
-        autoResolveIncident: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    alerts: [
-      {
-        title: incidentTitle,
-        description: incidentDescription,
-        alertSeverityId: args.alertSeverityId,
-        autoResolveAlert: true,
-        id: ObjectID.generate().toString(),
-        onCallPolicyIds: [],
-      },
-    ],
-    changeMonitorStatus: true,
-    createIncidents: true,
-    createAlerts: true,
-    name: args.criteriaName || `${args.monitorName} - Unhealthy`,
-    description:
-      args.criteriaDescription || `Criteria for detecting unhealthy state.`,
-  };
-
-  return instance;
+  return buildUnhealthyCriteriaInstance({
+    ...args,
+    resourceNoun: "Proxmox resource",
+  });
 }
 
 export function buildProxmoxOnlineCriteriaInstance(args: {
@@ -166,34 +122,11 @@ export function buildProxmoxOnlineCriteriaInstance(args: {
   metricAlias: string;
   filterType: FilterType;
   value: number;
+  recoveryValue?: number | undefined;
+  marginFraction?: number | undefined;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
 }): MonitorCriteriaInstance {
-  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
-
-  instance.data = {
-    id: ObjectID.generate().toString(),
-    monitorStatusId: args.onlineMonitorStatusId,
-    filterCondition: FilterCondition.Any,
-    filters: [
-      {
-        checkOn: CheckOn.MetricValue,
-        filterType: args.filterType,
-        metricMonitorOptions: {
-          metricAggregationType: EvaluateOverTimeType.AnyValue,
-          metricAlias: args.metricAlias,
-        },
-        value: args.value,
-      },
-    ],
-    incidents: [],
-    alerts: [],
-    changeMonitorStatus: true,
-    createIncidents: false,
-    createAlerts: false,
-    name: "Healthy",
-    description: "Criteria for healthy state.",
-  };
-
-  return instance;
+  return buildHealthyCriteriaInstance(args);
 }
 
 export function buildProxmoxMonitorConfig(args: {

--- a/Common/Types/Monitor/Recommendation/RecommendationCriteriaBuilder.ts
+++ b/Common/Types/Monitor/Recommendation/RecommendationCriteriaBuilder.ts
@@ -1,0 +1,356 @@
+import MonitorCriteriaInstance from "../MonitorCriteriaInstance";
+import ObjectID from "../../ObjectID";
+import FilterCondition from "../../Filter/FilterCondition";
+import {
+  CheckOn,
+  CriteriaFilter,
+  EvaluateOverTimeType,
+  FilterType,
+  NoDataPolicy,
+} from "../CriteriaFilter";
+
+/*
+ * One extra metric comparison OR'd (or AND'd) alongside the primary one.
+ *
+ * Ceph needs these: a single "PG Damaged" monitor watches PG_DAMAGED OR
+ * OSD_SCRUB_ERRORS, and recovers only when both have cleared.
+ */
+export interface AdditionalCriteriaFilterSpec {
+  metricAlias: string;
+  filterType: FilterType;
+  value: number;
+}
+
+/*
+ * The criteria pair every one-click monitor recommendation is built from.
+ *
+ * Before this module, nine `*AlertTemplates.ts` files each carried their own
+ * near-verbatim copy of these two functions. The copies had already silently
+ * diverged (Docker Swarm's group-by key, Ceph's second pair), and — more
+ * importantly — every copy hardcoded the same two defaults that made
+ * recommendation-created monitors flap:
+ *
+ *   1. `EvaluateOverTimeType.AnyValue` on the FIRE side, so a single sample
+ *      anywhere in the rolling window opened an alert. A window of
+ *      [72.35, 81.54, 79.95, 91.53, 87.73] against "> 90" fired on the one
+ *      sample that crossed.
+ *   2. The SAME threshold on both sides — fire at "> 90", recover at
+ *      "<= 90" — so a workload sitting near its threshold alternated
+ *      between the two on consecutive evaluations, forever. One customer
+ *      cluster produced 39 emails (19 open, 20 resolve) from a single
+ *      monitor in under two hours.
+ *
+ * Both defaults now live here, in one place, and both are inverted.
+ */
+
+/*
+ * "The condition held for the WHOLE window", not "at some point during it".
+ *
+ * `AllValues` is the quantifier ServiceAlertTemplates already used for the
+ * same reason. It is what makes `rollingTime` mean a duration: with
+ * `AnyValue`, a five-minute window and a one-minute window behave
+ * identically for anything that spikes, because both reduce to "did any
+ * sample cross".
+ */
+export const SustainedEvaluation: EvaluateOverTimeType =
+  EvaluateOverTimeType.AllValues;
+
+/*
+ * How far a metric must fall back past the firing threshold before the
+ * monitor is called healthy again, as a fraction of the threshold.
+ *
+ * A dead band is what stops a metric hovering at the threshold from
+ * toggling the monitor's status on every evaluation. 10% is deliberately
+ * modest: it is wide enough to absorb ordinary scrape-to-scrape jitter on a
+ * percentage metric, and narrow enough that a genuine recovery is still
+ * reported promptly.
+ *
+ * NOTE this makes the monitor STATUS sticky. It does not by itself stop an
+ * ALERT from resolving, because alert auto-resolution keys on the firing
+ * criteria no longer matching rather than on the healthy criteria matching
+ * (see MonitorResource.checkOpenAlertsAndCloseIfResolved). Sustained
+ * evaluation above is what does the work there.
+ */
+export const DefaultRecoveryMarginFraction: number = 0.1;
+
+/*
+ * The recovery threshold for a firing threshold, or `undefined` when the
+ * comparison has no meaningful dead band.
+ *
+ * Only the ordered comparisons get one. An equality or boolean criterion
+ * ("phase == Pending", "leader is false") has no "slightly better" state to
+ * sit in, and inventing one would just move the edge rather than widen it.
+ *
+ * A threshold of 0 also gets none: 10% of 0 is 0, and a count-based
+ * criterion ("> 0 failed jobs") recovers correctly at exactly 0.
+ */
+export function getRecoveryThreshold(data: {
+  filterType: FilterType;
+  value: number;
+  marginFraction?: number | undefined;
+}): number | undefined {
+  if (data.value === 0 || !Number.isFinite(data.value)) {
+    return undefined;
+  }
+
+  const margin: number =
+    Math.abs(data.value) *
+    (data.marginFraction ?? DefaultRecoveryMarginFraction);
+
+  switch (data.filterType) {
+    /*
+     * Fires when the metric climbs. Recover lower, so the metric has to
+     * come meaningfully back down.
+     */
+    case FilterType.GreaterThan:
+    case FilterType.GreaterThanOrEqualTo:
+      return data.value - margin;
+    /*
+     * Fires when the metric falls (free disk, battery, signal). Recover
+     * higher.
+     */
+    case FilterType.LessThan:
+    case FilterType.LessThanOrEqualTo:
+      return data.value + margin;
+    default:
+      return undefined;
+  }
+}
+
+/*
+ * The complementary comparison for the healthy criteria.
+ *
+ * Kept here rather than at each call site so a template cannot accidentally
+ * ship a healthy criteria that overlaps its own unhealthy one.
+ */
+export function getRecoveryFilterType(filterType: FilterType): FilterType {
+  switch (filterType) {
+    case FilterType.GreaterThan:
+      return FilterType.LessThanOrEqualTo;
+    case FilterType.GreaterThanOrEqualTo:
+      return FilterType.LessThan;
+    case FilterType.LessThan:
+      return FilterType.GreaterThanOrEqualTo;
+    case FilterType.LessThanOrEqualTo:
+      return FilterType.GreaterThan;
+    case FilterType.EqualTo:
+      return FilterType.NotEqualTo;
+    case FilterType.NotEqualTo:
+      return FilterType.EqualTo;
+    default:
+      return filterType;
+  }
+}
+
+/*
+ * Build the filter list for one criteria instance, applying the same
+ * aggregation and no-data policy to the primary comparison and to every
+ * additional one. Keeping this in one function is what stops an additional
+ * filter from quietly retaining `AnyValue` after the primary was moved off
+ * it — which is exactly how a "sustained" criteria would go on flapping.
+ */
+function buildFilters(data: {
+  metricAlias: string;
+  filterType: FilterType;
+  value: number;
+  metricAggregationType: EvaluateOverTimeType;
+  additionalFilters?: Array<AdditionalCriteriaFilterSpec> | undefined;
+  onNoDataPolicy?: NoDataPolicy | undefined;
+  deriveValue?: ((spec: AdditionalCriteriaFilterSpec) => number) | undefined;
+}): Array<CriteriaFilter> {
+  const specs: Array<AdditionalCriteriaFilterSpec> = [
+    {
+      metricAlias: data.metricAlias,
+      filterType: data.filterType,
+      value: data.value,
+    },
+    ...(data.additionalFilters || []),
+  ];
+
+  return specs.map((spec: AdditionalCriteriaFilterSpec) => {
+    return {
+      checkOn: CheckOn.MetricValue,
+      filterType: spec.filterType,
+      metricMonitorOptions: {
+        metricAggregationType: data.metricAggregationType,
+        metricAlias: spec.metricAlias,
+        ...(data.onNoDataPolicy ? { onNoDataPolicy: data.onNoDataPolicy } : {}),
+      },
+      value: data.deriveValue ? data.deriveValue(spec) : spec.value,
+    } as CriteriaFilter;
+  });
+}
+
+export interface UnhealthyCriteriaArgs {
+  offlineMonitorStatusId: ObjectID;
+  incidentSeverityId: ObjectID;
+  alertSeverityId: ObjectID;
+  monitorName: string;
+  metricAlias: string;
+  filterType: FilterType;
+  value: number;
+  incidentTitle?: string | undefined;
+  incidentDescription?: string | undefined;
+  criteriaName?: string | undefined;
+  criteriaDescription?: string | undefined;
+  /*
+   * What the default "See root cause for detailed X information." sentence
+   * calls the thing being monitored. Purely cosmetic; the only thing the
+   * nine copies of this function actually differed on.
+   */
+  resourceNoun?: string | undefined;
+  /*
+   * Override the sustained default. A template should only do this when the
+   * signal genuinely is a single event rather than a level — and should say
+   * why in a comment at the call site.
+   */
+  metricAggregationType?: EvaluateOverTimeType | undefined;
+  additionalFilters?: Array<AdditionalCriteriaFilterSpec> | undefined;
+  filterCondition?: FilterCondition | undefined;
+  treatNoDataAsZero?: boolean | undefined;
+}
+
+export function buildUnhealthyCriteriaInstance(
+  args: UnhealthyCriteriaArgs,
+): MonitorCriteriaInstance {
+  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+
+  const incidentTitle: string =
+    args.incidentTitle || `${args.monitorName} - Alert Triggered`;
+  const incidentDescription: string =
+    args.incidentDescription ||
+    `${args.monitorName} has triggered an alert condition. See root cause for detailed ${
+      args.resourceNoun || "resource"
+    } information.`;
+
+  instance.data = {
+    id: ObjectID.generate().toString(),
+    monitorStatusId: args.offlineMonitorStatusId,
+    filterCondition: args.filterCondition || FilterCondition.Any,
+    filters: buildFilters({
+      metricAlias: args.metricAlias,
+      filterType: args.filterType,
+      value: args.value,
+      metricAggregationType: args.metricAggregationType ?? SustainedEvaluation,
+      additionalFilters: args.additionalFilters,
+      onNoDataPolicy: args.treatNoDataAsZero
+        ? NoDataPolicy.TreatAsZero
+        : undefined,
+    }),
+    incidents: [
+      {
+        title: incidentTitle,
+        description: incidentDescription,
+        incidentSeverityId: args.incidentSeverityId,
+        autoResolveIncident: true,
+        id: ObjectID.generate().toString(),
+        onCallPolicyIds: [],
+      },
+    ],
+    alerts: [
+      {
+        title: incidentTitle,
+        description: incidentDescription,
+        alertSeverityId: args.alertSeverityId,
+        autoResolveAlert: true,
+        id: ObjectID.generate().toString(),
+        onCallPolicyIds: [],
+      },
+    ],
+    changeMonitorStatus: true,
+    createIncidents: true,
+    createAlerts: true,
+    name: args.criteriaName || `${args.monitorName} - Unhealthy`,
+    description:
+      args.criteriaDescription || `Criteria for detecting unhealthy state.`,
+  };
+
+  return instance;
+}
+
+export interface HealthyCriteriaArgs {
+  onlineMonitorStatusId: ObjectID;
+  metricAlias: string;
+  filterType: FilterType;
+  value: number;
+  /*
+   * The threshold the metric must reach to be called healthy again. Defaults
+   * to a dead band below/above `value` — see DefaultRecoveryMarginFraction.
+   * Pass the firing threshold explicitly to opt out.
+   */
+  recoveryValue?: number | undefined;
+  marginFraction?: number | undefined;
+  metricAggregationType?: EvaluateOverTimeType | undefined;
+  additionalFilters?: Array<AdditionalCriteriaFilterSpec> | undefined;
+  filterCondition?: FilterCondition | undefined;
+  /*
+   * Health-detail series exist only while the check is active, so a "= 0"
+   * recovery comparison would otherwise see no data and never match.
+   */
+  treatNoDataAsZero?: boolean | undefined;
+}
+
+export function buildHealthyCriteriaInstance(
+  args: HealthyCriteriaArgs,
+): MonitorCriteriaInstance {
+  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+
+  /*
+   * Callers pass the ALREADY-COMPLEMENTED filter type and the firing
+   * threshold, matching the shape the nine copies used. The dead band is
+   * derived from the firing comparison, so complement back to work out
+   * which direction "better" is.
+   */
+  const firingFilterType: FilterType = getRecoveryFilterType(args.filterType);
+
+  const value: number =
+    args.recoveryValue ??
+    getRecoveryThreshold({
+      filterType: firingFilterType,
+      value: args.value,
+      marginFraction: args.marginFraction,
+    }) ??
+    args.value;
+
+  instance.data = {
+    id: ObjectID.generate().toString(),
+    monitorStatusId: args.onlineMonitorStatusId,
+    filterCondition: args.filterCondition || FilterCondition.Any,
+    filters: buildFilters({
+      metricAlias: args.metricAlias,
+      filterType: args.filterType,
+      value: value,
+      metricAggregationType: args.metricAggregationType ?? SustainedEvaluation,
+      additionalFilters: args.additionalFilters,
+      onNoDataPolicy: args.treatNoDataAsZero
+        ? NoDataPolicy.TreatAsZero
+        : undefined,
+      /*
+       * Give every additional recovery comparison its own dead band too,
+       * derived the same way as the primary one.
+       */
+      deriveValue: (spec: AdditionalCriteriaFilterSpec) => {
+        if (spec.metricAlias === args.metricAlias) {
+          return value;
+        }
+
+        return (
+          getRecoveryThreshold({
+            filterType: getRecoveryFilterType(spec.filterType),
+            value: spec.value,
+            marginFraction: args.marginFraction,
+          }) ?? spec.value
+        );
+      },
+    }),
+    incidents: [],
+    alerts: [],
+    changeMonitorStatus: true,
+    createIncidents: false,
+    createAlerts: false,
+    name: "Healthy",
+    description: "Criteria for healthy state.",
+  };
+
+  return instance;
+}


### PR DESCRIPTION
## What prompted this

A single Kubernetes monitor created from a OneUptime **recommendation** sent **39 alert emails in under two hours** — 19 `[New Alert]` + 20 `[Resolved Alert]`, one open/resolve pair roughly every 5 minutes — for a pod whose CPU was hovering either side of its container limit. The project has 114 alerts, all from the same monitor. It was still firing while this was being investigated (ALT-114, ALT-115, ALT-116 arrived mid-session).

The emails were also wrong on their face. This is a real one:

> **ALERT TITLE:** [K8s] Pod CPU Saturating Container Limit (>90%) - oneuptime-test - Pod CPU Saturating Container Limit
> **RESOURCES AFFECTED:** oneuptime-test - Pod CPU Saturating Container Limit
> **SEVERITY:** Low
> **ROOT CAUSE:** Any value of `(used_cpu / limit_cpu) * 100` is 72.35, 81.54, 79.95, 91.53, 87.73 % which is greater than 90 %.

Four of those five numbers are **below** the threshold the sentence says they all exceed. The headline rendered as a bare `Alert ALT-113` with the title missing. "Resources Affected" is the monitor's own name — the pod that actually broke (`kubernetes-agent-logs-7t88f`) is on the alert row and never shown.

The dashboard's own evaluation log showed **both** criteria reporting `Met` in the same evaluation.

## The four defects

### 1. No sustain, no hysteresis — in nine copy-pasted builders

`grep -c evaluateOverTime Common/Types/Monitor/*AlertTemplates.ts` returned **0 for all ten files**. Nine of them carried a near-verbatim copy of the same two criteria builders, and every copy hardcoded `EvaluateOverTimeType.AnyValue` on **both** the firing and the recovering side, against the **same** threshold:

```ts
// fire
{ filterType: GreaterThan, value: 90, metricAggregationType: AnyValue }
// recover
{ filterType: LessThanOrEqualTo, value: 90, metricAggregationType: AnyValue }
```

One sample anywhere in the window opened an alert; one sample below it closed one. `rollingTime` was decorative — with `AnyValue`, a 5-minute window and a 1-minute window behave identically for anything that spikes.

The copies had also silently diverged (Ceph grew `additionalFilters` / `treatNoDataAsZero`, Docker Swarm's group-by key drifted), so there was no single place to fix it. They now all delegate to a new `Types/Monitor/Recommendation/RecommendationCriteriaBuilder.ts`, which:

- defaults the firing side to `AllValues` — the condition must hold for the **whole** window (the quantifier `ServiceAlertTemplates` already used), and
- derives the recovery threshold as a **10% dead band** inside the firing one.

Thresholds of zero and equality comparisons get no dead band, so count criteria (`> 0 failed jobs`) still recover at exactly zero.

**Against the customer's window, the monitor no longer fires at all.**

This covers all ten resource types — Kubernetes, Ceph, Docker, Docker Swarm, Host, IoT, Podman, Proxmox, RUM, Service — **84 alert templates**.

### 2. `Average`, `Sum`, `Maximum` and `Minimum` were silent no-ops

Every comparator in `CompareCriteria` branched on `AnyValue` and let **every other** evaluation type fall through to `.every()`. All four reducing aggregations — each selectable in the criteria UI, each stored on real monitors — were evaluated as "All Values". A user who asked to be paged on a five-minute **average** was paged only when **every** sample breached, which is a strictly rarer event and never the one they asked for.

### 3. The root cause line contradicted itself

`getCompareMessage` printed the whole window and then appended the filter's verdict over it. It now quotes only the samples that actually breached, names the aggregation (previously rendered as no prefix at all), and states how much of the window breached when it was partial:

```
before: Any value of (used_cpu / limit_cpu) * 100 is 72.35, 81.54, 79.95, 91.53, 87.73 % which is greater than 90 %.
after:  Any value of (used_cpu / limit_cpu) * 100 is 91.53 % which is greater than 90 %. 1 of 5 samples in the evaluation window breached this threshold.
```

### 4. Email rendering

- **The `concat` Handlebars helper took exactly two arguments.** `(concat "Alert " alertNumber ": " alertTitle)` rendered as `Alert ALT-113` and dropped the separator and the title — the headline of **every** alert and incident email was a bare identifier. Now variadic, and drops Handlebars' own trailing options object rather than stringifying it as `[object Object]`.
- **`Header.hbs` carried quoted-printable escapes** — `charset=3Dutf-8` and `width=3Ddevice-width` — breaking the charset declaration and the mobile viewport in **every email the product sends**. (`=3D` is the QP encoding of `=`; content was pasted out of a raw email body without being decoded.)
- **"Resources Affected" was `alert.monitor.name`.** A grouped metric monitor raises one alert per breaching series, and the identity was already on the row under `seriesLabels` — the dashboard renders it as "Affected Resource" — it just was never selected. It now reads `Pod: kubernetes-agent-logs-7t88f | Namespace: default`, via the same `SeriesLabelDisplay` formatter the alert title uses, and falls back to the monitor name for ungrouped monitors.

## Tests

Eight template suites asserted that the fire and recover thresholds were the **identical number** — the flapping configuration, locked in as an invariant, so the bug could not be fixed without them failing:

```ts
expect(offlineFilter.value).toBe(tc.threshold);
expect(onlineFilter.value).toBe(tc.threshold);   // <- the bug, as a test
```

They now share `Tests/Types/Monitor/Utils/RecommendationCriteriaAssertions.ts`, which requires a dead band instead, and the spec tables **derive** the recovery threshold rather than restating it — so a change to the dead band shows up in one place rather than as a diff across nine spec tables.

**90 new tests** across three files:

| File | Tests | Covers |
|---|---|---|
| `Common/Tests/Types/Monitor/Recommendation/RecommendationCriteriaBuilder.test.ts` | 42 | sustain defaults, dead-band derivation (incl. negative and zero thresholds), additional-filter inheritance, the production window end to end |
| `Common/Tests/Server/Utils/Monitor/Criteria/CompareCriteriaAggregation.test.ts` | 33 | all six evaluation types actually applied, the exact sentence the customer received no longer produced |
| `App/Tests/Notification/AlertOwnerEmailTemplates.test.ts` | 15 | variadic `concat`, headline regression, repo-wide `=3D` guard |

Plus 4 new cases in the existing `SendCreatedResourceNotification.test.ts` for `resourcesAffected`.

### Verification

- `Common`: **4,314** tests pass across `Tests/Types/Monitor` + `Tests/Server/Utils/Monitor`
- `App`: **199** tests pass across `Tests/Notification` + `Tests/Workers/Jobs/AlertOwners`
- `tsc --noEmit` clean; Prettier applied

## Behaviour changes to be aware of

1. **Existing recommendation-created monitors keep their stored criteria.** These changes affect templates at creation time; they do not migrate monitors already in the database. The flapping monitor in the reporting project needs its criteria updated (or the monitor recreated) to pick this up.
2. **RUM templates change semantics.** They already declared `EvaluateOverTimeType.Average`, which was a silent no-op evaluating as `AllValues`. With defect 2 fixed they now genuinely average — which is what the template asked for, but it is a real change in when those alerts fire.
3. **Sustained evaluation raises the bar rather than eliminating flapping entirely.** Alert auto-resolution keys on the *firing* criteria no longer matching, not on the healthy criteria matching (`MonitorResource.checkOpenAlertsAndCloseIfResolved`), so the dead band makes the monitor *status* sticky but does not by itself stop an alert resolving. `AllValues` on the fire side is what does the work. A workload parked exactly at its threshold can still open and close as the window alternates between all-above and mixed — genuinely eliminating that needs a minimum-clean-window requirement in the resolve path, which is not in this PR.

## Not in this PR

This came out of an audit that produced **224 findings**, 45 of which were adversarially verified before the run hit a session limit. This PR fixes the flapping and the email-correctness defects. Deliberately left for follow-ups:

- **Wrong metrics.** `k8s-high-disk-usage` compares a **bytes** gauge against the number 90 (permanently firing, its healthy criterion unreachable); `k8s-apiserver-throttling` sums a cumulative counter against `> 0` (can never resolve); `k8s-crashloopbackoff` alerts on a container's **lifetime** restart count; `k8s-pod-pending` filters on `resource.k8s.pod.phase`, an attribute that does not exist — the phase is the metric's *value*; Docker Swarm's `Task Down` can never fire.
- **Unit errors.** `KubernetesMetricCatalog` declares unit `"%"` for `k8s.pod.cpu.utilization`, which the codebase's own comment calls "a misnamed cores gauge, not a percent" — the chart renders `18.31%` for 0.183 cores.
- **Severity is decorative.** Every template's declared `Critical`/`Warning` is dropped; the observed alert showed `Low` for a template declaring `Warning`.
- **Doubled titles.** Every `incidentTitle` appends the monitor name, which already contains the template name — `[K8s] Pod CPU Saturating Container Limit (>90%) - oneuptime-test - Pod CPU Saturating Container Limit`.
- **Static descriptions.** Every `incidentDescription` is a fixed essay, byte-identical across every firing of every series, that tells the reader to "check the root cause".
- **Email volume + IA.** No threading headers (19 flaps = 19 Gmail threads), no "fired N times", no preheader, the burst-rollup threshold (4 per 10 min) sits just above the observed flap rate so it never engaged, and the resolved email carries no root cause at all.
- **Thresholds that fire on healthy systems.** `>90%` of a CPU *limit* is normal for a right-sized workload; IoT ships `70°C` and `-100 dBm` at Critical.
