### PR TITLE
fix(discovery): allow re-importing deleted network devices

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter.ts
@@ -334,11 +334,9 @@ export function isSelectableDiscoveredHost(
  * The scan's hosts with the ones imported during this sitting flipped to
  * already-registered.
  *
- * `isAlreadyRegistered` is computed server-side when the probe uploads its
- * results and then frozen into the jsonb column — nothing recomputes it on
- * read. So a host imported a moment ago still reports false, and the dialog
- * would happily offer it again, pre-checked, creating a second Network Device
- * for the same address.
+ * The server refreshes `isAlreadyRegistered` when a review opens. Imports
+ * made after that read are overlaid here so another batch in the same dialog
+ * cannot create a second Network Device for the same address.
  *
  * That was survivable when one press imported everything and closed the
  * dialog. Importing group by group is now the intended flow (#3322), which
@@ -380,11 +378,9 @@ export function markDiscoveredHostsAsRegistered(data: {
  *     different scan meanwhile, and a bare set written when that run finally
  *     lands would mark the OTHER scan's same-addressed hosts "Already added" —
  *     disabled, unticked, silently skipped by Import.
- *   - Keeping the record per scan lets it outlive the dialog, so closing and
- *     reopening the same scan does not resurrect what was just imported.
- *     `isAlreadyRegistered` is frozen into the jsonb at probe-upload time and
- *     never recomputed, so without that the reopened dialog offers imported
- *     hosts again, pre-checked, and Import creates duplicates.
+ *   - A successful refresh replaces only that scan's record with current
+ *     inventory state. Until then the record preserves what we know was
+ *     imported, including imports that finish during the refresh.
  *
  * A plain Record of arrays rather than a Map of Sets so the value stays
  * JSON-shaped: it is React state, it gets compared and asserted on, and

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -108,6 +108,11 @@ import React, {
 
 type DiscoveredDeviceEntry = DiscoveredNetworkDevice;
 
+interface ReviewRequest {
+  scanId: string;
+  importedIpAddresses: Set<string>;
+}
+
 /*
  * The scan's optional name — the first field of the create wizard, and the
  * first field of the Edit dialog.
@@ -615,6 +620,8 @@ const NetworkDeviceDiscovery: FunctionComponent<
 
   // Review Results modal state.
   const [showReviewModal, setShowReviewModal] = useState<boolean>(false);
+  const [isLoadingReview, setIsLoadingReview] = useState<boolean>(false);
+  const [isReviewReady, setIsReviewReady] = useState<boolean>(false);
   /*
    * The scan the Edit dialog is open for, or null.
    *
@@ -648,16 +655,9 @@ const NetworkDeviceDiscovery: FunctionComponent<
    */
   const [createPingMonitors, setCreatePingMonitors] = useState<boolean>(false);
   /*
-   * Addresses imported from each scan, per scan id. The scan's own
-   * `isAlreadyRegistered` flags were frozen when the probe uploaded its
-   * results, so without this the dialog would re-offer what it just imported
-   * — which now matters, because importing one group and then the other is
-   * the intended flow rather than an unusual one.
-   *
-   * Kept for the life of the page rather than the life of the dialog, so
-   * closing and reopening the same scan does not resurrect imported hosts;
-   * and keyed by scan so a long import that lands after the operator has
-   * moved to a different scan cannot mark that scan's hosts.
+   * Imports made since this review's inventory lookup. Each successful fresh
+   * read replaces that scan's record, so a deleted device becomes selectable
+   * again. Between reads the record still prevents repeated batch imports.
    */
   const [importedIpAddressesByScanId, setImportedIpAddressesByScanId] =
     useState<ImportedIpAddressesByScanId>({});
@@ -668,6 +668,9 @@ const NetworkDeviceDiscovery: FunctionComponent<
    * dialog I was importing for".
    */
   const reviewedScanIdRef: React.MutableRefObject<string> = useRef<string>("");
+  // Object identity distinguishes even two consecutive reviews of one scan.
+  const reviewRequestRef: React.MutableRefObject<ReviewRequest | null> =
+    useRef<ReviewRequest | null>(null);
 
   const fetchProbes: PromiseVoidFunction = async (): Promise<void> => {
     setIsLoading(true);
@@ -686,7 +689,9 @@ const NetworkDeviceDiscovery: FunctionComponent<
     });
   }, []);
 
-  type OpenReviewModalFunction = (scan: NetworkDeviceDiscoveryScan) => void;
+  type OpenReviewModalFunction = (
+    scan: NetworkDeviceDiscoveryScan,
+  ) => Promise<void>;
 
   type GetReviewHostsFunction = (
     scan: NetworkDeviceDiscoveryScan | null,
@@ -717,20 +722,20 @@ const NetworkDeviceDiscovery: FunctionComponent<
     });
   };
 
-  const openReviewModal: OpenReviewModalFunction = (
+  const openReviewModal: OpenReviewModalFunction = async (
     scan: NetworkDeviceDiscoveryScan,
-  ): void => {
+  ): Promise<void> => {
     setScanToReview(scan);
     // Answers "is this still the dialog I am importing for" from a stale run.
     reviewedScanIdRef.current = scan._id || "";
-    /*
-     * Preselect every host that is not already registered. Ping-only hosts
-     * are included: they import with no credentials and are pinged by the
-     * scan's probe, rather than carrying credentials they never answered to.
-     * Read through the overlay so reopening a scan does not re-tick what was
-     * already imported from it.
-     */
-    setSelectedIps(getInitialSelection(getReviewHosts(scan)));
+    const request: ReviewRequest = {
+      scanId: reviewedScanIdRef.current,
+      importedIpAddresses: new Set<string>(),
+    };
+    reviewRequestRef.current = request;
+    setSelectedIps({});
+    setIsReviewReady(false);
+    setIsLoadingReview(true);
     // Every scan opens on the whole list; narrowing is the operator's move.
     setHostFilter(DiscoveredHostFilter.All);
     setImportError("");
@@ -740,26 +745,94 @@ const NetworkDeviceDiscovery: FunctionComponent<
      */
     setCreatePingMonitors(false);
     setShowReviewModal(true);
+
+    try {
+      if (!scan.id) {
+        throw new BadDataException("This discovery scan could not be found.");
+      }
+
+      // The service reconciles registration against the current inventory on
+      // read. Fetch on every open: the table row and our prior import record
+      // may both predate a device's deletion or an import in another session.
+      const freshScan: NetworkDeviceDiscoveryScan | null =
+        await ModelAPI.getItem<NetworkDeviceDiscoveryScan>({
+          modelType: NetworkDeviceDiscoveryScan,
+          id: scan.id,
+          select: {
+            _id: true,
+            projectId: true,
+            name: true,
+            cidr: true,
+            status: true,
+            statusMessage: true,
+            discoveredDevices: true,
+            probeId: true,
+            isSnmpEnabled: true,
+            snmpConfigs: true,
+            snmpVersion: true,
+            snmpCommunityString: true,
+            snmpPort: true,
+            snmpV3SecurityLevel: true,
+            snmpV3Username: true,
+            snmpV3AuthProtocol: true,
+            snmpV3AuthKey: true,
+            snmpV3PrivProtocol: true,
+            snmpV3PrivKey: true,
+          },
+        });
+
+      if (reviewRequestRef.current !== request) {
+        return;
+      }
+
+      if (!freshScan) {
+        throw new BadDataException("This discovery scan could not be found.");
+      }
+
+      // An earlier import can finish while this read is in flight. Preserve
+      // those newly created addresses even if the response predates them.
+      const refreshedImports: ImportedIpAddressesByScanId = {
+        [request.scanId]: Array.from(request.importedIpAddresses),
+      };
+      setImportedIpAddressesByScanId((current: ImportedIpAddressesByScanId) => {
+        return { ...current, ...refreshedImports };
+      });
+      setScanToReview(freshScan);
+      setSelectedIps(
+        getInitialSelection(getReviewHosts(freshScan, refreshedImports)),
+      );
+      setIsReviewReady(true);
+    } catch (err) {
+      if (reviewRequestRef.current === request) {
+        setImportError(API.getFriendlyMessage(err));
+      }
+    } finally {
+      if (reviewRequestRef.current === request) {
+        setIsLoadingReview(false);
+      }
+    }
   };
 
   const closeReviewModal: VoidFunction = (): void => {
     setShowReviewModal(false);
     setScanToReview(null);
     reviewedScanIdRef.current = "";
+    reviewRequestRef.current = null;
+    setIsReviewReady(false);
+    setIsLoadingReview(false);
     setSelectedIps({});
     setHostFilter(DiscoveredHostFilter.All);
     setImportError("");
     setCreatePingMonitors(false);
     /*
-     * importedIpAddressesByScanId is deliberately NOT cleared. It is what
-     * stops a reopened scan offering hosts that are already in the inventory,
-     * and the scan row it describes does not change when the dialog closes.
+     * Keep the import record until a successful fresh inventory read replaces
+     * it. A failed request must never make remembered imports selectable.
      */
   };
 
   const importSelectedDevices: PromiseVoidFunction =
     async (): Promise<void> => {
-      if (!scanToReview) {
+      if (!scanToReview || !isReviewReady || isLoadingReview || isImporting) {
         return;
       }
 
@@ -771,6 +844,7 @@ const NetworkDeviceDiscovery: FunctionComponent<
        * whatever is on screen by then.
        */
       const runScanId: string = scanToReview._id || "";
+      const runReviewRequest: ReviewRequest | null = reviewRequestRef.current;
 
       /*
        * Selected AND currently shown. Scoping to the active filter is what
@@ -977,6 +1051,12 @@ const NetworkDeviceDiscovery: FunctionComponent<
 
       setIsImporting(false);
 
+      if (reviewRequestRef.current?.scanId === runScanId) {
+        for (const ipAddress of importedNow) {
+          reviewRequestRef.current.importedIpAddresses.add(ipAddress);
+        }
+      }
+
       /*
        * Retire what was imported so it cannot be imported a second time, and
        * so the row shows "Already added" like any other registered host.
@@ -1006,7 +1086,8 @@ const NetworkDeviceDiscovery: FunctionComponent<
        * not close it.
        */
       const isStillTheSameReview: boolean =
-        reviewedScanIdRef.current === runScanId;
+        reviewedScanIdRef.current === runScanId &&
+        reviewRequestRef.current === runReviewRequest;
 
       /*
        * A monitor that could not be created is reported alongside the import
@@ -1066,8 +1147,9 @@ const NetworkDeviceDiscovery: FunctionComponent<
     return <ErrorMessage message={error} />;
   }
 
-  const reviewEntries: Array<DiscoveredDeviceEntry> =
-    getReviewHosts(scanToReview);
+  const reviewEntries: Array<DiscoveredDeviceEntry> = isReviewReady
+    ? getReviewHosts(scanToReview)
+    : [];
 
   // Group sizes come off the whole scan, so every button keeps its own count.
   const hostFilterOptions: Array<FilterButtonOption> =
@@ -1627,8 +1709,11 @@ const NetworkDeviceDiscovery: FunctionComponent<
               item: NetworkDeviceDiscoveryScan,
               onCompleteAction: VoidFunction,
             ) => {
-              openReviewModal(item);
-              onCompleteAction();
+              try {
+                await openReviewModal(item);
+              } finally {
+                onCompleteAction();
+              }
             },
           },
         ]}
@@ -1724,10 +1809,11 @@ const NetworkDeviceDiscovery: FunctionComponent<
           }`}
           modalWidth={ModalWidth.Medium}
           isLoading={isImporting}
+          isBodyLoading={isLoadingReview}
           error={importError || undefined}
           onClose={closeReviewModal}
           submitButtonText={`Import Selected (${selectedCount})`}
-          disableSubmitButton={selectedCount === 0}
+          disableSubmitButton={!isReviewReady || selectedCount === 0}
           onSubmit={() => {
             importSelectedDevices().catch((err: Error) => {
               setIsImporting(false);
@@ -1831,7 +1917,7 @@ const NetworkDeviceDiscovery: FunctionComponent<
                 />
               </div>
             )}
-            {reviewEntries.length === 0 && (
+            {isReviewReady && reviewEntries.length === 0 && (
               <p className="text-sm text-gray-500">
                 {getDiscoveredHostFilterEmptyMessage(DiscoveredHostFilter.All)}
               </p>

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -9,7 +9,7 @@ import NetworkDeviceDiscoveryScan, {
   DiscoveredNetworkDevice,
 } from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import Probe from "Common/Models/DatabaseModels/Probe";
-import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
+import { PromiseVoidFunction, VoidFunction } from "Common/Types/FunctionTypes";
 import IconProp from "Common/Types/Icon/IconProp";
 import Button, {
   ButtonSize,
@@ -751,9 +751,11 @@ const NetworkDeviceDiscovery: FunctionComponent<
         throw new BadDataException("This discovery scan could not be found.");
       }
 
-      // The service reconciles registration against the current inventory on
-      // read. Fetch on every open: the table row and our prior import record
-      // may both predate a device's deletion or an import in another session.
+      /*
+       * The service reconciles registration against the current inventory on
+       * read. Fetch on every open: the table row and our prior import record
+       * may both predate a device's deletion or an import in another session.
+       */
       const freshScan: NetworkDeviceDiscoveryScan | null =
         await ModelAPI.getItem<NetworkDeviceDiscoveryScan>({
           modelType: NetworkDeviceDiscoveryScan,
@@ -789,8 +791,10 @@ const NetworkDeviceDiscovery: FunctionComponent<
         throw new BadDataException("This discovery scan could not be found.");
       }
 
-      // An earlier import can finish while this read is in flight. Preserve
-      // those newly created addresses even if the response predates them.
+      /*
+       * An earlier import can finish while this read is in flight. Preserve
+       * those newly created addresses even if the response predates them.
+       */
       const refreshedImports: ImportedIpAddressesByScanId = {
         [request.scanId]: Array.from(request.importedIpAddresses),
       };

--- a/App/Tests/Dashboard/DiscoveryImportedHostRetirement.test.ts
+++ b/App/Tests/Dashboard/DiscoveryImportedHostRetirement.test.ts
@@ -17,10 +17,9 @@ import {
  * WHAT THIS FILE GUARDS
  *
  * The Review Discovered Devices dialog decides what is still importable from
- * `isAlreadyRegistered`, and that flag is computed server-side when the probe
- * uploads its results and then FROZEN into the scan's jsonb column. Nothing
- * recomputes it on read. So a host imported sixty seconds ago still reports
- * false: the dialog re-offers it, pre-checked, and the next press of Import
+ * `isAlreadyRegistered`, refreshed server-side when the dialog opens. A host
+ * imported after that read still reports false in the dialog's snapshot:
+ * without the overlay it is re-offered, pre-checked, and the next Import
  * creates a SECOND Network Device for the same address. That was survivable
  * when one press imported everything and closed the dialog; importing group by
  * group is the intended flow since #3322, so coming back to a list that still

--- a/App/Tests/Dashboard/DiscoveryReviewFilterInvariants.test.ts
+++ b/App/Tests/Dashboard/DiscoveryReviewFilterInvariants.test.ts
@@ -164,7 +164,9 @@ describe("the Review Discovered Devices dialog imports only what it is showing",
     expect(code).toContain(
       "submitButtonText={`Import Selected (${selectedCount})`}",
     );
-    expect(code).toContain("disableSubmitButton={selectedCount === 0}");
+    expect(code).toContain(
+      "disableSubmitButton={!isReviewReady || selectedCount === 0}",
+    );
   });
 });
 

--- a/App/Tests/Dashboard/DiscoveryReviewLifecycleInvariants.test.ts
+++ b/App/Tests/Dashboard/DiscoveryReviewLifecycleInvariants.test.ts
@@ -23,10 +23,9 @@ import path from "path";
  *   - An import of thousands of hosts runs for minutes. If it does not check
  *     which scan it belongs to when it lands, it pushes its errors onto — or
  *     closes — a different scan's dialog that the operator opened meanwhile.
- *   - `isAlreadyRegistered` is frozen into the scan's jsonb at probe-upload
- *     time and never recomputed, so if the page's own record of what it just
- *     imported is cleared or keyed wrong, a reopened dialog re-offers imported
- *     hosts pre-checked and Import creates duplicate Network Devices.
+ *   - Imports made after the review's inventory read must be overlaid until
+ *     the next successful refresh. A record cleared too early or keyed wrong
+ *     re-offers those hosts and Import creates duplicate Network Devices.
  *   - A row key taken from the filtered list's index changes on every filter
  *     click, remounting each row; CheckboxElement seeds itself from
  *     `initialValue` and only reconciles `value` in a passive effect, so the
@@ -370,16 +369,13 @@ describe("the page's record of what this sitting has imported", () => {
     );
   });
 
-  test("neither opening nor closing a review clears the store", () => {
-    /*
-     * Clearing it is what resurrects imported hosts: the scan's own
-     * `isAlreadyRegistered` flags were frozen at probe-upload time, so a
-     * reopened dialog with no overlay offers what was just imported, ticked,
-     * and Import duplicates every one of those devices.
-     */
-    expect(openReviewModalBody()).not.toContain(
-      "setImportedIpAddressesByScanId",
+  test("opening refreshes the scan's record after a successful current read", () => {
+    const body: string = openReviewModalBody();
+
+    expect(body.indexOf("setImportedIpAddressesByScanId")).toBeGreaterThan(
+      body.indexOf("await ModelAPI.getItem"),
     );
+    expect(body).toContain("return { ...current, ...refreshedImports }");
     expect(closeReviewModalBody()).not.toContain(
       "setImportedIpAddressesByScanId",
     );
@@ -415,7 +411,7 @@ describe("what the dialog opens with, imports, and resets", () => {
     const body: string = openReviewModalBody();
 
     expect(body).toContain(
-      "setSelectedIps(getInitialSelection(getReviewHosts(scan)))",
+      "getInitialSelection(getReviewHosts(freshScan, refreshedImports))",
     );
     expect(body).not.toContain("getInitialSelection(getDiscoveredHosts(");
     expect(body).toContain("setScanToReview(scan)");

--- a/Common/Server/Services/NetworkDeviceAutoImportRuleEngineService.ts
+++ b/Common/Server/Services/NetworkDeviceAutoImportRuleEngineService.ts
@@ -244,6 +244,9 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
         },
         props: {
           isRoot: true,
+          // Keep the stored payload for stampScan; the engine checks live
+          // inventory itself before evaluating these hosts.
+          ignoreHooks: true,
         },
       });
 
@@ -605,7 +608,8 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
             discoveredDevices: true,
             ...AUTO_IMPORT_SCAN_CREDENTIAL_SELECT,
           },
-          props: { isRoot: true },
+          // Preserve the raw scan rows for the compare-and-set write-back.
+          props: { isRoot: true, ignoreHooks: true },
         });
 
       // Re-queued or deleted since the stub query — nothing to evaluate.
@@ -1180,22 +1184,13 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
       let deviceWasCreated: boolean = false;
 
       /*
-       * The frozen isAlreadyRegistered flag AND the live set: the flag is a
-       * point-in-time answer from the last upload, the set covers devices
-       * created since — including by this very run, which is what collapses
-       * duplicate rows and overlapping scans into one device.
+       * Current inventory is authoritative. The stored isAlreadyRegistered
+       * flag can outlive a deleted device and must not veto re-importing it.
+       * The map also includes devices created during this run, keeping
+       * duplicate rows and overlapping scans idempotent.
        */
-      if (host.isAlreadyRegistered || networkDevice) {
+      if (networkDevice) {
         result.hostsSkippedAlreadyRegistered++;
-
-        /*
-         * A stale scan can claim a deleted device is still registered. With
-         * no live row there is neither a safe binding nor enough intent to
-         * recreate it from old data, so preserve the established skip.
-         */
-        if (!networkDevice) {
-          continue;
-        }
       }
 
       if (result.matchedIpAddressSample.length < MAX_MATCHED_IP_SAMPLE) {

--- a/Common/Server/Services/NetworkDeviceAutoImportRuleEngineService.ts
+++ b/Common/Server/Services/NetworkDeviceAutoImportRuleEngineService.ts
@@ -244,8 +244,10 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
         },
         props: {
           isRoot: true,
-          // Keep the stored payload for stampScan; the engine checks live
-          // inventory itself before evaluating these hosts.
+          /*
+           * Keep the stored payload for stampScan; the engine checks live
+           * inventory itself before evaluating these hosts.
+           */
           ignoreHooks: true,
         },
       });

--- a/Common/Server/Services/NetworkDeviceDiscoveryScanService.ts
+++ b/Common/Server/Services/NetworkDeviceDiscoveryScanService.ts
@@ -183,8 +183,10 @@ export class Service extends DatabaseService<Model> {
     onFind: OnFind<Model>,
     items: Array<Model>,
   ): Promise<OnFind<Model>> {
-    // Registration is current inventory state, not a fact about the scan.
-    // Refresh both directions so old results can be used after a deletion.
+    /*
+     * Registration is current inventory state, not a fact about the scan.
+     * Refresh both directions so old results can be used after a deletion.
+     */
     const hostnamesByProject: Map<string, Set<string>> = new Map();
 
     for (const scan of items) {
@@ -216,8 +218,10 @@ export class Service extends DatabaseService<Model> {
         await NetworkDeviceService.getRegisteredHostnames({
           projectId: new ObjectID(projectId),
           hostnames: Array.from(hostnames),
-          // The scan read has already passed its access checks. Return only
-          // the same existence flag as probe ingest, scoped to this project.
+          /*
+           * The scan read has already passed its access checks. Return only
+           * the same existence flag as probe ingest, scoped to this project.
+           */
           props: { isRoot: true },
         }),
       );

--- a/Common/Server/Services/NetworkDeviceDiscoveryScanService.ts
+++ b/Common/Server/Services/NetworkDeviceDiscoveryScanService.ts
@@ -1,6 +1,8 @@
 import DatabaseService from "./DatabaseService";
-import Model from "../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
-import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import Model, {
+  DiscoveredNetworkDevice,
+} from "../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import { OnCreate, OnFind, OnUpdate } from "../Types/Database/Hooks";
 import CreateBy from "../Types/Database/CreateBy";
 import UpdateBy from "../Types/Database/UpdateBy";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
@@ -20,6 +22,7 @@ import SnmpScanConfigUtil, {
 } from "../../Utils/NetworkDiscovery/SnmpScanConfigUtil";
 import { getNextScanAt } from "../../Utils/NetworkDiscovery/RescanIntervalUtil";
 import ScanModeUtil from "../../Utils/NetworkDiscovery/ScanModeUtil";
+import NetworkDeviceService from "./NetworkDeviceService";
 
 /*
  * The two spellings a many-to-one reference reaches a hook under: the
@@ -173,6 +176,84 @@ interface ScanUpdatePlan {
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  @CaptureSpan()
+  protected override async onFindSuccess(
+    onFind: OnFind<Model>,
+    items: Array<Model>,
+  ): Promise<OnFind<Model>> {
+    // Registration is current inventory state, not a fact about the scan.
+    // Refresh both directions so old results can be used after a deletion.
+    const hostnamesByProject: Map<string, Set<string>> = new Map();
+
+    for (const scan of items) {
+      const projectId: ObjectID | undefined =
+        scan.projectId || onFind.findBy.props.tenantId;
+
+      if (!projectId || !Array.isArray(scan.discoveredDevices)) {
+        continue;
+      }
+
+      for (const host of scan.discoveredDevices) {
+        const hostname: string = this.getDiscoveredHostname(host);
+        if (!hostname) {
+          continue;
+        }
+
+        const projectKey: string = projectId.toString();
+        if (!hostnamesByProject.has(projectKey)) {
+          hostnamesByProject.set(projectKey, new Set());
+        }
+        hostnamesByProject.get(projectKey)!.add(hostname);
+      }
+    }
+
+    const registeredByProject: Map<string, Set<string>> = new Map();
+    for (const [projectId, hostnames] of hostnamesByProject) {
+      registeredByProject.set(
+        projectId,
+        await NetworkDeviceService.getRegisteredHostnames({
+          projectId: new ObjectID(projectId),
+          hostnames: Array.from(hostnames),
+          // The scan read has already passed its access checks. Return only
+          // the same existence flag as probe ingest, scoped to this project.
+          props: { isRoot: true },
+        }),
+      );
+    }
+
+    return {
+      ...onFind,
+      carryForward: items.map((scan: Model): Model => {
+        const projectId: ObjectID | undefined =
+          scan.projectId || onFind.findBy.props.tenantId;
+        const registered: Set<string> | undefined = projectId
+          ? registeredByProject.get(projectId.toString())
+          : undefined;
+
+        if (!registered || !Array.isArray(scan.discoveredDevices)) {
+          return scan;
+        }
+
+        return Object.assign(new Model(), scan, {
+          discoveredDevices: scan.discoveredDevices.map(
+            (host: DiscoveredNetworkDevice): DiscoveredNetworkDevice => {
+              const hostname: string = this.getDiscoveredHostname(host);
+              return hostname
+                ? { ...host, isAlreadyRegistered: registered.has(hostname) }
+                : host;
+            },
+          ),
+        });
+      }),
+    };
+  }
+
+  private getDiscoveredHostname(host: DiscoveredNetworkDevice): string {
+    return host && typeof host.ipAddress === "string"
+      ? host.ipAddress.trim()
+      : "";
   }
 
   /*

--- a/Common/Tests/App/Dashboard/DiscoveryReviewInventoryRefresh.test.tsx
+++ b/Common/Tests/App/Dashboard/DiscoveryReviewInventoryRefresh.test.tsx
@@ -1,0 +1,500 @@
+import "@testing-library/jest-dom";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import DiscoveryPage from "../../../../App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery";
+import ProbeUtil from "../../../../App/FeatureSet/Dashboard/src/Utils/Probe";
+import NetworkDeviceDiscoveryScan, {
+  DiscoveredNetworkDevice,
+} from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import Project from "../../../Models/DatabaseModels/Project";
+import ObjectID from "../../../Types/ObjectID";
+import Route from "../../../Types/API/Route";
+import Permission from "../../../Types/Permission";
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "../../../UI/Utils/Project";
+import PermissionUtil from "../../../UI/Utils/Permission";
+import { ComponentProps as ModalProps } from "../../../UI/Components/Modal/Modal";
+
+// Keep the page's review, selection and import handlers real. The table mock
+// exposes its actual row action; the modal mock removes animation and portals.
+interface TableProps {
+  actionButtons: Array<{
+    title: string;
+    onClick: (
+      scan: NetworkDeviceDiscoveryScan,
+      onComplete: VoidFunction,
+    ) => Promise<void>;
+  }>;
+}
+
+let capturedTable: TableProps | null = null;
+let capturedModal: ModalProps | null = null;
+
+jest.mock("../../../UI/Components/ModelTable/ModelTable", () => {
+  return {
+    __esModule: true,
+    default: (props: TableProps) => {
+      capturedTable = props;
+      return null;
+    },
+  };
+});
+
+jest.mock("../../../UI/Components/Modal/Modal", () => {
+  return {
+    __esModule: true,
+    ModalWidth: { Medium: 1 },
+    default: (props: ModalProps) => {
+      capturedModal = props;
+      return (
+        <div role="dialog" aria-label={props.title}>
+          <p>{props.description}</p>
+          {props.error && <p role="alert">{props.error}</p>}
+          {props.isBodyLoading ? <p>Refreshing inventory</p> : props.children}
+          <button onClick={props.onClose}>Close review</button>
+          <button
+            disabled={props.disableSubmitButton || props.isLoading}
+            onClick={props.onSubmit}
+          >
+            {props.submitButtonText}
+          </button>
+        </div>
+      );
+    },
+  };
+});
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const SCAN_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+const OTHER_SCAN_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const PROBE_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+
+let getItemSpy: jest.SpyInstance;
+let createSpy: jest.SpyInstance;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => {};
+  let reject: (error: Error) => void = () => {};
+  const promise: Promise<T> = new Promise<T>(
+    (
+      resolvePromise: (value: T | PromiseLike<T>) => void,
+      rejectPromise: (reason?: unknown) => void,
+    ) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    },
+  );
+  return { promise, resolve, reject };
+}
+
+function host(
+  ipAddress: string,
+  isAlreadyRegistered: boolean,
+): DiscoveredNetworkDevice {
+  return { ipAddress, isAlreadyRegistered, snmpReachable: false };
+}
+
+function scan(
+  hosts: Array<DiscoveredNetworkDevice>,
+  id: ObjectID = SCAN_ID,
+): NetworkDeviceDiscoveryScan {
+  const value: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+  value.id = id;
+  value.projectId = PROJECT_ID;
+  value.probeId = PROBE_ID;
+  value.name =
+    id.toString() === SCAN_ID.toString() ? "Primary scan" : "Other scan";
+  value.cidr = "10.0.0.0/24";
+  value.status = "Completed";
+  value.discoveredDevices = hosts;
+  return value;
+}
+
+async function renderPage(): Promise<void> {
+  const project: Project = new Project();
+  project.id = PROJECT_ID;
+  render(
+    <MemoryRouter>
+      <DiscoveryPage
+        pageRoute={new Route("/dashboard/network-devices/discovery")}
+        currentProject={project}
+        hasPaymentMethod={true}
+      />
+    </MemoryRouter>,
+  );
+  await waitFor(() => {
+    expect(capturedTable).not.toBeNull();
+  });
+}
+
+function reviewAction(): TableProps["actionButtons"][number] {
+  const action: TableProps["actionButtons"][number] | undefined =
+    capturedTable?.actionButtons.find(
+      (button: TableProps["actionButtons"][number]) => {
+        return button.title === "Review Results";
+      },
+    );
+  if (!action) {
+    throw new Error("Review Results action was not rendered");
+  }
+  return action;
+}
+
+async function openReview(value: NetworkDeviceDiscoveryScan): Promise<void> {
+  await act(async () => {
+    await reviewAction().onClick(value, () => {});
+  });
+}
+
+function checkbox(ipAddress: string): HTMLElement {
+  return screen.getByTestId(`discovered-device-checkbox-${ipAddress}`);
+}
+
+function submit(): HTMLElement {
+  return screen.getByRole("button", { name: /Import Selected/ });
+}
+
+async function importSelected(): Promise<void> {
+  fireEvent.click(submit());
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+}
+
+beforeEach(() => {
+  capturedTable = null;
+  capturedModal = null;
+  jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(PROJECT_ID);
+  jest.spyOn(ProbeUtil, "getAllProbes").mockResolvedValue([]);
+  jest
+    .spyOn(PermissionUtil, "getAllPermissions")
+    .mockReturnValue([Permission.ProjectAdmin]);
+  getItemSpy = jest.spyOn(ModelAPI, "getItem");
+  createSpy = jest
+    .spyOn(ModelAPI, "create")
+    .mockResolvedValue(undefined as never);
+});
+
+afterEach(() => {
+  cleanup();
+  jest.restoreAllMocks();
+});
+
+describe("Discovery review refreshes registration from current inventory", () => {
+  test("a deleted device becomes selectable, while a newly registered device cannot be imported", async () => {
+    const oldScan: NetworkDeviceDiscoveryScan = scan([
+      host("10.0.0.1", true),
+      host("10.0.0.2", false),
+    ]);
+    getItemSpy.mockResolvedValue(
+      scan([host("10.0.0.1", false), host("10.0.0.2", true)]),
+    );
+    await renderPage();
+    await openReview(oldScan);
+
+    expect(checkbox("10.0.0.1")).toBeEnabled();
+    expect(checkbox("10.0.0.1")).toBeChecked();
+    expect(checkbox("10.0.0.2")).toBeDisabled();
+    expect(checkbox("10.0.0.2")).not.toBeChecked();
+    expect(submit()).toHaveTextContent("Import Selected (1)");
+
+    await importSelected();
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(createSpy.mock.calls[0]![0].model.hostname).toBe("10.0.0.1");
+    expect(createSpy.mock.calls[0]![0].modelType).toBe(NetworkDevice);
+    expect(oldScan.discoveredDevices![0]!.isAlreadyRegistered).toBe(true);
+  });
+
+  test("requests the scan identity, current results, probe and all import credentials", async () => {
+    const freshScan: NetworkDeviceDiscoveryScan = scan([
+      { ...host("10.0.0.1", false), snmpReachable: true },
+    ]);
+    freshScan.snmpCommunityString = "refreshed-community";
+    freshScan.snmpVersion = "2c";
+    getItemSpy.mockResolvedValue(freshScan);
+    await renderPage();
+    await openReview(scan([host("10.0.0.1", true)]));
+
+    expect(getItemSpy).toHaveBeenCalledTimes(1);
+    expect(getItemSpy.mock.calls[0]![0]).toEqual({
+      modelType: NetworkDeviceDiscoveryScan,
+      id: SCAN_ID,
+      select: {
+        _id: true,
+        projectId: true,
+        name: true,
+        cidr: true,
+        status: true,
+        statusMessage: true,
+        discoveredDevices: true,
+        probeId: true,
+        isSnmpEnabled: true,
+        snmpConfigs: true,
+        snmpVersion: true,
+        snmpCommunityString: true,
+        snmpPort: true,
+        snmpV3SecurityLevel: true,
+        snmpV3Username: true,
+        snmpV3AuthProtocol: true,
+        snmpV3AuthKey: true,
+        snmpV3PrivProtocol: true,
+        snmpV3PrivKey: true,
+      },
+    });
+    await importSelected();
+    const device: NetworkDevice = createSpy.mock.calls[0]![0].model;
+    expect(device.probeId?.toString()).toBe(PROBE_ID.toString());
+    expect(device.snmpCommunityString).toBe("refreshed-community");
+  });
+
+  test("reopening on the same page allows reimport after deleting a device imported during this visit", async () => {
+    const oldScan: NetworkDeviceDiscoveryScan = scan([host("10.0.0.1", false)]);
+    getItemSpy.mockResolvedValue(scan([host("10.0.0.1", false)]));
+    await renderPage();
+    await openReview(oldScan);
+    await importSelected();
+
+    // The inventory no longer contains the device; the page still remembers
+    // importing it, but a successful new read supersedes that old record.
+    await openReview(oldScan);
+    expect(checkbox("10.0.0.1")).toBeEnabled();
+    expect(checkbox("10.0.0.1")).toBeChecked();
+    await importSelected();
+    expect(createSpy).toHaveBeenCalledTimes(2);
+    expect(getItemSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("reopening keeps an existing device disabled even when its monitor was removed", async () => {
+    const oldScan: NetworkDeviceDiscoveryScan = scan([host("10.0.0.1", false)]);
+    getItemSpy.mockResolvedValueOnce(oldScan);
+    await renderPage();
+    await openReview(oldScan);
+    await importSelected();
+
+    getItemSpy.mockResolvedValue(scan([host("10.0.0.1", true)]));
+    await openReview(oldScan);
+
+    expect(checkbox("10.0.0.1")).toBeDisabled();
+    expect(screen.getByText("Already added")).toBeInTheDocument();
+    expect(submit()).toBeDisabled();
+    fireEvent.click(submit());
+    expect(createSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps a successful batch retired while allowing the failed host to be retried", async () => {
+    getItemSpy.mockResolvedValue(
+      scan([host("10.0.0.1", false), host("10.0.0.2", false)]),
+    );
+    createSpy
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("Device creation failed"))
+      .mockRejectedValueOnce(new Error("Device creation failed"));
+    await renderPage();
+    await openReview(scan([]));
+    fireEvent.click(submit());
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Device creation failed",
+      );
+    });
+
+    expect(checkbox("10.0.0.1")).toBeDisabled();
+    expect(checkbox("10.0.0.2")).toBeEnabled();
+    expect(checkbox("10.0.0.2")).toBeChecked();
+    expect(submit()).toHaveTextContent("Import Selected (1)");
+    await importSelected();
+    expect(createSpy).toHaveBeenCalledTimes(4);
+    expect(createSpy.mock.calls[3]![0].model.hostname).toBe("10.0.0.2");
+  });
+});
+
+describe("Discovery review waits for a successful current response", () => {
+  test("does not expose stale selection or import while the inventory read is pending", async () => {
+    const pending: Deferred<NetworkDeviceDiscoveryScan | null> = deferred();
+    getItemSpy.mockReturnValue(pending.promise);
+    await renderPage();
+    let opening: Promise<void> = Promise.resolve();
+    await act(async () => {
+      opening = reviewAction().onClick(
+        scan([host("10.0.0.1", false)]),
+        () => {},
+      );
+    });
+
+    expect(screen.getByText("Refreshing inventory")).toBeInTheDocument();
+    expect(submit()).toBeDisabled();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    await act(async () => {
+      capturedModal?.onSubmit?.();
+    });
+    expect(createSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      pending.resolve(scan([host("10.0.0.1", true)]));
+      await opening;
+    });
+    expect(checkbox("10.0.0.1")).toBeDisabled();
+  });
+
+  test("a failed refresh cannot fall back to a stale importable row and can be retried by reopening", async () => {
+    getItemSpy.mockRejectedValueOnce(new Error("Inventory refresh failed"));
+    await renderPage();
+    const oldScan: NetworkDeviceDiscoveryScan = scan([host("10.0.0.1", false)]);
+    await openReview(oldScan);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Inventory refresh failed",
+    );
+    expect(submit()).toBeDisabled();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    await act(async () => {
+      capturedModal?.onSubmit?.();
+    });
+    expect(createSpy).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Close review"));
+    getItemSpy.mockResolvedValue(scan([host("10.0.0.1", false)]));
+    await openReview(oldScan);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(checkbox("10.0.0.1")).toBeChecked();
+    expect(submit()).toBeEnabled();
+  });
+
+  test("a scan deleted since the table loaded leaves import disabled", async () => {
+    getItemSpy.mockResolvedValue(null);
+    await renderPage();
+    await openReview(scan([host("10.0.0.1", false)]));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "This discovery scan could not be found.",
+    );
+    expect(submit()).toBeDisabled();
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  test("closing during a pending read does not reopen the dialog when the read completes", async () => {
+    const pending: Deferred<NetworkDeviceDiscoveryScan | null> = deferred();
+    getItemSpy.mockReturnValue(pending.promise);
+    const completed: jest.Mock = jest.fn();
+    await renderPage();
+    let opening: Promise<void> = Promise.resolve();
+    await act(async () => {
+      opening = reviewAction().onClick(scan([]), completed);
+    });
+    fireEvent.click(screen.getByText("Close review"));
+
+    await act(async () => {
+      pending.resolve(scan([host("10.0.0.1", false)]));
+      await opening;
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(completed).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([false, true])(
+    "an older response cannot replace a newer review (same scan: %s)",
+    async (sameScan: boolean) => {
+      const older: Deferred<NetworkDeviceDiscoveryScan | null> = deferred();
+      getItemSpy.mockReturnValueOnce(older.promise);
+      getItemSpy.mockResolvedValueOnce(
+        scan([host("10.0.0.2", true)], sameScan ? SCAN_ID : OTHER_SCAN_ID),
+      );
+      await renderPage();
+      let opening: Promise<void> = Promise.resolve();
+      await act(async () => {
+        opening = reviewAction().onClick(scan([]), () => {});
+      });
+      await openReview(scan([], sameScan ? SCAN_ID : OTHER_SCAN_ID));
+
+      await act(async () => {
+        older.resolve(scan([host("10.0.0.1", false)]));
+        await opening;
+      });
+
+      expect(
+        screen.queryByTestId("discovered-device-checkbox-10.0.0.1"),
+      ).not.toBeInTheDocument();
+      expect(checkbox("10.0.0.2")).toBeDisabled();
+      expect(submit()).toBeDisabled();
+    },
+  );
+
+  test("an older failure cannot show an error on the current review", async () => {
+    const older: Deferred<NetworkDeviceDiscoveryScan | null> = deferred();
+    getItemSpy.mockReturnValueOnce(older.promise);
+    getItemSpy.mockResolvedValueOnce(
+      scan([host("10.0.0.2", false)], OTHER_SCAN_ID),
+    );
+    await renderPage();
+    let opening: Promise<void> = Promise.resolve();
+    await act(async () => {
+      opening = reviewAction().onClick(scan([]), () => {});
+    });
+    await openReview(scan([], OTHER_SCAN_ID));
+    await act(async () => {
+      older.reject(new Error("Old request failed"));
+      await opening;
+    });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(checkbox("10.0.0.2")).toBeChecked();
+    expect(submit()).toBeEnabled();
+  });
+
+  test("an import finishing during a reopened review's read remains retired even if the read predates it", async () => {
+    const importPending: Deferred<undefined> = deferred();
+    const refreshPending: Deferred<NetworkDeviceDiscoveryScan | null> =
+      deferred();
+    const oldScan: NetworkDeviceDiscoveryScan = scan([host("10.0.0.1", false)]);
+    getItemSpy
+      .mockResolvedValueOnce(oldScan)
+      .mockReturnValueOnce(refreshPending.promise);
+    createSpy.mockReturnValueOnce(importPending.promise);
+    await renderPage();
+    await openReview(oldScan);
+    fireEvent.click(submit());
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+    fireEvent.click(screen.getByText("Close review"));
+    let opening: Promise<void> = Promise.resolve();
+    await act(async () => {
+      opening = reviewAction().onClick(oldScan, () => {});
+    });
+
+    await act(async () => {
+      importPending.resolve(undefined);
+    });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Refreshing inventory")).toBeInTheDocument();
+
+    await act(async () => {
+      refreshPending.resolve(scan([host("10.0.0.1", false)]));
+      await opening;
+    });
+    expect(checkbox("10.0.0.1")).toBeDisabled();
+    expect(submit()).toBeDisabled();
+    expect(createSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/App/Dashboard/DiscoveryReviewInventoryRefresh.test.tsx
+++ b/Common/Tests/App/Dashboard/DiscoveryReviewInventoryRefresh.test.tsx
@@ -20,13 +20,16 @@ import Project from "../../../Models/DatabaseModels/Project";
 import ObjectID from "../../../Types/ObjectID";
 import Route from "../../../Types/API/Route";
 import Permission from "../../../Types/Permission";
+import { VoidFunction } from "../../../Types/FunctionTypes";
 import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "../../../UI/Utils/Project";
 import PermissionUtil from "../../../UI/Utils/Permission";
 import { ComponentProps as ModalProps } from "../../../UI/Components/Modal/Modal";
 
-// Keep the page's review, selection and import handlers real. The table mock
-// exposes its actual row action; the modal mock removes animation and portals.
+/*
+ * Keep the page's review, selection and import handlers real. The table mock
+ * exposes its actual row action; the modal mock removes animation and portals.
+ */
 interface TableProps {
   actionButtons: Array<{
     title: string;
@@ -275,8 +278,10 @@ describe("Discovery review refreshes registration from current inventory", () =>
     await openReview(oldScan);
     await importSelected();
 
-    // The inventory no longer contains the device; the page still remembers
-    // importing it, but a successful new read supersedes that old record.
+    /*
+     * The inventory no longer contains the device; the page still remembers
+     * importing it, but a successful new read supersedes that old record.
+     */
     await openReview(oldScan);
     expect(checkbox("10.0.0.1")).toBeEnabled();
     expect(checkbox("10.0.0.1")).toBeChecked();

--- a/Common/Tests/Server/Services/NetworkDeviceAutoImportRuleEngineService.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceAutoImportRuleEngineService.test.ts
@@ -587,6 +587,7 @@ describe("NetworkDeviceAutoImportRuleEngineService.processCompletedScan", () => 
     const unmatchedRow: DiscoveredNetworkDevice = makeHost({
       ipAddress: "192.168.1.5",
       sysName: "printer-01",
+      isAlreadyRegistered: true,
     });
 
     scanFindOneByMock.mockResolvedValue(
@@ -611,6 +612,10 @@ describe("NetworkDeviceAutoImportRuleEngineService.processCompletedScan", () => 
     expect(createMock).toHaveBeenCalledTimes(1);
     expect(monitorFindByMock).not.toHaveBeenCalled();
     expect(monitorTemplateFindByMock).not.toHaveBeenCalled();
+    expect(scanFindOneByMock.mock.calls[0]![0].props).toEqual({
+      isRoot: true,
+      ignoreHooks: true,
+    });
     const device: NetworkDevice = createdDevice(0);
     // The address is the hostname AND the dedup key downstream.
     expect(device.hostname).toBe("10.0.0.5");
@@ -1818,6 +1823,8 @@ describe("NetworkDeviceAutoImportRuleEngineService.applyRuleToCompletedScans", (
     ]);
     expect(rereadCall.query.projectId.toString()).toBe(PROJECT_ID.toString());
     expect(rereadCall.select.discoveredDevices).toBe(true);
+    expect(rereadCall.props).toEqual({ isRoot: true, ignoreHooks: true });
+    expect(listCall.props).toEqual({ isRoot: true });
   });
 
   it("skips a scan that vanished between the stub listing and the re-read", async () => {
@@ -2059,6 +2066,244 @@ describe("NetworkDeviceAutoImportRuleEngineService.applyRuleToCompletedScans", (
       expect(scanFindByMock).not.toHaveBeenCalled();
       expect(monitorCreateMock).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("re-import after deleting discovered devices or monitors (issue #3560)", () => {
+  it.each([false, true])(
+    "uses current inventory when a processed scan still marks a deleted device registered (dry run: %s)",
+    async (isDryRun: boolean) => {
+      ruleFindOneByMock.mockResolvedValue(
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      );
+      ruleFindByMock.mockResolvedValue([]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+      mockRunNowScans([
+        makeScan({
+          completedAt: new Date("2020-01-01T00:00:00.000Z"),
+          autoImportProcessedAt: OneUptimeDate.getCurrentDate(),
+          discoveredDevices: [makeHost({ isAlreadyRegistered: true })],
+        }),
+      ]);
+
+      const result: AutoImportRuleRunResult = await runRule(isDryRun);
+
+      expect(result).toMatchObject({
+        hostsMatched: 1,
+        hostsSkippedAlreadyRegistered: 0,
+        devicesCreated: isDryRun ? 0 : 1,
+        monitorsCreated: isDryRun ? 0 : 1,
+        monitorsWouldCreate: isDryRun ? 1 : 0,
+        devicesFailed: 0,
+        monitorsFailed: 0,
+        matchedIpAddressSample: ["10.0.0.5"],
+        isTruncated: false,
+        isDryRun,
+      });
+      expect(createMock).toHaveBeenCalledTimes(isDryRun ? 0 : 1);
+      expect(monitorCreateMock).toHaveBeenCalledTimes(isDryRun ? 0 : 1);
+      expect(scanUpdateMock).toHaveBeenCalledTimes(isDryRun ? 0 : 1);
+
+      if (!isDryRun) {
+        const device: NetworkDevice = createdDevice(0);
+        expect(device.hostname).toBe("10.0.0.5");
+        expect(device.snmpCommunityString).toBe("public");
+        expect(device.projectId?.toString()).toBe(PROJECT_ID.toString());
+        expect(
+          provisionedMonitor(0).autoProvisionedNetworkDeviceId?.toString(),
+        ).toBe(device.id?.toString());
+        expect(scanUpdateMock.mock.calls[0]![0].data).toEqual({
+          discoveredDevices: [makeHost({ isAlreadyRegistered: true })],
+        });
+      }
+    },
+  );
+
+  it("imports a deleted device from fresh automatic results with a stale registration flag", async () => {
+    scanFindOneByMock.mockResolvedValue(
+      makeScan({
+        discoveredDevices: [makeHost({ isAlreadyRegistered: true })],
+      }),
+    );
+
+    const result: AutoImportRuleRunResult | null = await processScan();
+
+    expect(result).toMatchObject({
+      devicesCreated: 1,
+      hostsSkippedAlreadyRegistered: 0,
+    });
+    expect(
+      scanUpdateMock.mock.calls[0]![0].data.autoImportProcessedAt,
+    ).toBeInstanceOf(Date);
+  });
+
+  it.each([false, true])(
+    "restores a deleted template monitor while retaining its registered device (dry run: %s)",
+    async (isDryRun: boolean) => {
+      const existingDevice: NetworkDevice = makeExistingDevice();
+      deviceFindByMock.mockResolvedValue([existingDevice]);
+      ruleFindOneByMock.mockResolvedValue(
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      );
+      ruleFindByMock.mockResolvedValue([]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+      mockRunNowScans([
+        makeScan({
+          autoImportProcessedAt: OneUptimeDate.getCurrentDate(),
+          discoveredDevices: [makeHost({ isAlreadyRegistered: true })],
+        }),
+      ]);
+
+      const result: AutoImportRuleRunResult = await runRule(isDryRun);
+
+      expect(result).toMatchObject({
+        hostsSkippedAlreadyRegistered: 1,
+        devicesCreated: 0,
+        monitorsCreated: isDryRun ? 0 : 1,
+        monitorsWouldCreate: isDryRun ? 1 : 0,
+        monitorsSkippedAlreadyExisting: 0,
+      });
+      expect(createMock).not.toHaveBeenCalled();
+      expect(scanUpdateMock).not.toHaveBeenCalled();
+      if (!isDryRun) {
+        expect(
+          provisionedMonitor(0).autoProvisionedNetworkDeviceId?.toString(),
+        ).toBe(existingDevice.id?.toString());
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "deduplicates stale registered rows within and across scans (dry run: %s)",
+    async (isDryRun: boolean) => {
+      ruleFindOneByMock.mockResolvedValue(
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      );
+      ruleFindByMock.mockResolvedValue([]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+      mockRunNowScans([
+        makeScan({
+          discoveredDevices: [
+            makeHost({ isAlreadyRegistered: true }),
+            makeHost({ ipAddress: " 10.0.0.5 ", isAlreadyRegistered: false }),
+          ],
+        }),
+        makeScan({
+          id: ObjectID.generate(),
+          discoveredDevices: [makeHost({ isAlreadyRegistered: true })],
+        }),
+      ]);
+
+      const result: AutoImportRuleRunResult = await runRule(isDryRun);
+
+      expect(result).toMatchObject({
+        hostsMatched: 3,
+        hostsSkippedAlreadyRegistered: 2,
+        devicesCreated: isDryRun ? 0 : 1,
+        monitorsCreated: isDryRun ? 0 : 1,
+        monitorsWouldCreate: isDryRun ? 1 : 0,
+        monitorsSkippedAlreadyExisting: 2,
+        matchedIpAddressSample: ["10.0.0.5"],
+      });
+      expect(createMock).toHaveBeenCalledTimes(isDryRun ? 0 : 1);
+      expect(monitorCreateMock).toHaveBeenCalledTimes(isDryRun ? 0 : 1);
+    },
+  );
+
+  it("still honors exclusions when the registered device has been deleted", async () => {
+    ruleFindOneByMock.mockResolvedValue(makeRule());
+    ruleFindByMock.mockResolvedValue([
+      makeRule({
+        id: ObjectID.generate(),
+        isExclusion: true,
+        ipMatchTarget: "10.0.0.5",
+      }),
+    ]);
+    mockRunNowScans([
+      makeScan({
+        discoveredDevices: [makeHost({ isAlreadyRegistered: true })],
+      }),
+    ]);
+
+    const result: AutoImportRuleRunResult = await runRule(false);
+
+    expect(result).toMatchObject({
+      hostsExcluded: 1,
+      hostsMatched: 0,
+      devicesCreated: 0,
+    });
+    expect(createMock).not.toHaveBeenCalled();
+    expect(scanUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("resumes re-importing a deleted 903-device fleet across the run cap without duplicates", async () => {
+    const hosts: Array<DiscoveredNetworkDevice> = Array.from(
+      { length: 903 },
+      (_value: unknown, index: number): DiscoveredNetworkDevice => {
+        return makeHost({
+          ipAddress: `10.0.${Math.floor(index / 256)}.${index % 256}`,
+          sysName: `switch-${index}`,
+          isAlreadyRegistered: true,
+        });
+      },
+    );
+    const scan: NetworkDeviceDiscoveryScan = makeScan({
+      autoImportProcessedAt: OneUptimeDate.getCurrentDate(),
+      discoveredDevices: hosts,
+    });
+    const inventory: Map<string, NetworkDevice> = new Map();
+    devicesByHostnamesMock.mockImplementation(
+      async (data: {
+        hostnames: Array<string>;
+      }): Promise<Map<string, NetworkDevice>> => {
+        const found: Map<string, NetworkDevice> = new Map();
+        for (const hostname of data.hostnames) {
+          const device: NetworkDevice | undefined = inventory.get(hostname);
+          if (device) {
+            found.set(hostname, device);
+          }
+        }
+        return found;
+      },
+    );
+    createMock.mockImplementation(
+      async ({ data }: { data: NetworkDevice }): Promise<NetworkDevice> => {
+        data.id = ObjectID.generate();
+        inventory.set(data.hostname!, data);
+        return data;
+      },
+    );
+    ruleFindOneByMock.mockResolvedValue(
+      makeRule({ ipMatchTarget: "10.0.0.0/8" }),
+    );
+    ruleFindByMock.mockResolvedValue([]);
+
+    mockRunNowScans([scan]);
+    const firstRun: AutoImportRuleRunResult = await runRule(false);
+    expect(firstRun).toMatchObject({
+      devicesCreated: MAX_DEVICES_PER_AUTO_IMPORT_RUN,
+      hostsSkippedAlreadyRegistered: 0,
+      isTruncated: true,
+    });
+
+    mockRunNowScans([scan]);
+    const secondRun: AutoImportRuleRunResult = await runRule(false);
+    expect(secondRun).toMatchObject({
+      devicesCreated: hosts.length - MAX_DEVICES_PER_AUTO_IMPORT_RUN,
+      hostsSkippedAlreadyRegistered: MAX_DEVICES_PER_AUTO_IMPORT_RUN,
+      isTruncated: false,
+    });
+
+    mockRunNowScans([scan]);
+    const thirdRun: AutoImportRuleRunResult = await runRule(false);
+    expect(thirdRun).toMatchObject({
+      devicesCreated: 0,
+      hostsSkippedAlreadyRegistered: hosts.length,
+      isTruncated: false,
+    });
+    expect(inventory.size).toBe(hosts.length);
+    expect(createMock).toHaveBeenCalledTimes(hosts.length);
+    expect(scanUpdateMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/Common/Tests/Server/Services/NetworkDeviceDiscoveryScanRegistration.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceDiscoveryScanRegistration.test.ts
@@ -273,7 +273,7 @@ describe("NetworkDeviceDiscoveryScanService current registration on read", () =>
     const saved: NetworkDeviceDiscoveryScan = scanWith([
       host("10.0.0.5", true),
     ]);
-    saved.projectId = undefined;
+    delete saved.projectId;
     const result: Array<NetworkDeviceDiscoveryScan> = await readScans(
       [saved],
       context({ tenantId: PROJECT_ID }),
@@ -306,7 +306,7 @@ describe("NetworkDeviceDiscoveryScanService current registration on read", () =>
     const saved: NetworkDeviceDiscoveryScan = scanWith([
       host("10.0.0.5", true),
     ]);
-    saved.projectId = undefined;
+    delete saved.projectId;
 
     const result: Array<NetworkDeviceDiscoveryScan> = await readScans([saved]);
 
@@ -433,7 +433,7 @@ describe("discovery registration with the inventory lookup service", () => {
   it("keeps a live device registered after its monitor has been deleted", async () => {
     const device: NetworkDevice = new NetworkDevice();
     device.hostname = "10.0.0.5";
-    device.monitorId = undefined;
+    delete device.monitorId;
     const findSpy: jest.SpyInstance = jest
       .spyOn(NetworkDeviceService, "findBy")
       .mockResolvedValue([device]);
@@ -498,20 +498,23 @@ describe("discovery registration with the inventory lookup service", () => {
 
     expect(findSpy).toHaveBeenCalledTimes(3);
     expect(
-      requestedChunks.map((chunk: Array<string>): number => chunk.length),
+      requestedChunks.map((chunk: Array<string>): number => {
+        return chunk.length;
+      }),
     ).toEqual([500, 500, 1]);
     expect(requestedChunks.flat()).toEqual(
-      hosts.map((item: DiscoveredNetworkDevice): string => item.ipAddress),
+      hosts.map((item: DiscoveredNetworkDevice): string => {
+        return item.ipAddress;
+      }),
     );
     expect(discoveredAt(result)).toHaveLength(1001);
     for (const item of discoveredAt(result)) {
       expect(item.isAlreadyRegistered).toBe(liveHostnames.has(item.ipAddress));
     }
     expect(
-      hosts.every(
-        (item: DiscoveredNetworkDevice): boolean =>
-          item.isAlreadyRegistered === true,
-      ),
+      hosts.every((item: DiscoveredNetworkDevice): boolean => {
+        return item.isAlreadyRegistered === true;
+      }),
     ).toBe(true);
   });
 });

--- a/Common/Tests/Server/Services/NetworkDeviceDiscoveryScanRegistration.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceDiscoveryScanRegistration.test.ts
@@ -1,0 +1,517 @@
+import NetworkDeviceDiscoveryScanService from "../../../Server/Services/NetworkDeviceDiscoveryScanService";
+import NetworkDeviceService from "../../../Server/Services/NetworkDeviceService";
+import NetworkDeviceDiscoveryScan, {
+  DiscoveredNetworkDevice,
+} from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import { OnFind } from "../../../Server/Types/Database/Hooks";
+import FindBy from "../../../Server/Types/Database/FindBy";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import ObjectID from "../../../Types/ObjectID";
+import { FindOperator } from "typeorm";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+interface FindSuccessHook {
+  onFindSuccess(
+    onFind: OnFind<NetworkDeviceDiscoveryScan>,
+    items: Array<NetworkDeviceDiscoveryScan>,
+  ): Promise<OnFind<NetworkDeviceDiscoveryScan>>;
+}
+
+function context(
+  props: DatabaseCommonInteractionProps = { isRoot: true },
+): OnFind<NetworkDeviceDiscoveryScan> {
+  return {
+    findBy: {
+      query: {},
+      select: { discoveredDevices: true },
+      skip: 0,
+      limit: 100,
+      props,
+    },
+    carryForward: undefined,
+  };
+}
+
+function host(
+  ipAddress: string,
+  isAlreadyRegistered?: boolean,
+): DiscoveredNetworkDevice {
+  return { ipAddress, isAlreadyRegistered };
+}
+
+// JSONB can contain older or malformed payloads, so accept unknown here.
+function scanWith(
+  discoveredDevices: unknown,
+  projectId: ObjectID | undefined = PROJECT_ID,
+): NetworkDeviceDiscoveryScan {
+  const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+  scan.projectId = projectId;
+  (scan as unknown as Record<string, unknown>)["discoveredDevices"] =
+    discoveredDevices;
+  return scan;
+}
+
+async function readScans(
+  items: Array<NetworkDeviceDiscoveryScan>,
+  onFind: OnFind<NetworkDeviceDiscoveryScan> = context(),
+): Promise<Array<NetworkDeviceDiscoveryScan>> {
+  const result: OnFind<NetworkDeviceDiscoveryScan> = await (
+    NetworkDeviceDiscoveryScanService as unknown as FindSuccessHook
+  ).onFindSuccess(onFind, items);
+
+  expect(result.findBy).toBe(onFind.findBy);
+  return result.carryForward as Array<NetworkDeviceDiscoveryScan>;
+}
+
+function discoveredAt(
+  scans: Array<NetworkDeviceDiscoveryScan>,
+  scanIndex: number = 0,
+): Array<DiscoveredNetworkDevice> {
+  return scans[scanIndex]!.discoveredDevices!;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("NetworkDeviceDiscoveryScanService current registration on read", () => {
+  let registrationSpy: jest.SpyInstance;
+  let updateSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    registrationSpy = jest
+      .spyOn(NetworkDeviceService, "getRegisteredHostnames")
+      .mockResolvedValue(new Set<string>());
+    updateSpy = jest
+      .spyOn(NetworkDeviceDiscoveryScanService, "updateBy")
+      .mockResolvedValue(0);
+  });
+
+  it("clears a stored registered flag when the device has been deleted", async () => {
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([
+      scanWith([host("10.0.0.5", true)]),
+    ]);
+
+    expect(discoveredAt(result)).toEqual([host("10.0.0.5", false)]);
+    expect(registrationSpy).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      props: { isRoot: true },
+    });
+  });
+
+  it("marks a stored unregistered host registered after an import", async () => {
+    registrationSpy.mockResolvedValue(new Set(["10.0.0.5"]));
+
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([
+      scanWith([host("10.0.0.5", false)]),
+    ]);
+
+    expect(discoveredAt(result)).toEqual([host("10.0.0.5", true)]);
+  });
+
+  it("derives registration for results written before the flag existed", async () => {
+    registrationSpy.mockResolvedValue(new Set(["10.0.0.5"]));
+
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([
+      scanWith([{ ipAddress: "10.0.0.5" }, { ipAddress: "10.0.0.6" }]),
+    ]);
+
+    expect(discoveredAt(result)).toEqual([
+      host("10.0.0.5", true),
+      host("10.0.0.6", false),
+    ]);
+  });
+
+  it("keeps both registered and unregistered hosts accurate in the same result", async () => {
+    registrationSpy.mockResolvedValue(new Set(["10.0.0.5", "10.0.0.7"]));
+
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([
+      scanWith([
+        host("10.0.0.5", true),
+        host("10.0.0.6", true),
+        host("10.0.0.7", false),
+        host("10.0.0.8", false),
+      ]),
+    ]);
+
+    expect(discoveredAt(result)).toEqual([
+      host("10.0.0.5", true),
+      host("10.0.0.6", false),
+      host("10.0.0.7", true),
+      host("10.0.0.8", false),
+    ]);
+  });
+
+  it("rechecks inventory on every read across import, deletion and reimport", async () => {
+    const saved: NetworkDeviceDiscoveryScan = scanWith([
+      host("10.0.0.5", true),
+    ]);
+    registrationSpy
+      .mockResolvedValueOnce(new Set(["10.0.0.5"]))
+      .mockResolvedValueOnce(new Set<string>())
+      .mockResolvedValueOnce(new Set(["10.0.0.5"]));
+
+    expect(discoveredAt(await readScans([saved]))[0]!.isAlreadyRegistered).toBe(
+      true,
+    );
+    expect(discoveredAt(await readScans([saved]))[0]!.isAlreadyRegistered).toBe(
+      false,
+    );
+    expect(discoveredAt(await readScans([saved]))[0]!.isAlreadyRegistered).toBe(
+      true,
+    );
+    expect(registrationSpy).toHaveBeenCalledTimes(3);
+    expect(saved.discoveredDevices).toEqual([host("10.0.0.5", true)]);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("copies results without changing persisted scan data or model methods", async () => {
+    const originalHost: DiscoveredNetworkDevice = {
+      ipAddress: "10.0.0.5",
+      isAlreadyRegistered: true,
+      sysName: "Core switch",
+      sysDescr: "A managed switch",
+      sysObjectId: "1.3.6.1.4.1.9",
+      sysLocation: "Rack 2",
+      sysContact: "Network team",
+      sysUpTimeSeconds: 1234,
+      dnsHostname: "switch.example.test",
+      snmpReachable: true,
+      snmpConfigId: "office-snmp",
+    };
+    const originalHosts: Array<DiscoveredNetworkDevice> = [originalHost];
+    const saved: NetworkDeviceDiscoveryScan = scanWith(originalHosts);
+    saved.name = "Office discovery";
+    saved.status = "Completed";
+    saved.completedAt = new Date("2026-09-01T10:00:00Z");
+    saved.scannedHostCount = 256;
+    saved.respondedHostCount = 1;
+    Object.freeze(originalHost);
+    Object.freeze(originalHosts);
+    Object.freeze(saved);
+    const originalItems: Array<NetworkDeviceDiscoveryScan> = [saved];
+    Object.freeze(originalItems);
+
+    const result: Array<NetworkDeviceDiscoveryScan> =
+      await readScans(originalItems);
+
+    expect(result).not.toBe(originalItems);
+    expect(result[0]).not.toBe(saved);
+    expect(result[0]).toBeInstanceOf(NetworkDeviceDiscoveryScan);
+    expect(Object.getPrototypeOf(result[0])).toBe(Object.getPrototypeOf(saved));
+    expect(result[0]).toEqual({
+      ...saved,
+      discoveredDevices: [{ ...originalHost, isAlreadyRegistered: false }],
+    });
+    expect(discoveredAt(result)).not.toBe(originalHosts);
+    expect(discoveredAt(result)[0]).not.toBe(originalHost);
+    expect(originalHost.isAlreadyRegistered).toBe(true);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("batches and deduplicates all hosts for the same project across scans", async () => {
+    registrationSpy.mockResolvedValue(new Set(["10.0.0.6"]));
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([
+      scanWith([host("10.0.0.5"), host("10.0.0.5"), host("10.0.0.6")]),
+      scanWith(
+        [host("10.0.0.6"), host("10.0.0.7")],
+        new ObjectID(PROJECT_ID.toString()),
+      ),
+    ]);
+
+    expect(registrationSpy).toHaveBeenCalledTimes(1);
+    expect(registrationSpy).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5", "10.0.0.6", "10.0.0.7"],
+      props: { isRoot: true },
+    });
+    expect(discoveredAt(result, 0)).toEqual([
+      host("10.0.0.5", false),
+      host("10.0.0.5", false),
+      host("10.0.0.6", true),
+    ]);
+    expect(discoveredAt(result, 1)).toEqual([
+      host("10.0.0.6", true),
+      host("10.0.0.7", false),
+    ]);
+  });
+
+  it("keeps the same address independent between projects", async () => {
+    registrationSpy.mockImplementation(
+      async (data: { projectId: ObjectID }): Promise<Set<string>> => {
+        return data.projectId.toString() === PROJECT_ID.toString()
+          ? new Set(["10.0.0.5"])
+          : new Set<string>();
+      },
+    );
+
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([
+      scanWith([host("10.0.0.5", false)], PROJECT_ID),
+      scanWith([host("10.0.0.5", true)], OTHER_PROJECT_ID),
+    ]);
+
+    expect(registrationSpy).toHaveBeenCalledTimes(2);
+    expect(registrationSpy).toHaveBeenCalledWith({
+      projectId: OTHER_PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      props: { isRoot: true },
+    });
+    expect(discoveredAt(result, 0)[0]!.isAlreadyRegistered).toBe(true);
+    expect(discoveredAt(result, 1)[0]!.isAlreadyRegistered).toBe(false);
+  });
+
+  it("uses the request tenant when projectId was not selected", async () => {
+    const saved: NetworkDeviceDiscoveryScan = scanWith([
+      host("10.0.0.5", true),
+    ]);
+    saved.projectId = undefined;
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans(
+      [saved],
+      context({ tenantId: PROJECT_ID }),
+    );
+
+    expect(discoveredAt(result)[0]!.isAlreadyRegistered).toBe(false);
+    expect(registrationSpy).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      props: { isRoot: true },
+    });
+    expect(result[0]!.projectId).toBeUndefined();
+  });
+
+  it("uses the scan project before the request tenant", async () => {
+    await readScans(
+      [scanWith([host("10.0.0.5", true)], OTHER_PROJECT_ID)],
+      context({ tenantId: PROJECT_ID }),
+    );
+
+    expect(registrationSpy).toHaveBeenCalledTimes(1);
+    expect(registrationSpy).toHaveBeenCalledWith({
+      projectId: OTHER_PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      props: { isRoot: true },
+    });
+  });
+
+  it("leaves results unchanged when neither project nor tenant is available", async () => {
+    const saved: NetworkDeviceDiscoveryScan = scanWith([
+      host("10.0.0.5", true),
+    ]);
+    saved.projectId = undefined;
+
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([saved]);
+
+    expect(result[0]).toBe(saved);
+    expect(registrationSpy).not.toHaveBeenCalled();
+  });
+
+  it("normalizes whitespace for lookup without rewriting the stored address", async () => {
+    registrationSpy.mockResolvedValue(new Set(["10.0.0.5"]));
+
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([
+      scanWith([host(" 10.0.0.5 \t", false), host("10.0.0.5", false)]),
+    ]);
+
+    expect(registrationSpy).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      props: { isRoot: true },
+    });
+    expect(discoveredAt(result)).toEqual([
+      host(" 10.0.0.5 \t", true),
+      host("10.0.0.5", true),
+    ]);
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["null", null],
+    ["empty", []],
+    ["object", { ipAddress: "10.0.0.5" }],
+    ["string", "10.0.0.5"],
+    ["number", 42],
+  ])(
+    "does not query inventory for %s results",
+    async (_label: string, payload: unknown) => {
+      const saved: NetworkDeviceDiscoveryScan = scanWith(payload);
+
+      const result: Array<NetworkDeviceDiscoveryScan> = await readScans([
+        saved,
+      ]);
+
+      expect(result[0]).toBe(saved);
+      expect(registrationSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not query inventory for an empty scan page", async () => {
+    expect(await readScans([])).toEqual([]);
+    expect(registrationSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not query inventory for only malformed host entries", async () => {
+    const junk: Array<unknown> = [
+      null,
+      false,
+      42,
+      "10.0.0.5",
+      [],
+      {},
+      { ipAddress: null },
+      { ipAddress: 10 },
+      { ipAddress: "", isAlreadyRegistered: true },
+      { ipAddress: " \t\n ", isAlreadyRegistered: true },
+    ];
+    const saved: NetworkDeviceDiscoveryScan = scanWith(junk);
+
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([saved]);
+
+    expect(result[0]).toBe(saved);
+    expect(result[0]!.discoveredDevices).toBe(junk);
+    expect(registrationSpy).not.toHaveBeenCalled();
+  });
+
+  it("preserves malformed entries among valid hosts", async () => {
+    const junkObject: Record<string, unknown> = {
+      ipAddress: 10,
+      isAlreadyRegistered: true,
+    };
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([
+      scanWith([null, junkObject, host("10.0.0.5", true), "invalid"]),
+    ]);
+
+    expect(discoveredAt(result)).toEqual([
+      null,
+      junkObject,
+      host("10.0.0.5", false),
+      "invalid",
+    ]);
+    expect(discoveredAt(result)[1]).toBe(junkObject);
+    expect(registrationSpy).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      props: { isRoot: true },
+    });
+  });
+
+  it("preserves unselected rows beside rows that need registration refresh", async () => {
+    const unselected: NetworkDeviceDiscoveryScan = scanWith(undefined);
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([
+      unselected,
+      scanWith([host("10.0.0.5", true)]),
+    ]);
+
+    expect(result[0]).toBe(unselected);
+    expect(discoveredAt(result, 1)[0]!.isAlreadyRegistered).toBe(false);
+    expect(registrationSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates lookup failure instead of reporting all hosts as importable", async () => {
+    const error: Error = new Error("inventory lookup unavailable");
+    registrationSpy.mockRejectedValue(error);
+    const saved: NetworkDeviceDiscoveryScan = scanWith([
+      host("10.0.0.5", true),
+    ]);
+
+    await expect(readScans([saved])).rejects.toBe(error);
+
+    expect(saved.discoveredDevices).toEqual([host("10.0.0.5", true)]);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("discovery registration with the inventory lookup service", () => {
+  it("keeps a live device registered after its monitor has been deleted", async () => {
+    const device: NetworkDevice = new NetworkDevice();
+    device.hostname = "10.0.0.5";
+    device.monitorId = undefined;
+    const findSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "findBy")
+      .mockResolvedValue([device]);
+
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([
+      scanWith([host("10.0.0.5", false)]),
+    ]);
+
+    expect(discoveredAt(result)[0]!.isAlreadyRegistered).toBe(true);
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    expect(findSpy.mock.calls[0]![0].query).toEqual({
+      projectId: PROJECT_ID,
+      hostname: expect.any(FindOperator),
+    });
+  });
+
+  it("refreshes more than 900 hosts through bounded inventory lookup chunks", async () => {
+    const hosts: Array<DiscoveredNetworkDevice> = Array.from(
+      { length: 1001 },
+      (_value: unknown, index: number): DiscoveredNetworkDevice => {
+        return host(`10.99.${Math.floor(index / 256)}.${index % 256}`, true);
+      },
+    );
+    const liveHostnames: Set<string> = new Set([
+      hosts[0]!.ipAddress,
+      hosts[500]!.ipAddress,
+      hosts[1000]!.ipAddress,
+    ]);
+    const requestedChunks: Array<Array<string>> = [];
+    const findSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "findBy")
+      .mockImplementation(
+        async (
+          findBy: FindBy<NetworkDevice>,
+        ): Promise<Array<NetworkDevice>> => {
+          expect(findBy.query.projectId).toEqual(PROJECT_ID);
+          expect(findBy.props).toEqual({ isRoot: true });
+          const operator: FindOperator<string> = findBy.query
+            .hostname as unknown as FindOperator<string>;
+          const parameters: Record<string, unknown> =
+            operator.objectLiteralParameters || {};
+          const requested: Array<string> = Object.values(
+            parameters,
+          )[0] as Array<string>;
+          requestedChunks.push(requested);
+
+          return requested
+            .filter((hostname: string): boolean => {
+              return liveHostnames.has(hostname);
+            })
+            .map((hostname: string): NetworkDevice => {
+              const device: NetworkDevice = new NetworkDevice();
+              device.hostname = hostname;
+              return device;
+            });
+        },
+      );
+
+    const result: Array<NetworkDeviceDiscoveryScan> = await readScans([
+      scanWith(hosts),
+    ]);
+
+    expect(findSpy).toHaveBeenCalledTimes(3);
+    expect(
+      requestedChunks.map((chunk: Array<string>): number => chunk.length),
+    ).toEqual([500, 500, 1]);
+    expect(requestedChunks.flat()).toEqual(
+      hosts.map((item: DiscoveredNetworkDevice): string => item.ipAddress),
+    );
+    expect(discoveredAt(result)).toHaveLength(1001);
+    for (const item of discoveredAt(result)) {
+      expect(item.isAlreadyRegistered).toBe(liveHostnames.has(item.ipAddress));
+    }
+    expect(
+      hosts.every(
+        (item: DiscoveredNetworkDevice): boolean =>
+          item.isAlreadyRegistered === true,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Discovery results could keep a deleted network device marked "Already added" indefinitely. The review dialog trusted the saved registration flag and its previous imports, while auto-import skipped a missing device whenever that historical flag was true.

Resolve registration against current project inventory when reading scan results and opening the review dialog. Auto-import now uses its live device lookup, allowing deleted devices to be imported again while retaining duplicate prevention, exclusions, and bounded processing. Its internal scan reads preserve raw snapshots and avoid repeating the review lookup.

Deleting only a monitor intentionally retains the network device inventory entry. Current master already recreates missing template monitors for those devices; regression tests cover that behavior too. No database migration is needed.

### Validation

- Added 47 regression cases covering manual and automatic re-import, dry runs, overlapping scans, a 903-device fleet across multiple runs, inventory lookup batching across 1,001 hosts, project isolation, and asynchronous dialog races.
- Six new engine regressions fail on the original implementation and pass with the fix.
- 945 relevant tests passed locally across 19 suites: 553 App discovery tests, 170 mounted UI tests, 67 auto-import engine tests, and 155 scan-service tests.
- Type checking passed for all three changed Common test files and their imported source graph. Full typed lint passed for the six changed UI files.
- All CI checks passed on the final revision, including full-repository lint, Common/App/Dashboard compilation, and all test workflows.

The local full-repository `npm run fix` was started but interrupted under severe host contention. Changed-file fixes were applied locally; full-repository lint and compilation were verified in CI. The local Docker endpoint was unavailable, so browser behavior was validated with mounted component tests.

Closes #3560.
