### PR TITLE
fix(discovery): run independent scans concurrently

### DIFF
--- a/App/FeatureSet/Docs/Content/en/probe/custom-probe.md
+++ b/App/FeatureSet/Docs/Content/en/probe/custom-probe.md
@@ -214,6 +214,9 @@ The probe supports the following environment variables:
 - `PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS` - Deadline for one network discovery sweep, after which it is abandoned and the scan is reported failed (default: 5400000, i.e. 90 minutes)
 - `PROBE_DISCOVERY_PROGRESS_INTERVAL_IN_MS` - How often a running discovery sweep uploads the hosts it has found so far, so a long scan shows progress and its devices can be imported before it finishes (default: 30000, minimum: 5000)
 - `PROBE_DISCOVERY_SCAN_CONCURRENCY` - Fixed number of addresses a discovery sweep probes at once. Leave unset (or 0) to size it from the scan's target, which is what you want unless the probe container is unusually small or unusually large (default: 0)
+- `PROBE_DISCOVERY_MAX_CONCURRENT_SCANS` - Maximum independent discovery scans running on this probe at once (default: 4, range: 1–16). The probe checks for another pending scan every minute while capacity is available, so a long scan does not block all other scans. When all slots are occupied, additional scans remain pending until a slot is free. Each scan has its own host concurrency, so resource usage grows with both settings; lower either limit for small containers. Set this to 1 to run scans sequentially.
+
+Upgrade the OneUptime server before upgrading custom probes to use concurrent discovery. The server must support excluding scans that the probe is still running, so editing a running scan safely queues its new configuration. When connecting an updated probe to an older server, set `PROBE_DISCOVERY_MAX_CONCURRENT_SCANS=1` until the server is upgraded.
 
 #### Proxy Configuration
 

--- a/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
@@ -14,6 +14,7 @@ import ScanModeUtil from "Common/Utils/NetworkDiscovery/ScanModeUtil";
 import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import NetworkDeviceService from "Common/Server/Services/NetworkDeviceService";
 import QueryDeepPartialEntity from "Common/Types/Database/PartialEntity";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
 import Express, {
   ExpressResponse,
   ExpressRouter,
@@ -34,6 +35,7 @@ const router: ExpressRouter = Express.getRouter();
  * it here instead: a clipped explanation beats a lost result.
  */
 const MAX_STATUS_MESSAGE_LENGTH: number = 500;
+const MAX_EXCLUDED_SCAN_IDS: number = 128;
 
 /*
  * Hands the requesting probe its pending subnet-discovery scans and marks
@@ -60,11 +62,50 @@ router.post(
         );
       }
 
+      const excludeScanIds: unknown = req.body["excludeScanIds"];
+
+      if (
+        excludeScanIds !== undefined &&
+        (!Array.isArray(excludeScanIds) ||
+          excludeScanIds.length > MAX_EXCLUDED_SCAN_IDS)
+      ) {
+        throw new BadDataException(
+          `excludeScanIds must be an array of at most ${MAX_EXCLUDED_SCAN_IDS} scan IDs.`,
+        );
+      }
+
+      const excludedIds: Array<ObjectID> = [];
+
+      if (Array.isArray(excludeScanIds)) {
+        for (const excludedId of excludeScanIds) {
+          if (
+            typeof excludedId !== "string" ||
+            !ObjectID.isValidUUID(excludedId)
+          ) {
+            throw new BadDataException(
+              "excludeScanIds must contain only valid scan ID strings.",
+            );
+          }
+
+          excludedIds.push(new ObjectID(excludedId));
+        }
+      }
+
       const scans: Array<NetworkDeviceDiscoveryScan> =
         await NetworkDeviceDiscoveryScanService.findBy({
           query: {
             probeId: probeId,
             status: "Pending",
+            /*
+             * A settings edit puts an active scan back in Pending. Keep its
+             * ID out of this claim while the probe finishes the old run:
+             * claiming it again would turn it In Progress and allow the old
+             * result past the Pending guard below. Deduplicating on the probe
+             * after this response would already be too late.
+             */
+            ...(excludedIds.length > 0
+              ? { _id: QueryHelper.notIn(excludedIds) }
+              : {}),
           },
           select: {
             _id: true,
@@ -102,7 +143,10 @@ router.post(
           sort: {
             createdAt: SortOrder.Ascending,
           },
-          // One subnet scan at a time per probe — sweeps are heavy.
+          /*
+           * Claim one scan per poll. The probe limits concurrent execution
+           * and keeps polling while it has capacity for another scan.
+           */
           limit: 1,
           skip: 0,
           props: {

--- a/App/FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts
+++ b/App/FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts
@@ -228,12 +228,10 @@ export async function explainUnclaimedScans(): Promise<void> {
   }
 
   /*
-   * A probe runs one sweep at a time (the claim endpoint's `limit: 1`), so
-   * every other scan assigned to a probe that is mid-sweep is legitimately
-   * queued — for as long as that sweep takes, which at the scan-size ceiling
-   * is the better part of an hour. Reporting those as unclaimed would turn
-   * normal queueing into an alarm, so a probe with work in flight is skipped
-   * entirely.
+   * A probe has a configurable limit on simultaneous scans; older probes
+   * run one at a time. Pending work may legitimately be waiting for capacity,
+   * which this worker cannot observe. Skip probes with work in flight so
+   * normal queueing is not reported as a failure to claim scans.
    */
   const busyScans: Array<NetworkDeviceDiscoveryScan> =
     await NetworkDeviceDiscoveryScanService.findAllBy({

--- a/App/Tests/Telemetry/ProbeIngestDiscoveryScanExclusions.test.ts
+++ b/App/Tests/Telemetry/ProbeIngestDiscoveryScanExclusions.test.ts
@@ -1,0 +1,399 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { mockRouter } from "Common/Tests/Server/API/Helpers";
+import NetworkDeviceDiscoveryScanService from "Common/Server/Services/NetworkDeviceDiscoveryScanService";
+import Response from "Common/Server/Utils/Response";
+import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import Probe from "Common/Models/DatabaseModels/Probe";
+import ObjectID from "Common/Types/ObjectID";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import { JSONObject } from "Common/Types/JSON";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+
+jest.mock("Common/Server/Utils/Express", () => {
+  return {
+    __esModule: true,
+    default: {
+      getRouter: () => {
+        return mockRouter;
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendErrorResponse: jest.fn(),
+      sendEntityArrayResponse: jest.fn(),
+      sendJsonObjectResponse: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/NetworkDeviceDiscoveryScanService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+      findOneBy: jest.fn(),
+      updateOneById: jest.fn(),
+      updateColumnsByIdWithoutHooks: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/NetworkDeviceService", () => {
+  return {
+    __esModule: true,
+    default: { getRegisteredHostnames: jest.fn() },
+  };
+});
+
+jest.mock("../../FeatureSet/Telemetry/Middleware/ProbeAuthorization", () => {
+  return {
+    __esModule: true,
+    default: { isAuthorizedServiceMiddleware: jest.fn() },
+  };
+});
+
+import "../../FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan";
+
+interface RawExclusion {
+  getSql: (alias: string) => string;
+  objectLiteralParameters: Record<string, Array<string>>;
+}
+
+interface FindScansArgs {
+  query: {
+    probeId: ObjectID;
+    status: string;
+    _id?: RawExclusion;
+  };
+  limit: number;
+  skip: number;
+  sort: { createdAt: SortOrder };
+}
+
+interface ClaimArgs {
+  id: ObjectID;
+  data: { status: string; startedAt: Date; statusMessage: null };
+  expectedData: { status: string; probeId: ObjectID };
+}
+
+const scanService: {
+  findBy: jest.Mock;
+  findOneBy: jest.Mock;
+  updateOneById: jest.Mock;
+  updateColumnsByIdWithoutHooks: jest.Mock;
+} = NetworkDeviceDiscoveryScanService as never;
+
+const response: {
+  sendErrorResponse: jest.Mock;
+  sendEntityArrayResponse: jest.Mock;
+  sendJsonObjectResponse: jest.Mock;
+} = Response as never;
+
+const probeId: ObjectID = ObjectID.generate();
+const otherProbeId: ObjectID = ObjectID.generate();
+const mockResponse: ExpressResponse = {} as ExpressResponse;
+
+async function callEndpoint(
+  route: "list" | "result",
+  body: JSONObject = {},
+  authenticatedProbe: ObjectID | null = probeId,
+): Promise<NextFunction> {
+  const request: ExpressRequest = {
+    body,
+    ...(authenticatedProbe ? { probe: new Probe(authenticatedProbe) } : {}),
+  } as unknown as ExpressRequest;
+  const next: NextFunction = jest.fn() as unknown as NextFunction;
+  await mockRouter
+    .match("post", `/probe/discovery-scan/${route}`)
+    .handlerFunction(request, mockResponse, next);
+  return next;
+}
+
+function findArgs(): FindScansArgs {
+  return scanService.findBy.mock.calls[0]![0] as FindScansArgs;
+}
+
+function excludedIds(query: FindScansArgs["query"]): Array<string> {
+  return query._id
+    ? Object.values(query._id.objectLiteralParameters).flat()
+    : [];
+}
+
+function makeScan(
+  status: string = "Pending",
+  assignedProbe: ObjectID = probeId,
+): NetworkDeviceDiscoveryScan {
+  const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan(
+    ObjectID.generate(),
+  );
+  scan.probeId = assignedProbe;
+  scan.status = status;
+  scan.cidr = "192.0.2.0/30";
+  return scan;
+}
+
+/*
+ * Exercise list claims and result rejection against the same mutable rows.
+ * Filtering consumes the real query's bound exclusion values before its limit.
+ */
+function useRows(rows: Array<NetworkDeviceDiscoveryScan>): void {
+  scanService.findBy.mockImplementation((input: unknown) => {
+    const args: FindScansArgs = input as FindScansArgs;
+    const excluded: Array<string> = excludedIds(args.query);
+    return Promise.resolve(
+      rows
+        .filter((row: NetworkDeviceDiscoveryScan): boolean => {
+          return (
+            row.probeId?.toString() === args.query.probeId.toString() &&
+            row.status === args.query.status &&
+            !excluded.includes(row.id!.toString())
+          );
+        })
+        .slice(args.skip, args.skip + args.limit),
+    );
+  });
+  scanService.updateColumnsByIdWithoutHooks.mockImplementation(
+    (input: unknown) => {
+      const args: ClaimArgs = input as ClaimArgs;
+      const row: NetworkDeviceDiscoveryScan | undefined = rows.find(
+        (scan: NetworkDeviceDiscoveryScan): boolean => {
+          return (
+            scan.id?.toString() === args.id.toString() &&
+            scan.status === args.expectedData.status &&
+            scan.probeId?.toString() === args.expectedData.probeId.toString()
+          );
+        },
+      );
+      if (row) {
+        Object.assign(row, args.data);
+      }
+      return Promise.resolve();
+    },
+  );
+  scanService.findOneBy.mockImplementation((input: unknown) => {
+    const query: { _id: ObjectID; probeId: ObjectID } = (
+      input as {
+        query: { _id: ObjectID; probeId: ObjectID };
+      }
+    ).query;
+    return Promise.resolve(
+      rows.find((row: NetworkDeviceDiscoveryScan): boolean => {
+        return (
+          row.id?.toString() === query._id.toString() &&
+          row.probeId?.toString() === query.probeId.toString()
+        );
+      }) || null,
+    );
+  });
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  scanService.findBy.mockResolvedValue([] as never);
+  scanService.updateColumnsByIdWithoutHooks.mockResolvedValue(
+    undefined as never,
+  );
+});
+
+describe("discovery claims exclude scans still reserved by the probe (#3597)", () => {
+  test.each([{}, { excludeScanIds: [] }])(
+    "keeps older and idle probes' queries unchanged: %j",
+    async (body: JSONObject) => {
+      const next: NextFunction = await callEndpoint("list", body);
+      expect(next).not.toHaveBeenCalled();
+      expect(findArgs().query).toEqual({ probeId, status: "Pending" });
+      expect(response.sendEntityArrayResponse).toHaveBeenCalledWith(
+        expect.anything(),
+        mockResponse,
+        [],
+        0,
+        NetworkDeviceDiscoveryScan,
+      );
+    },
+  );
+
+  test("adds a parameterized ID exclusion before the oldest pending scan is selected", async () => {
+    const ids: Array<string> = [
+      ObjectID.generate().toString(),
+      ObjectID.generate().toString(),
+    ];
+    await callEndpoint("list", {
+      excludeScanIds: ids,
+      probeId: otherProbeId.toString(),
+    });
+    const args: FindScansArgs = findArgs();
+    expect(args.query.probeId.toString()).toBe(probeId.toString());
+    expect(args.query.status).toBe("Pending");
+    expect(excludedIds(args.query)).toEqual(ids);
+    expect(args.query._id!.getSql('"scan"."_id"')).toMatch(/NOT IN \(:\.\.\./);
+    for (const id of ids) {
+      expect(args.query._id!.getSql('"scan"."_id"')).not.toContain(id);
+    }
+    expect(args.limit).toBe(1);
+    expect(args.skip).toBe(0);
+    expect(args.sort).toEqual({ createdAt: SortOrder.Ascending });
+  });
+
+  test("accepts the bounded exclusion list, including the maximum scheduler capacity", async () => {
+    const ids: Array<string> = Array.from({ length: 128 }, (): string => {
+      return ObjectID.generate().toString();
+    });
+    const next: NextFunction = await callEndpoint("list", {
+      excludeScanIds: ids,
+    });
+    expect(next).not.toHaveBeenCalled();
+    expect(excludedIds(findArgs().query)).toEqual(ids);
+  });
+
+  test.each([
+    { name: "null", value: null },
+    { name: "a string", value: "scan-id" },
+    { name: "a number", value: 1 },
+    { name: "a boolean", value: true },
+    { name: "an object", value: {} },
+    { name: "a null entry", value: [null] },
+    { name: "a numeric entry", value: [1] },
+    { name: "a boolean entry", value: [true] },
+    { name: "an object entry", value: [{}] },
+    { name: "an empty entry", value: [""] },
+    { name: "a malformed UUID", value: ["not-a-uuid"] },
+    { name: "an address", value: ["192.0.2.1"] },
+    {
+      name: "an invalid entry after a valid one",
+      value: [ObjectID.generate().toString(), "invalid"],
+    },
+    {
+      name: "a serialized ObjectID instead of a string",
+      value: [ObjectID.generate().toJSON()],
+    },
+    {
+      name: "more than 128 entries",
+      value: Array.from({ length: 129 }, (): string => {
+        return ObjectID.generate().toString();
+      }),
+    },
+  ])(
+    "rejects $name before reading or claiming any scan",
+    async ({ value }: { value: unknown }) => {
+      const next: NextFunction = await callEndpoint("list", {
+        excludeScanIds: value,
+      } as JSONObject);
+      expect(next).toHaveBeenCalledWith(expect.any(BadDataException));
+      expect(scanService.findBy).not.toHaveBeenCalled();
+      expect(scanService.updateColumnsByIdWithoutHooks).not.toHaveBeenCalled();
+      expect(response.sendEntityArrayResponse).not.toHaveBeenCalled();
+    },
+  );
+
+  test("authenticates before processing an exclusion list", async () => {
+    await callEndpoint("list", { excludeScanIds: ["invalid"] }, null);
+    expect(response.sendErrorResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      mockResponse,
+      expect.any(BadDataException),
+    );
+    expect(scanService.findBy).not.toHaveBeenCalled();
+    expect(scanService.updateColumnsByIdWithoutHooks).not.toHaveBeenCalled();
+  });
+
+  test("keeps an edited active scan Pending, discards its old result, then claims the edited run", async () => {
+    const edited: NetworkDeviceDiscoveryScan = makeScan();
+    edited.cidr = "198.51.100.0/30";
+    edited.statusMessage =
+      "Settings changed, so this scan is queued to run again.";
+    const independent: NetworkDeviceDiscoveryScan = makeScan();
+    const otherProbe: NetworkDeviceDiscoveryScan = makeScan(
+      "Pending",
+      otherProbeId,
+    );
+    const completed: NetworkDeviceDiscoveryScan = makeScan("Completed");
+    useRows([otherProbe, completed, edited, independent]);
+
+    await callEndpoint("list", { excludeScanIds: [edited.id!.toString()] });
+
+    expect(edited.status).toBe("Pending");
+    expect(edited.statusMessage).toContain("Settings changed");
+    expect(independent.status).toBe("In Progress");
+    expect(otherProbe.status).toBe("Pending");
+    expect(completed.status).toBe("Completed");
+    expect(scanService.updateColumnsByIdWithoutHooks).toHaveBeenCalledTimes(1);
+    expect(
+      (
+        scanService.updateColumnsByIdWithoutHooks.mock.calls[0]![0] as ClaimArgs
+      ).id.toString(),
+    ).toBe(independent.id!.toString());
+    expect(response.sendEntityArrayResponse).toHaveBeenLastCalledWith(
+      expect.anything(),
+      mockResponse,
+      [independent],
+      1,
+      NetworkDeviceDiscoveryScan,
+    );
+
+    for (const oldResult of [
+      { success: true, discoveredDevices: [] },
+      { success: true, isPartial: true, discoveredDevices: [] },
+      { success: false, statusMessage: "Old sweep failed" },
+    ]) {
+      await callEndpoint("result", {
+        scanId: edited.id!.toString(),
+        ...oldResult,
+      });
+      expect(response.sendJsonObjectResponse).toHaveBeenLastCalledWith(
+        expect.anything(),
+        mockResponse,
+        { result: "discarded" },
+      );
+      expect(scanService.updateOneById).not.toHaveBeenCalled();
+      expect(edited.status).toBe("Pending");
+    }
+
+    await callEndpoint("list", { excludeScanIds: [] });
+    expect(edited.status).toBe("In Progress");
+    expect(response.sendEntityArrayResponse).toHaveBeenLastCalledWith(
+      expect.anything(),
+      mockResponse,
+      [edited],
+      1,
+      NetworkDeviceDiscoveryScan,
+    );
+    expect(edited.cidr).toBe("198.51.100.0/30");
+  });
+
+  test("returns nothing and writes nothing when the only pending scan remains reserved", async () => {
+    const reserved: NetworkDeviceDiscoveryScan = makeScan();
+    useRows([reserved]);
+    await callEndpoint("list", { excludeScanIds: [reserved.id!.toString()] });
+    expect(reserved.status).toBe("Pending");
+    expect(scanService.updateColumnsByIdWithoutHooks).not.toHaveBeenCalled();
+    expect(response.sendEntityArrayResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      mockResponse,
+      [],
+      0,
+      NetworkDeviceDiscoveryScan,
+    );
+  });
+});

--- a/Probe/Config.ts
+++ b/Probe/Config.ts
@@ -248,20 +248,9 @@ export const PROBE_MONITOR_CHECK_TIMEOUT_IN_MS: number =
   });
 
 /*
- * Hard ceiling on ONE network discovery sweep, for exactly the reason
- * PROBE_MONITOR_CHECK_TIMEOUT_IN_MS exists — and the discovery job needs it
- * more, not less.
- *
- * The discovery cron holds a single-flight guard across the WHOLE cycle
- * (Jobs/Discovery/FetchScans.ts): list fetch, sweep, and result upload. Every
- * HTTP call in that cycle carries PROBE_API_REQUEST_TIMEOUT_IN_MS, but the
- * sweep between them had no deadline of any kind. A sweep opens one ICMP
- * child process and one UDP SNMP session per address — up to
- * ScanTargetUtil.MAX_SCAN_HOSTS of them — so it is exactly the kind of code
- * where one non-settling promise is plausible, and a single one of those
- * strands the guard set. Not for a cycle: FOREVER. Every later scan then sits
- * in "Pending" until someone restarts the probe container, with nothing in
- * the product to say why (OneUptime issue #3287).
+ * Hard ceiling on ONE network discovery sweep. Every HTTP call already has
+ * PROBE_API_REQUEST_TIMEOUT_IN_MS, but the sweep also needs a deadline so a
+ * wedged ICMP or SNMP operation cannot occupy a scheduler slot forever.
  *
  * The number is a wall-clock budget with two sides to fit between.
  *
@@ -279,8 +268,7 @@ export const PROBE_MONITOR_CHECK_TIMEOUT_IN_MS: number =
  * The ceiling is the server: it declares an In Progress scan abandoned after
  * 2 hours (Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts). The
  * probe has to give up FIRST, or a wedged sweep is reaped server-side while
- * the probe is still holding its guard — the scan reads Failed while
- * discovery on that probe stays stopped.
+ * the probe is still occupying its slot.
  *
  * 90 minutes sits between the two: comfortably above any sweep that is
  * genuinely making progress, and comfortably below the server's window, so
@@ -293,6 +281,21 @@ export const PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS: number =
     defaultValue: 90 * 60 * 1000,
     min: 1000,
     max: MAX_NODE_TIMER_DELAY_IN_MS,
+  });
+
+/*
+ * Independent discovery scans allowed to run on this probe at once (#3597).
+ * The probe still claims one scan per minute, whenever capacity is available.
+ * This is separate from PROBE_DISCOVERY_SCAN_CONCURRENCY, which limits host
+ * probes WITHIN each sweep. Their resource costs multiply; small containers
+ * can lower either limit, and 1 restores sequential scan execution.
+ */
+export const PROBE_DISCOVERY_MAX_CONCURRENT_SCANS: number =
+  NumberUtil.parseNumberWithDefault({
+    value: process.env["PROBE_DISCOVERY_MAX_CONCURRENT_SCANS"],
+    defaultValue: 4,
+    min: 1,
+    max: 16,
   });
 
 /*

--- a/Probe/Jobs/Discovery/FetchScans.ts
+++ b/Probe/Jobs/Discovery/FetchScans.ts
@@ -1,10 +1,12 @@
 import {
   PROBE_DISCOVERY_PROGRESS_INTERVAL_IN_MS,
+  PROBE_DISCOVERY_MAX_CONCURRENT_SCANS,
   PROBE_DISCOVERY_SCAN_CONCURRENCY,
   PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS,
   PROBE_INGEST_URL,
 } from "../../Config";
 import ProbeAPIRequest from "../../Utils/ProbeAPIRequest";
+import DiscoveryScanScheduler from "../../Utils/Discovery/DiscoveryScanScheduler";
 import SubnetScanner, {
   DiscoveredHost,
   type SubnetScanConfig,
@@ -18,6 +20,7 @@ import HTTPMethod from "Common/Types/API/HTTPMethod";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 import URL from "Common/Types/API/URL";
 import { JSONArray } from "Common/Types/JSON";
+import { VoidFunction } from "Common/Types/FunctionTypes";
 import API from "Common/Utils/API";
 import logger from "Common/Server/Utils/Logger";
 import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
@@ -592,18 +595,21 @@ export class ScanProgressReporter {
   }
 }
 
-/*
- * node-cron fires every tick regardless of whether the previous run
- * finished. A subnet sweep legitimately runs for many minutes (up to 4096
- * hosts), and a slow/unresponsive server can hang the list fetch itself —
- * either way, without this guard every subsequent tick stacks another
- * request/sweep on top of the stuck one. One discovery cycle at a time.
- */
-let isDiscoveryRunInProgress: boolean = false;
+let discoveryScanScheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler(
+  {
+    maxConcurrentScans: PROBE_DISCOVERY_MAX_CONCURRENT_SCANS,
+    fetchScans: fetchScans,
+    runScan: runScan,
+  },
+);
 
 // Exported for tests: lets a wedged-state test reset between cases.
 export function resetDiscoveryRunInProgress(): void {
-  isDiscoveryRunInProgress = false;
+  discoveryScanScheduler = new DiscoveryScanScheduler({
+    maxConcurrentScans: PROBE_DISCOVERY_MAX_CONCURRENT_SCANS,
+    fetchScans: fetchScans,
+    runScan: runScan,
+  });
 }
 
 const InitJob: VoidFunction = (): void => {
@@ -614,22 +620,11 @@ const InitJob: VoidFunction = (): void => {
       runOnStartup: true,
     },
     runFunction: async () => {
-      if (isDiscoveryRunInProgress) {
-        logger.debug(
-          "Previous discovery scan run is still in progress. Skipping this tick.",
-        );
-        return;
-      }
-
-      isDiscoveryRunInProgress = true;
-
       try {
         await fetchAndRunScans();
       } catch (err) {
         logger.error("Discovery scan fetch failed");
         logger.error(err);
-      } finally {
-        isDiscoveryRunInProgress = false;
       }
     },
   });
@@ -670,16 +665,11 @@ export function getRejectionReason(
  * Mirrors probeMonitorWithDeadline in Jobs/Monitor/FetchList.ts, and exists
  * for the same reason: Promise.race subscribes to both promises, so a sweep
  * that settles late is still observed and can never surface as an unhandled
- * rejection, and nothing here can cancel the sweep — the point is that the
- * discovery CYCLE stops waiting on it.
- *
- * That matters more here than it does for a monitor. The discovery cron holds
- * a process-lifetime single-flight guard across the whole cycle, so a sweep
- * that never settles does not cost one cycle: it stops discovery on this
- * probe permanently, and every scan queued behind it stays "Pending" until
- * the container is restarted. Rejecting on the deadline drops into runScan's
- * existing catch, which reports the scan Failed with this reason, so the
- * operator gets a sentence instead of a row that never changes.
+ * rejection, and nothing here can cancel the sweep — the scheduler stops
+ * waiting on it and can reclaim the slot after the failure report. Rejecting
+ * on the deadline drops into runScan's existing catch, which reports the scan
+ * Failed with this reason. Without a deadline, enough wedged sweeps could
+ * occupy every slot permanently and leave later scans Pending.
  */
 export async function scanWithDeadline(
   config: SubnetScanConfig,
@@ -766,6 +756,12 @@ export async function scanWithDeadline(
 
 // Exported for tests: this is the probe's half of the discovery lifecycle.
 export async function fetchAndRunScans(): Promise<void> {
+  await discoveryScanScheduler.run();
+}
+
+async function fetchScans(
+  excludeScanIds: Array<string>,
+): Promise<Array<NetworkDeviceDiscoveryScan>> {
   const listUrl: URL = URL.fromString(PROBE_INGEST_URL.toString()).addRoute(
     "/probe/discovery-scan/list",
   );
@@ -776,6 +772,7 @@ export async function fetchAndRunScans(): Promise<void> {
       url: listUrl,
       data: {
         ...ProbeAPIRequest.getDefaultRequestBody(),
+        excludeScanIds: excludeScanIds,
       },
       headers: {},
       options: ProbeAPIRequest.getDefaultRequestOptions(listUrl),
@@ -799,7 +796,7 @@ export async function fetchAndRunScans(): Promise<void> {
         `No scan on this probe can leave "Pending" until that is resolved.`,
     );
 
-    return;
+    return [];
   }
 
   /*
@@ -814,17 +811,13 @@ export async function fetchAndRunScans(): Promise<void> {
         `Something between this probe and the server is answering for it — check PROBE_INGEST_URL and any proxy in front of it.`,
     );
 
-    return;
+    return [];
   }
 
-  const scans: Array<NetworkDeviceDiscoveryScan> = BaseModel.fromJSONArray(
+  return BaseModel.fromJSONArray(
     result.data as JSONArray,
     NetworkDeviceDiscoveryScan,
   );
-
-  for (const scan of scans) {
-    await runScan(scan);
-  }
 }
 
 // Exported for tests: sweeps one scan and reports the outcome back.

--- a/Probe/Tests/ConfigDiscoveryScanConcurrency.test.ts
+++ b/Probe/Tests/ConfigDiscoveryScanConcurrency.test.ts
@@ -1,0 +1,126 @@
+interface DiscoveryConcurrencyConfig {
+  PROBE_DISCOVERY_MAX_CONCURRENT_SCANS: number;
+  PROBE_DISCOVERY_SCAN_CONCURRENCY: number;
+}
+
+describe("discovery scan concurrency configuration", () => {
+  const environmentKeys: Array<string> = [
+    "ONEUPTIME_URL",
+    "PROBE_KEY",
+    "PROBE_DISCOVERY_MAX_CONCURRENT_SCANS",
+    "PROBE_DISCOVERY_SCAN_CONCURRENCY",
+  ];
+  const originalEnvironment: Record<string, string | undefined> =
+    Object.fromEntries(
+      environmentKeys.map((key: string): [string, string | undefined] => {
+        return [key, process.env[key]];
+      }),
+    );
+
+  beforeEach(() => {
+    process.env["ONEUPTIME_URL"] = "http://oneuptime.test";
+    process.env["PROBE_KEY"] = "test-probe-key";
+    delete process.env["PROBE_DISCOVERY_MAX_CONCURRENT_SCANS"];
+    delete process.env["PROBE_DISCOVERY_SCAN_CONCURRENCY"];
+  });
+
+  afterAll(() => {
+    for (const key of environmentKeys) {
+      const value: string | undefined = originalEnvironment[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  test("defaults to four scans and preserves automatic per-host concurrency", () => {
+    expect(loadConfig()).toEqual({
+      PROBE_DISCOVERY_MAX_CONCURRENT_SCANS: 4,
+      PROBE_DISCOVERY_SCAN_CONCURRENCY: 0,
+    });
+  });
+
+  test.each([
+    ["one scan", "1", 1],
+    ["two scans", "2", 2],
+    ["the default explicitly", "4", 4],
+    ["a larger pool", "8", 8],
+    ["the maximum allowed pool", "16", 16],
+    ["surrounding whitespace", " 3 ", 3],
+  ])("accepts %s", (_name: string, configured: string, expected: number) => {
+    process.env["PROBE_DISCOVERY_MAX_CONCURRENT_SCANS"] = configured;
+    expect(loadConfig().PROBE_DISCOVERY_MAX_CONCURRENT_SCANS).toBe(expected);
+  });
+
+  test.each([
+    ["an empty value", ""],
+    ["whitespace", " "],
+    ["zero", "0"],
+    ["a negative number", "-1"],
+    ["a value above the maximum", "17"],
+    ["an excessive value", "999999"],
+    ["text", "invalid"],
+    ["NaN", "NaN"],
+    ["Infinity", "Infinity"],
+  ])("falls back to four for %s", (_name: string, configured: string) => {
+    process.env["PROBE_DISCOVERY_MAX_CONCURRENT_SCANS"] = configured;
+    expect(loadConfig().PROBE_DISCOVERY_MAX_CONCURRENT_SCANS).toBe(4);
+  });
+
+  test("changing simultaneous scans leaves the per-host setting at its default", () => {
+    process.env["PROBE_DISCOVERY_MAX_CONCURRENT_SCANS"] = "2";
+    expect(loadConfig()).toEqual({
+      PROBE_DISCOVERY_MAX_CONCURRENT_SCANS: 2,
+      PROBE_DISCOVERY_SCAN_CONCURRENCY: 0,
+    });
+  });
+
+  test("changing per-host concurrency leaves the simultaneous scan default intact", () => {
+    process.env["PROBE_DISCOVERY_SCAN_CONCURRENCY"] = "64";
+    expect(loadConfig()).toEqual({
+      PROBE_DISCOVERY_MAX_CONCURRENT_SCANS: 4,
+      PROBE_DISCOVERY_SCAN_CONCURRENCY: 64,
+    });
+  });
+
+  test("operators can set independent scan and host limits", () => {
+    process.env["PROBE_DISCOVERY_MAX_CONCURRENT_SCANS"] = "3";
+    process.env["PROBE_DISCOVERY_SCAN_CONCURRENCY"] = "128";
+    expect(loadConfig()).toEqual({
+      PROBE_DISCOVERY_MAX_CONCURRENT_SCANS: 3,
+      PROBE_DISCOVERY_SCAN_CONCURRENCY: 128,
+    });
+  });
+
+  test("an invalid scan limit does not discard a valid per-host override", () => {
+    process.env["PROBE_DISCOVERY_MAX_CONCURRENT_SCANS"] = "17";
+    process.env["PROBE_DISCOVERY_SCAN_CONCURRENCY"] = "1024";
+    expect(loadConfig()).toEqual({
+      PROBE_DISCOVERY_MAX_CONCURRENT_SCANS: 4,
+      PROBE_DISCOVERY_SCAN_CONCURRENCY: 1024,
+    });
+  });
+
+  function loadConfig(): DiscoveryConcurrencyConfig {
+    let result: DiscoveryConcurrencyConfig | undefined;
+    jest.isolateModules(() => {
+      /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+      const config: DiscoveryConcurrencyConfig =
+        require("../Config") as DiscoveryConcurrencyConfig;
+      /* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+      result = {
+        PROBE_DISCOVERY_MAX_CONCURRENT_SCANS:
+          config.PROBE_DISCOVERY_MAX_CONCURRENT_SCANS,
+        PROBE_DISCOVERY_SCAN_CONCURRENCY:
+          config.PROBE_DISCOVERY_SCAN_CONCURRENCY,
+      };
+    });
+
+    if (!result) {
+      throw new Error("Probe configuration did not load");
+    }
+    return result;
+  }
+});

--- a/Probe/Tests/Jobs/Discovery/FetchScansConcurrency.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansConcurrency.test.ts
@@ -1,0 +1,592 @@
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+process.env["PROBE_DISCOVERY_MAX_CONCURRENT_SCANS"] = "2";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import API, { APIFetchOptions } from "Common/Utils/API";
+import logger from "Common/Server/Utils/Logger";
+import { PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS } from "../../../Config";
+import SubnetScanner, {
+  SubnetScanConfig,
+  SubnetScanResult,
+} from "../../../Utils/Discovery/SubnetScanner";
+import InitJob, {
+  fetchAndRunScans,
+  resetDiscoveryRunInProgress,
+} from "../../../Jobs/Discovery/FetchScans";
+import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverseDns";
+
+type CapturedCronJob = {
+  runFunction: PromiseVoidFunction;
+};
+
+const mockCapturedCronJobs: Array<CapturedCronJob> = [];
+
+// Drive the exact closure registered in production without a real scheduler.
+jest.mock("Common/Server/Utils/BasicCron", () => {
+  return {
+    __esModule: true,
+    default: (props: CapturedCronJob): void => {
+      mockCapturedCronJobs.push(props);
+    },
+  };
+});
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: Error) => void;
+}
+
+const cleanupResolvers: Array<() => void> = [];
+const pendingTicks: Array<Promise<void>> = [];
+const listedBatches: Array<JSONArray> = [];
+
+function deferred<T>(cleanupValue: T): Deferred<T> {
+  let resolvePromise: (value: T) => void = (): void => {};
+  let rejectPromise: (reason: Error) => void = (): void => {};
+  const promise: Promise<T> = new Promise<T>(
+    (resolve: (value: T) => void, reject: (reason: Error) => void): void => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    },
+  );
+  cleanupResolvers.push((): void => {
+    resolvePromise(cleanupValue);
+  });
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+function scanRow(cidr: string): JSONObject {
+  return { _id: ObjectID.generate().toString(), cidr };
+}
+
+function scanResult(): SubnetScanResult {
+  return {
+    discoveredHosts: [],
+    scannedHostCount: 254,
+    respondedToPingCount: 0,
+    scannedPorts: [161],
+    responderCountByConfigId: {},
+    snmpErrorHostCount: 0,
+    icmpFilteredFallbackHostCount: 0,
+  };
+}
+
+function startTick(run: PromiseVoidFunction): Promise<void> {
+  const tick: Promise<void> = run();
+  pendingTicks.push(tick);
+  return tick;
+}
+
+function capturedRunFunction(): PromiseVoidFunction {
+  InitJob();
+  const captured: CapturedCronJob | undefined = mockCapturedCronJobs.pop();
+  if (!captured) {
+    throw new Error("InitJob did not register the discovery cron job");
+  }
+  return captured.runFunction;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve: () => void): void => {
+    setImmediate(resolve);
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/typedef
+let fetchSpy = jest.spyOn(API, "fetch");
+// eslint-disable-next-line @typescript-eslint/typedef
+let scanSpy = jest.spyOn(SubnetScanner, "scan");
+
+function listCalls(): Array<APIFetchOptions> {
+  return fetchSpy.mock.calls
+    .map((call: [APIFetchOptions]): APIFetchOptions => {
+      return call[0];
+    })
+    .filter((call: APIFetchOptions): boolean => {
+      return String(call.url).endsWith("/discovery-scan/list");
+    });
+}
+
+function resultBodies(): Array<JSONObject> {
+  return fetchSpy.mock.calls
+    .filter((call: [APIFetchOptions]): boolean => {
+      return String(call[0].url).endsWith("/discovery-scan/result");
+    })
+    .map((call: [APIFetchOptions]): JSONObject => {
+      return call[0].data as JSONObject;
+    });
+}
+
+beforeEach((): void => {
+  resetDiscoveryRunInProgress();
+  mockCapturedCronJobs.length = 0;
+  listedBatches.length = 0;
+  fetchSpy = jest
+    .spyOn(API, "fetch")
+    .mockImplementation((request: APIFetchOptions) => {
+      return Promise.resolve({
+        data: String(request.url).endsWith("/discovery-scan/list")
+          ? listedBatches.shift() || []
+          : [],
+      }) as never;
+    });
+  scanSpy = jest.spyOn(SubnetScanner, "scan").mockResolvedValue(scanResult());
+  jest.spyOn(logger, "error").mockImplementation((): void => {});
+});
+
+// Every started operation is settled before spies and scheduler state reset.
+afterEach(async (): Promise<void> => {
+  for (const resolve of cleanupResolvers.splice(0)) {
+    resolve();
+  }
+  await Promise.allSettled(pendingTicks.splice(0));
+  resetDiscoveryRunInProgress();
+  jest.useRealTimers();
+});
+
+afterEach((): void => {
+  jest.restoreAllMocks();
+});
+
+stubReverseDnsAsResolvingNothing();
+
+describe("discovery scheduling across overlapping cron ticks (#3597)", () => {
+  test("a later tick completes a small scan while an earlier large scan is still running", async (): Promise<void> => {
+    const run: PromiseVoidFunction = capturedRunFunction();
+    const large: JSONObject = scanRow("192.0.2.0/24");
+    const small: JSONObject = scanRow("198.51.100.0/30");
+    const largeSweep: Deferred<SubnetScanResult> = deferred(scanResult());
+    listedBatches.push([large], [small]);
+    scanSpy.mockImplementation((config: SubnetScanConfig) => {
+      return config.cidr === large["cidr"]
+        ? largeSweep.promise
+        : Promise.resolve(scanResult());
+    });
+
+    let firstTickFinished: boolean = false;
+    const firstTick: Promise<void> = startTick(run).then((): void => {
+      firstTickFinished = true;
+    });
+    await flushMicrotasks();
+    await startTick(run);
+
+    expect(firstTickFinished).toBe(false);
+    expect(listCalls()).toHaveLength(2);
+    expect((listCalls()[1]!.data as JSONObject)["excludeScanIds"]).toEqual([
+      large["_id"],
+    ]);
+    expect(scanSpy).toHaveBeenCalledTimes(2);
+    expect(resultBodies()).toEqual([
+      expect.objectContaining({ scanId: small["_id"], success: true }),
+    ]);
+
+    largeSweep.resolve(scanResult());
+    await firstTick;
+    expect(resultBodies()).toHaveLength(2);
+    expect(resultBodies()[1]).toEqual(
+      expect.objectContaining({ scanId: large["_id"], success: true }),
+    );
+
+    await startTick(run);
+    expect(
+      (listCalls()[2]!.data as JSONObject)["excludeScanIds"] || [],
+    ).toEqual([]);
+  });
+
+  test("all cron registrations and direct callers share one in-flight list request", async (): Promise<void> => {
+    const firstRun: PromiseVoidFunction = capturedRunFunction();
+    const secondRun: PromiseVoidFunction = capturedRunFunction();
+    const list: Deferred<{ data: JSONArray }> = deferred({
+      data: [] as JSONArray,
+    });
+    const scan: JSONObject = scanRow("192.0.2.0/30");
+    fetchSpy.mockReturnValueOnce(list.promise as never);
+
+    const firstTick: Promise<void> = startTick(firstRun);
+    await flushMicrotasks();
+    await startTick(secondRun);
+    await startTick(fetchAndRunScans);
+
+    expect(listCalls()).toHaveLength(1);
+    expect(scanSpy).not.toHaveBeenCalled();
+
+    list.resolve({ data: [scan] });
+    await firstTick;
+    expect(scanSpy).toHaveBeenCalledTimes(1);
+    expect(resultBodies()[0]).toEqual(
+      expect.objectContaining({ scanId: scan["_id"], success: true }),
+    );
+
+    await startTick(secondRun);
+    expect(listCalls()).toHaveLength(2);
+  });
+
+  test("scans returned in one batch run concurrently and queued scans start when a slot opens", async (): Promise<void> => {
+    const rows: Array<JSONObject> = Array.from(
+      { length: 5 },
+      (_value: unknown, index: number): JSONObject => {
+        return scanRow(`192.0.2.${index * 4}/30`);
+      },
+    );
+    const sweeps: Array<Deferred<SubnetScanResult>> = rows.map(
+      (): Deferred<SubnetScanResult> => {
+        return deferred(scanResult());
+      },
+    );
+    listedBatches.push(rows);
+    scanSpy.mockImplementation((config: SubnetScanConfig) => {
+      const index: number = rows.findIndex((row: JSONObject): boolean => {
+        return row["cidr"] === config.cidr;
+      });
+      return sweeps[index]!.promise;
+    });
+
+    let batchFinished: boolean = false;
+    const batch: Promise<void> = startTick(fetchAndRunScans).then((): void => {
+      batchFinished = true;
+    });
+    await flushMicrotasks();
+    expect(scanSpy).toHaveBeenCalledTimes(2);
+
+    await startTick(capturedRunFunction());
+    expect(listCalls()).toHaveLength(1);
+
+    sweeps[0]!.resolve(scanResult());
+    await flushMicrotasks();
+    expect(scanSpy).toHaveBeenCalledTimes(3);
+    expect(resultBodies()).toHaveLength(1);
+    expect(batchFinished).toBe(false);
+
+    sweeps[2]!.resolve(scanResult());
+    await flushMicrotasks();
+    expect(scanSpy).toHaveBeenCalledTimes(4);
+
+    sweeps[1]!.resolve(scanResult());
+    await flushMicrotasks();
+    expect(scanSpy).toHaveBeenCalledTimes(5);
+    expect(batchFinished).toBe(false);
+
+    sweeps[3]!.resolve(scanResult());
+    sweeps[4]!.resolve(scanResult());
+    await batch;
+
+    expect(resultBodies()).toHaveLength(5);
+    expect(
+      new Set(
+        resultBodies().map((body: JSONObject): string => {
+          return String(body["scanId"]);
+        }),
+      ).size,
+    ).toBe(5);
+  });
+
+  test("the cap applies across batches and polling resumes as soon as one scan finishes", async (): Promise<void> => {
+    const run: PromiseVoidFunction = capturedRunFunction();
+    const first: JSONObject = scanRow("192.0.2.0/24");
+    const second: JSONObject = scanRow("198.51.100.0/24");
+    const third: JSONObject = scanRow("203.0.113.0/30");
+    const firstSweep: Deferred<SubnetScanResult> = deferred(scanResult());
+    const secondSweep: Deferred<SubnetScanResult> = deferred(scanResult());
+    listedBatches.push([first], [second], [third]);
+    scanSpy.mockImplementation((config: SubnetScanConfig) => {
+      if (config.cidr === first["cidr"]) {
+        return firstSweep.promise;
+      }
+      if (config.cidr === second["cidr"]) {
+        return secondSweep.promise;
+      }
+      return Promise.resolve(scanResult());
+    });
+
+    const firstTick: Promise<void> = startTick(run);
+    await flushMicrotasks();
+    const secondTick: Promise<void> = startTick(run);
+    await flushMicrotasks();
+    await startTick(run);
+
+    expect(listCalls()).toHaveLength(2);
+    expect(scanSpy).toHaveBeenCalledTimes(2);
+
+    secondSweep.resolve(scanResult());
+    await secondTick;
+    await startTick(run);
+
+    expect(listCalls()).toHaveLength(3);
+    expect(scanSpy).toHaveBeenCalledTimes(3);
+    expect(resultBodies()).toEqual([
+      expect.objectContaining({ scanId: second["_id"], success: true }),
+      expect.objectContaining({ scanId: third["_id"], success: true }),
+    ]);
+
+    firstSweep.resolve(scanResult());
+    await firstTick;
+  });
+
+  test("a duplicate active scan in a later list does not run twice or consume the free slot", async (): Promise<void> => {
+    const run: PromiseVoidFunction = capturedRunFunction();
+    const active: JSONObject = scanRow("192.0.2.0/24");
+    const next: JSONObject = scanRow("198.51.100.0/30");
+    const activeSweep: Deferred<SubnetScanResult> = deferred(scanResult());
+    listedBatches.push([active], [active, active, next, next]);
+    scanSpy.mockImplementation((config: SubnetScanConfig) => {
+      return config.cidr === active["cidr"]
+        ? activeSweep.promise
+        : Promise.resolve(scanResult());
+    });
+
+    const firstTick: Promise<void> = startTick(run);
+    await flushMicrotasks();
+    await startTick(run);
+
+    expect(scanSpy).toHaveBeenCalledTimes(2);
+    expect(resultBodies()).toEqual([
+      expect.objectContaining({ scanId: next["_id"], success: true }),
+    ]);
+
+    activeSweep.resolve(scanResult());
+    await firstTick;
+    expect(resultBodies()).toHaveLength(2);
+  });
+
+  test("duplicates of queued scans are deduplicated before the scan starts", async (): Promise<void> => {
+    const first: JSONObject = scanRow("192.0.2.0/24");
+    const second: JSONObject = scanRow("198.51.100.0/24");
+    const queued: JSONObject = scanRow("203.0.113.0/30");
+    const firstSweep: Deferred<SubnetScanResult> = deferred(scanResult());
+    const secondSweep: Deferred<SubnetScanResult> = deferred(scanResult());
+    listedBatches.push([first, second, queued, queued]);
+    scanSpy
+      .mockReturnValueOnce(firstSweep.promise)
+      .mockReturnValueOnce(secondSweep.promise);
+
+    const batch: Promise<void> = startTick(fetchAndRunScans);
+    await flushMicrotasks();
+    expect(scanSpy).toHaveBeenCalledTimes(2);
+
+    firstSweep.resolve(scanResult());
+    secondSweep.resolve(scanResult());
+    await batch;
+
+    expect(scanSpy).toHaveBeenCalledTimes(3);
+    expect(
+      resultBodies().filter((body: JSONObject): boolean => {
+        return body["scanId"] === queued["_id"];
+      }),
+    ).toHaveLength(1);
+  });
+
+  test("a recurring scan with the same ID can run again after its previous result was reported", async (): Promise<void> => {
+    const recurring: JSONObject = scanRow("192.0.2.0/30");
+    listedBatches.push([recurring], [recurring]);
+
+    await startTick(fetchAndRunScans);
+    await startTick(capturedRunFunction());
+
+    expect(listCalls()).toHaveLength(2);
+    expect(scanSpy).toHaveBeenCalledTimes(2);
+    expect(resultBodies()).toEqual([
+      expect.objectContaining({ scanId: recurring["_id"], success: true }),
+      expect.objectContaining({ scanId: recurring["_id"], success: true }),
+    ]);
+  });
+
+  test("a transient list failure leaves an active scan alone and the next tick can fetch new work", async (): Promise<void> => {
+    const run: PromiseVoidFunction = capturedRunFunction();
+    const active: JSONObject = scanRow("192.0.2.0/24");
+    const next: JSONObject = scanRow("198.51.100.0/30");
+    const activeSweep: Deferred<SubnetScanResult> = deferred(scanResult());
+    listedBatches.push([active], [next]);
+    scanSpy.mockReturnValueOnce(activeSweep.promise);
+
+    const firstTick: Promise<void> = startTick(run);
+    await flushMicrotasks();
+    fetchSpy.mockRejectedValueOnce(new Error("ingest temporarily unavailable"));
+
+    await expect(startTick(run)).resolves.toBeUndefined();
+    expect(resultBodies()).toHaveLength(0);
+    expect(scanSpy).toHaveBeenCalledTimes(1);
+
+    await startTick(run);
+    expect(listCalls()).toHaveLength(3);
+    expect(scanSpy).toHaveBeenCalledTimes(2);
+    expect(resultBodies()).toEqual([
+      expect.objectContaining({ scanId: next["_id"], success: true }),
+    ]);
+
+    activeSweep.resolve(scanResult());
+    await firstTick;
+  });
+
+  test("a scan retains its slot until its final result upload completes", async (): Promise<void> => {
+    const run: PromiseVoidFunction = capturedRunFunction();
+    const first: JSONObject = scanRow("192.0.2.0/30");
+    const second: JSONObject = scanRow("198.51.100.0/30");
+    const third: JSONObject = scanRow("203.0.113.0/30");
+    const firstUpload: Deferred<{ data: JSONArray }> = deferred({
+      data: [] as JSONArray,
+    });
+    const secondUpload: Deferred<{ data: JSONArray }> = deferred({
+      data: [] as JSONArray,
+    });
+    listedBatches.push([first, second], [third]);
+    fetchSpy.mockImplementation((request: APIFetchOptions) => {
+      if (String(request.url).endsWith("/discovery-scan/list")) {
+        return Promise.resolve({ data: listedBatches.shift() || [] }) as never;
+      }
+      const body: JSONObject = request.data as JSONObject;
+      if (body["scanId"] === first["_id"]) {
+        return firstUpload.promise as never;
+      }
+      if (body["scanId"] === second["_id"]) {
+        return secondUpload.promise as never;
+      }
+      return Promise.resolve({ data: [] }) as never;
+    });
+
+    const firstTick: Promise<void> = startTick(run);
+    await flushMicrotasks();
+    expect(scanSpy).toHaveBeenCalledTimes(2);
+    expect(resultBodies()).toHaveLength(2);
+
+    await startTick(run);
+    expect(listCalls()).toHaveLength(1);
+
+    secondUpload.resolve({ data: [] });
+    await flushMicrotasks();
+    await startTick(run);
+    expect(listCalls()).toHaveLength(2);
+    expect((listCalls()[1]!.data as JSONObject)["excludeScanIds"]).toEqual([
+      first["_id"],
+    ]);
+    expect(scanSpy).toHaveBeenCalledTimes(3);
+    expect(resultBodies()[2]).toEqual(
+      expect.objectContaining({ scanId: third["_id"], success: true }),
+    );
+
+    firstUpload.resolve({ data: [] });
+    await firstTick;
+  });
+
+  test.each([true, false])(
+    "a rejected result upload releases its slot after a sweep with success=%s",
+    async (success: boolean): Promise<void> => {
+      const run: PromiseVoidFunction = capturedRunFunction();
+      const active: JSONObject = scanRow("192.0.2.0/24");
+      const reported: JSONObject = scanRow("198.51.100.0/30");
+      const next: JSONObject = scanRow("203.0.113.0/30");
+      const activeSweep: Deferred<SubnetScanResult> = deferred(scanResult());
+      const report: Deferred<{ data: JSONArray }> = deferred({
+        data: [] as JSONArray,
+      });
+      listedBatches.push([active, reported], [next]);
+      scanSpy.mockImplementation((config: SubnetScanConfig) => {
+        if (config.cidr === active["cidr"]) {
+          return activeSweep.promise;
+        }
+        if (config.cidr === reported["cidr"] && !success) {
+          return Promise.reject(new Error("sweep failed"));
+        }
+        return Promise.resolve(scanResult());
+      });
+      fetchSpy.mockImplementation((request: APIFetchOptions) => {
+        if (String(request.url).endsWith("/discovery-scan/list")) {
+          return Promise.resolve({
+            data: listedBatches.shift() || [],
+          }) as never;
+        }
+        if ((request.data as JSONObject)["scanId"] === reported["_id"]) {
+          return report.promise as never;
+        }
+        return Promise.resolve({ data: [] }) as never;
+      });
+
+      const firstTick: Promise<void> = startTick(run);
+      await flushMicrotasks();
+      await startTick(run);
+      expect(listCalls()).toHaveLength(1);
+
+      report.reject(new Error("result upload timed out"));
+      await flushMicrotasks();
+      await startTick(run);
+
+      expect(listCalls()).toHaveLength(2);
+      expect(scanSpy).toHaveBeenCalledTimes(3);
+      expect(
+        resultBodies().filter((body: JSONObject): boolean => {
+          return body["scanId"] === reported["_id"];
+        }),
+      ).toEqual([expect.objectContaining({ success })]);
+      expect(resultBodies()[1]).toEqual(
+        expect.objectContaining({ scanId: next["_id"], success: true }),
+      );
+
+      activeSweep.resolve(scanResult());
+      await firstTick;
+    },
+  );
+
+  test("a sweep deadline releases only that scan's slot and observes its late rejection", async (): Promise<void> => {
+    jest.useFakeTimers({ doNotFake: ["setImmediate", "performance"] });
+    const run: PromiseVoidFunction = capturedRunFunction();
+    const expired: JSONObject = scanRow("192.0.2.0/24");
+    const active: JSONObject = scanRow("198.51.100.0/24");
+    const next: JSONObject = scanRow("203.0.113.0/30");
+    const expiredSweep: Deferred<SubnetScanResult> = deferred(scanResult());
+    const activeSweep: Deferred<SubnetScanResult> = deferred(scanResult());
+    listedBatches.push([expired], [active], [next]);
+    scanSpy
+      .mockReturnValueOnce(expiredSweep.promise)
+      .mockReturnValueOnce(activeSweep.promise);
+
+    const firstTick: Promise<void> = startTick(run);
+    await flushMicrotasks();
+    jest.advanceTimersByTime(1);
+    const secondTick: Promise<void> = startTick(run);
+    await flushMicrotasks();
+    await startTick(run);
+    expect(listCalls()).toHaveLength(2);
+
+    jest.advanceTimersByTime(PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS - 1);
+    await firstTick;
+    expect(resultBodies()).toEqual([
+      expect.objectContaining({ scanId: expired["_id"], success: false }),
+    ]);
+    expect(String(resultBodies()[0]!["statusMessage"])).toContain(
+      "did not finish within",
+    );
+
+    await startTick(run);
+    expect(listCalls()).toHaveLength(3);
+    expect((listCalls()[2]!.data as JSONObject)["excludeScanIds"]).toEqual([
+      active["_id"],
+    ]);
+    expect(resultBodies()[1]).toEqual(
+      expect.objectContaining({ scanId: next["_id"], success: true }),
+    );
+
+    /*
+     * The deadline's Promise.race must retain a rejection handler on the
+     * abandoned sweep, and it must never upload a second terminal result.
+     */
+    expiredSweep.reject(new Error("late sweep failure"));
+    await flushMicrotasks();
+    expect(resultBodies()).toHaveLength(2);
+
+    activeSweep.resolve(scanResult());
+    await secondTick;
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/Probe/Tests/Jobs/Discovery/FetchScansGuardAndTimeout.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansGuardAndTimeout.test.ts
@@ -56,9 +56,9 @@ import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverse
  *   - every control-plane request carries an explicit deadline (axios's
  *     default timeout is 0 = infinite, and a hung list fetch is exactly what
  *     wedged the customer's probe), and
- *   - one discovery cycle at a time: a subnet sweep legitimately runs many
- *     minutes (up to 4096 hosts), and before the guard every minutely tick
- *     stacked another fetch/sweep on top of the one still in flight.
+ *   - one claim request at a time: an unresponsive list endpoint must not
+ *     accumulate overlapping requests on every minutely tick. Independent
+ *     sweeps can overlap, as covered by FetchScansConcurrency.test.ts.
  */
 
 const scanId: ObjectID = ObjectID.generate();
@@ -209,7 +209,7 @@ describe("request deadlines — no discovery request may hang forever", () => {
   });
 });
 
-describe("overlap guard — one discovery cycle at a time", () => {
+describe("overlap guard — one discovery claim request at a time", () => {
   function capturedRunFunction(): PromiseVoidFunction {
     InitJob();
     const captured: CapturedCronJob | undefined =
@@ -230,9 +230,8 @@ describe("overlap guard — one discovery cycle at a time", () => {
     );
 
     /*
-     * A subnet sweep legitimately runs for many minutes; before the guard
-     * every minutely tick stacked another fetch/sweep on top of the stuck
-     * one. The second tick must return without fetching.
+     * The list request is still pending. The second tick must return without
+     * starting another claim request against the same unresponsive endpoint.
      */
     const firstTick: Promise<void> = runFunction();
     await flushMicrotasks();

--- a/Probe/Tests/Jobs/Discovery/FetchScansLifecycle.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansLifecycle.test.ts
@@ -695,10 +695,12 @@ describe("runScan — failures are reported, never swallowed", () => {
   });
 
   test("one scan failing does not stop the next scan in the batch", async () => {
+    const failedScanId: string = ObjectID.generate().toString();
+    const successfulScanId: string = ObjectID.generate().toString();
     fetchSpy.mockResolvedValueOnce({
       data: [
-        { _id: ObjectID.generate().toString(), cidr: "10.0.0.0/24" },
-        { _id: ObjectID.generate().toString(), cidr: "10.1.0.0/24" },
+        { _id: failedScanId, cidr: "10.0.0.0/24" },
+        { _id: successfulScanId, cidr: "10.1.0.0/24" },
       ],
     } as never);
     scanSpy
@@ -714,7 +716,11 @@ describe("runScan — failures are reported, never swallowed", () => {
         return call.body;
       });
     expect(resultBodies).toHaveLength(2);
-    expect(resultBodies[0]!["success"]).toBe(false);
-    expect(resultBodies[1]!["success"]).toBe(true);
+    expect(resultBodies).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ scanId: failedScanId, success: false }),
+        expect.objectContaining({ scanId: successfulScanId, success: true }),
+      ]),
+    );
   });
 });

--- a/Probe/Tests/Jobs/Discovery/FetchScansSweepDeadline.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansSweepDeadline.test.ts
@@ -56,17 +56,10 @@ import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverse
 /*
  * A sweep that never settles must not stop discovery forever.
  *
- * The discovery cron holds a single-flight guard for the WHOLE cycle — list
- * fetch, sweep, result upload — and clears it only in a `finally`. Both HTTP
- * calls carry a 45s deadline, but the sweep between them had none, and a
- * sweep is the part most likely to hang: it opens one ICMP child process and
- * one UDP SNMP session per address, up to 32,768 of them.
- *
- * One non-settling promise in there did not cost a cycle. It stranded the
- * guard set for the lifetime of the process, so the probe never asked for
- * another scan, and every scan afterwards sat in "Pending" until someone
- * restarted the container — with nothing anywhere in the product to say why.
- * That is the failure mode OneUptime issue #3287 describes.
+ * Each scan occupies a scheduler slot through its result upload. Both HTTP
+ * calls carry a 45s deadline, and the sweep between them needs one too so
+ * wedged sweeps cannot eventually occupy every slot forever. Before bounded
+ * scan concurrency (#3597), one such sweep blocked the entire probe (#3287).
  *
  * FetchScansGuardAndTimeout.test.ts already pins that the guard releases when
  * the FETCH fails. These pin the case it could not reach: the sweep itself.
@@ -296,7 +289,7 @@ describe("runScan — a wedged sweep is reported, not swallowed", () => {
   });
 });
 
-describe("the overlap guard survives a wedged sweep", () => {
+describe("the scheduler releases capacity after a wedged sweep", () => {
   function capturedRunFunction(): PromiseVoidFunction {
     InitJob();
     const captured: CapturedCronJob | undefined =
@@ -308,11 +301,10 @@ describe("the overlap guard survives a wedged sweep", () => {
   }
 
   /*
-   * THE regression test for issue #3287's failure mode. Before the deadline,
-   * this second tick returned immediately without fetching — and so did every
-   * tick after it, forever.
+   * Regression for issue #3287: the invocation must eventually finish even
+   * when its sweep never settles, and later ticks must still fetch work.
    */
-  test("a tick whose sweep never settles still releases the guard, so the next tick fetches again", async () => {
+  test("a tick whose sweep never settles still completes, so the next tick fetches again", async () => {
     const runFunction: PromiseVoidFunction = capturedRunFunction();
 
     fetchSpy.mockResolvedValue({

--- a/Probe/Tests/Utils/Discovery/DiscoveryScanScheduler.test.ts
+++ b/Probe/Tests/Utils/Discovery/DiscoveryScanScheduler.test.ts
@@ -1,0 +1,587 @@
+import DiscoveryScanScheduler from "../../../Utils/Discovery/DiscoveryScanScheduler";
+import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import ObjectID from "Common/Types/ObjectID";
+import logger from "Common/Server/Utils/Logger";
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+    },
+  };
+});
+
+interface Deferred<Value> {
+  promise: Promise<Value>;
+  resolve: (value: Value) => void;
+  reject: (error: Error) => void;
+}
+
+type FetchScans = (
+  excludeScanIds: Array<string>,
+) => Promise<Array<NetworkDeviceDiscoveryScan>>;
+type RunScan = (scan: NetworkDeviceDiscoveryScan) => Promise<void>;
+
+interface ControlledScans {
+  runScan: jest.MockedFunction<RunScan>;
+  started: Array<NetworkDeviceDiscoveryScan>;
+  active: number;
+  peak: number;
+  complete: (scan: NetworkDeviceDiscoveryScan) => void;
+  fail: (scan: NetworkDeviceDiscoveryScan, error: Error) => void;
+}
+
+function createDeferred<Value>(): Deferred<Value> {
+  let resolve: (value: Value) => void = (): void => {};
+  let reject: (error: Error) => void = (): void => {};
+  const promise: Promise<Value> = new Promise<Value>(
+    (
+      promiseResolve: (value: Value) => void,
+      promiseReject: (error: Error) => void,
+    ) => {
+      resolve = promiseResolve;
+      reject = promiseReject;
+    },
+  );
+
+  return { promise, resolve, reject };
+}
+
+function makeScan(
+  id: ObjectID = ObjectID.generate(),
+): NetworkDeviceDiscoveryScan {
+  return { id } as NetworkDeviceDiscoveryScan;
+}
+
+function createControlledScans(): ControlledScans {
+  const gates: Map<string, Deferred<void>> = new Map();
+
+  function getGate(scan: NetworkDeviceDiscoveryScan): Deferred<void> {
+    const id: string = scan.id!.toString();
+    let gate: Deferred<void> | undefined = gates.get(id);
+    if (!gate) {
+      gate = createDeferred<void>();
+      gates.set(id, gate);
+    }
+    return gate;
+  }
+
+  const controller: ControlledScans = {
+    started: [],
+    active: 0,
+    peak: 0,
+    runScan: jest.fn(
+      async (scan: NetworkDeviceDiscoveryScan): Promise<void> => {
+        controller.started.push(scan);
+        controller.active++;
+        controller.peak = Math.max(controller.peak, controller.active);
+        try {
+          await getGate(scan).promise;
+        } finally {
+          controller.active--;
+        }
+      },
+    ),
+    complete: (scan: NetworkDeviceDiscoveryScan): void => {
+      getGate(scan).resolve();
+    },
+    fail: (scan: NetworkDeviceDiscoveryScan, error: Error): void => {
+      getGate(scan).reject(error);
+    },
+  };
+
+  return controller;
+}
+
+async function flushPromises(): Promise<void> {
+  await new Promise<void>((resolve: () => void) => {
+    setImmediate(resolve);
+  });
+}
+
+describe("DiscoveryScanScheduler", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("runs an oversized batch at the configured limit and drains it in FIFO order", async () => {
+    const scans: Array<NetworkDeviceDiscoveryScan> = Array.from(
+      { length: 5 },
+      (): NetworkDeviceDiscoveryScan => {
+        return makeScan();
+      },
+    );
+    const work: ControlledScans = createControlledScans();
+    const fetchScans: jest.MockedFunction<FetchScans> = jest
+      .fn<ReturnType<FetchScans>, Parameters<FetchScans>>()
+      .mockResolvedValue(scans);
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 2,
+      fetchScans,
+      runScan: work.runScan,
+    });
+
+    let settled: boolean = false;
+    const run: Promise<void> = scheduler.run().then(() => {
+      settled = true;
+    });
+    await flushPromises();
+    expect(work.started).toEqual(scans.slice(0, 2));
+    expect(settled).toBe(false);
+
+    work.complete(scans[1]!);
+    await flushPromises();
+    expect(work.started).toEqual(scans.slice(0, 3));
+    work.complete(scans[2]!);
+    await flushPromises();
+    expect(work.started).toEqual(scans.slice(0, 4));
+    work.complete(scans[0]!);
+    await flushPromises();
+    expect(work.started).toEqual(scans);
+    expect(settled).toBe(false);
+
+    work.complete(scans[3]!);
+    work.complete(scans[4]!);
+    await run;
+    expect(work.peak).toBe(2);
+    expect(work.active).toBe(0);
+    expect(settled).toBe(true);
+  });
+
+  test("supports an explicit limit of one", async () => {
+    const first: NetworkDeviceDiscoveryScan = makeScan();
+    const second: NetworkDeviceDiscoveryScan = makeScan();
+    const work: ControlledScans = createControlledScans();
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 1,
+      fetchScans: async (): Promise<Array<NetworkDeviceDiscoveryScan>> => {
+        return [first, second];
+      },
+      runScan: work.runScan,
+    });
+
+    const run: Promise<void> = scheduler.run();
+    await flushPromises();
+    expect(work.started).toEqual([first]);
+    work.complete(first);
+    await flushPromises();
+    expect(work.started).toEqual([first, second]);
+    work.complete(second);
+    await run;
+    expect(work.peak).toBe(1);
+  });
+
+  test("skips overlapping fetches and allows polling again after an empty response", async () => {
+    const response: Deferred<Array<NetworkDeviceDiscoveryScan>> =
+      createDeferred<Array<NetworkDeviceDiscoveryScan>>();
+    const fetchScans: jest.MockedFunction<FetchScans> = jest
+      .fn<ReturnType<FetchScans>, Parameters<FetchScans>>()
+      .mockReturnValueOnce(response.promise)
+      .mockResolvedValue([]);
+    const work: ControlledScans = createControlledScans();
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 4,
+      fetchScans,
+      runScan: work.runScan,
+    });
+
+    const firstRun: Promise<void> = scheduler.run();
+    await Promise.all([scheduler.run(), scheduler.run(), scheduler.run()]);
+    expect(fetchScans).toHaveBeenCalledTimes(1);
+    expect(fetchScans).toHaveBeenNthCalledWith(1, []);
+    expect(work.runScan).not.toHaveBeenCalled();
+
+    response.resolve([]);
+    await firstRun;
+    await scheduler.run();
+    expect(fetchScans).toHaveBeenCalledTimes(2);
+    expect(fetchScans).toHaveBeenNthCalledWith(2, []);
+  });
+
+  test("fills a spare slot on a later poll while an earlier scan is still running", async () => {
+    const first: NetworkDeviceDiscoveryScan = makeScan();
+    const second: NetworkDeviceDiscoveryScan = makeScan();
+    const work: ControlledScans = createControlledScans();
+    const fetchScans: jest.MockedFunction<FetchScans> = jest
+      .fn<ReturnType<FetchScans>, Parameters<FetchScans>>()
+      .mockResolvedValueOnce([first])
+      .mockResolvedValueOnce([second]);
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 2,
+      fetchScans,
+      runScan: work.runScan,
+    });
+
+    let firstSettled: boolean = false;
+    const firstRun: Promise<void> = scheduler.run().then(() => {
+      firstSettled = true;
+    });
+    await flushPromises();
+    const secondRun: Promise<void> = scheduler.run();
+    await flushPromises();
+
+    expect(work.started).toEqual([first, second]);
+    expect(work.peak).toBe(2);
+    expect(fetchScans).toHaveBeenNthCalledWith(1, []);
+    expect(fetchScans).toHaveBeenNthCalledWith(2, [first.id!.toString()]);
+    work.complete(second);
+    await secondRun;
+    expect(firstSettled).toBe(false);
+    expect(work.active).toBe(1);
+
+    work.complete(first);
+    await firstRun;
+  });
+
+  test("skips polling while all slots are held and resumes when one is released", async () => {
+    const first: NetworkDeviceDiscoveryScan = makeScan();
+    const second: NetworkDeviceDiscoveryScan = makeScan();
+    const third: NetworkDeviceDiscoveryScan = makeScan();
+    const work: ControlledScans = createControlledScans();
+    const fetchScans: jest.MockedFunction<FetchScans> = jest
+      .fn<ReturnType<FetchScans>, Parameters<FetchScans>>()
+      .mockResolvedValueOnce([first, second])
+      .mockResolvedValueOnce([third]);
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 2,
+      fetchScans,
+      runScan: work.runScan,
+    });
+
+    const firstRun: Promise<void> = scheduler.run();
+    await flushPromises();
+    await scheduler.run();
+    expect(fetchScans).toHaveBeenCalledTimes(1);
+
+    work.complete(second);
+    await flushPromises();
+    const secondRun: Promise<void> = scheduler.run();
+    await flushPromises();
+    expect(fetchScans).toHaveBeenCalledTimes(2);
+    expect(fetchScans).toHaveBeenNthCalledWith(2, [first.id!.toString()]);
+    expect(work.started).toEqual([first, second, third]);
+    expect(work.peak).toBe(2);
+    work.complete(first);
+    work.complete(third);
+    await Promise.all([firstRun, secondRun]);
+  });
+
+  test("reserves queued scans so repeated ticks cannot grow an oversized backlog", async () => {
+    const scans: Array<NetworkDeviceDiscoveryScan> = [
+      makeScan(),
+      makeScan(),
+      makeScan(),
+    ];
+    const work: ControlledScans = createControlledScans();
+    const fetchScans: jest.MockedFunction<FetchScans> = jest
+      .fn<ReturnType<FetchScans>, Parameters<FetchScans>>()
+      .mockResolvedValue(scans);
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 1,
+      fetchScans,
+      runScan: work.runScan,
+    });
+
+    const run: Promise<void> = scheduler.run();
+    await flushPromises();
+    await scheduler.run();
+    work.complete(scans[0]!);
+    await flushPromises();
+    await scheduler.run();
+    expect(fetchScans).toHaveBeenCalledTimes(1);
+    expect(work.started).toEqual(scans.slice(0, 2));
+
+    work.complete(scans[1]!);
+    await flushPromises();
+    await scheduler.run();
+    expect(fetchScans).toHaveBeenCalledTimes(1);
+    work.complete(scans[2]!);
+    await run;
+    expect(work.started).toEqual(scans);
+  });
+
+  test("snapshots excluded IDs for each request and drops completed IDs from later requests", async () => {
+    const first: NetworkDeviceDiscoveryScan = makeScan();
+    const second: NetworkDeviceDiscoveryScan = makeScan();
+    const third: NetworkDeviceDiscoveryScan = makeScan();
+    const delayedResponse: Deferred<Array<NetworkDeviceDiscoveryScan>> =
+      createDeferred<Array<NetworkDeviceDiscoveryScan>>();
+    const work: ControlledScans = createControlledScans();
+    const fetchScans: jest.MockedFunction<FetchScans> = jest
+      .fn<ReturnType<FetchScans>, Parameters<FetchScans>>()
+      .mockResolvedValueOnce([first, second])
+      .mockReturnValueOnce(delayedResponse.promise)
+      .mockResolvedValue([]);
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 3,
+      fetchScans,
+      runScan: work.runScan,
+    });
+
+    const firstRun: Promise<void> = scheduler.run();
+    await flushPromises();
+    const secondRun: Promise<void> = scheduler.run();
+    await flushPromises();
+    const requestSnapshot: Array<string> = fetchScans.mock.calls[1]![0];
+    expect(requestSnapshot).toEqual([
+      first.id!.toString(),
+      second.id!.toString(),
+    ]);
+
+    /*
+     * Finishing work while the HTTP request is pending must not change the
+     * exclusions already handed to that request.
+     */
+    work.complete(first);
+    await flushPromises();
+    expect(requestSnapshot).toEqual([
+      first.id!.toString(),
+      second.id!.toString(),
+    ]);
+    await scheduler.run();
+    expect(fetchScans).toHaveBeenCalledTimes(2);
+
+    delayedResponse.resolve([third]);
+    await flushPromises();
+    await scheduler.run();
+    expect(fetchScans).toHaveBeenNthCalledWith(3, [
+      second.id!.toString(),
+      third.id!.toString(),
+    ]);
+    expect(requestSnapshot).toEqual([
+      first.id!.toString(),
+      second.id!.toString(),
+    ]);
+
+    work.complete(second);
+    work.complete(third);
+    await Promise.all([firstRun, secondRun]);
+    await scheduler.run();
+    expect(fetchScans).toHaveBeenNthCalledWith(4, []);
+  });
+
+  test("deduplicates active and queued IDs by value within the same response", async () => {
+    const first: NetworkDeviceDiscoveryScan = makeScan();
+    const second: NetworkDeviceDiscoveryScan = makeScan();
+    const duplicateFirst: NetworkDeviceDiscoveryScan = makeScan(
+      new ObjectID(first.id!.toString()),
+    );
+    const duplicateSecond: NetworkDeviceDiscoveryScan = makeScan(
+      new ObjectID(second.id!.toString()),
+    );
+    const work: ControlledScans = createControlledScans();
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 1,
+      fetchScans: async (): Promise<Array<NetworkDeviceDiscoveryScan>> => {
+        return [first, duplicateFirst, second, duplicateSecond];
+      },
+      runScan: work.runScan,
+    });
+
+    const run: Promise<void> = scheduler.run();
+    await flushPromises();
+    work.complete(first);
+    await flushPromises();
+    work.complete(second);
+    await run;
+    expect(work.started).toEqual([first, second]);
+    expect(work.peak).toBe(1);
+  });
+
+  test("ignores an active ID returned again on a later poll without waiting for it", async () => {
+    const scan: NetworkDeviceDiscoveryScan = makeScan();
+    const duplicate: NetworkDeviceDiscoveryScan = makeScan(
+      new ObjectID(scan.id!.toString()),
+    );
+    const work: ControlledScans = createControlledScans();
+    const fetchScans: jest.MockedFunction<FetchScans> = jest
+      .fn<ReturnType<FetchScans>, Parameters<FetchScans>>()
+      .mockResolvedValueOnce([scan])
+      .mockResolvedValueOnce([duplicate]);
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 2,
+      fetchScans,
+      runScan: work.runScan,
+    });
+
+    const firstRun: Promise<void> = scheduler.run();
+    await flushPromises();
+    await expect(scheduler.run()).resolves.toBeUndefined();
+    expect(work.started).toEqual([scan]);
+    expect(work.active).toBe(1);
+    work.complete(scan);
+    await firstRun;
+  });
+
+  test("bounds a later oversized response using slots shared with earlier polls", async () => {
+    const scans: Array<NetworkDeviceDiscoveryScan> = [
+      makeScan(),
+      makeScan(),
+      makeScan(),
+    ];
+    const work: ControlledScans = createControlledScans();
+    const fetchScans: jest.MockedFunction<FetchScans> = jest
+      .fn<ReturnType<FetchScans>, Parameters<FetchScans>>()
+      .mockResolvedValueOnce([scans[0]!])
+      .mockResolvedValueOnce([scans[1]!, scans[2]!]);
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 2,
+      fetchScans,
+      runScan: work.runScan,
+    });
+
+    const firstRun: Promise<void> = scheduler.run();
+    await flushPromises();
+    let secondSettled: boolean = false;
+    const secondRun: Promise<void> = scheduler.run().then(() => {
+      secondSettled = true;
+    });
+    await flushPromises();
+    expect(work.started).toEqual(scans.slice(0, 2));
+
+    work.complete(scans[0]!);
+    await firstRun;
+    await flushPromises();
+    expect(work.started).toEqual(scans);
+    expect(secondSettled).toBe(false);
+    expect(work.peak).toBe(2);
+    work.complete(scans[1]!);
+    work.complete(scans[2]!);
+    await secondRun;
+  });
+
+  test.each(["synchronous", "asynchronous"])(
+    "releases the fetch guard after %s fetch failures",
+    async (failureType: string) => {
+      const error: Error = new Error("list request failed");
+      const scan: NetworkDeviceDiscoveryScan = makeScan();
+      const runScan: jest.MockedFunction<RunScan> = jest
+        .fn<ReturnType<RunScan>, Parameters<RunScan>>()
+        .mockResolvedValue(undefined);
+      const fetchScans: jest.MockedFunction<FetchScans> = jest
+        .fn<ReturnType<FetchScans>, Parameters<FetchScans>>()
+        .mockImplementationOnce(
+          (): Promise<Array<NetworkDeviceDiscoveryScan>> => {
+            if (failureType === "synchronous") {
+              throw error;
+            }
+            return Promise.reject(error);
+          },
+        )
+        .mockResolvedValueOnce([scan]);
+      const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+        maxConcurrentScans: 2,
+        fetchScans,
+        runScan,
+      });
+
+      await expect(scheduler.run()).rejects.toBe(error);
+      await expect(scheduler.run()).resolves.toBeUndefined();
+      expect(fetchScans).toHaveBeenCalledTimes(2);
+      expect(runScan).toHaveBeenCalledTimes(1);
+      expect(runScan).toHaveBeenCalledWith(scan);
+    },
+  );
+
+  test("a rejected scan releases its slot, logs the error, and does not stop queued work", async () => {
+    const first: NetworkDeviceDiscoveryScan = makeScan();
+    const second: NetworkDeviceDiscoveryScan = makeScan();
+    const third: NetworkDeviceDiscoveryScan = makeScan();
+    const work: ControlledScans = createControlledScans();
+    const fetchScans: jest.MockedFunction<FetchScans> = jest
+      .fn<ReturnType<FetchScans>, Parameters<FetchScans>>()
+      .mockResolvedValueOnce([first, second])
+      .mockResolvedValueOnce([third]);
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 1,
+      fetchScans,
+      runScan: work.runScan,
+    });
+
+    const firstRun: Promise<void> = scheduler.run();
+    await flushPromises();
+    work.fail(first, new Error("scan failed"));
+    await flushPromises();
+    expect(work.started).toEqual([first, second]);
+    expect(logger.error).toHaveBeenCalled();
+    work.complete(second);
+    await expect(firstRun).resolves.toBeUndefined();
+
+    const nextRun: Promise<void> = scheduler.run();
+    await flushPromises();
+    expect(work.started).toEqual([first, second, third]);
+    work.complete(third);
+    await nextRun;
+    expect(work.peak).toBe(1);
+    expect(work.active).toBe(0);
+  });
+
+  test("a synchronous scan exception does not lose other scans in the response", async () => {
+    const first: NetworkDeviceDiscoveryScan = makeScan();
+    const second: NetworkDeviceDiscoveryScan = makeScan();
+    const error: Error = new Error("invalid scan");
+    const runScan: jest.MockedFunction<RunScan> = jest
+      .fn<ReturnType<RunScan>, Parameters<RunScan>>()
+      .mockImplementationOnce((): Promise<void> => {
+        throw error;
+      })
+      .mockResolvedValue(undefined);
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 1,
+      fetchScans: async (): Promise<Array<NetworkDeviceDiscoveryScan>> => {
+        return [first, second];
+      },
+      runScan,
+    });
+
+    await expect(scheduler.run()).resolves.toBeUndefined();
+    expect(runScan).toHaveBeenNthCalledWith(1, first);
+    expect(runScan).toHaveBeenNthCalledWith(2, second);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  test("releases completed IDs so a later retry can execute", async () => {
+    const scan: NetworkDeviceDiscoveryScan = makeScan();
+    const runScan: jest.MockedFunction<RunScan> = jest
+      .fn<ReturnType<RunScan>, Parameters<RunScan>>()
+      .mockRejectedValueOnce(new Error("first attempt failed"))
+      .mockResolvedValue(undefined);
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 1,
+      fetchScans: async (): Promise<Array<NetworkDeviceDiscoveryScan>> => {
+        return [scan];
+      },
+      runScan,
+    });
+
+    await scheduler.run();
+    await scheduler.run();
+    await scheduler.run();
+    expect(runScan).toHaveBeenCalledTimes(3);
+  });
+
+  test("skips records without an ID and continues running valid records", async () => {
+    const scan: NetworkDeviceDiscoveryScan = makeScan();
+    const missingId: NetworkDeviceDiscoveryScan =
+      {} as NetworkDeviceDiscoveryScan;
+    const runScan: jest.MockedFunction<RunScan> = jest
+      .fn<ReturnType<RunScan>, Parameters<RunScan>>()
+      .mockResolvedValue(undefined);
+    const scheduler: DiscoveryScanScheduler = new DiscoveryScanScheduler({
+      maxConcurrentScans: 1,
+      fetchScans: async (): Promise<Array<NetworkDeviceDiscoveryScan>> => {
+        return [missingId, scan, missingId];
+      },
+      runScan,
+    });
+
+    await expect(scheduler.run()).resolves.toBeUndefined();
+    expect(runScan).toHaveBeenCalledTimes(1);
+    expect(runScan).toHaveBeenCalledWith(scan);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/Probe/Utils/Discovery/DiscoveryScanScheduler.ts
+++ b/Probe/Utils/Discovery/DiscoveryScanScheduler.ts
@@ -1,0 +1,122 @@
+import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import logger from "Common/Server/Utils/Logger";
+
+interface SchedulerOptions {
+  maxConcurrentScans: number;
+  fetchScans: (
+    excludeScanIds: Array<string>,
+  ) => Promise<Array<NetworkDeviceDiscoveryScan>>;
+  runScan: (scan: NetworkDeviceDiscoveryScan) => Promise<void>;
+}
+
+interface QueuedScan {
+  scan: NetworkDeviceDiscoveryScan;
+  scanId: string;
+  resolve: () => void;
+}
+
+/**
+ * Serializes claims, while allowing independent scans to run across cron ticks.
+ * A reservation lasts through the result upload, so another tick cannot exceed
+ * the limit or start the same scan while its previous result is still in flight.
+ */
+export default class DiscoveryScanScheduler {
+  private readonly options: SchedulerOptions;
+  private isFetching: boolean = false;
+  private activeScanCount: number = 0;
+  private readonly scanIds: Set<string> = new Set();
+  private readonly queue: Array<QueuedScan> = [];
+
+  public constructor(options: SchedulerOptions) {
+    this.options = options;
+  }
+
+  public async run(): Promise<void> {
+    /*
+     * The server marks a scan In Progress as soon as it hands it out. Leave
+     * work Pending on the server until this probe has room to execute it.
+     */
+    if (
+      this.isFetching ||
+      this.scanIds.size >= this.options.maxConcurrentScans
+    ) {
+      return;
+    }
+
+    const runs: Array<Promise<void>> = [];
+    this.isFetching = true;
+
+    try {
+      /*
+       * An edit can requeue a running scan. Exclude reserved IDs BEFORE
+       * the server claims them, so the old run's result is still rejected
+       * while that edited row remains Pending.
+       */
+      const scans: Array<NetworkDeviceDiscoveryScan> =
+        await this.options.fetchScans(Array.from(this.scanIds));
+
+      for (const scan of scans) {
+        const scanId: string | undefined = scan.id?.toString();
+
+        if (!scanId) {
+          logger.error("Ignoring a discovery scan without an ID.");
+          continue;
+        }
+
+        if (this.scanIds.has(scanId)) {
+          continue;
+        }
+
+        this.scanIds.add(scanId);
+        runs.push(
+          new Promise<void>((resolve: () => void) => {
+            this.queue.push({ scan, scanId, resolve });
+          }),
+        );
+      }
+
+      this.startQueuedScans();
+    } finally {
+      /*
+       * Only claiming is single-flight. Waiting for a sweep here would block
+       * every later cron tick for the duration of the longest scan (#3597).
+       */
+      this.isFetching = false;
+    }
+
+    await Promise.all(runs);
+  }
+
+  private startQueuedScans(): void {
+    /*
+     * The current server returns one scan per poll. Also handle batches
+     * without exceeding the execution limit or discarding already claimed work.
+     */
+    while (
+      this.activeScanCount < this.options.maxConcurrentScans &&
+      this.queue.length > 0
+    ) {
+      const queued: QueuedScan = this.queue.shift()!;
+      this.activeScanCount++;
+      void this.executeScan(queued);
+    }
+  }
+
+  private async executeScan(queued: QueuedScan): Promise<void> {
+    try {
+      await this.options.runScan(queued.scan);
+    } catch (err) {
+      /*
+       * runScan normally reports failures itself. An unexpected exception
+       * must still release capacity and let the other scans finish.
+       */
+      logger.error(`Discovery scan ${queued.scanId} failed unexpectedly.`);
+      logger.error(err);
+    } finally {
+      this.activeScanCount--;
+      this.scanIds.delete(queued.scanId);
+      queued.resolve();
+      this.startQueuedScans();
+    }
+  }
+}


### PR DESCRIPTION
Fixes #3597.

The recent large-range discovery improvements parallelized hosts within a sweep, but the probe still held one guard across the entire scan. A long scan therefore prevented every later polling tick from claiming independent work.

Add a scheduler that serializes claim requests while allowing up to four independent scans per probe. `PROBE_DISCOVERY_MAX_CONCURRENT_SCANS` accepts 1–16; each slot remains reserved through result upload, and full probes leave additional work Pending on the server. Scan failures, upload failures, and deadlines release capacity independently.

List requests include reserved scan IDs, which the server excludes before claiming rows. This keeps an edited running scan Pending until its obsolete run finishes, while other scans remain claimable. Older probes can continue omitting the new field. Upgrade the server before custom probes; use a scan limit of 1 with older servers until they are upgraded.

Added 70 tests covering scheduler limits and recovery, configuration, overlapping cron ticks, duplicate claims, result uploads, deadlines, and server-side exclusion of edited scans. The main concurrency regression was also run against the original implementation and failed as expected.

Validation: 311 probe discovery tests and 146 discovery API tests passed (457 total). Probe compilation passed locally. Repository lint and both App and Probe compilation passed in CI. Tests use controlled transport/database boundaries and do not perform live network scans.
