### PR TITLE
feat(telemetry): span and exception lists on alert / incident pages

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionsViewer.tsx
@@ -41,11 +41,17 @@ import {
   MAX_SCOPED_FINGERPRINTS,
   applyExceptionFingerprintScope,
   buildExceptionInstanceScopeQuery,
+  mergeExceptionInstanceScopes,
   getExceptionAttributeSelections,
   getExceptionInstanceScopeKey,
   hasExceptionInstanceScope,
   isExceptionAttributeFacetKey,
 } from "../../Utils/ExceptionsAttributeScope";
+import {
+  ExceptionQueryScope,
+  buildExceptionQueryScope,
+} from "../../Utils/ExceptionQueryScope";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
 import {
   EXCEPTION_ERROR_CLASS_COLUMN,
   EXCEPTION_FIELD_ALIASES,
@@ -390,17 +396,102 @@ function readInitialUrlState(): InitialUrlState {
 
 export interface ExceptionsViewerProps {
   defaultStatus?: ExceptionStatus;
+  /*
+   * Opening lens. The standalone tabs keep the "Issues" default, which hides
+   * user errors and expected denials; a host showing the exceptions of ONE
+   * event has to pass "all", or an exception the classifier called a user
+   * error vanishes from the event that fired on it.
+   */
+  defaultClassScope?: ExceptionClassScope | undefined;
   primaryEntityId?: ObjectID | undefined;
+  /*
+   * A STORED exception-instance query to host — the slice an exception
+   * monitor evaluated, kept on the incident / alert row.
+   *
+   * This viewer lists Postgres exception GROUPS while the stored query
+   * selects ClickHouse instances, and `fingerprint` is the only join between
+   * them. So the query is resolved through the instance scope this viewer
+   * already owns: one `GROUP BY fingerprint` read narrows the list, the
+   * histogram and the facet counts together. See Utils/ExceptionQueryScope.
+   *
+   * Its `time` window is adopted as a pinned CUSTOM range, and — because the
+   * fingerprints were resolved INSIDE that window — the group query's own
+   * `lastSeenAt` clause is dropped while it is set. Keeping both would hide
+   * every exception still firing after the snapshot ended, which is the set
+   * an operator most needs to see.
+   */
+  exceptionInstanceQuery?: Query<ExceptionInstance> | undefined;
+  /*
+   * Initial page size. Embedded snapshot cards pass a small number so the
+   * block does not run the length of the page.
+   */
+  limit?: number | undefined;
+  /** Empty-state copy, so an embed can name the window it searched. */
+  emptyMessage?: string | undefined;
+  /*
+   * Embedded hosts own the page URL: when true the viewer neither seeds from
+   * nor mirrors state to the query string. Same polarity as TracesViewer's
+   * prop of this name.
+   */
+  disableUrlSync?: boolean | undefined;
 }
 
 const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
   props: ExceptionsViewerProps,
 ): ReactElement => {
   /*
+   * The host's stored exception-instance query, read once into the instance
+   * scope this viewer resolves fingerprints from. See
+   * Utils/ExceptionQueryScope.
+   */
+  const hostScope: ExceptionQueryScope = useMemo(() => {
+    return buildExceptionQueryScope(props.exceptionInstanceQuery);
+  }, [props.exceptionInstanceQuery]);
+
+  /*
+   * The window the monitor evaluated over, as a picker value. Always CUSTOM,
+   * so live re-anchoring cannot walk it forward off the event.
+   */
+  const pinnedTimeRange: RangeStartAndEndDateTime | null = useMemo(() => {
+    return TelemetryQueryTimeRange.toRangeStartAndEndDateTime(hostScope.window);
+  }, [hostScope.window]);
+
+  /*
+   * Whether the HOST, not the URL, owns what this view shows: do not seed
+   * from the query string, and do not write back to it. An embed on an
+   * incident page would otherwise rewrite that page's address bar, and the
+   * user would come back from an exception to `?search=…&range=…&status=…`
+   * hanging off the incident.
+   */
+  const hostOwnsView: boolean = Boolean(
+    props.disableUrlSync || props.exceptionInstanceQuery,
+  );
+
+  /*
    * Parse filter state from the URL once on first mount so refresh and
    * back-from-exception-detail restore the view.
    */
-  const initialUrlState: InitialUrlState = useMemo(readInitialUrlState, []);
+  const initialUrlState: InitialUrlState = useMemo((): InitialUrlState => {
+    if (hostOwnsView) {
+      return {
+        search: "",
+        filters: [],
+        timeRange: pinnedTimeRange || { range: TimeRange.PAST_ONE_DAY },
+        page: 1,
+        pageSize: props.limit || DEFAULT_PAGE_SIZE,
+        status: null,
+        classScope: null,
+      };
+    }
+
+    /*
+     * Seeded once on mount, exactly as the bare `useMemo(readInitialUrlState,
+     * [])` this replaced: it is a seed, not a derivation. A later render must
+     * not recompute it, or a host rebuilding its query would keep yanking the
+     * user back to the pin.
+     */
+    return readInitialUrlState();
+  }, []);
 
   const defaultStatus: ExceptionStatus = props.defaultStatus || "unresolved";
 
@@ -409,7 +500,9 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
   );
 
   const [classScope, setClassScope] = useState<ExceptionClassScope>(
-    initialUrlState.classScope || DEFAULT_EXCEPTION_CLASS_SCOPE,
+    initialUrlState.classScope ||
+      props.defaultClassScope ||
+      DEFAULT_EXCEPTION_CLASS_SCOPE,
   );
 
   const [exceptions, setExceptions] = useState<Array<TelemetryException>>([]);
@@ -486,6 +579,15 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
    * tweaks don't push extra entries.
    */
   useEffect(() => {
+    /*
+     * An embedded viewer must not rewrite its host page's address bar. Left
+     * on, an incident page would grow `?search=…&range=…&status=…` the moment
+     * this mounted, and the user would land back on that URL from Back.
+     */
+    if (hostOwnsView) {
+      return;
+    }
+
     const params: URLSearchParams = new URLSearchParams();
     if (submittedSearch) {
       params.set("search", submittedSearch);
@@ -534,6 +636,7 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
       class: classScope === DEFAULT_EXCEPTION_CLASS_SCOPE ? null : classScope,
     });
   }, [
+    hostOwnsView,
     submittedSearch,
     activeFilters,
     timeRange,
@@ -942,15 +1045,40 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
       ];
     }
 
-    return {
+    const userScope: ExceptionInstanceScope = {
       attributeSelections: getExceptionAttributeSelections({ facetGroups }),
       attributePredicates,
       columnPredicates,
     };
-  }, [facetGroups, parsedSearch, searchFieldFilters, resolvedServices]);
+
+    /*
+     * ANDed with the host's stored scope, not layered over it: an incident
+     * whose monitor matched `exceptionType IN (...)` still means that when
+     * the user adds a chip. The merge concatenates per-key predicate lists,
+     * which is what makes the two filters intersect rather than the later
+     * one silently replacing the earlier.
+     */
+    return hostScope.hasScope
+      ? mergeExceptionInstanceScopes(hostScope.instanceScope, userScope)
+      : userScope;
+  }, [
+    facetGroups,
+    parsedSearch,
+    searchFieldFilters,
+    resolvedServices,
+    hostScope,
+  ]);
 
   const instanceScopeKey: string | null = useMemo(() => {
-    if (!hasExceptionInstanceScope(instanceScope)) {
+    /*
+     * A hosted view ALWAYS resolves, even with nothing to filter on. The very
+     * common "any exception in the last 60 seconds" monitor stores only its
+     * window, and the window is the scope: the groups to show are the ones
+     * that OCCURRED in it. Falling back to the group query's `lastSeenAt`
+     * would answer a different question — where each group was last seen
+     * anywhere — and silently drop every exception still firing.
+     */
+    if (!hasExceptionInstanceScope(instanceScope) && !hostScope.isHosted) {
       return null;
     }
     const dateRange: InBetween<Date> =
@@ -960,7 +1088,7 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
       windowStartMs: dateRange.startValue.getTime(),
       windowEndMs: dateRange.endValue.getTime(),
     });
-  }, [instanceScope, timeRange]);
+  }, [instanceScope, timeRange, hostScope.isHosted]);
 
   const [scopeResolution, setScopeResolution] = useState<{
     key: string;
@@ -1050,6 +1178,17 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
     instanceScopeKey && scopeResolution?.key === instanceScopeKey
       ? scopeResolution.fingerprints
       : null;
+
+  /*
+   * While the fingerprints for the CURRENT scope are still in flight the list
+   * query carries the no-match sentinel, so it comes back empty by design —
+   * showing more would be a lie. But rendering that as the empty STATE is a
+   * different lie: an incident card would flash "No exceptions found" and
+   * then fill in. Report it as loading instead.
+   */
+  const isResolvingScope: boolean = Boolean(
+    instanceScopeKey && scopeResolution?.key !== instanceScopeKey,
+  );
 
   const query: Query<TelemetryException> = useMemo(() => {
     const q: Query<TelemetryException> = {};
@@ -1144,13 +1283,23 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
     /*
      * Scope the list by the selected time range using lastSeenAt so the
      * viewer + histogram share the same window.
+     *
+     * NOT when a host pinned an instance query. The fingerprints below were
+     * resolved from instances INSIDE the window, so the group set is already
+     * window-correct — and `lastSeenAt` is the group's LAST occurrence
+     * anywhere, which for an exception still firing after the snapshot ended
+     * sits past the window. ANDing both would drop exactly the exceptions an
+     * operator opens an incident to find, and drop them silently: the list
+     * would read "No exceptions found".
      */
-    const dateRange: InBetween<Date> =
-      RangeStartAndEndDateTimeUtil.getStartAndEndDate(timeRange);
-    (q as Record<string, unknown>)["lastSeenAt"] = new InBetween<Date>(
-      dateRange.startValue,
-      dateRange.endValue,
-    );
+    if (!hostScope.isHosted) {
+      const dateRange: InBetween<Date> =
+        RangeStartAndEndDateTimeUtil.getStartAndEndDate(timeRange);
+      (q as Record<string, unknown>)["lastSeenAt"] = new InBetween<Date>(
+        dateRange.startValue,
+        dateRange.endValue,
+      );
+    }
 
     /*
      * Instance scope: resolved fingerprints narrow the list; while the
@@ -1172,6 +1321,7 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
     resolvedServices,
     parsedSearch,
     timeRange,
+    hostScope,
     instanceScopeKey,
     resolvedScopeFingerprints,
   ]);
@@ -1726,8 +1876,24 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
         }),
       );
     }
+    /*
+     * The host's stored scope, as chips the user can see but not remove — a
+     * snapshot that filters silently makes a short list look like the whole
+     * truth.
+     */
+    for (const chip of hostScope.chips) {
+      base.push(
+        resolveDisplay({
+          facetKey: chip.facetKey,
+          value: chip.value,
+          displayKey: chip.displayKey,
+          displayValue: chip.displayValue,
+          readOnly: true,
+        }),
+      );
+    }
     return [...base, ...activeFilters.map(resolveDisplay)];
-  }, [props.primaryEntityId, activeFilters, facetConfigs]);
+  }, [props.primaryEntityId, hostScope, activeFilters, facetConfigs]);
 
   // Row click → navigate to exception detail
   const handleRowClick: (exception: TelemetryException) => void = useCallback(
@@ -1890,13 +2056,13 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
   return (
     <TelemetryViewer<TelemetryException>
       items={exceptions}
-      isLoading={isLoading}
+      isLoading={isLoading || isResolvingScope}
       error={error || undefined}
       onRefresh={() => {
         void fetchExceptions();
         void fetchHistogram();
       }}
-      emptyMessage="No exceptions found"
+      emptyMessage={props.emptyMessage || "No exceptions found"}
       itemLabel="exceptions"
       renderRow={(exception: TelemetryException): ReactElement => {
         const service: Service | undefined = exception.primaryEntityId

--- a/App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetryCompanionSignalTabs.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetryCompanionSignalTabs.tsx
@@ -29,8 +29,8 @@ import AnalyticsModelAPI, {
 import API from "Common/UI/Utils/API/API";
 import ProjectUtil from "Common/UI/Utils/Project";
 import DashboardLogsViewer from "../Logs/LogsViewer";
-import TraceTable from "../Traces/TraceTable";
-import ExceptionInstanceTable from "../Exceptions/ExceptionInstanceTable";
+import TracesViewer from "../Traces/TracesViewer";
+import ExceptionsViewer from "../Exceptions/ExceptionsViewer";
 import EmbeddedMetricCard from "../Metrics/EmbeddedMetricCard";
 import useServiceNames from "./useServiceNames";
 import {
@@ -144,6 +144,7 @@ const CompanionLogsTab: FunctionComponent<CompanionLogsTabProps> = (
 interface CompanionTracesTabProps {
   spec: CompanionTracesSpec;
   snapshotWindowAlert?: ReactElement | undefined;
+  eventNoun: string;
 }
 
 const CompanionTracesTab: FunctionComponent<CompanionTracesTabProps> = (
@@ -152,13 +153,19 @@ const CompanionTracesTab: FunctionComponent<CompanionTracesTabProps> = (
   return (
     <div>
       <CompanionScopeHint notes={props.spec.notCarried} />
-      <TraceTable
-        spanQuery={props.spec.spanQuery}
+      <Card
+        title={"Spans"}
+        description={`Spans in this ${props.eventNoun}'s telemetry scope during the snapshot window.`}
         rightElement={props.snapshotWindowAlert}
-        // Pinned to the snapshot; a URL-restored filter must not replace it.
-        disableUrlState={true}
-        noItemsMessage="No spans found in the snapshot window."
-      />
+      >
+        <TracesViewer
+          spanQuery={props.spec.spanQuery}
+          limit={10}
+          // Pinned to the snapshot; the host page owns the URL.
+          disableUrlSync={true}
+          emptyMessage="No spans found in the snapshot window."
+        />
+      </Card>
     </div>
   );
 };
@@ -175,14 +182,25 @@ const CompanionExceptionsTab: FunctionComponent<CompanionExceptionsTabProps> = (
   return (
     <div>
       <CompanionScopeHint notes={props.spec.notCarried} />
-      <ExceptionInstanceTable
-        title="Exceptions"
+      <Card
+        title={"Exceptions"}
         description={`Exceptions in this ${props.eventNoun}'s telemetry scope during the snapshot window.`}
-        query={props.spec.exceptionQuery}
         rightElement={props.snapshotWindowAlert}
-        // Pinned to the snapshot; a URL-restored filter must not replace it.
-        disableUrlState={true}
-      />
+      >
+        <ExceptionsViewer
+          exceptionInstanceQuery={props.spec.exceptionQuery}
+          /*
+           * An event shows the exceptions it fired on, whoever has since
+           * resolved them and whatever the classifier made of them.
+           */
+          defaultStatus="all"
+          defaultClassScope="all"
+          limit={10}
+          // Pinned to the snapshot; the host page owns the URL.
+          disableUrlSync={true}
+          emptyMessage="No exceptions found in the snapshot window."
+        />
+      </Card>
     </div>
   );
 };
@@ -460,6 +478,7 @@ const TelemetryCompanionSignalTabs: FunctionComponent<ComponentProps> = (
             <CompanionTracesTab
               spec={companions.traces}
               snapshotWindowAlert={props.snapshotWindowAlert}
+              eventNoun={props.eventNoun}
             />
           ),
         });

--- a/App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetrySnapshotPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetrySnapshotPanel.tsx
@@ -9,9 +9,9 @@ import Log from "Common/Models/AnalyticsModels/Log";
 import Span from "Common/Models/AnalyticsModels/Span";
 import Card from "Common/UI/Components/Card/Card";
 import DashboardLogsViewer from "../Logs/LogsViewer";
-import ExceptionInstanceTable from "../Exceptions/ExceptionInstanceTable";
+import ExceptionsViewer from "../Exceptions/ExceptionsViewer";
 import MetricView from "../Metrics/MetricView";
-import TraceTable from "../Traces/TraceTable";
+import TracesViewer from "../Traces/TracesViewer";
 import TelemetryCompanionSignalTabs from "./TelemetryCompanionSignalTabs";
 import TelemetrySnapshotWindowAlert from "./TelemetrySnapshotWindowAlert";
 
@@ -79,12 +79,22 @@ const TelemetrySnapshotPanel: FunctionComponent<ComponentProps> = (
           {telemetryQuery.telemetryType === TelemetryType.Trace &&
             telemetryQuery.telemetryQuery && (
               <div>
-                <TraceTable
-                  spanQuery={telemetryQuery.telemetryQuery as Query<Span>}
+                <Card
+                  title={"Spans"}
+                  description={`Spans for this ${eventNoun}.`}
                   rightElement={snapshotWindowAlert}
-                  // Pinned to the snapshot; a URL-restored filter must not replace it.
-                  disableUrlState={true}
-                />
+                >
+                  <TracesViewer
+                    spanQuery={telemetryQuery.telemetryQuery as Query<Span>}
+                    limit={10}
+                    /*
+                     * Pinned to the snapshot: the host page owns the URL, so the
+                     * viewer neither reads a filter out of it nor writes back.
+                     */
+                    disableUrlSync={true}
+                    emptyMessage="No spans found"
+                  />
+                </Card>
               </div>
             )}
 
@@ -115,16 +125,27 @@ const TelemetrySnapshotPanel: FunctionComponent<ComponentProps> = (
 
           {telemetryQuery.telemetryType === TelemetryType.Exception &&
             telemetryQuery.telemetryQuery && (
-              <ExceptionInstanceTable
-                title="Exceptions"
+              <Card
+                title={"Exceptions"}
                 description={`Exceptions related to this ${eventNoun}.`}
-                query={
-                  telemetryQuery.telemetryQuery as Query<ExceptionInstance>
-                }
                 rightElement={snapshotWindowAlert}
-                // Pinned to the snapshot; a URL-restored filter must not replace it.
-                disableUrlState={true}
-              />
+              >
+                <ExceptionsViewer
+                  exceptionInstanceQuery={
+                    telemetryQuery.telemetryQuery as Query<ExceptionInstance>
+                  }
+                  /*
+                   * An event shows the exceptions it fired on, whoever has since
+                   * resolved them and whatever the classifier made of them.
+                   */
+                  defaultStatus="all"
+                  defaultClassScope="all"
+                  limit={10}
+                  // Pinned to the snapshot; the host page owns the URL.
+                  disableUrlSync={true}
+                  emptyMessage="No exceptions found"
+                />
+              </Card>
             )}
         </Fragment>
       }

--- a/App/FeatureSet/Dashboard/src/Components/Traces/TracesViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Traces/TracesViewer.tsx
@@ -83,6 +83,12 @@ import TraceRecordingRuleDefinition, {
   TraceRecordingRuleAttributeFilter,
 } from "Common/Types/Trace/TraceRecordingRuleDefinition";
 import { writeTelemetryViewerUrlState } from "../../Utils/TelemetryViewerUrlState";
+import {
+  SpanQueryScope,
+  SpanScopeChip,
+  buildSpanQueryScope,
+} from "../../Utils/SpanQueryScope";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
 import { buildUrlScopeOverrides } from "../../Utils/InitialSavedView";
 import Icon from "Common/UI/Components/Icon/Icon";
 import IconProp from "Common/Types/Icon/IconProp";
@@ -498,9 +504,62 @@ interface Props {
    * for incident embeds. Standalone explorer pages leave this unset.
    */
   disableUrlSync?: boolean | undefined;
+  /*
+   * A STORED span query to host — the slice a trace monitor evaluated, kept
+   * on the incident / alert row. This is the traces counterpart of the logs
+   * viewer's `logQuery`: the query's filters become a read-only scope on the
+   * list, the histogram and the facets alike (one reading, in
+   * buildSpanQueryScope, so the chart cannot count rows the list excludes),
+   * and its `startTime` window is adopted as a pinned CUSTOM range so the
+   * view describes the moment the monitor fired rather than the past hour.
+   *
+   * A query with a window makes the host the owner of the view: the URL is
+   * not read, and the project's default saved view does not auto-apply over
+   * the pin.
+   */
+  spanQuery?: Query<Span> | undefined;
+  /*
+   * Initial page size. Embedded snapshot cards pass a small number (the logs
+   * embed uses 10) so the block does not run the length of the page; the
+   * user can still change it in the pagination footer.
+   */
+  limit?: number | undefined;
+  /** Empty-state copy, so an embed can name the window it searched. */
+  emptyMessage?: string | undefined;
 }
 
 const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
+  /*
+   * The host's stored span query, read once into every vocabulary the viewer
+   * speaks. See Utils/SpanQueryScope — the single reading is what keeps the
+   * list, the histogram and the facet counts describing the same rows.
+   */
+  const spanScope: SpanQueryScope = useMemo(() => {
+    return buildSpanQueryScope(props.spanQuery);
+  }, [props.spanQuery]);
+
+  /*
+   * The window the monitor evaluated over, as a picker value. Always CUSTOM
+   * (see TelemetryQueryTimeRange): the window is an absolute instant in the
+   * past and must never re-anchor to "now" the way a relative range does —
+   * the failure that renders the last hour of unrelated spans under an
+   * incident's heading.
+   */
+  const pinnedTimeRange: RangeStartAndEndDateTime | null = useMemo(() => {
+    return TelemetryQueryTimeRange.toRangeStartAndEndDateTime(spanScope.window);
+  }, [spanScope.window]);
+
+  /*
+   * Whether the HOST, not the URL, owns what this view shows. A pinned
+   * window, a controlled window or an explicit opt-out all mean the same
+   * thing: do not seed from the query string, and do not let a default saved
+   * view apply itself over the host's scope a tick after mount. The logs
+   * viewer makes the identical guarantee for its incident embeds.
+   */
+  const hostOwnsView: boolean = Boolean(
+    props.disableUrlSync || props.spanQuery || props.timeRangeOverride,
+  );
+
   /*
    * Parse all filter state from the URL once on first mount. SpanViewer's
    * "filter by" action lands here with `?search=...` so users arrive with
@@ -512,19 +571,21 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
    * host page's query params are not this viewer's state.
    */
   const [initialUrlState] = useState<InitialUrlState>((): InitialUrlState => {
-    if (props.disableUrlSync) {
+    if (hostOwnsView) {
       return {
         search: "",
         filters: [],
-        timeRange: props.timeRangeOverride || {
-          range: TimeRange.PAST_ONE_HOUR,
-        },
+        timeRange: pinnedTimeRange ||
+          props.timeRangeOverride || {
+            range: TimeRange.PAST_ONE_HOUR,
+          },
         page: 1,
-        pageSize: DEFAULT_PAGE_SIZE,
+        pageSize: props.limit || DEFAULT_PAGE_SIZE,
         viewMode: "spans",
-        rootOnly: false,
+        // Host scope may pin it; a snapshot otherwise shows every span it matched.
+        rootOnly: spanScope.rootOnly,
         savedViewId: null,
-        hasRange: false,
+        hasRange: Boolean(pinnedTimeRange || props.timeRangeOverride),
       };
     }
     return readInitialUrlState();
@@ -580,8 +641,13 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
     Array<KubernetesCluster>
   >([]);
 
+  /*
+   * A pinned snapshot window outranks a controlled one and the URL: it
+   * describes the moment being investigated, not a window the user or a
+   * sibling view is steering.
+   */
   const [timeRange, setTimeRange] = useState<RangeStartAndEndDateTime>(
-    props.timeRangeOverride || initialUrlState.timeRange,
+    pinnedTimeRange || props.timeRangeOverride || initialUrlState.timeRange,
   );
 
   /*
@@ -600,6 +666,16 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
    * equal and is skipped, which is what breaks the feedback loop.
    */
   useEffect(() => {
+    /*
+     * A pin describes the moment being investigated; a controlled window is a
+     * sibling view steering. The pin wins, or a host that passes both would
+     * have the snapshot yanked off the event on mount while its window badge
+     * kept claiming the original.
+     */
+    if (pinnedTimeRange) {
+      return;
+    }
+
     if (
       !shouldAdoptTimeRangeOverride(
         props.timeRangeOverride,
@@ -610,7 +686,7 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
     }
     setTimeRange(props.timeRangeOverride!);
     setPage(1);
-  }, [props.timeRangeOverride]);
+  }, [props.timeRangeOverride, pinnedTimeRange]);
 
   const [searchValue, setSearchValue] = useState<string>(
     initialUrlState.search,
@@ -721,6 +797,84 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
 
     if (props.primaryEntityId) {
       query.primaryEntityId = props.primaryEntityId;
+    }
+
+    /*
+     * The host's stored span scope, written BEFORE the user's filters so a
+     * facet click or a typed token on the same column narrows within it
+     * rather than being overwritten by it — the same precedence
+     * `props.primaryEntityId` has always had. `attributes` is the documented
+     * exception: it rides compileTraceAttributeFilters' `scope`, which owns
+     * its keys outright. `entityKeys` is merged after the facets, with the
+     * entityKeysFilter prop.
+     */
+    for (const [key, value] of Object.entries(spanScope.passthrough)) {
+      (query as Record<string, unknown>)[key] = value;
+    }
+
+    if (spanScope.serviceIds.length > 0) {
+      (query as Record<string, unknown>)["primaryEntityId"] =
+        spanScope.serviceIds.length === 1
+          ? spanScope.serviceIds[0]!
+          : new Includes(spanScope.serviceIds);
+    }
+
+    if (spanScope.statusCodes.length > 0) {
+      (query as Record<string, unknown>)["statusCode"] =
+        spanScope.statusCodes.length === 1
+          ? spanScope.statusCodes[0]!
+          : new Includes(spanScope.statusCodes);
+    }
+
+    if (spanScope.spanKinds.length > 0) {
+      (query as Record<string, unknown>)["kind"] =
+        spanScope.spanKinds.length === 1
+          ? spanScope.spanKinds[0]!
+          : new Includes(spanScope.spanKinds);
+    }
+
+    if (spanScope.traceIds.length > 0) {
+      (query as Record<string, unknown>)["traceId"] =
+        spanScope.traceIds.length === 1
+          ? spanScope.traceIds[0]!
+          : new Includes(spanScope.traceIds);
+    }
+
+    if (spanScope.spanIds.length > 0) {
+      (query as Record<string, unknown>)["spanId"] =
+        spanScope.spanIds.length === 1
+          ? spanScope.spanIds[0]!
+          : new Includes(spanScope.spanIds);
+    }
+
+    if (spanScope.hasException !== null) {
+      (query as Record<string, unknown>)["hasException"] =
+        spanScope.hasException;
+    }
+
+    /*
+     * A single stored name is a SUBSTRING match, exactly as a single chip
+     * value is (TEXT_CHIP_FIELDS below) — a monitor stores `new Search(...)`,
+     * and exact-matching a fragment against a full span name returns nothing.
+     */
+    if (spanScope.spanNameSearch) {
+      (query as Record<string, unknown>)["name"] = new Search(
+        spanScope.spanNameSearch,
+      );
+    } else if (spanScope.spanNames.length > 0) {
+      (query as Record<string, unknown>)["name"] = new Includes(
+        spanScope.spanNames,
+      );
+    }
+
+    if (spanScope.statusMessageSearch) {
+      (query as Record<string, unknown>)["statusMessage"] = new Search(
+        spanScope.statusMessageSearch,
+      );
+    } else if (spanScope.statusMessages.length > 0) {
+      (query as Record<string, unknown>)["statusMessage"] = new Includes(
+        spanScope.statusMessages,
+      );
     }
 
     const dateRange: InBetween<Date> =
@@ -961,16 +1115,31 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
         chipValues: attributeChipValues,
         parsed: parsed.attributeFilters,
         legacyContainsChips: attributeSearchChips,
-        scope: props.attributeFilters || {},
+        scope: { ...(props.attributeFilters || {}), ...spanScope.attributes },
       });
-    if (Object.keys(attributeFilters.queryAttributes).length > 0) {
-      (query as Record<string, unknown>)["attributes"] =
-        attributeFilters.queryAttributes;
+    /*
+     * Attribute filters the scope reader could not model ride the LIST only:
+     * the analytics compiler understands more value shapes than the
+     * aggregation payload does, and a narrower list with a hint beats a list
+     * that quietly shows spans the monitor never matched. The widening of the
+     * chart is reported through spanScope.notCarried.
+     */
+    const queryAttributes: Record<string, unknown> = {
+      ...spanScope.attributesPassthrough,
+      ...attributeFilters.queryAttributes,
+    };
+    if (Object.keys(queryAttributes).length > 0) {
+      (query as Record<string, unknown>)["attributes"] = queryAttributes;
     }
 
-    if (props.entityKeysFilter && props.entityKeysFilter.length > 0) {
+    const scopedEntityKeys: Array<string> = [
+      ...(props.entityKeysFilter || []),
+      ...spanScope.entityKeys,
+    ];
+
+    if (scopedEntityKeys.length > 0) {
       (query as Record<string, unknown>)["entityKeys"] = new Includes(
-        props.entityKeysFilter,
+        Array.from(new Set(scopedEntityKeys)),
       );
     }
 
@@ -985,6 +1154,7 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
     props.attributeFilters,
     props.entityKeysFilter,
     props.entityScope,
+    spanScope,
     timeRange,
     activeFilters,
     submittedSearch,
@@ -1016,7 +1186,13 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
    * link from before this change.
    */
   useEffect(() => {
-    if (props.disableUrlSync) {
+    /*
+     * hostOwnsView, not disableUrlSync alone: a host that pins a query or a
+     * window owns the address bar just as much as one that opted out by name,
+     * and an embed writing `?search=…&range=…` onto an incident page is the
+     * URL the user comes back to from Back.
+     */
+    if (hostOwnsView) {
       return;
     }
     const params: URLSearchParams = new URLSearchParams();
@@ -1061,7 +1237,7 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
 
     writeTelemetryViewerUrlState(Object.fromEntries(params.entries()));
   }, [
-    props.disableUrlSync,
+    hostOwnsView,
     submittedSearch,
     activeFilters,
     timeRange,
@@ -1330,7 +1506,7 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
         chipValues: attributeChipValues,
         parsed: parsed.attributeFilters,
         legacyContainsChips: attributeSearchChips,
-        scope: props.attributeFilters || {},
+        scope: { ...(props.attributeFilters || {}), ...spanScope.attributes },
       });
     if (Object.keys(attributeFilters.payloadAttributes).length > 0) {
       payload["attributes"] = attributeFilters.payloadAttributes;
@@ -1343,16 +1519,72 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
      * Entity scope must constrain the histogram/facets too, not just the
      * span list — otherwise the counts above the list are project-wide.
      */
-    if (props.entityKeysFilter && props.entityKeysFilter.length > 0) {
-      payload["entityKeys"] = [...props.entityKeysFilter];
+    const scopedEntityKeys: Array<string> = Array.from(
+      new Set([...(props.entityKeysFilter || []), ...spanScope.entityKeys]),
+    );
+
+    if (scopedEntityKeys.length > 0) {
+      payload["entityKeys"] = scopedEntityKeys;
     }
 
-    // Scope by primaryEntityId prop if present
-    if (props.primaryEntityId) {
-      if (!groups["primaryEntityId"]) {
-        groups["primaryEntityId"] = [];
+    /*
+     * The host's stored span scope, seeded into the SAME groups the chips and
+     * search tokens feed — and only where the user has not filtered that
+     * column. That reproduces the list's precedence exactly: there the scope
+     * is written first and an explicit selection overwrites it. Reading the
+     * scope once, in buildSpanQueryScope, and rendering it into both
+     * transports from that one reading is what stops the chart above the list
+     * counting rows the list excludes.
+     *
+     * The `primaryEntityId` PROP goes through the same gate, last, so the
+     * three-way precedence — user selection, then stored scope, then the host
+     * page's own resource — is the one the list applies rather than a union
+     * of all three.
+     */
+    const applyScopeGroup: (key: string, values: Array<string>) => void = (
+      key: string,
+      values: Array<string>,
+    ): void => {
+      if (values.length === 0) {
+        return;
       }
-      groups["primaryEntityId"]!.push(props.primaryEntityId.toString());
+
+      if (groups[key] && groups[key]!.length > 0) {
+        return;
+      }
+
+      groups[key] = [...values];
+    };
+
+    applyScopeGroup("primaryEntityId", spanScope.serviceIds);
+    applyScopeGroup(
+      "statusCode",
+      spanScope.statusCodes.map((statusCode: number): string => {
+        return String(statusCode);
+      }),
+    );
+    applyScopeGroup("kind", spanScope.spanKinds);
+    applyScopeGroup("traceId", spanScope.traceIds);
+    applyScopeGroup("spanId", spanScope.spanIds);
+    applyScopeGroup(
+      "name",
+      spanScope.spanNameSearch
+        ? [spanScope.spanNameSearch]
+        : spanScope.spanNames,
+    );
+    applyScopeGroup(
+      "statusMessage",
+      spanScope.statusMessageSearch
+        ? [spanScope.statusMessageSearch]
+        : spanScope.statusMessages,
+    );
+
+    if (spanScope.hasException !== null) {
+      applyScopeGroup("hasException", [String(spanScope.hasException)]);
+    }
+
+    if (props.primaryEntityId) {
+      applyScopeGroup("primaryEntityId", [props.primaryEntityId.toString()]);
     }
 
     /*
@@ -1466,7 +1698,19 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
       }
     }
 
-    if (freeText && freeText.length > 0) {
+    /*
+     * Bare free text matches span names as a substring — but ONLY when
+     * nothing else has claimed the name column, which is exactly the rule the
+     * list applies (`Query<Span>` holds one predicate per column, so an
+     * explicit name filter wins there). Sending it unconditionally used to
+     * make the chart narrower than the list; with a stored scope pinning
+     * `name` that stopped being an edge case, so the two now agree.
+     */
+    if (
+      freeText &&
+      freeText.length > 0 &&
+      !(groups["name"] && groups["name"].length > 0)
+    ) {
       payload["nameSearchText"] = freeText;
     }
 
@@ -1478,6 +1722,7 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
     props.primaryEntityId,
     props.attributeFilters,
     props.entityKeysFilter,
+    spanScope,
     rootOnly,
   ]);
 
@@ -2027,6 +2272,60 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
         }),
       );
     }
+    /*
+     * The host's stored scope, as chips the user can see but not remove. A
+     * snapshot that filters silently is the thing that makes a short list
+     * look like the whole truth.
+     *
+     * A column the user has since filtered themselves is skipped: on that
+     * column their selection REPLACES the scope (drill-down, the precedence
+     * `primaryEntityId` has always had), so leaving the scope's chip up would
+     * show a filter the query no longer applies. The exceptions viewer needs
+     * no such rule — there the two AND together.
+     */
+    const userFilteredFacetKeys: Set<string> = new Set<string>(
+      activeFilters.map((filter: ActiveFilter): string => {
+        return filter.facetKey;
+      }),
+    );
+
+    /*
+     * Chips are not the only way a user claims a column. `status:`, `kind:`
+     * and `duration:` — and any value carrying grammar (a wildcard, a
+     * negation, a range) — deliberately do NOT become chips
+     * (resolveTraceSearchChip returns null, and the search bar leaves the
+     * token in the input); they live in the submitted search string and are
+     * folded into the same overwrite path by MERGED_CHIP_FIELDS. Reading
+     * only `activeFilters` would leave the scope's chip on screen while a
+     * typed `status:ok` had already replaced it in the query.
+     */
+    const typedSearch: ParsedTraceSearch = parseTraceSearch(submittedSearch);
+
+    for (const fieldKey of Object.keys(typedSearch.fieldFilters)) {
+      userFilteredFacetKeys.add(fieldKey);
+    }
+
+    for (const attributeFilter of typedSearch.attributeFilters) {
+      userFilteredFacetKeys.add(
+        `${ATTRIBUTE_CHIP_PREFIX}${attributeFilter.key}`,
+      );
+    }
+
+    for (const chip of spanScope.chips as Array<SpanScopeChip>) {
+      if (userFilteredFacetKeys.has(chip.facetKey)) {
+        continue;
+      }
+
+      base.push(
+        resolveDisplay({
+          facetKey: chip.facetKey,
+          value: chip.value,
+          displayKey: chip.displayKey,
+          displayValue: chip.displayValue,
+          readOnly: true,
+        }),
+      );
+    }
     if (props.attributeFilters) {
       for (const [key, value] of Object.entries(props.attributeFilters)) {
         if (!value) {
@@ -2066,7 +2365,9 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
     props.primaryEntityId,
     props.attributeFilters,
     props.attributeFilterDisplayKeys,
+    spanScope,
     activeFilters,
+    submittedSearch,
     facetConfigs,
     rootOnly,
   ]);
@@ -2372,6 +2673,9 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
   const enableSavedViews: boolean =
     !props.primaryEntityId &&
     !props.entityScope &&
+    // A hosted view (a pinned incident snapshot, a controlled window) is not the user's to save over.
+    !hostOwnsView &&
+    !spanScope.hasScope &&
     (!props.attributeFilters ||
       Object.keys(props.attributeFilters).length === 0);
 
@@ -2383,12 +2687,21 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
    */
   const hasInitialUrlState: boolean = useMemo((): boolean => {
     return (
+      /*
+       * A host-owned view counts as scope of its own. Without this, an embed
+       * pinned to an incident's window would have the project's DEFAULT saved
+       * view auto-applied over the pin a tick after mount — the same defect
+       * the logs viewer guards against for its incident embeds. Belt and
+       * braces: `enableSavedViews` already hides the control for such hosts,
+       * so nothing would resolve a view at all.
+       */
+      hostOwnsView ||
       Boolean(props.timeRangeOverride) ||
       initialUrlState.search.length > 0 ||
       initialUrlState.filters.length > 0 ||
       initialUrlState.timeRange.range !== TimeRange.PAST_ONE_HOUR
     );
-  }, [initialUrlState, props.timeRangeOverride]);
+  }, [initialUrlState, props.timeRangeOverride, hostOwnsView]);
 
   // Capture the current explorer state for Save / Update of a saved view.
   const captureCurrentState: () => TelemetrySavedViewState =
@@ -2436,7 +2749,15 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
       setPage(1);
     }, []);
 
-  return (
+  /*
+   * The half of the host's scope the aggregation payload cannot express. The
+   * list applies it, the chart and the facet counts above the list do not, so
+   * it is named on screen — the module computes it precisely so this never
+   * has to be silent.
+   */
+  const scopeHint: string = spanScope.notCarried.join(", ");
+
+  const viewer: ReactElement = (
     <TelemetryViewer<Span>
       items={spans}
       isLoading={isLoading}
@@ -2472,8 +2793,17 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
            * tooltip lists any filters the target grammar cannot express so
            * the narrowing is never silent.
            */}
+          {/*
+           * Hidden for a hosted snapshot: the pivots carry the chips and the
+           * window, not the host's stored scope, so from an incident card
+           * they would open the logs / metrics explorer project-wide under a
+           * button that promises "scoped like this view". The snapshot card
+           * already offers correctly-scoped Logs and Metrics tabs of its own.
+           */}
           <div
-            className="inline-flex items-center gap-0.5 rounded-lg border border-gray-200 bg-white p-0.5 shadow-sm"
+            className={`items-center gap-0.5 rounded-lg border border-gray-200 bg-white p-0.5 shadow-sm ${
+              props.spanQuery ? "hidden" : "inline-flex"
+            }`}
             aria-label="Related telemetry signals"
           >
             <Tooltip
@@ -2545,7 +2875,7 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
            */}
         </>
       }
-      emptyMessage="No traces found"
+      emptyMessage={props.emptyMessage || "No traces found"}
       itemLabel="traces"
       renderRow={(span: Span): ReactElement => {
         const service: Service | undefined = span.primaryEntityId
@@ -2736,6 +3066,19 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
         setPage(1);
       }}
     />
+  );
+
+  if (!scopeHint) {
+    return viewer;
+  }
+
+  return (
+    <div className="flex min-h-0 w-full flex-1 flex-col gap-3">
+      <div className="text-xs text-gray-500">
+        {`The chart and facet counts above are not narrowed by: ${scopeHint}. The list is.`}
+      </div>
+      {viewer}
+    </div>
   );
 };
 

--- a/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
@@ -37,7 +37,7 @@ import Card from "Common/UI/Components/Card/Card";
 import DashboardLogsViewer from "../../../Components/Logs/LogsViewer";
 import TelemetryType from "Common/Types/Telemetry/TelemetryType";
 import JSONFunctions from "Common/Types/JSONFunctions";
-import TraceTable from "../../../Components/Traces/TraceTable";
+import TracesViewer from "../../../Components/Traces/TracesViewer";
 import MonitorElement from "../../../Components/Monitor/Monitor";
 import AffectedResourcesDisplay from "../../../Components/AffectedResources/AffectedResourcesDisplay";
 import AffectedResourcesPicker, {
@@ -71,7 +71,7 @@ import EntityRunbooks from "../../../Components/Runbook/EntityRunbooks";
 import RemediationSuggestionCard from "../../../Components/AutoRemediation/RemediationSuggestionCard";
 import AlertAffectedResources from "./AffectedResources";
 import MonitorSummarySnapshotCard from "../../../Components/Monitor/MonitorSummarySnapshotCard";
-import ExceptionInstanceTable from "../../../Components/Exceptions/ExceptionInstanceTable";
+import ExceptionsViewer from "../../../Components/Exceptions/ExceptionsViewer";
 import Query from "Common/Types/BaseDatabase/Query";
 import ExceptionInstance from "Common/Models/AnalyticsModels/ExceptionInstance";
 import Span from "Common/Models/AnalyticsModels/Span";
@@ -487,14 +487,25 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
                   {telemetryQuery.telemetryType === TelemetryType.Trace &&
                     telemetryQuery.telemetryQuery && (
                       <div>
-                        <TraceTable
-                          spanQuery={
-                            telemetryQuery.telemetryQuery as Query<Span>
-                          }
+                        <Card
+                          title={"Spans"}
+                          description={"Spans for this alert."}
                           rightElement={snapshotWindowAlert}
-                          // Pinned to the snapshot; a URL-restored filter must not replace it.
-                          disableUrlState={true}
-                        />
+                        >
+                          <TracesViewer
+                            spanQuery={
+                              telemetryQuery.telemetryQuery as Query<Span>
+                            }
+                            limit={10}
+                            /*
+                             * Pinned to the snapshot: this page owns the URL,
+                             * so the viewer neither reads a filter out of it
+                             * nor writes its own state back into it.
+                             */
+                            disableUrlSync={true}
+                            emptyMessage="No spans found"
+                          />
+                        </Card>
                       </div>
                     )}
 
@@ -525,16 +536,30 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
 
                   {telemetryQuery.telemetryType === TelemetryType.Exception &&
                     telemetryQuery.telemetryQuery && (
-                      <ExceptionInstanceTable
-                        title="Exceptions"
-                        description="Exceptions for this alert."
-                        query={
-                          telemetryQuery.telemetryQuery as Query<ExceptionInstance>
-                        }
+                      <Card
+                        title={"Exceptions"}
+                        description={"Exceptions for this alert."}
                         rightElement={snapshotWindowAlert}
-                        // Pinned to the snapshot; a URL-restored filter must not replace it.
-                        disableUrlState={true}
-                      />
+                      >
+                        <ExceptionsViewer
+                          exceptionInstanceQuery={
+                            telemetryQuery.telemetryQuery as Query<ExceptionInstance>
+                          }
+                          /*
+                           * An event shows the exceptions it fired on,
+                           * whoever has since resolved them and whatever the
+                           * classifier made of them — the explorer's
+                           * "unresolved issues" defaults would hide exactly
+                           * those.
+                           */
+                          defaultStatus="all"
+                          defaultClassScope="all"
+                          limit={10}
+                          // Pinned to the snapshot; this page owns the URL.
+                          disableUrlSync={true}
+                          emptyMessage="No exceptions found"
+                        />
+                      </Card>
                     )}
                 </Fragment>
               }

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
@@ -39,7 +39,7 @@ import Card from "Common/UI/Components/Card/Card";
 import DashboardLogsViewer from "../../../Components/Logs/LogsViewer";
 import TelemetryType from "Common/Types/Telemetry/TelemetryType";
 import JSONFunctions from "Common/Types/JSONFunctions";
-import TraceTable from "../../../Components/Traces/TraceTable";
+import TracesViewer from "../../../Components/Traces/TracesViewer";
 import { TelemetryQuery } from "Common/Types/Telemetry/TelemetryQuery";
 import MetricView from "../../../Components/Metrics/MetricView";
 import MetricViewData from "Common/Types/Metrics/MetricViewData";
@@ -74,7 +74,7 @@ import FormValues from "Common/UI/Components/Forms/Types/FormValues";
 import { CustomElementProps } from "Common/UI/Components/Forms/Types/Field";
 import MonitorStatus from "Common/Models/DatabaseModels/MonitorStatus";
 import StatusPageSubscriberNotificationStatus from "Common/Types/StatusPage/StatusPageSubscriberNotificationStatus";
-import ExceptionInstanceTable from "../../../Components/Exceptions/ExceptionInstanceTable";
+import ExceptionsViewer from "../../../Components/Exceptions/ExceptionsViewer";
 import Query from "Common/Types/BaseDatabase/Query";
 import Span from "Common/Models/AnalyticsModels/Span";
 import Log from "Common/Models/AnalyticsModels/Log";
@@ -542,14 +542,25 @@ const IncidentView: FunctionComponent<
                   {telemetryQuery.telemetryType === TelemetryType.Trace &&
                     telemetryQuery.telemetryQuery && (
                       <div>
-                        <TraceTable
-                          spanQuery={
-                            telemetryQuery.telemetryQuery as Query<Span>
-                          }
+                        <Card
+                          title={"Spans"}
+                          description={"Spans for this incident."}
                           rightElement={snapshotWindowAlert}
-                          // Pinned to the snapshot; a URL-restored filter must not replace it.
-                          disableUrlState={true}
-                        />
+                        >
+                          <TracesViewer
+                            spanQuery={
+                              telemetryQuery.telemetryQuery as Query<Span>
+                            }
+                            limit={10}
+                            /*
+                             * Pinned to the snapshot: this page owns the URL,
+                             * so the viewer neither reads a filter out of it
+                             * nor writes its own state back into it.
+                             */
+                            disableUrlSync={true}
+                            emptyMessage="No spans found"
+                          />
+                        </Card>
                       </div>
                     )}
 
@@ -580,16 +591,30 @@ const IncidentView: FunctionComponent<
 
                   {telemetryQuery.telemetryType === TelemetryType.Exception &&
                     telemetryQuery.telemetryQuery && (
-                      <ExceptionInstanceTable
-                        title="Exceptions"
-                        description="Exceptions related to this incident."
-                        query={
-                          telemetryQuery.telemetryQuery as Query<ExceptionInstance>
-                        }
+                      <Card
+                        title={"Exceptions"}
+                        description={"Exceptions related to this incident."}
                         rightElement={snapshotWindowAlert}
-                        // Pinned to the snapshot; a URL-restored filter must not replace it.
-                        disableUrlState={true}
-                      />
+                      >
+                        <ExceptionsViewer
+                          exceptionInstanceQuery={
+                            telemetryQuery.telemetryQuery as Query<ExceptionInstance>
+                          }
+                          /*
+                           * An event shows the exceptions it fired on,
+                           * whoever has since resolved them and whatever the
+                           * classifier made of them — the explorer's
+                           * "unresolved issues" defaults would hide exactly
+                           * those.
+                           */
+                          defaultStatus="all"
+                          defaultClassScope="all"
+                          limit={10}
+                          // Pinned to the snapshot; this page owns the URL.
+                          disableUrlSync={true}
+                          emptyMessage="No exceptions found"
+                        />
+                      </Card>
                     )}
                 </Fragment>
               }

--- a/App/FeatureSet/Dashboard/src/Utils/ExceptionQueryScope.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/ExceptionQueryScope.ts
@@ -1,0 +1,260 @@
+import Dictionary from "Common/Types/Dictionary";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import Query from "Common/Types/BaseDatabase/Query";
+import Search from "Common/Types/BaseDatabase/Search";
+import ExceptionInstance from "Common/Models/AnalyticsModels/ExceptionInstance";
+import TelemetryType from "Common/Types/Telemetry/TelemetryType";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
+import { JSONObject } from "Common/Types/JSON";
+import { SearchQueryValue } from "Common/Types/Telemetry/TelemetrySearchQuery";
+import { ExceptionInstanceScope } from "./ExceptionsAttributeScope";
+import {
+  TelemetryScopeAttributeValue,
+  getFilterAttributes,
+  getFilterSearchValue,
+  getFilterStringValues,
+  isEmptyFilterValue,
+} from "./TelemetryQueryFilterValues";
+
+/*
+ * Read a stored `Query<ExceptionInstance>` — the slice an exception monitor
+ * evaluated, kept on the incident / alert row — as an INSTANCE SCOPE the
+ * exceptions explorer can host.
+ *
+ * The awkward part of this signal is that the two surfaces list different
+ * rows. The stored query selects ClickHouse `ExceptionInstance` occurrences;
+ * the /exceptions page lists Postgres `TelemetryException` GROUPS. They are
+ * joined by `fingerprint` and nothing else — there is no foreign key, the
+ * hash is computed identically on both write paths, and it already folds in
+ * projectId + primaryEntityId so it cannot collide across services.
+ *
+ * `ExceptionsViewer` already owns that join: every filter it cannot express
+ * on the group row (attributes, any operator-carrying filter) is resolved
+ * against the instance table `GROUP BY fingerprint`, and the resulting
+ * fingerprints narrow the list, the histogram AND the facet counts together.
+ * So the right way to host an alert's exception query is to feed it into
+ * that same resolution rather than to bolt a second filter path onto the
+ * group query — which is also why this reader has no `notCarried`: whatever
+ * it puts on the instance query constrains all three surfaces at once.
+ *
+ * Pure, so App/Tests/Dashboard can exercise it against a real
+ * `MonitorStepExceptionMonitorUtil.toAnalyticsQuery` result without a
+ * renderer.
+ */
+
+export interface ExceptionScopeChip {
+  facetKey: string;
+  value: string;
+  displayKey: string;
+  displayValue: string;
+}
+
+export interface ExceptionQueryScope {
+  /** Merged into the viewer's own instance scope before fingerprint resolution. */
+  instanceScope: ExceptionInstanceScope;
+  /** The evaluation window, off `time`. Null when none was stored. */
+  window: InBetween<Date> | null;
+  chips: Array<ExceptionScopeChip>;
+  /** False when the query carried no column or attribute filter of its own. */
+  hasScope: boolean;
+  /**
+   * Whether a host handed over a query AT ALL — true even for the very common
+   * monitor that filters nothing and stores only its evaluation window.
+   *
+   * This is the flag the viewer must branch on, not `hasScope`. A window-only
+   * query still says something precise: "the exceptions that OCCURRED in this
+   * window". Answering it from the group row's `lastSeenAt` instead — the
+   * group's last occurrence ANYWHERE — silently drops every exception that is
+   * still firing, which on an incident page is the set the operator came for.
+   * So a hosted view always resolves its groups through the instance table,
+   * even with nothing else to filter on.
+   */
+  isHosted: boolean;
+}
+
+export const EMPTY_EXCEPTION_QUERY_SCOPE: ExceptionQueryScope = {
+  instanceScope: {
+    attributeSelections: {},
+    attributePredicates: {},
+    columnPredicates: {},
+  },
+  window: null,
+  chips: [],
+  hasScope: false,
+  isHosted: false,
+};
+
+/*
+ * Consumed by the reader itself: `projectId` is stamped by the resolution
+ * query and `time` becomes the pinned window rather than a filter.
+ */
+const CONSUMED_QUERY_KEYS: Set<string> = new Set<string>([
+  "projectId",
+  "time",
+  "attributes",
+]);
+
+/** Chip labels for the instance columns a stored query can carry. */
+const COLUMN_CHIP_LABELS: Dictionary<string> = {
+  primaryEntityId: "Service",
+  entityKeys: "Resource",
+  exceptionType: "Type",
+  message: "Message",
+  environment: "Environment",
+  release: "Release",
+  traceId: "Trace",
+  spanId: "Span",
+  sessionId: "Session",
+  fingerprint: "Fingerprint",
+  spanName: "Span Name",
+};
+
+/*
+ * Columns whose values are matched as a MEMBERSHIP rather than by equality.
+ * `entityKeys` is a ClickHouse array column, so an `Includes` on it compiles
+ * to `hasAny(entityKeys, [...])` — writing a bare string there would compare
+ * an array to a scalar and match nothing.
+ */
+const ARRAY_COLUMNS: Set<string> = new Set<string>(["entityKeys"]);
+
+function chipLabelForColumn(column: string): string {
+  return COLUMN_CHIP_LABELS[column] || column;
+}
+
+/**
+ * Read a stored exception-instance query as a viewer scope. A null /
+ * non-object query, or one that scopes nothing, yields
+ * `EMPTY_EXCEPTION_QUERY_SCOPE` — the viewer then behaves exactly as it does
+ * on the standalone /exceptions page.
+ */
+export function buildExceptionQueryScope(
+  query: Query<ExceptionInstance> | JSONObject | null | undefined,
+): ExceptionQueryScope {
+  if (!query || typeof query !== "object" || Array.isArray(query)) {
+    return EMPTY_EXCEPTION_QUERY_SCOPE;
+  }
+
+  const record: JSONObject = query as JSONObject;
+
+  /*
+   * An empty object is not a hosted query — it is a caller passing `{}`. Any
+   * key at all (in practice always at least `time`) means a host is scoping
+   * this view.
+   */
+  const isHosted: boolean = Object.keys(record).length > 0;
+
+  const attributePredicates: Dictionary<Array<SearchQueryValue>> = {};
+  const columnPredicates: Dictionary<Array<SearchQueryValue>> = {};
+  const columnQuery: Query<ExceptionInstance> = {};
+  const chips: Array<ExceptionScopeChip> = [];
+
+  const window: InBetween<Date> | null = TelemetryQueryTimeRange.getQueryWindow(
+    record,
+    TelemetryType.Exception,
+  );
+
+  const addChip: (
+    facetKey: string,
+    value: string,
+    displayKey: string,
+  ) => void = (facetKey: string, value: string, displayKey: string): void => {
+    chips.push({
+      facetKey: facetKey,
+      value: value,
+      displayKey: displayKey,
+      displayValue: value,
+    });
+  };
+
+  const attributes: Dictionary<TelemetryScopeAttributeValue> =
+    getFilterAttributes(record["attributes"]);
+
+  for (const [key, value] of Object.entries(attributes)) {
+    /*
+     * A scalar attribute compiles to the fast `attributes['k'] = 'v'` map
+     * subscript. Numbers and booleans are stringified because the attributes
+     * map is String -> String in ClickHouse; the monitor form writes them the
+     * same way.
+     */
+    attributePredicates[key] = [String(value)];
+    addChip(`attributes.${key}`, String(value), key);
+  }
+
+  if (
+    Object.keys(attributes).length === 0 &&
+    record["attributes"] !== undefined &&
+    record["attributes"] !== null
+  ) {
+    /*
+     * An attributes value we could not read is forwarded verbatim rather than
+     * dropped — the analytics compiler understands more shapes than this
+     * reader does, and a widened list under an incident heading is the bug
+     * this whole file exists to avoid.
+     */
+    (columnQuery as JSONObject)["attributes"] = record["attributes"] as never;
+  }
+
+  for (const key of Object.keys(record)) {
+    if (CONSUMED_QUERY_KEYS.has(key)) {
+      continue;
+    }
+
+    const raw: unknown = record[key];
+
+    if (raw === undefined || raw === null || isEmptyFilterValue(raw)) {
+      continue;
+    }
+
+    const search: string | null = getFilterSearchValue(raw);
+
+    if (search !== null) {
+      columnPredicates[key] = [new Search<string>(search)];
+      addChip(key, search, chipLabelForColumn(key));
+      continue;
+    }
+
+    const values: Array<string> = getFilterStringValues(raw);
+
+    if (values.length === 0) {
+      // Unreadable shape: forward it verbatim so the list stays narrow.
+      (columnQuery as JSONObject)[key] = raw as never;
+      continue;
+    }
+
+    columnPredicates[key] =
+      values.length === 1 && !ARRAY_COLUMNS.has(key)
+        ? [values[0]!]
+        : [new Includes(values)];
+
+    for (const value of values) {
+      addChip(key, value, chipLabelForColumn(key));
+    }
+  }
+
+  const hasScope: boolean =
+    Object.keys(attributePredicates).length > 0 ||
+    Object.keys(columnPredicates).length > 0 ||
+    Object.keys(columnQuery).length > 0;
+
+  if (!hasScope) {
+    return {
+      ...EMPTY_EXCEPTION_QUERY_SCOPE,
+      window: window,
+      isHosted: isHosted,
+    };
+  }
+
+  return {
+    instanceScope: {
+      attributeSelections: {},
+      attributePredicates: attributePredicates,
+      columnPredicates: columnPredicates,
+      columnQuery: columnQuery,
+    },
+    window: window,
+    chips: chips,
+    hasScope: true,
+    isHosted: isHosted,
+  };
+}

--- a/App/FeatureSet/Dashboard/src/Utils/ExceptionsAttributeScope.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/ExceptionsAttributeScope.ts
@@ -55,10 +55,9 @@ type ScopeValue = ScopePredicate | Array<ScopePredicate>;
 /**
  * Everything the ClickHouse instance query has to match.
  *
- * The three sources are kept apart because they arrive compiled
- * differently: chips carry the value as the user wrote it (grammar text,
- * compiled here), while search tokens arrive already compiled by the
- * parser.
+ * The sources are kept apart because they arrive compiled differently:
+ * chips carry the value as the user wrote it (grammar text, compiled here),
+ * while search tokens arrive already compiled by the parser.
  */
 export interface ExceptionInstanceScope {
   /** attribute key -> chip values, written in the search grammar. */
@@ -67,6 +66,109 @@ export interface ExceptionInstanceScope {
   attributePredicates: Dictionary<Array<SearchQueryValue>>;
   /** ExceptionInstance column -> predicates no other transport can carry. */
   columnPredicates: Dictionary<Array<SearchQueryValue>>;
+  /**
+   * Raw query fragment ANDed onto the instance query, for filter shapes this
+   * module's predicate vocabulary cannot describe. A host that scopes the
+   * viewer from a STORED query (the incident / alert snapshot) uses it as an
+   * escape hatch: the analytics compiler understands more value shapes than
+   * `SearchQueryValue` covers, and forwarding one verbatim keeps the list
+   * narrow where dropping it would quietly widen the list under an event's
+   * heading. Written before the window and projectId, which always win.
+   */
+  columnQuery?: Query<ExceptionInstance> | undefined;
+}
+
+/**
+ * AND two scopes together — a host-supplied scope (an incident's stored
+ * exception query) with the one the user built out of chips and search.
+ *
+ * Per-key predicate lists concatenate, which is what makes them AND: a host
+ * pinned to `exceptionType IN (...)` plus a typed `@type:Timeout*` matches
+ * instances satisfying both, rather than letting the later write silently
+ * replace the earlier one.
+ */
+export function mergeExceptionInstanceScopes(
+  base: ExceptionInstanceScope,
+  overlay: ExceptionInstanceScope,
+): ExceptionInstanceScope {
+  const mergeSelections: (
+    a: ExceptionAttributeSelections,
+    b: ExceptionAttributeSelections,
+  ) => ExceptionAttributeSelections = (
+    a: ExceptionAttributeSelections,
+    b: ExceptionAttributeSelections,
+  ): ExceptionAttributeSelections => {
+    const merged: ExceptionAttributeSelections = {};
+
+    for (const source of [a, b]) {
+      for (const key of Object.keys(source)) {
+        const values: Array<string> = source[key] || [];
+
+        if (values.length === 0) {
+          continue;
+        }
+
+        if (!merged[key]) {
+          merged[key] = [];
+        }
+
+        for (const value of values) {
+          if (!merged[key]!.includes(value)) {
+            merged[key]!.push(value);
+          }
+        }
+      }
+    }
+
+    return merged;
+  };
+
+  const mergePredicates: (
+    a: Dictionary<Array<SearchQueryValue>>,
+    b: Dictionary<Array<SearchQueryValue>>,
+  ) => Dictionary<Array<SearchQueryValue>> = (
+    a: Dictionary<Array<SearchQueryValue>>,
+    b: Dictionary<Array<SearchQueryValue>>,
+  ): Dictionary<Array<SearchQueryValue>> => {
+    const merged: Dictionary<Array<SearchQueryValue>> = {};
+
+    for (const source of [a, b]) {
+      for (const key of Object.keys(source)) {
+        const values: Array<SearchQueryValue> = source[key] || [];
+
+        if (values.length === 0) {
+          continue;
+        }
+
+        merged[key] = [...(merged[key] || []), ...values];
+      }
+    }
+
+    return merged;
+  };
+
+  const columnQuery: Query<ExceptionInstance> = {
+    ...(base.columnQuery || {}),
+    ...(overlay.columnQuery || {}),
+  };
+
+  return {
+    attributeSelections: mergeSelections(
+      base.attributeSelections,
+      overlay.attributeSelections,
+    ),
+    attributePredicates: mergePredicates(
+      base.attributePredicates,
+      overlay.attributePredicates,
+    ),
+    columnPredicates: mergePredicates(
+      base.columnPredicates,
+      overlay.columnPredicates,
+    ),
+    ...(Object.keys(columnQuery).length > 0
+      ? { columnQuery: columnQuery }
+      : {}),
+  };
 }
 
 export function isExceptionAttributeFacetKey(facetKey: string): boolean {
@@ -127,8 +229,36 @@ export function hasExceptionInstanceScope(
   return (
     Object.keys(scope.attributeSelections).length > 0 ||
     Object.keys(scope.attributePredicates).length > 0 ||
-    Object.keys(scope.columnPredicates).length > 0
+    Object.keys(scope.columnPredicates).length > 0 ||
+    Object.keys(scope.columnQuery || {}).length > 0
   );
+}
+
+/*
+ * The raw fragment, keyed for the resolution cache. Query operators are
+ * compared by their serialized form for the same reason predicates are: two
+ * equal filters are different object identities on every render, and
+ * identity comparison would refetch the fingerprints forever.
+ */
+function serializeColumnQuery(
+  columnQuery: Query<ExceptionInstance> | undefined,
+): Record<string, unknown> {
+  if (!columnQuery) {
+    return {};
+  }
+
+  const ordered: Record<string, unknown> = {};
+
+  for (const key of Object.keys(columnQuery).sort()) {
+    const value: unknown = (columnQuery as Record<string, unknown>)[key];
+
+    ordered[key] =
+      value && typeof value === "object" && "toJSON" in value
+        ? (value as { toJSON: () => unknown }).toJSON()
+        : value;
+  }
+
+  return ordered;
 }
 
 function serializePredicates(
@@ -169,6 +299,7 @@ export function getExceptionInstanceScopeKey(input: {
     orderedSelections,
     serializePredicates(input.scope.attributePredicates),
     serializePredicates(input.scope.columnPredicates),
+    serializeColumnQuery(input.scope.columnQuery),
     input.windowStartMs,
     input.windowEndMs,
   ]);
@@ -263,7 +394,13 @@ export function buildExceptionInstanceScopeQuery(input: {
     }
   }
 
+  /*
+   * Order matters: the raw host fragment goes down first so a predicate the
+   * chips or the search produced for the same column overwrites it, then the
+   * window and projectId, which no scope may override.
+   */
   return {
+    ...(input.scope.columnQuery || {}),
     ...columns,
     projectId: input.projectId,
     time: input.window,

--- a/App/FeatureSet/Dashboard/src/Utils/SpanQueryScope.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/SpanQueryScope.ts
@@ -1,0 +1,479 @@
+import Dictionary from "Common/Types/Dictionary";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import Query from "Common/Types/BaseDatabase/Query";
+import Span from "Common/Models/AnalyticsModels/Span";
+import TelemetryType from "Common/Types/Telemetry/TelemetryType";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
+import { JSONObject } from "Common/Types/JSON";
+import {
+  TelemetryScopeAttributeValue,
+  getFilterAttributes,
+  getFilterNumberValues,
+  getFilterSearchValue,
+  getFilterStringValues,
+  isEmptyFilterValue,
+} from "./TelemetryQueryFilterValues";
+
+/*
+ * Read a stored `Query<Span>` — the slice a trace monitor evaluated, kept on
+ * the incident / alert row — as a SCOPE the spans explorer can host.
+ *
+ * The alert and incident pages used to render that query through a dense
+ * `AnalyticsModelTable`; they now embed the same `TracesViewer` the /traces
+ * page uses, the way those pages already embed the logs viewer. That means
+ * the query has to reach FOUR places, not one:
+ *
+ *   1. the span list query,
+ *   2. the histogram + facet aggregation payload, which speaks a different
+ *      vocabulary (`serviceIds`, `spanNameSearches`, `statusCodes`, ...),
+ *   3. the read-only chips that tell the user what the list is scoped to,
+ *   4. the time picker, pinned to the evaluation window.
+ *
+ * If (1) and (2) disagree the chart counts rows the list excludes — the
+ * failure this file exists to prevent. So every dimension is read ONCE here
+ * and rendered into both vocabularies together, and anything that cannot be
+ * expressed in the payload is reported in `notCarried` rather than dropped
+ * silently.
+ *
+ * Pure, so App/Tests/Dashboard can exercise it against a real
+ * `MonitorStepTraceMonitorUtil.toQuery` result without a renderer.
+ */
+
+/**
+ * A read-only scope chip. `displayKey` / `displayValue` are seeds — the
+ * viewer re-derives them from its facet configs so a service id shows as the
+ * service's name once services load.
+ */
+export interface SpanScopeChip {
+  facetKey: string;
+  value: string;
+  displayKey: string;
+  displayValue: string;
+}
+
+export interface SpanQueryScope {
+  /** Service ids (the `primaryEntityId` column for OTLP telemetry). */
+  serviceIds: Array<string>;
+  /** Stable telemetry entity keys — `hasAny(entityKeys, [...])`. */
+  entityKeys: Array<string>;
+  /**
+   * Attribute equality scope, applied by both transports.
+   *
+   * Values are STRINGS even when the monitor stored a number or a boolean.
+   * Two reasons, and they point the same way: the ClickHouse `attributes`
+   * column is a Map(String, String), and the aggregation endpoint's body
+   * parser (parseAttributeFilterRecord in Common/Server/API/TelemetryAPI.ts)
+   * keeps only strings, string arrays and serialized operators — it DROPS a
+   * bare number. Passing one through would have narrowed the list by
+   * `http.status_code = 500` while the chart and the facet counts above it
+   * silently ignored the filter.
+   */
+  attributes: Dictionary<string>;
+  /**
+   * Attribute entries whose value this reader could not model. Applied to the
+   * LIST query so it stays narrow; absent from the aggregation payload, and
+   * named in `notCarried` so the wider chart is never silent.
+   */
+  attributesPassthrough: JSONObject;
+  /** `SpanStatus` members. */
+  statusCodes: Array<number>;
+  /** A single span-name value matches as a SUBSTRING (the monitor's Search). */
+  spanNameSearch: string | null;
+  /** Several span-name values match exactly. */
+  spanNames: Array<string>;
+  statusMessageSearch: string | null;
+  statusMessages: Array<string>;
+  traceIds: Array<string>;
+  spanIds: Array<string>;
+  spanKinds: Array<string>;
+  /** Tri-state: null when the query said nothing about it. */
+  hasException: boolean | null;
+  /** True when the query pinned `isRootSpan`. */
+  rootOnly: boolean;
+  /** The evaluation window, off `startTime`. Null when none was stored. */
+  window: InBetween<Date> | null;
+  chips: Array<SpanScopeChip>;
+  /**
+   * Query keys this reader could not render into the aggregation payload.
+   * They are still applied to the LIST (see `passthrough`) — a narrower list
+   * with a hint beats a wrong list — and named here so the widening of the
+   * chart above it is never silent.
+   */
+  notCarried: Array<string>;
+  /**
+   * Unreadable keys, forwarded to the list query verbatim.
+   *
+   * Typed as a plain record rather than `Query<Span>`: the consumer copies
+   * the entries onto its own query, and iterating `Query<Span>` with
+   * `Object.entries` makes the checker expand that mapped type to the point
+   * of TS2589 ("type instantiation is excessively deep").
+   */
+  passthrough: JSONObject;
+  /** False when the query scoped nothing at all (or was absent / malformed). */
+  hasScope: boolean;
+}
+
+export const EMPTY_SPAN_QUERY_SCOPE: SpanQueryScope = {
+  serviceIds: [],
+  entityKeys: [],
+  attributes: {},
+  attributesPassthrough: {},
+  statusCodes: [],
+  spanNameSearch: null,
+  spanNames: [],
+  statusMessageSearch: null,
+  statusMessages: [],
+  traceIds: [],
+  spanIds: [],
+  spanKinds: [],
+  hasException: null,
+  rootOnly: false,
+  window: null,
+  chips: [],
+  notCarried: [],
+  passthrough: {},
+  hasScope: false,
+};
+
+/*
+ * Keys the scope consumes itself, so the passthrough loop does not forward
+ * them to the list a second time. `projectId` is implicit on every viewer
+ * query and `startTime` becomes the pinned window, not a filter.
+ */
+const CONSUMED_QUERY_KEYS: Set<string> = new Set<string>([
+  "projectId",
+  "startTime",
+  "primaryEntityId",
+  "entityKeys",
+  "attributes",
+  "statusCode",
+  "name",
+  "statusMessage",
+  "traceId",
+  "spanId",
+  "kind",
+  "hasException",
+  "isRootSpan",
+]);
+
+/** Human labels for the keys a hint may have to name. */
+const QUERY_KEY_LABELS: Dictionary<string> = {
+  durationUnixNano: "span duration filter",
+  endTime: "span end time filter",
+  parentSpanId: "parent span filter",
+  sessionId: "session filter",
+  attributeKeys: "attribute-presence filter",
+};
+
+const SPAN_STATUS_LABELS: Dictionary<string> = {
+  "0": "Unset",
+  "1": "Ok",
+  "2": "Error",
+};
+
+function labelForKey(key: string): string {
+  return QUERY_KEY_LABELS[key] || key;
+}
+
+function pushUniqueLabel(labels: Array<string>, label: string): void {
+  if (label.length > 0 && !labels.includes(label)) {
+    labels.push(label);
+  }
+}
+
+function readBoolean(value: unknown): boolean | null {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const lower: string = value.trim().toLowerCase();
+
+    if (lower === "true") {
+      return true;
+    }
+
+    if (lower === "false") {
+      return false;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Read a stored span query as a viewer scope. A null / non-object query, or
+ * one that scopes nothing, yields `EMPTY_SPAN_QUERY_SCOPE` — the viewer then
+ * behaves exactly as it does on the standalone /traces page.
+ */
+export function buildSpanQueryScope(
+  query: Query<Span> | JSONObject | null | undefined,
+): SpanQueryScope {
+  if (!query || typeof query !== "object" || Array.isArray(query)) {
+    return EMPTY_SPAN_QUERY_SCOPE;
+  }
+
+  const record: JSONObject = query as JSONObject;
+
+  const scope: SpanQueryScope = {
+    ...EMPTY_SPAN_QUERY_SCOPE,
+    serviceIds: [],
+    entityKeys: [],
+    attributes: {},
+    attributesPassthrough: {},
+    statusCodes: [],
+    spanNames: [],
+    statusMessages: [],
+    traceIds: [],
+    spanIds: [],
+    spanKinds: [],
+    chips: [],
+    notCarried: [],
+    passthrough: {},
+  };
+
+  scope.window = TelemetryQueryTimeRange.getQueryWindow(
+    record,
+    TelemetryType.Trace,
+  );
+
+  const addChip: (
+    facetKey: string,
+    value: string,
+    displayKey: string,
+    displayValue?: string,
+  ) => void = (
+    facetKey: string,
+    value: string,
+    displayKey: string,
+    displayValue?: string,
+  ): void => {
+    scope.chips.push({
+      facetKey: facetKey,
+      value: value,
+      displayKey: displayKey,
+      displayValue: displayValue || value,
+    });
+  };
+
+  /*
+   * A key whose value we could not read is NOT the same as a key that scopes
+   * nothing: the first has to be forwarded to the list and reported, the
+   * second is a no-op the monitor happened to store.
+   */
+  const takeStrings: (key: string) => Array<string> = (
+    key: string,
+  ): Array<string> => {
+    const raw: unknown = record[key];
+
+    if (raw === undefined || raw === null) {
+      return [];
+    }
+
+    const values: Array<string> = getFilterStringValues(raw);
+
+    if (values.length === 0 && !isEmptyFilterValue(raw)) {
+      scope.passthrough[key] = raw as never;
+      pushUniqueLabel(scope.notCarried, labelForKey(key));
+    }
+
+    return values;
+  };
+
+  scope.serviceIds = takeStrings("primaryEntityId");
+  for (const serviceId of scope.serviceIds) {
+    addChip("primaryEntityId", serviceId, "Service");
+  }
+
+  scope.entityKeys = takeStrings("entityKeys");
+  for (const entityKey of scope.entityKeys) {
+    addChip("entityKeys", entityKey, "Resource");
+  }
+
+  scope.traceIds = takeStrings("traceId");
+  for (const traceId of scope.traceIds) {
+    addChip("traceId", traceId, "Trace");
+  }
+
+  scope.spanIds = takeStrings("spanId");
+  for (const spanId of scope.spanIds) {
+    addChip("spanId", spanId, "Span");
+  }
+
+  scope.spanKinds = takeStrings("kind");
+  for (const kind of scope.spanKinds) {
+    addChip("kind", kind, "Kind");
+  }
+
+  scope.statusCodes = getFilterNumberValues(record["statusCode"]);
+  if (
+    scope.statusCodes.length === 0 &&
+    record["statusCode"] !== undefined &&
+    record["statusCode"] !== null &&
+    !isEmptyFilterValue(record["statusCode"])
+  ) {
+    scope.passthrough["statusCode"] = record["statusCode"] as never;
+    pushUniqueLabel(scope.notCarried, "span status filter");
+  }
+  for (const statusCode of scope.statusCodes) {
+    addChip(
+      "statusCode",
+      String(statusCode),
+      "Status",
+      SPAN_STATUS_LABELS[String(statusCode)] || String(statusCode),
+    );
+  }
+
+  /*
+   * `name` and `statusMessage` are the two text columns the list matches as
+   * a substring when a single value is given (see TEXT_CHIP_FIELDS in
+   * TracesViewer) and exactly when several are. The payload mirrors that
+   * with `spanNameSearches` / `spanNames`, so the split is decided here once
+   * for both.
+   */
+  const readTextColumn: (key: string) => {
+    search: string | null;
+    values: Array<string>;
+  } = (key: string): { search: string | null; values: Array<string> } => {
+    const raw: unknown = record[key];
+
+    if (raw === undefined || raw === null) {
+      return { search: null, values: [] };
+    }
+
+    const search: string | null = getFilterSearchValue(raw);
+
+    if (search) {
+      return { search: search, values: [] };
+    }
+
+    const values: Array<string> = getFilterStringValues(raw);
+
+    if (values.length === 0) {
+      if (!isEmptyFilterValue(raw)) {
+        scope.passthrough[key] = raw as never;
+        pushUniqueLabel(scope.notCarried, labelForKey(key));
+      }
+
+      return { search: null, values: [] };
+    }
+
+    // One exact value still matches as a substring, mirroring the list.
+    if (values.length === 1) {
+      return { search: values[0]!, values: [] };
+    }
+
+    return { search: null, values: values };
+  };
+
+  const spanName: { search: string | null; values: Array<string> } =
+    readTextColumn("name");
+  scope.spanNameSearch = spanName.search;
+  scope.spanNames = spanName.values;
+  for (const value of scope.spanNameSearch
+    ? [scope.spanNameSearch]
+    : scope.spanNames) {
+    addChip("name", value, "Name");
+  }
+
+  const statusMessage: { search: string | null; values: Array<string> } =
+    readTextColumn("statusMessage");
+  scope.statusMessageSearch = statusMessage.search;
+  scope.statusMessages = statusMessage.values;
+  for (const value of scope.statusMessageSearch
+    ? [scope.statusMessageSearch]
+    : scope.statusMessages) {
+    addChip("statusMessage", value, "Status Message");
+  }
+
+  const scalarAttributes: Dictionary<TelemetryScopeAttributeValue> =
+    getFilterAttributes(record["attributes"]);
+
+  for (const [key, value] of Object.entries(scalarAttributes)) {
+    scope.attributes[key] = String(value);
+  }
+
+  /*
+   * An attributes map can be PARTIALLY readable: the scalars compile to the
+   * fast map-subscript equality both transports speak, while an operator
+   * value (a contains, a range, an is-any-of) does not. Dropping the half we
+   * cannot model would widen the list under an event's heading, so those
+   * entries ride the list query verbatim — the analytics compiler
+   * understands more shapes than this reader does — and are named in the
+   * hint, because the aggregation payload genuinely cannot carry them.
+   */
+  const rawAttributes: unknown = record["attributes"];
+
+  if (rawAttributes !== undefined && rawAttributes !== null) {
+    const unmodelled: JSONObject = {};
+
+    if (
+      typeof rawAttributes === "object" &&
+      !Array.isArray(rawAttributes) &&
+      Object.keys(rawAttributes as JSONObject).length > 0
+    ) {
+      for (const [key, value] of Object.entries(rawAttributes as JSONObject)) {
+        if (scalarAttributes[key] === undefined && value !== undefined) {
+          unmodelled[key] = value as never;
+          pushUniqueLabel(scope.notCarried, `attribute filter on ${key}`);
+        }
+      }
+    } else {
+      pushUniqueLabel(scope.notCarried, "attribute filter");
+    }
+
+    if (Object.keys(unmodelled).length > 0) {
+      scope.attributesPassthrough = unmodelled;
+    }
+  }
+
+  for (const [key, value] of Object.entries(scope.attributes)) {
+    addChip(`attributes.${key}`, value, key);
+  }
+
+  scope.hasException = readBoolean(record["hasException"]);
+  if (scope.hasException !== null) {
+    addChip(
+      "hasException",
+      String(scope.hasException),
+      "Has Exception",
+      scope.hasException ? "Yes" : "No",
+    );
+  }
+
+  scope.rootOnly = readBoolean(record["isRootSpan"]) === true;
+
+  for (const key of Object.keys(record)) {
+    if (CONSUMED_QUERY_KEYS.has(key)) {
+      continue;
+    }
+
+    const value: unknown = record[key];
+
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    scope.passthrough[key] = value as never;
+    pushUniqueLabel(scope.notCarried, labelForKey(key));
+  }
+
+  scope.hasScope =
+    scope.serviceIds.length > 0 ||
+    scope.entityKeys.length > 0 ||
+    Object.keys(scope.attributes).length > 0 ||
+    Object.keys(scope.attributesPassthrough).length > 0 ||
+    scope.statusCodes.length > 0 ||
+    scope.spanNameSearch !== null ||
+    scope.spanNames.length > 0 ||
+    scope.statusMessageSearch !== null ||
+    scope.statusMessages.length > 0 ||
+    scope.traceIds.length > 0 ||
+    scope.spanIds.length > 0 ||
+    scope.spanKinds.length > 0 ||
+    scope.hasException !== null ||
+    scope.rootOnly ||
+    Object.keys(scope.passthrough).length > 0;
+
+  return scope;
+}

--- a/App/FeatureSet/Dashboard/src/Utils/TelemetryCompanionSignals.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/TelemetryCompanionSignals.ts
@@ -3,7 +3,7 @@ import InBetween from "Common/Types/BaseDatabase/InBetween";
 import Includes from "Common/Types/BaseDatabase/Includes";
 import ObjectID from "Common/Types/ObjectID";
 import Query from "Common/Types/BaseDatabase/Query";
-import { JSONObject, ObjectType } from "Common/Types/JSON";
+import { JSONObject } from "Common/Types/JSON";
 import Log from "Common/Models/AnalyticsModels/Log";
 import Metric from "Common/Models/AnalyticsModels/Metric";
 import Span from "Common/Models/AnalyticsModels/Span";
@@ -20,6 +20,10 @@ import {
   buildCrossSignalScopeFromMetricViewData,
   extractScopeFiltersFromQueryConfigs,
 } from "./MetricsCrossSignalPivot";
+import {
+  getFilterStringValues,
+  isEmptyFilterValue,
+} from "./TelemetryQueryFilterValues";
 
 /*
  * Companion-signal derivation for the incident / alert "Telemetry snapshot"
@@ -149,104 +153,6 @@ function isPlainRecord(value: unknown): value is JSONObject {
     !(value instanceof ObjectID) &&
     !(value as JSONObject)["_type"]
   );
-}
-
-/*
- * Read the string values a query filter holds, across every shape the
- * store/load round trip can produce: an Includes instance, its serialized
- * `{ _type: "Includes", value: [...] }` form, a bare array, a single
- * string / number / ObjectID (instance or serialized).
- */
-function getFilterStringValues(value: unknown): Array<string> {
-  const collect: (items: Array<unknown>) => Array<string> = (
-    items: Array<unknown>,
-  ): Array<string> => {
-    const values: Array<string> = [];
-
-    for (const item of items) {
-      if (
-        typeof item === "string" ||
-        typeof item === "number" ||
-        item instanceof ObjectID
-      ) {
-        const stringValue: string = item.toString().trim();
-
-        if (stringValue.length > 0 && !values.includes(stringValue)) {
-          values.push(stringValue);
-        }
-      }
-    }
-
-    return values;
-  };
-
-  if (value === null || value === undefined) {
-    return [];
-  }
-
-  if (value instanceof Includes) {
-    return collect(value.values as Array<unknown>);
-  }
-
-  if (Array.isArray(value)) {
-    return collect(value);
-  }
-
-  if (
-    typeof value === "string" ||
-    typeof value === "number" ||
-    value instanceof ObjectID
-  ) {
-    return collect([value]);
-  }
-
-  if (typeof value === "object") {
-    const json: JSONObject = value as JSONObject;
-
-    if (json["_type"] === ObjectType.Includes && Array.isArray(json["value"])) {
-      return collect(json["value"] as Array<unknown>);
-    }
-
-    if (
-      json["_type"] === ObjectType.ObjectID &&
-      typeof json["value"] === "string"
-    ) {
-      return collect([json["value"]]);
-    }
-  }
-
-  return [];
-}
-
-/*
- * Whether a filter value carries no scope AT ALL (an empty membership, an
- * empty string) — as opposed to a value we failed to read. The former is
- * omitted silently (it filters nothing), the latter must be reported.
- */
-function isEmptyFilterValue(value: unknown): boolean {
-  if (value instanceof Includes) {
-    return value.values.length === 0;
-  }
-
-  if (Array.isArray(value)) {
-    return value.length === 0;
-  }
-
-  if (typeof value === "string") {
-    return value.trim().length === 0;
-  }
-
-  if (typeof value === "object" && value !== null) {
-    const json: JSONObject = value as JSONObject;
-
-    return (
-      json["_type"] === ObjectType.Includes &&
-      Array.isArray(json["value"]) &&
-      (json["value"] as Array<unknown>).length === 0
-    );
-  }
-
-  return false;
 }
 
 interface ExtractedPrimaryScope {

--- a/App/FeatureSet/Dashboard/src/Utils/TelemetryQueryFilterValues.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/TelemetryQueryFilterValues.ts
@@ -1,0 +1,260 @@
+import Dictionary from "Common/Types/Dictionary";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import ObjectID from "Common/Types/ObjectID";
+import Search from "Common/Types/BaseDatabase/Search";
+import { JSONObject, ObjectType } from "Common/Types/JSON";
+
+/*
+ * Readers for the filter values a STORED telemetry query holds.
+ *
+ * A monitor stamps its evaluation query onto the incident / alert row, and
+ * the blob round-trips through `JSON.stringify` on the way in. What comes
+ * back depends on whether the caller ran `JSONFunctions.deserialize`: an
+ * `Includes` instance, or the plain `{ _type: "Includes", value: [...] }`
+ * object it serializes to. Both shapes have to read the same, or a viewer
+ * scoped from a stored query silently loses the scope on one page and keeps
+ * it on another.
+ *
+ * Everything here is pure so App/Tests/Dashboard can exercise it without a
+ * renderer. Extracted from TelemetryCompanionSignals, which had the first
+ * two of these privately and now imports them, so the companion tabs and
+ * the span / exception snapshot lists read a stored query identically.
+ */
+
+/** Scope-attribute values the analytics query grammar can carry verbatim. */
+export type TelemetryScopeAttributeValue = string | number | boolean;
+
+/**
+ * Read the string values a query filter holds, across every shape the
+ * store/load round trip can produce: an Includes instance, its serialized
+ * `{ _type: "Includes", value: [...] }` form, a bare array, a single
+ * string / number / ObjectID (instance or serialized).
+ */
+export function getFilterStringValues(value: unknown): Array<string> {
+  const collect: (items: Array<unknown>) => Array<string> = (
+    items: Array<unknown>,
+  ): Array<string> => {
+    const values: Array<string> = [];
+
+    for (const item of items) {
+      let scalar: string | number | ObjectID | null = null;
+
+      if (
+        typeof item === "string" ||
+        typeof item === "number" ||
+        item instanceof ObjectID
+      ) {
+        scalar = item;
+      } else if (
+        typeof item === "object" &&
+        item !== null &&
+        (item as JSONObject)["_type"] === ObjectType.ObjectID &&
+        typeof (item as JSONObject)["value"] === "string"
+      ) {
+        /*
+         * A membership of ObjectIDs that was NOT run through
+         * JSONFunctions.deserialize still holds each id in its serialized
+         * `{ _type: "ObjectID", value }` form. Missing this read an
+         * `Includes` of service ids as EMPTY — a scope that fails open, so
+         * the surface shows every service's rows and says nothing about it.
+         */
+        scalar = (item as JSONObject)["value"] as string;
+      }
+
+      if (scalar === null) {
+        continue;
+      }
+
+      const stringValue: string = scalar.toString().trim();
+
+      if (stringValue.length > 0 && !values.includes(stringValue)) {
+        values.push(stringValue);
+      }
+    }
+
+    return values;
+  };
+
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  if (value instanceof Includes) {
+    return collect(value.values as Array<unknown>);
+  }
+
+  if (Array.isArray(value)) {
+    return collect(value);
+  }
+
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    value instanceof ObjectID
+  ) {
+    return collect([value]);
+  }
+
+  if (typeof value === "object") {
+    const json: JSONObject = value as JSONObject;
+
+    if (json["_type"] === ObjectType.Includes && Array.isArray(json["value"])) {
+      return collect(json["value"] as Array<unknown>);
+    }
+
+    if (
+      json["_type"] === ObjectType.ObjectID &&
+      typeof json["value"] === "string"
+    ) {
+      return collect([json["value"]]);
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Whether a filter value carries no scope AT ALL (an empty membership, an
+ * empty string) — as opposed to a value we failed to read. The former is
+ * omitted silently (it filters nothing), the latter must be reported.
+ */
+export function isEmptyFilterValue(value: unknown): boolean {
+  if (value instanceof Includes) {
+    return value.values.length === 0;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length === 0;
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const json: JSONObject = value as JSONObject;
+
+    return (
+      json["_type"] === ObjectType.Includes &&
+      Array.isArray(json["value"]) &&
+      (json["value"] as Array<unknown>).length === 0
+    );
+  }
+
+  return false;
+}
+
+/**
+ * The substring a `Search` filter carries, in either shape, or null when the
+ * value is not a Search at all.
+ *
+ * Kept apart from `getFilterStringValues` on purpose: a monitor's span name
+ * / exception message filter is a CONTAINS match, and reading it as an exact
+ * value would scope a list to rows whose whole column equals the fragment —
+ * usually none.
+ */
+export function getFilterSearchValue(value: unknown): string | null {
+  if (value instanceof Search) {
+    const searchValue: string = value.toString().trim();
+
+    return searchValue.length > 0 ? searchValue : null;
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const json: JSONObject = value as JSONObject;
+
+    if (json["_type"] === ObjectType.Search) {
+      const searchValue: string = String(json["value"] ?? "").trim();
+
+      return searchValue.length > 0 ? searchValue : null;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The numeric values a filter holds — `statusCode` arrives as an `Includes`
+ * of `SpanStatus` members, which serialize to numbers or their decimal
+ * strings depending on the round trip. Anything that is not a finite number
+ * is dropped rather than coerced, so a malformed value narrows nothing
+ * instead of narrowing to NaN.
+ */
+export function getFilterNumberValues(value: unknown): Array<number> {
+  const values: Array<number> = [];
+
+  for (const raw of getFilterStringValues(value)) {
+    const parsed: number = Number(raw);
+
+    if (Number.isFinite(parsed) && !values.includes(parsed)) {
+      values.push(parsed);
+    }
+  }
+
+  return values;
+}
+
+/**
+ * The `attributes` record a stored query carries. Only scalar values are
+ * kept: the analytics grammar compiles those to a map-subscript equality,
+ * while an operator instance stored under an attribute key would have to be
+ * re-serialized per transport and is reported as un-carried instead.
+ */
+export function getFilterAttributes(
+  value: unknown,
+): Dictionary<TelemetryScopeAttributeValue> {
+  const attributes: Dictionary<TelemetryScopeAttributeValue> = {};
+
+  /*
+   * Plain records only. A live query operator is an object with neither a
+   * `_type` marker nor an Array shape, so an `instanceof` list can never be
+   * complete — `Search` slipped through one and had its private
+   * `_searchValue` field read as an attribute named `_searchValue`. Testing
+   * the prototype instead admits object literals and JSON.parse output, and
+   * nothing else.
+   */
+  const prototype: unknown =
+    typeof value === "object" && value !== null
+      ? Object.getPrototypeOf(value)
+      : null;
+
+  /*
+   * `_type` only disqualifies a record when it names a KNOWN serialized
+   * operator. A telemetry attribute may legitimately be called `_type`, and
+   * rejecting its whole map would unscope the list while the same filter kept
+   * scoping every other surface.
+   */
+  const typeMarker: unknown =
+    typeof value === "object" && value !== null
+      ? (value as JSONObject)["_type"]
+      : undefined;
+  const isSerializedOperator: boolean =
+    typeof typeMarker === "string" &&
+    (Object.values(ObjectType) as Array<string>).includes(typeMarker);
+
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    (prototype !== Object.prototype && prototype !== null) ||
+    isSerializedOperator
+  ) {
+    return attributes;
+  }
+
+  for (const [key, attributeValue] of Object.entries(value as JSONObject)) {
+    if (key.trim().length === 0) {
+      continue;
+    }
+
+    if (
+      typeof attributeValue === "string" ||
+      typeof attributeValue === "number" ||
+      typeof attributeValue === "boolean"
+    ) {
+      attributes[key] = attributeValue;
+    }
+  }
+
+  return attributes;
+}

--- a/App/Tests/Dashboard/ExceptionQueryScope.test.ts
+++ b/App/Tests/Dashboard/ExceptionQueryScope.test.ts
@@ -1,0 +1,527 @@
+import { describe, expect, test } from "@jest/globals";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import ObjectID from "Common/Types/ObjectID";
+import Query from "Common/Types/BaseDatabase/Query";
+import Search from "Common/Types/BaseDatabase/Search";
+import ExceptionInstance from "Common/Models/AnalyticsModels/ExceptionInstance";
+import TelemetryException from "Common/Models/DatabaseModels/TelemetryException";
+import { JSONObject } from "Common/Types/JSON";
+import JSONFunctions from "Common/Types/JSONFunctions";
+import { MonitorStepExceptionMonitorUtil } from "Common/Types/Monitor/MonitorStepExceptionMonitor";
+import { SearchQueryValue } from "Common/Types/Telemetry/TelemetrySearchQuery";
+import {
+  EMPTY_EXCEPTION_QUERY_SCOPE,
+  ExceptionQueryScope,
+  ExceptionScopeChip,
+  buildExceptionQueryScope,
+} from "../../FeatureSet/Dashboard/src/Utils/ExceptionQueryScope";
+import {
+  ExceptionInstanceScope,
+  MAX_SCOPED_FINGERPRINTS,
+  NO_MATCH_FINGERPRINT,
+  applyExceptionFingerprintScope,
+  buildExceptionInstanceScopeQuery,
+  getExceptionInstanceScopeKey,
+  hasExceptionInstanceScope,
+  mergeExceptionInstanceScopes,
+} from "../../FeatureSet/Dashboard/src/Utils/ExceptionsAttributeScope";
+
+/*
+ * The exceptions snapshot on an Alert / Incident page is the awkward signal:
+ * the monitor stored a `Query<ExceptionInstance>` against ClickHouse
+ * OCCURRENCES, while the exceptions explorer the page now embeds lists
+ * Postgres exception GROUPS. `fingerprint` is the only join between them,
+ * and the viewer already owns that join — one `GROUP BY fingerprint` read
+ * narrows the list, the histogram and the facet counts together.
+ *
+ * So the stored query has to become an INSTANCE SCOPE, not a second filter
+ * path on the group query. This file pins that translation, and the two
+ * properties that make it safe: the host's filters AND with the user's
+ * rather than replacing them, and nothing the reader cannot express is
+ * dropped.
+ */
+
+const SERVICE_ID_A: string = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+).toString();
+const SERVICE_ID_B: string = new ObjectID(
+  "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+).toString();
+const PROJECT_ID: ObjectID = new ObjectID(
+  "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+);
+
+function roundTrip(query: Query<ExceptionInstance>): Query<ExceptionInstance> {
+  return JSONFunctions.deserialize(
+    JSONFunctions.anyObjectToJSONObject(query as unknown as JSONObject),
+  ) as unknown as Query<ExceptionInstance>;
+}
+
+function storedOnly(query: Query<ExceptionInstance>): JSONObject {
+  return JSONFunctions.anyObjectToJSONObject(query as unknown as JSONObject);
+}
+
+function exceptionMonitorQuery(
+  overrides: Partial<
+    Parameters<typeof MonitorStepExceptionMonitorUtil.toAnalyticsQuery>[0]
+  >,
+): Query<ExceptionInstance> {
+  return MonitorStepExceptionMonitorUtil.toAnalyticsQuery({
+    ...MonitorStepExceptionMonitorUtil.getDefault(),
+    ...overrides,
+  });
+}
+
+const STORED: Query<ExceptionInstance> = exceptionMonitorQuery({
+  telemetryServiceIds: [new ObjectID(SERVICE_ID_A), new ObjectID(SERVICE_ID_B)],
+  entityKeys: ["service:checkout", "k8s.pod:checkout-abc"],
+  exceptionTypes: ["TimeoutError", "TypeError"],
+  message: "connection reset",
+  lastXSecondsOfExceptions: 300,
+});
+
+const EMPTY_USER_SCOPE: ExceptionInstanceScope = {
+  attributeSelections: {},
+  attributePredicates: {},
+  columnPredicates: {},
+};
+
+describe("a real exception monitor's stored query", () => {
+  test("every key an exception monitor emits is accounted for", () => {
+    expect(Object.keys(STORED).sort()).toEqual([
+      "entityKeys",
+      "exceptionType",
+      "message",
+      "primaryEntityId",
+      "time",
+    ]);
+  });
+
+  test("reads identically whether or not the page deserialized it", () => {
+    for (const shape of [roundTrip(STORED), storedOnly(STORED)]) {
+      const scope: ExceptionQueryScope = buildExceptionQueryScope(
+        shape as Query<ExceptionInstance>,
+      );
+
+      expect(scope.hasScope).toBe(true);
+      expect(
+        scope.instanceScope.columnPredicates["primaryEntityId"],
+      ).toHaveLength(1);
+      expect(
+        scope.instanceScope.columnPredicates["exceptionType"],
+      ).toHaveLength(1);
+      expect(scope.instanceScope.columnPredicates["message"]).toHaveLength(1);
+      expect(scope.instanceScope.columnPredicates["entityKeys"]).toHaveLength(
+        1,
+      );
+    }
+  });
+
+  test("the message stays a substring match", () => {
+    /*
+     * The monitor stores `new Search(message)`. Compiled as equality it would
+     * match only exceptions whose entire message is the fragment, and the
+     * alert would show none of the exceptions it fired on.
+     */
+    const scope: ExceptionQueryScope = buildExceptionQueryScope(
+      roundTrip(STORED),
+    );
+    const predicate: SearchQueryValue =
+      scope.instanceScope.columnPredicates["message"]![0]!;
+
+    expect(predicate).toBeInstanceOf(Search);
+    expect((predicate as Search<string>).toString()).toBe("connection reset");
+  });
+
+  test("entityKeys stays a membership even for a single value", () => {
+    /*
+     * `entityKeys` is a ClickHouse ARRAY column: an Includes compiles to
+     * hasAny(entityKeys, [...]), while a bare string would compare an array
+     * against a scalar and match nothing at all.
+     */
+    const scope: ExceptionQueryScope = buildExceptionQueryScope(
+      roundTrip(exceptionMonitorQuery({ entityKeys: ["service:checkout"] })),
+    );
+
+    expect(
+      scope.instanceScope.columnPredicates["entityKeys"]![0],
+    ).toBeInstanceOf(Includes);
+  });
+
+  test("a single service id is a plain equality, keeping the fast path", () => {
+    const scope: ExceptionQueryScope = buildExceptionQueryScope(
+      roundTrip(
+        exceptionMonitorQuery({
+          telemetryServiceIds: [new ObjectID(SERVICE_ID_A)],
+        }),
+      ),
+    );
+
+    expect(scope.instanceScope.columnPredicates["primaryEntityId"]).toEqual([
+      SERVICE_ID_A,
+    ]);
+  });
+
+  test("the window becomes a pin and never a column predicate", () => {
+    const scope: ExceptionQueryScope = buildExceptionQueryScope(
+      roundTrip(STORED),
+    );
+
+    expect(scope.window).not.toBeNull();
+    expect(
+      scope.window!.endValue.getTime() - scope.window!.startValue.getTime(),
+    ).toBe(300 * 1000);
+    expect(scope.instanceScope.columnPredicates).not.toHaveProperty("time");
+    expect(scope.instanceScope.columnQuery || {}).not.toHaveProperty("time");
+  });
+
+  test("projectId is dropped — the resolution query stamps its own", () => {
+    const scope: ExceptionQueryScope = buildExceptionQueryScope({
+      ...roundTrip(STORED),
+      projectId: PROJECT_ID,
+    } as Query<ExceptionInstance>);
+
+    expect(scope.instanceScope.columnPredicates).not.toHaveProperty(
+      "projectId",
+    );
+    expect(scope.instanceScope.columnQuery || {}).not.toHaveProperty(
+      "projectId",
+    );
+  });
+
+  test("every scoped dimension surfaces as a chip", () => {
+    const scope: ExceptionQueryScope = buildExceptionQueryScope(
+      roundTrip(STORED),
+    );
+
+    const byKey: (key: string) => Array<ExceptionScopeChip> = (
+      key: string,
+    ): Array<ExceptionScopeChip> => {
+      return scope.chips.filter((chip: ExceptionScopeChip): boolean => {
+        return chip.facetKey === key;
+      });
+    };
+
+    expect(byKey("primaryEntityId")).toHaveLength(2);
+    expect(
+      byKey("exceptionType").map((c: ExceptionScopeChip) => {
+        return c.value;
+      }),
+    ).toEqual(["TimeoutError", "TypeError"]);
+    expect(byKey("entityKeys")).toHaveLength(2);
+    expect(byKey("message")[0]!.value).toBe("connection reset");
+    expect(byKey("message")[0]!.displayKey).toBe("Message");
+  });
+
+  test("attributes become attribute predicates, stringified for the map column", () => {
+    /*
+     * ClickHouse stores attributes as Map(String, String); a number written
+     * as a number would compare against a column that only holds strings.
+     */
+    const scope: ExceptionQueryScope = buildExceptionQueryScope({
+      attributes: { "http.status_code": 500, "http.route": "/checkout" },
+    } as unknown as Query<ExceptionInstance>);
+
+    expect(scope.instanceScope.attributePredicates).toEqual({
+      "http.status_code": ["500"],
+      "http.route": ["/checkout"],
+    });
+    expect(scope.instanceScope.attributeSelections).toEqual({});
+  });
+});
+
+describe("nothing is dropped", () => {
+  test("an unreadable value is forwarded verbatim on the raw fragment", () => {
+    /*
+     * Unlike the traces side there is no `notCarried` here: everything the
+     * reader puts on the instance query constrains the list, the chart AND
+     * the facet counts at once, because all three ride the resolved
+     * fingerprints. So the only requirement is that nothing is lost.
+     */
+    const weird: unknown = { some: "operator we do not model" };
+    const scope: ExceptionQueryScope = buildExceptionQueryScope({
+      spanStatusCode: weird,
+    } as unknown as Query<ExceptionInstance>);
+
+    expect(scope.hasScope).toBe(true);
+    expect(scope.instanceScope.columnQuery).toEqual({ spanStatusCode: weird });
+  });
+
+  test("an unreadable attributes value is forwarded rather than ignored", () => {
+    const scope: ExceptionQueryScope = buildExceptionQueryScope({
+      attributes: new Includes(["not-a-record"]),
+    } as unknown as Query<ExceptionInstance>);
+
+    expect(scope.hasScope).toBe(true);
+    expect(scope.instanceScope.columnQuery).toHaveProperty("attributes");
+  });
+
+  test("an EMPTY membership scopes nothing and is skipped", () => {
+    const scope: ExceptionQueryScope = buildExceptionQueryScope({
+      primaryEntityId: new Includes([]),
+      exceptionType: new Includes([]),
+    } as unknown as Query<ExceptionInstance>);
+
+    expect(scope.hasScope).toBe(false);
+    expect(scope.chips).toEqual([]);
+  });
+
+  test("null / undefined / non-object yield the empty scope", () => {
+    for (const value of [null, undefined, [], "nope", 7]) {
+      const scope: ExceptionQueryScope = buildExceptionQueryScope(
+        value as unknown as Query<ExceptionInstance>,
+      );
+
+      expect(scope.hasScope).toBe(false);
+      expect(scope.window).toBeNull();
+    }
+  });
+
+  test("a window-only query pins the picker but scopes nothing", () => {
+    const scope: ExceptionQueryScope = buildExceptionQueryScope(
+      roundTrip(exceptionMonitorQuery({ lastXSecondsOfExceptions: 60 })),
+    );
+
+    expect(scope.window).not.toBeNull();
+    expect(scope.hasScope).toBe(false);
+    expect(EMPTY_EXCEPTION_QUERY_SCOPE.hasScope).toBe(false);
+  });
+});
+
+describe("the host scope reaches the ClickHouse resolution query", () => {
+  const window: InBetween<Date> = new InBetween<Date>(
+    new Date("2026-01-01T00:00:00.000Z"),
+    new Date("2026-01-01T00:05:00.000Z"),
+  );
+
+  test("every host filter lands on the instance query, with the window and project", () => {
+    const scope: ExceptionQueryScope = buildExceptionQueryScope(
+      roundTrip(STORED),
+    );
+
+    const query: Record<string, unknown> = buildExceptionInstanceScopeQuery({
+      projectId: PROJECT_ID,
+      window: window,
+      scope: scope.instanceScope,
+    }) as unknown as Record<string, unknown>;
+
+    expect(query["projectId"]).toBe(PROJECT_ID);
+    expect(query["time"]).toBe(window);
+    expect(query["exceptionType"]).toBeInstanceOf(Includes);
+    expect(query["message"]).toBeInstanceOf(Search);
+    expect(query["entityKeys"]).toBeInstanceOf(Includes);
+    expect(query["primaryEntityId"]).toBeInstanceOf(Includes);
+  });
+
+  test("the raw fragment is applied, but never over the window or project", () => {
+    const query: Record<string, unknown> = buildExceptionInstanceScopeQuery({
+      projectId: PROJECT_ID,
+      window: window,
+      scope: {
+        ...EMPTY_USER_SCOPE,
+        columnQuery: {
+          release: "1.2.3",
+          // A malicious/stale fragment must not be able to widen the window.
+          time: new InBetween<Date>(new Date(0), new Date(1)),
+          projectId: new ObjectID("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
+        } as unknown as Query<ExceptionInstance>,
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(query["release"]).toBe("1.2.3");
+    expect(query["time"]).toBe(window);
+    expect(query["projectId"]).toBe(PROJECT_ID);
+  });
+
+  test("hasExceptionInstanceScope sees a fragment-only scope", () => {
+    /*
+     * Otherwise a host whose whole scope was unreadable would resolve nothing
+     * and the viewer would show the UNFILTERED project-wide list.
+     */
+    expect(
+      hasExceptionInstanceScope({
+        ...EMPTY_USER_SCOPE,
+        columnQuery: {
+          release: "1.2.3",
+        } as unknown as Query<ExceptionInstance>,
+      }),
+    ).toBe(true);
+    expect(hasExceptionInstanceScope(EMPTY_USER_SCOPE)).toBe(false);
+  });
+
+  test("the resolution cache key changes when the fragment does", () => {
+    /*
+     * The key pairs a resolved fingerprint set with the filters that produced
+     * it. A fragment left out of the key would let a stale resolution be
+     * reused after the host's scope changed — the list would show another
+     * event's exceptions.
+     */
+    const keyOf: (release: string) => string = (release: string): string => {
+      return getExceptionInstanceScopeKey({
+        scope: {
+          ...EMPTY_USER_SCOPE,
+          columnQuery: { release } as unknown as Query<ExceptionInstance>,
+        },
+        windowStartMs: 0,
+        windowEndMs: 1000,
+      });
+    };
+
+    expect(keyOf("1.2.3")).not.toBe(keyOf("1.2.4"));
+    expect(keyOf("1.2.3")).toBe(keyOf("1.2.3"));
+  });
+
+  test("the key compares operators by value, not identity", () => {
+    /*
+     * Two equal filters are different objects on every render; identity
+     * comparison would refetch the fingerprints forever.
+     */
+    const keyOf: () => string = (): string => {
+      return getExceptionInstanceScopeKey({
+        scope: {
+          ...EMPTY_USER_SCOPE,
+          columnQuery: {
+            exceptionType: new Includes(["TimeoutError"]),
+          } as unknown as Query<ExceptionInstance>,
+        },
+        windowStartMs: 0,
+        windowEndMs: 1000,
+      });
+    };
+
+    expect(keyOf()).toBe(keyOf());
+  });
+});
+
+describe("mergeExceptionInstanceScopes", () => {
+  test("predicates on the same column AND rather than replace", () => {
+    /*
+     * An incident pinned to `exceptionType IN (TimeoutError)` still means
+     * that when the user types `@type:Timeout*`. Replacing would let a chip
+     * silently widen the list past the event it belongs to.
+     */
+    const host: ExceptionInstanceScope = {
+      ...EMPTY_USER_SCOPE,
+      columnPredicates: { exceptionType: [new Includes(["TimeoutError"])] },
+    };
+    const user: ExceptionInstanceScope = {
+      ...EMPTY_USER_SCOPE,
+      columnPredicates: { exceptionType: [new Search<string>("Timeout")] },
+    };
+
+    const merged: ExceptionInstanceScope = mergeExceptionInstanceScopes(
+      host,
+      user,
+    );
+
+    expect(merged.columnPredicates["exceptionType"]).toHaveLength(2);
+  });
+
+  test("attribute predicates and selections merge without duplicating", () => {
+    const merged: ExceptionInstanceScope = mergeExceptionInstanceScopes(
+      {
+        attributeSelections: { "http.route": ["/checkout"] },
+        attributePredicates: { env: ["prod"] },
+        columnPredicates: {},
+      },
+      {
+        attributeSelections: { "http.route": ["/checkout", "/cart"] },
+        attributePredicates: { region: ["eu"] },
+        columnPredicates: {},
+      },
+    );
+
+    expect(merged.attributeSelections["http.route"]).toEqual([
+      "/checkout",
+      "/cart",
+    ]);
+    expect(Object.keys(merged.attributePredicates).sort()).toEqual([
+      "env",
+      "region",
+    ]);
+  });
+
+  test("raw fragments merge, with the overlay winning a shared key", () => {
+    const merged: ExceptionInstanceScope = mergeExceptionInstanceScopes(
+      {
+        ...EMPTY_USER_SCOPE,
+        columnQuery: {
+          release: "host",
+          environment: "prod",
+        } as unknown as Query<ExceptionInstance>,
+      },
+      {
+        ...EMPTY_USER_SCOPE,
+        columnQuery: { release: "user" } as unknown as Query<ExceptionInstance>,
+      },
+    );
+
+    expect(merged.columnQuery).toEqual({
+      release: "user",
+      environment: "prod",
+    });
+  });
+
+  test("merging two empty scopes leaves no fragment key at all", () => {
+    const merged: ExceptionInstanceScope = mergeExceptionInstanceScopes(
+      EMPTY_USER_SCOPE,
+      EMPTY_USER_SCOPE,
+    );
+
+    expect(hasExceptionInstanceScope(merged)).toBe(false);
+    expect(merged.columnQuery).toBeUndefined();
+  });
+
+  test("an empty per-key list never creates a key", () => {
+    const merged: ExceptionInstanceScope = mergeExceptionInstanceScopes(
+      { ...EMPTY_USER_SCOPE, columnPredicates: { exceptionType: [] } },
+      EMPTY_USER_SCOPE,
+    );
+
+    expect(merged.columnPredicates).toEqual({});
+  });
+});
+
+describe("applyExceptionFingerprintScope, the group-side half of the join", () => {
+  test("a resolved set narrows the group query", () => {
+    const query: Query<TelemetryException> = {};
+
+    applyExceptionFingerprintScope(query, ["fp1", "fp2"]);
+
+    expect((query as Record<string, unknown>)["fingerprint"]).toBeInstanceOf(
+      Includes,
+    );
+  });
+
+  test("an empty resolution narrows to nothing, it does not widen", () => {
+    /*
+     * The failure mode this sentinel prevents: a scope that matched no
+     * instances silently showing every exception in the project under an
+     * incident's heading.
+     */
+    const query: Query<TelemetryException> = {};
+
+    applyExceptionFingerprintScope(query, []);
+
+    expect(
+      ((query as Record<string, unknown>)["fingerprint"] as Includes).values,
+    ).toEqual([NO_MATCH_FINGERPRINT]);
+  });
+
+  test("the fingerprint list is capped", () => {
+    const many: Array<string> = Array.from(
+      { length: MAX_SCOPED_FINGERPRINTS + 10 },
+      (_unused: unknown, index: number): string => {
+        return `fp-${index}`;
+      },
+    );
+    const query: Query<TelemetryException> = {};
+
+    applyExceptionFingerprintScope(query, many);
+
+    expect(
+      ((query as Record<string, unknown>)["fingerprint"] as Includes).values,
+    ).toHaveLength(MAX_SCOPED_FINGERPRINTS);
+  });
+});

--- a/App/Tests/Dashboard/SnapshotSpanExceptionLists.test.ts
+++ b/App/Tests/Dashboard/SnapshotSpanExceptionLists.test.ts
@@ -1,0 +1,590 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * The Alert and Incident detail pages (and the episode pages, and the
+ * companion-signal tabs on all four) used to render a trace monitor's spans
+ * and an exception monitor's occurrences through two dense
+ * `AnalyticsModelTable`s. They now embed the SAME explorers the /traces and
+ * /exceptions pages use, which is what the logs branch has always done with
+ * `DashboardLogsViewer`.
+ *
+ * Everything decidable without a renderer is decided in the pure readers and
+ * covered properly in SpanQueryScope.test.ts / ExceptionQueryScope.test.ts.
+ * What is left is the wiring — and wiring is exactly where this change can
+ * fail invisibly: an embed that forgets `disableUrlSync` rewrites the
+ * incident's address bar, one that forgets `defaultStatus="all"` shows an
+ * empty list for an incident whose exceptions were since resolved, and one
+ * that keeps the group query's `lastSeenAt` clause hides every exception
+ * still firing. None of those throw; they just show the wrong rows.
+ *
+ * The App suite runs in plain Node with no renderer (App/jest.config.json:
+ * "testEnvironment": "node"), the same constraint
+ * TelemetryPreviewSnapshotWindow.test.ts works around the same way. Sources
+ * are comment-stripped and whitespace-squashed first, so a prettier re-wrap
+ * cannot turn a real regression check into a red herring.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/gm, " ");
+}
+
+function readSource(...relativeParts: Array<string>): string {
+  return squash(
+    stripComments(
+      fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8"),
+    ),
+  );
+}
+
+/** Source with comments intact — for asserting a rule is explained, not just applied. */
+function readRaw(...relativeParts: Array<string>): string {
+  return fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8");
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+const ALERT_VIEW: string = readSource("Pages", "Alerts", "View", "Index.tsx");
+const INCIDENT_VIEW: string = readSource(
+  "Pages",
+  "Incidents",
+  "View",
+  "Index.tsx",
+);
+const SNAPSHOT_PANEL: string = readSource(
+  "Components",
+  "Telemetry",
+  "TelemetrySnapshotPanel.tsx",
+);
+const COMPANION_TABS: string = readSource(
+  "Components",
+  "Telemetry",
+  "TelemetryCompanionSignalTabs.tsx",
+);
+const TRACES_VIEWER: string = readSource(
+  "Components",
+  "Traces",
+  "TracesViewer.tsx",
+);
+const EXCEPTIONS_VIEWER: string = readSource(
+  "Components",
+  "Exceptions",
+  "ExceptionsViewer.tsx",
+);
+const EXCEPTIONS_VIEWER_RAW: string = readRaw(
+  "Components",
+  "Exceptions",
+  "ExceptionsViewer.tsx",
+);
+
+/*
+ * The four surfaces that must move together. TelemetrySnapshotPanel is the
+ * extracted twin of the two Index pages and is what the alert / incident
+ * EPISODE pages mount, so leaving it behind would silently give episodes the
+ * old tables. The companion tabs render the trace / exception panels on ALL
+ * of them (and in the AI investigation drawer), so a Log-primary incident's
+ * Traces tab would otherwise be a table while a Trace-primary one is a list.
+ */
+const SNAPSHOT_HOSTS: Array<[string, string]> = [
+  ["alert page", ALERT_VIEW],
+  ["incident page", INCIDENT_VIEW],
+  ["shared snapshot panel", SNAPSHOT_PANEL],
+  ["companion signal tabs", COMPANION_TABS],
+];
+
+describe("the snapshot hosts embed the explorers, not the tables", () => {
+  test.each(SNAPSHOT_HOSTS)(
+    "%s mounts TracesViewer and ExceptionsViewer",
+    (_name: string, source: string) => {
+      expect(source).toContain("<TracesViewer");
+      expect(source).toContain("<ExceptionsViewer");
+    },
+  );
+
+  test.each(SNAPSHOT_HOSTS)(
+    "%s no longer mounts the dense tables",
+    (_name: string, source: string) => {
+      expect(source).not.toContain("<TraceTable");
+      expect(source).not.toContain("<ExceptionInstanceTable");
+    },
+  );
+
+  test.each(SNAPSHOT_HOSTS)(
+    "%s hands the stored query straight to the explorer",
+    (_name: string, source: string) => {
+      /*
+       * The whole point: the explorer is scoped by the query the monitor
+       * evaluated, not by a hand-copied subset of it.
+       */
+      expect(source).toContain("spanQuery=");
+      expect(source).toContain("exceptionInstanceQuery=");
+    },
+  );
+
+  test.each(SNAPSHOT_HOSTS)(
+    "%s owns the URL, so the embed cannot rewrite the host page's address bar",
+    (_name: string, source: string) => {
+      expect(countOccurrences(source, "disableUrlSync={true}")).toBe(2);
+      expect(source).not.toContain("disableUrlState");
+    },
+  );
+
+  test.each(SNAPSHOT_HOSTS)(
+    "%s opens the exception list on every status and every error class",
+    (_name: string, source: string) => {
+      /*
+       * The explorer's own defaults are "unresolved" + the "issues" class
+       * lens. On an event page those hide exactly the rows the operator came
+       * for: an exception someone resolved after the incident, or one the
+       * classifier called a user error. The list would read "No exceptions
+       * found" with nothing on screen explaining why.
+       */
+      expect(source).toContain('defaultStatus="all"');
+      expect(source).toContain('defaultClassScope="all"');
+    },
+  );
+
+  test.each(SNAPSHOT_HOSTS)(
+    "%s keeps the block short with an explicit page size",
+    (_name: string, source: string) => {
+      /*
+       * The logs embed's `limit={10}`, for the same reason: a snapshot card
+       * must not run the length of the page.
+       */
+      expect(countOccurrences(source, "limit={10}")).toBeGreaterThanOrEqual(2);
+    },
+  );
+
+  test.each(SNAPSHOT_HOSTS)(
+    "%s names the empty state instead of leaving the explorer's generic copy",
+    (_name: string, source: string) => {
+      expect(source).toContain("emptyMessage=");
+    },
+  );
+});
+
+describe("the snapshot window stays visible on every card", () => {
+  test.each([
+    ["alert page", ALERT_VIEW],
+    ["incident page", INCIDENT_VIEW],
+    ["shared snapshot panel", SNAPSHOT_PANEL],
+  ])(
+    "%s badges all four preview cards with the window",
+    (_name: string, source: string) => {
+      /*
+       * Card ownership moved from the components to the hosts when the tables
+       * were swapped out — the tables drew their own card, the explorers do
+       * not. The badge had to move with it: a snapshot with nothing on screen
+       * claiming a window reads as live data.
+       */
+      expect(
+        countOccurrences(source, "rightElement={snapshotWindowAlert}"),
+      ).toBe(4);
+    },
+  );
+
+  test("the companion tabs badge their cards from the host's element", () => {
+    /*
+     * Five, not four: the logs, spans, exceptions and metrics tabs, plus the
+     * metrics tab's "no metrics in this scope" card, which has to carry the
+     * window too — an empty result is the case where "empty of what?" matters
+     * most.
+     */
+    expect(
+      countOccurrences(
+        COMPANION_TABS,
+        "rightElement={props.snapshotWindowAlert}",
+      ),
+    ).toBe(5);
+  });
+
+  test.each([
+    ["alert page", ALERT_VIEW],
+    ["incident page", INCIDENT_VIEW],
+    ["shared snapshot panel", SNAPSHOT_PANEL],
+  ])(
+    "%s wraps the span list in its own card",
+    (_name: string, source: string) => {
+      expect(source).toContain('title={"Spans"}');
+    },
+  );
+});
+
+describe("TracesViewer hosts a stored span query", () => {
+  test("it takes the query, a page size and an empty message", () => {
+    expect(TRACES_VIEWER).toContain("spanQuery?: Query<Span> | undefined;");
+    expect(TRACES_VIEWER).toContain("limit?: number | undefined;");
+    expect(TRACES_VIEWER).toContain("emptyMessage?: string | undefined;");
+  });
+
+  test("the scope is read ONCE, by the shared reader", () => {
+    /*
+     * The list query and the histogram / facet payload speak different
+     * vocabularies. Reading the stored query separately for each is how a
+     * chart ends up counting rows the list excludes, so both must derive from
+     * one buildSpanQueryScope result.
+     */
+    expect(TRACES_VIEWER).toContain("buildSpanQueryScope(props.spanQuery)");
+    expect(countOccurrences(TRACES_VIEWER, "buildSpanQueryScope")).toBe(2);
+  });
+
+  test("the scope reaches the list query", () => {
+    expect(TRACES_VIEWER).toContain("spanScope.serviceIds");
+    expect(TRACES_VIEWER).toContain("spanScope.entityKeys");
+    expect(TRACES_VIEWER).toContain("spanScope.attributes");
+    expect(TRACES_VIEWER).toContain("spanScope.statusCodes");
+    expect(TRACES_VIEWER).toContain("spanScope.spanNameSearch");
+    // Scope the payload cannot express still filters the list — never dropped.
+    expect(TRACES_VIEWER).toContain(
+      "for (const [key, value] of Object.entries(spanScope.passthrough))",
+    );
+  });
+
+  test("the scope reaches the histogram and facet payload too", () => {
+    // applyScopeGroup feeds the same `groups` map the chips and search feed.
+    expect(TRACES_VIEWER).toContain("const applyScopeGroup:");
+    expect(TRACES_VIEWER).toContain(
+      'applyScopeGroup("primaryEntityId", spanScope.serviceIds)',
+    );
+    expect(TRACES_VIEWER).toContain(
+      'applyScopeGroup( "statusCode", spanScope.statusCodes',
+    );
+    expect(TRACES_VIEWER).toContain(
+      'applyScopeGroup( "name", spanScope.spanNameSearch',
+    );
+    /*
+     * entityKeys does not ride `groups` — it is its own payload field, and it
+     * has to carry the entityKeysFilter prop AND the stored scope together or
+     * the counts above the list are project-wide.
+     */
+    expect(TRACES_VIEWER).toContain(
+      "new Set([...(props.entityKeysFilter || []), ...spanScope.entityKeys]),",
+    );
+    expect(TRACES_VIEWER).toContain(
+      'payload["entityKeys"] = scopedEntityKeys;',
+    );
+  });
+
+  test("a user's own filter on a scoped column wins, in both transports", () => {
+    /*
+     * Drill-down, matching how `primaryEntityId` has always behaved: the
+     * scope is written first in the list query and an explicit selection
+     * overwrites it, so the payload must skip a column the user has filtered
+     * rather than OR the scope back in.
+     */
+    expect(TRACES_VIEWER).toContain(
+      "if (groups[key] && groups[key]!.length > 0) { return; }",
+    );
+
+    /*
+     * The primaryEntityId PROP goes through the same gate, and after the
+     * stored scope — otherwise a host that set both would union them in the
+     * payload while the list intersects, and the chart would count services
+     * the list excludes.
+     */
+    const scopeIndex: number = TRACES_VIEWER.indexOf(
+      'applyScopeGroup("primaryEntityId", spanScope.serviceIds)',
+    );
+    const propIndex: number = TRACES_VIEWER.indexOf(
+      'applyScopeGroup("primaryEntityId", [props.primaryEntityId.toString()])',
+    );
+
+    expect(scopeIndex).toBeGreaterThan(-1);
+    expect(propIndex).toBeGreaterThan(scopeIndex);
+    expect(TRACES_VIEWER).not.toContain('groups["primaryEntityId"]!.push(');
+  });
+
+  test("the window is adopted as a pin, and the pin outranks a controlled window", () => {
+    expect(TRACES_VIEWER).toContain(
+      "TelemetryQueryTimeRange.toRangeStartAndEndDateTime(spanScope.window)",
+    );
+    expect(TRACES_VIEWER).toContain(
+      "pinnedTimeRange || props.timeRangeOverride || initialUrlState.timeRange",
+    );
+  });
+
+  test("a hosted view is not seeded from, or saved over by, the URL", () => {
+    /*
+     * `hostOwnsView` is the traces counterpart of the logs viewer's guarantee
+     * for its incident embeds. Without the saved-view half, the project's
+     * DEFAULT saved view auto-applies over the pin a tick after mount, and
+     * the card silently shows someone's saved filters instead of the event.
+     */
+    expect(TRACES_VIEWER).toContain(
+      "const hostOwnsView: boolean = Boolean( props.disableUrlSync || props.spanQuery || props.timeRangeOverride, );",
+    );
+    expect(TRACES_VIEWER).toContain('if (hostOwnsView) { return { search: "",');
+    expect(TRACES_VIEWER).toContain("!hostOwnsView && !spanScope.hasScope &&");
+    expect(TRACES_VIEWER).toContain("return ( hostOwnsView ||");
+  });
+
+  test("the URL mirror follows hostOwnsView, not just the explicit opt-out", () => {
+    /*
+     * A host that pins a query owns the address bar as much as one that
+     * opted out by name. Gating only on `disableUrlSync` would let a future
+     * embed write `?search=…&range=…` onto the incident page it sits on.
+     */
+    expect(TRACES_VIEWER).toContain("if (hostOwnsView) { return; }");
+    expect(TRACES_VIEWER).not.toContain(
+      "if (props.disableUrlSync) { return; }",
+    );
+  });
+
+  test("a pinned window is not steered by a controlled one", () => {
+    expect(TRACES_VIEWER).toContain(
+      "if (pinnedTimeRange) { return; } if ( !shouldAdoptTimeRangeOverride(",
+    );
+  });
+
+  test("the cross-signal pivots are hidden on a hosted snapshot", () => {
+    /*
+     * They carry the chips and the window, not the host's stored scope, so
+     * from an incident card they would open the logs explorer project-wide
+     * under a button promising "scoped like this view".
+     */
+    expect(TRACES_VIEWER).toContain(
+      'props.spanQuery ? "hidden" : "inline-flex"',
+    );
+  });
+
+  test("a scope chip disappears once the user filters that column themselves", () => {
+    /*
+     * On that column the user's selection REPLACES the scope, so a chip
+     * claiming the scope still applies would be describing a filter that is
+     * no longer in the query.
+     */
+    expect(TRACES_VIEWER).toContain(
+      "if (userFilteredFacetKeys.has(chip.facetKey)) { continue; }",
+    );
+
+    /*
+     * Chips are not the only way a column gets claimed. `status:`, `kind:`
+     * and `duration:` deliberately never become chips — their typed spelling
+     * is not the value that reaches the database, so the search bar keeps the
+     * token in the input and submits it as text. Reading only `activeFilters`
+     * left the scope's "Status: Error" chip on screen after a typed
+     * `status:ok` had already replaced it in the query.
+     */
+    expect(TRACES_VIEWER).toContain(
+      "const typedSearch: ParsedTraceSearch = parseTraceSearch(submittedSearch);",
+    );
+    expect(TRACES_VIEWER).toContain(
+      "for (const fieldKey of Object.keys(typedSearch.fieldFilters)) { userFilteredFacetKeys.add(fieldKey); }",
+    );
+  });
+
+  test("free text narrows the chart exactly when it narrows the list", () => {
+    /*
+     * The list applies bare free text to `name` only when nothing else has
+     * claimed that column. With a stored scope pinning `name` — every trace
+     * monitor that names a span — an unconditional `nameSearchText` made the
+     * chart filter while the list did not.
+     */
+    expect(TRACES_VIEWER).toContain(
+      'if ( freeText && freeText.length > 0 && !(groups["name"] && groups["name"].length > 0) ) { payload["nameSearchText"] = freeText; }',
+    );
+  });
+
+  test("attribute scope values are strings, because the payload parser drops anything else", () => {
+    /*
+     * Common/Server/API/TelemetryAPI.ts parseAttributeFilterRecord keeps
+     * strings, string arrays and serialized operators — a bare number is
+     * DROPPED. A numeric monitor attribute would have narrowed the list while
+     * the chart and facet counts above it silently ignored the filter.
+     */
+    const SPAN_SCOPE: string = readSource("Utils", "SpanQueryScope.ts");
+
+    expect(SPAN_SCOPE).toContain("attributes: Dictionary<string>;");
+    expect(SPAN_SCOPE).toContain("scope.attributes[key] = String(value);");
+  });
+
+  test("the un-carried scope is rendered, not merely computed", () => {
+    // The module's whole "never silent" guarantee depends on a consumer.
+    expect(TRACES_VIEWER).toContain(
+      'const scopeHint: string = spanScope.notCarried.join(", ");',
+    );
+    expect(TRACES_VIEWER).toContain("if (!scopeHint) { return viewer; }");
+  });
+});
+
+describe("ExceptionsViewer hosts a stored exception-instance query", () => {
+  test("it takes the query, the lens overrides, a page size and an empty message", () => {
+    expect(EXCEPTIONS_VIEWER).toContain(
+      "exceptionInstanceQuery?: Query<ExceptionInstance> | undefined;",
+    );
+    expect(EXCEPTIONS_VIEWER).toContain(
+      "defaultClassScope?: ExceptionClassScope | undefined;",
+    );
+    expect(EXCEPTIONS_VIEWER).toContain("limit?: number | undefined;");
+    expect(EXCEPTIONS_VIEWER).toContain("emptyMessage?: string | undefined;");
+    expect(EXCEPTIONS_VIEWER).toContain(
+      "disableUrlSync?: boolean | undefined;",
+    );
+  });
+
+  test("the host scope rides the existing fingerprint join, not a second filter path", () => {
+    /*
+     * TelemetryException has no attributes column, no entityKeys and no
+     * per-occurrence time — the join through ClickHouse fingerprints is the
+     * only thing that can carry an instance query onto the group list, and it
+     * is already what narrows the list, the histogram and the facet counts
+     * together.
+     */
+    expect(EXCEPTIONS_VIEWER).toContain(
+      "buildExceptionQueryScope(props.exceptionInstanceQuery)",
+    );
+    expect(EXCEPTIONS_VIEWER).toContain(
+      "mergeExceptionInstanceScopes(hostScope.instanceScope, userScope)",
+    );
+  });
+
+  test("the class lens can be opened by the host", () => {
+    expect(EXCEPTIONS_VIEWER).toContain(
+      "initialUrlState.classScope || props.defaultClassScope || DEFAULT_EXCEPTION_CLASS_SCOPE",
+    );
+  });
+
+  test("a hosted view neither seeds from nor writes to the URL", () => {
+    expect(EXCEPTIONS_VIEWER).toContain(
+      "const hostOwnsView: boolean = Boolean( props.disableUrlSync || props.exceptionInstanceQuery, );",
+    );
+    expect(EXCEPTIONS_VIEWER).toContain("if (hostOwnsView) { return; }");
+  });
+
+  test("the pinned window seeds the picker", () => {
+    expect(EXCEPTIONS_VIEWER).toContain(
+      "TelemetryQueryTimeRange.toRangeStartAndEndDateTime(hostScope.window)",
+    );
+    expect(EXCEPTIONS_VIEWER).toContain(
+      "timeRange: pinnedTimeRange || { range: TimeRange.PAST_ONE_DAY }",
+    );
+  });
+
+  test("a window-only stored query still counts as hosted", () => {
+    /*
+     * THE case that makes the trap bite. The default exception monitor
+     * ("any exception in the last 60 seconds") filters nothing, so its stored
+     * query is `{ time }` and nothing else. Branching on "does it filter
+     * anything" would leave that — the most common monitor there is — on the
+     * lastSeenAt path, hiding every exception still firing. `isHosted` is
+     * true for any query a host handed over, filters or not.
+     */
+    expect(EXCEPTIONS_VIEWER).toContain(
+      "if (!hasExceptionInstanceScope(instanceScope) && !hostScope.isHosted) { return null; }",
+    );
+  });
+
+  test("the group query drops lastSeenAt while a host query is pinned", () => {
+    /*
+     * THE trap of the group approach. `lastSeenAt` is the group's last
+     * occurrence ANYWHERE, so for an exception still firing after the
+     * snapshot ended it sits past the window. ANDing it with the fingerprint
+     * set — which was already resolved from instances INSIDE the window —
+     * drops exactly the exceptions an operator opens an incident to find, and
+     * drops them silently: the list just reads "No exceptions found".
+     */
+    expect(EXCEPTIONS_VIEWER).toContain(
+      'if (!hostScope.isHosted) { const dateRange: InBetween<Date> = RangeStartAndEndDateTimeUtil.getStartAndEndDate(timeRange); (q as Record<string, unknown>)["lastSeenAt"] = new InBetween<Date>( dateRange.startValue, dateRange.endValue, ); }',
+    );
+    // Exactly one write, so no later line can put the clause back.
+    expect(countOccurrences(EXCEPTIONS_VIEWER, '["lastSeenAt"] =')).toBe(1);
+  });
+
+  test("an in-flight fingerprint resolution reads as loading, not as empty", () => {
+    /*
+     * While the resolution is in flight the list query carries the no-match
+     * sentinel and comes back empty BY DESIGN. Rendering that as the empty
+     * state would flash "No exceptions found" on an incident card and then
+     * fill in.
+     */
+    expect(EXCEPTIONS_VIEWER).toContain(
+      "isLoading={isLoading || isResolvingScope}",
+    );
+  });
+
+  test("the reason lastSeenAt is dropped is written down next to the code", () => {
+    // A future reader deleting this branch as redundant is the regression.
+    expect(EXCEPTIONS_VIEWER_RAW).toContain("still firing");
+  });
+});
+
+describe("both explorers surface the host's scope as read-only chips", () => {
+  test.each([
+    ["TracesViewer", TRACES_VIEWER, "spanScope.chips as Array<SpanScopeChip>"],
+    ["ExceptionsViewer", EXCEPTIONS_VIEWER, "hostScope.chips"],
+  ])(
+    "%s renders the scope chips and marks them read-only",
+    (_name: string, source: string, chipsExpression: string) => {
+      /*
+       * A snapshot that filters silently makes a short list look like the
+       * whole truth. The chips are also what stops a user "clearing all"
+       * their way out of the event's own scope.
+       */
+      expect(source).toContain(`for (const chip of ${chipsExpression})`);
+      expect(source).toContain("readOnly: true,");
+    },
+  );
+});
+
+describe("the surviving table call sites are untouched", () => {
+  /*
+   * Both tables are still the right component for a live monitor-config
+   * preview, a trace's own exceptions and the session-replay panel — none of
+   * which is an event snapshot. Deleting them would also break
+   * TelemetryPreviewSnapshotWindow.test.ts, which readFileSyncs both.
+   */
+  test.each([
+    [
+      "monitor trace preview",
+      ["Components", "Monitor", "TraceMonitor", "TraceMonitorPreview.tsx"],
+      "<TraceTable",
+    ],
+    [
+      "monitor detail page",
+      ["Pages", "Monitor", "View", "Index.tsx"],
+      "<TraceTable",
+    ],
+    [
+      "trace detail exceptions",
+      ["Components", "Traces", "TraceExplorer.tsx"],
+      "<ExceptionInstanceTable",
+    ],
+    [
+      "exception monitor preview",
+      [
+        "Components",
+        "Form",
+        "Monitor",
+        "ExceptionMonitor",
+        "ExceptionMonitorStepForm.tsx",
+      ],
+      "<ExceptionInstanceTable",
+    ],
+    [
+      "session replay panel",
+      ["Components", "SessionReplay", "ReplayCorrelationPanel.tsx"],
+      "<ExceptionInstanceTable",
+    ],
+  ])(
+    "%s still mounts its table",
+    (_name: string, parts: Array<string>, marker: string) => {
+      expect(readSource(...parts)).toContain(marker);
+    },
+  );
+});

--- a/App/Tests/Dashboard/SpanQueryScope.test.ts
+++ b/App/Tests/Dashboard/SpanQueryScope.test.ts
@@ -1,0 +1,416 @@
+import { describe, expect, test } from "@jest/globals";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import ObjectID from "Common/Types/ObjectID";
+import Query from "Common/Types/BaseDatabase/Query";
+import Search from "Common/Types/BaseDatabase/Search";
+import Span, { SpanStatus } from "Common/Models/AnalyticsModels/Span";
+import { JSONObject } from "Common/Types/JSON";
+import JSONFunctions from "Common/Types/JSONFunctions";
+import { MonitorStepTraceMonitorUtil } from "Common/Types/Monitor/MonitorStepTraceMonitor";
+import TelemetryType from "Common/Types/Telemetry/TelemetryType";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
+import {
+  EMPTY_SPAN_QUERY_SCOPE,
+  SpanQueryScope,
+  SpanScopeChip,
+  buildSpanQueryScope,
+} from "../../FeatureSet/Dashboard/src/Utils/SpanQueryScope";
+
+/*
+ * The Alert and Incident pages used to render a trace monitor's stored query
+ * through a dense table that took the query verbatim. They now embed the
+ * spans explorer, which needs the SAME query in three different vocabularies
+ * at once — the list query, the histogram/facet aggregation payload, and the
+ * read-only chips — plus the window for the picker.
+ *
+ * Splitting one filter across those three by hand is how a chart ends up
+ * counting rows the list excludes, so the split is made once, here, and this
+ * file is where the correspondences are pinned. The inputs are real
+ * `MonitorStepTraceMonitorUtil.toQuery` output taken through the same
+ * store/load round trip the pages perform, not hand-written objects, so a
+ * change to what a monitor stores breaks this file rather than the pages.
+ */
+
+const SERVICE_ID_A: string = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+).toString();
+const SERVICE_ID_B: string = new ObjectID(
+  "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+).toString();
+
+/** Persist the way the worker does; restore the way the pages do. */
+function roundTrip(query: Query<Span>): Query<Span> {
+  return JSONFunctions.deserialize(
+    JSONFunctions.anyObjectToJSONObject(query as unknown as JSONObject),
+  ) as unknown as Query<Span>;
+}
+
+/** Persist without deserializing — the shape a raw JSON consumer sees. */
+function storedOnly(query: Query<Span>): JSONObject {
+  return JSONFunctions.anyObjectToJSONObject(query as unknown as JSONObject);
+}
+
+function traceMonitorQuery(
+  overrides: Partial<Parameters<typeof MonitorStepTraceMonitorUtil.toQuery>[0]>,
+): Query<Span> {
+  return MonitorStepTraceMonitorUtil.toQuery({
+    ...MonitorStepTraceMonitorUtil.getDefault(),
+    ...overrides,
+  });
+}
+
+function chipFor(
+  scope: SpanQueryScope,
+  facetKey: string,
+): Array<SpanScopeChip> {
+  return scope.chips.filter((chip: SpanScopeChip): boolean => {
+    return chip.facetKey === facetKey;
+  });
+}
+
+describe("a real trace monitor's stored query", () => {
+  const stored: Query<Span> = traceMonitorQuery({
+    telemetryServiceIds: [
+      new ObjectID(SERVICE_ID_A),
+      new ObjectID(SERVICE_ID_B),
+    ],
+    entityKeys: ["service:checkout", "k8s.pod:checkout-abc"],
+    attributes: { "http.route": "/checkout", "http.status_code": 500 },
+    spanStatuses: [SpanStatus.Error],
+    spanName: "POST /checkout",
+    lastXSecondsOfSpans: 300,
+  });
+
+  test("every key a trace monitor emits is read into the scope", () => {
+    /*
+     * The list of keys is the contract. If MonitorStepTraceMonitorUtil grows
+     * one, this test still passes but `notCarried` names it — see the
+     * unknown-key test below — so the widening is at least visible.
+     */
+    expect(Object.keys(stored).sort()).toEqual([
+      "attributes",
+      "entityKeys",
+      "name",
+      "primaryEntityId",
+      "startTime",
+      "statusCode",
+    ]);
+  });
+
+  test("reads identically whether or not the page deserialized it", () => {
+    const deserialized: SpanQueryScope = buildSpanQueryScope(roundTrip(stored));
+    const raw: SpanQueryScope = buildSpanQueryScope(storedOnly(stored));
+
+    for (const scope of [deserialized, raw]) {
+      expect(scope.serviceIds).toEqual([SERVICE_ID_A, SERVICE_ID_B]);
+      expect(scope.entityKeys).toEqual([
+        "service:checkout",
+        "k8s.pod:checkout-abc",
+      ]);
+      /*
+       * Stringified: the ClickHouse attributes column is Map(String, String),
+       * and the aggregation endpoint's body parser drops a bare number
+       * outright — a numeric attribute would have narrowed the list while the
+       * chart above it silently ignored the filter.
+       */
+      expect(scope.attributes).toEqual({
+        "http.route": "/checkout",
+        "http.status_code": "500",
+      });
+      expect(scope.statusCodes).toEqual([SpanStatus.Error]);
+      expect(scope.spanNameSearch).toBe("POST /checkout");
+      expect(scope.hasScope).toBe(true);
+    }
+  });
+
+  test("nothing is left over: no passthrough, no un-carried scope", () => {
+    /*
+     * Every key of a trace monitor's query has an exact counterpart in the
+     * aggregation payload (parseTraceFilterBody accepts serviceIds,
+     * entityKeys, statusCodes, spanNames/spanNameSearches, attributes), so a
+     * trace snapshot must never report a widened chart.
+     */
+    const scope: SpanQueryScope = buildSpanQueryScope(roundTrip(stored));
+
+    expect(scope.passthrough).toEqual({});
+    expect(scope.notCarried).toEqual([]);
+  });
+
+  test("the window becomes a pin, not a filter", () => {
+    const scope: SpanQueryScope = buildSpanQueryScope(roundTrip(stored));
+
+    expect(scope.window).not.toBeNull();
+    expect(
+      scope.window!.endValue.getTime() - scope.window!.startValue.getTime(),
+    ).toBe(300 * 1000);
+
+    // It must not survive as a query filter — the picker owns the window.
+    expect(scope.passthrough).not.toHaveProperty("startTime");
+
+    // And it is the same window the pages badge the card with.
+    const pageWindow: InBetween<Date> | null =
+      TelemetryQueryTimeRange.getQueryWindow(
+        roundTrip(stored),
+        TelemetryType.Trace,
+      );
+
+    expect(scope.window!.startValue.getTime()).toBe(
+      pageWindow!.startValue.getTime(),
+    );
+  });
+
+  test("projectId is dropped — the viewer stamps its own", () => {
+    const scope: SpanQueryScope = buildSpanQueryScope({
+      ...roundTrip(stored),
+      projectId: new ObjectID(SERVICE_ID_A),
+    } as Query<Span>);
+
+    expect(scope.passthrough).not.toHaveProperty("projectId");
+    expect(scope.notCarried).toEqual([]);
+  });
+
+  test("every scoped dimension surfaces as a chip", () => {
+    /*
+     * A snapshot that filters silently makes a short list look like the whole
+     * truth, so each dimension has to be visible to the reader.
+     */
+    const scope: SpanQueryScope = buildSpanQueryScope(roundTrip(stored));
+
+    expect(
+      chipFor(scope, "primaryEntityId").map((c: SpanScopeChip) => {
+        return c.value;
+      }),
+    ).toEqual([SERVICE_ID_A, SERVICE_ID_B]);
+    expect(chipFor(scope, "entityKeys")).toHaveLength(2);
+    expect(
+      chipFor(scope, "name").map((c: SpanScopeChip) => {
+        return c.value;
+      }),
+    ).toEqual(["POST /checkout"]);
+    expect(chipFor(scope, "attributes.http.route")).toHaveLength(1);
+    expect(chipFor(scope, "attributes.http.status_code")[0]!.value).toBe("500");
+
+    // Status shows as its name, not the enum's number.
+    expect(chipFor(scope, "statusCode")[0]!.displayValue).toBe("Error");
+  });
+});
+
+describe("span name and status message: substring vs exact", () => {
+  test("a monitor's Search stays a substring match", () => {
+    /*
+     * `MonitorStepTraceMonitorUtil.toQuery` stores `new Search(spanName)`.
+     * Reading it as an exact value would scope the list to spans whose WHOLE
+     * name equals the fragment — usually none — and the incident would read
+     * "No spans found".
+     */
+    const scope: SpanQueryScope = buildSpanQueryScope(
+      roundTrip(traceMonitorQuery({ spanName: "checkout" })),
+    );
+
+    expect(scope.spanNameSearch).toBe("checkout");
+    expect(scope.spanNames).toEqual([]);
+  });
+
+  test("a single exact value is still a substring, mirroring a chip", () => {
+    // TEXT_CHIP_FIELDS in TracesViewer: one value → Search, several → Includes.
+    const scope: SpanQueryScope = buildSpanQueryScope({
+      name: "GET /api",
+    } as unknown as Query<Span>);
+
+    expect(scope.spanNameSearch).toBe("GET /api");
+    expect(scope.spanNames).toEqual([]);
+  });
+
+  test("several values are matched exactly", () => {
+    const scope: SpanQueryScope = buildSpanQueryScope({
+      name: new Includes(["GET /a", "GET /b"]),
+    } as unknown as Query<Span>);
+
+    expect(scope.spanNameSearch).toBeNull();
+    expect(scope.spanNames).toEqual(["GET /a", "GET /b"]);
+  });
+
+  test("statusMessage follows the same rule", () => {
+    const single: SpanQueryScope = buildSpanQueryScope({
+      statusMessage: new Search<string>("timeout"),
+    } as unknown as Query<Span>);
+    const many: SpanQueryScope = buildSpanQueryScope({
+      statusMessage: new Includes(["timeout", "refused"]),
+    } as unknown as Query<Span>);
+
+    expect(single.statusMessageSearch).toBe("timeout");
+    expect(single.statusMessages).toEqual([]);
+    expect(many.statusMessageSearch).toBeNull();
+    expect(many.statusMessages).toEqual(["timeout", "refused"]);
+  });
+});
+
+describe("the other span columns the aggregation payload can express", () => {
+  test("trace / span ids, kind and hasException are read, not passed through", () => {
+    const scope: SpanQueryScope = buildSpanQueryScope({
+      traceId: new Includes(["t1", "t2"]),
+      spanId: "s1",
+      kind: "SPAN_KIND_SERVER",
+      hasException: true,
+    } as unknown as Query<Span>);
+
+    expect(scope.traceIds).toEqual(["t1", "t2"]);
+    expect(scope.spanIds).toEqual(["s1"]);
+    expect(scope.spanKinds).toEqual(["SPAN_KIND_SERVER"]);
+    expect(scope.hasException).toBe(true);
+    expect(scope.passthrough).toEqual({});
+    expect(scope.notCarried).toEqual([]);
+  });
+
+  test("hasException is tri-state, so 'unfiltered' and 'false' differ", () => {
+    expect(buildSpanQueryScope({} as Query<Span>).hasException).toBeNull();
+    expect(
+      buildSpanQueryScope({ hasException: false } as unknown as Query<Span>)
+        .hasException,
+    ).toBe(false);
+    // A JSON round trip can leave it as a string.
+    expect(
+      buildSpanQueryScope({ hasException: "true" } as unknown as Query<Span>)
+        .hasException,
+    ).toBe(true);
+  });
+
+  test("isRootSpan becomes the root-only toggle rather than a raw filter", () => {
+    const scope: SpanQueryScope = buildSpanQueryScope({
+      isRootSpan: true,
+    } as unknown as Query<Span>);
+
+    expect(scope.rootOnly).toBe(true);
+    expect(scope.passthrough).not.toHaveProperty("isRootSpan");
+  });
+});
+
+describe("attributes", () => {
+  test("a boolean scope value is stringified too", () => {
+    const scope: SpanQueryScope = buildSpanQueryScope({
+      attributes: { "error.escaped": true },
+    } as unknown as Query<Span>);
+
+    expect(scope.attributes).toEqual({ "error.escaped": "true" });
+  });
+
+  test("an unmodelled entry still filters the list, and says the chart is wider", () => {
+    /*
+     * A partially readable attributes map is the dangerous case: dropping the
+     * half we cannot model would widen the LIST under an event's heading with
+     * nothing on screen saying so.
+     */
+    const contains: unknown = { _type: "Search", value: "checkout" };
+    const scope: SpanQueryScope = buildSpanQueryScope({
+      attributes: { "http.route": contains, "http.method": "GET" },
+    } as unknown as Query<Span>);
+
+    expect(scope.attributes).toEqual({ "http.method": "GET" });
+    expect(scope.attributesPassthrough).toEqual({ "http.route": contains });
+    expect(scope.notCarried).toContain("attribute filter on http.route");
+    expect(scope.hasScope).toBe(true);
+  });
+
+  test("an attributes value that is not a record at all is reported", () => {
+    const scope: SpanQueryScope = buildSpanQueryScope({
+      attributes: "nonsense",
+    } as unknown as Query<Span>);
+
+    expect(scope.notCarried).toContain("attribute filter");
+  });
+});
+
+describe("scope the payload cannot express is reported, never dropped", () => {
+  test("an unknown key still filters the list and names itself in the hint", () => {
+    /*
+     * The alternative — dropping it — widens the list under an event's
+     * heading with nothing on screen saying so. A narrower list plus a hint
+     * that the chart above is wider is the honest failure mode.
+     */
+    const scope: SpanQueryScope = buildSpanQueryScope({
+      durationUnixNano: new Includes([1, 2]),
+      someFutureColumn: "x",
+    } as unknown as Query<Span>);
+
+    expect(scope.passthrough).toHaveProperty("durationUnixNano");
+    expect(scope.passthrough).toHaveProperty("someFutureColumn");
+    expect(scope.notCarried).toContain("span duration filter");
+    expect(scope.notCarried).toContain("someFutureColumn");
+    expect(scope.hasScope).toBe(true);
+  });
+
+  test("an unreadable value on a known column is forwarded and reported", () => {
+    const scope: SpanQueryScope = buildSpanQueryScope({
+      statusCode: { weird: true },
+    } as unknown as Query<Span>);
+
+    expect(scope.statusCodes).toEqual([]);
+    expect(scope.passthrough).toHaveProperty("statusCode");
+    expect(scope.notCarried).toContain("span status filter");
+  });
+
+  test("an EMPTY membership is silent — it filters nothing", () => {
+    /*
+     * A monitor with no services selected stores `Includes([])`. Reporting
+     * that as un-carried scope would put a hint on every such incident.
+     */
+    const scope: SpanQueryScope = buildSpanQueryScope({
+      primaryEntityId: new Includes([]),
+    } as unknown as Query<Span>);
+
+    expect(scope.serviceIds).toEqual([]);
+    expect(scope.notCarried).toEqual([]);
+    expect(scope.passthrough).toEqual({});
+    expect(scope.hasScope).toBe(false);
+  });
+});
+
+describe("absent and degenerate queries", () => {
+  test("null / undefined / non-object yield the empty scope", () => {
+    for (const value of [null, undefined, [], "nope", 7]) {
+      const scope: SpanQueryScope = buildSpanQueryScope(
+        value as unknown as Query<Span>,
+      );
+
+      expect(scope.hasScope).toBe(false);
+      expect(scope.window).toBeNull();
+      expect(scope.chips).toEqual([]);
+    }
+  });
+
+  test("a window-only query pins the picker but scopes nothing", () => {
+    /*
+     * A monitor with no filters at all still stores its evaluation window.
+     * The viewer must adopt the window and otherwise behave exactly as the
+     * standalone explorer does.
+     */
+    const scope: SpanQueryScope = buildSpanQueryScope(
+      roundTrip(traceMonitorQuery({ lastXSecondsOfSpans: 60 })),
+    );
+
+    expect(scope.window).not.toBeNull();
+    expect(scope.hasScope).toBe(false);
+    expect(scope.chips).toEqual([]);
+  });
+
+  test("the exported empty scope is inert", () => {
+    expect(EMPTY_SPAN_QUERY_SCOPE.hasScope).toBe(false);
+    expect(EMPTY_SPAN_QUERY_SCOPE.window).toBeNull();
+    expect(EMPTY_SPAN_QUERY_SCOPE.hasException).toBeNull();
+    expect(EMPTY_SPAN_QUERY_SCOPE.rootOnly).toBe(false);
+  });
+
+  test("reading a query twice does not mutate the shared empty scope", () => {
+    // The builder spreads EMPTY_SPAN_QUERY_SCOPE; a shallow copy would leak.
+    buildSpanQueryScope({
+      primaryEntityId: SERVICE_ID_A,
+      traceId: "t1",
+    } as unknown as Query<Span>);
+
+    expect(EMPTY_SPAN_QUERY_SCOPE.serviceIds).toEqual([]);
+    expect(EMPTY_SPAN_QUERY_SCOPE.traceIds).toEqual([]);
+    expect(EMPTY_SPAN_QUERY_SCOPE.chips).toEqual([]);
+    expect(EMPTY_SPAN_QUERY_SCOPE.passthrough).toEqual({});
+  });
+});

--- a/App/Tests/Dashboard/TelemetryCompanionSignals.test.ts
+++ b/App/Tests/Dashboard/TelemetryCompanionSignals.test.ts
@@ -907,8 +907,11 @@ describe("page and card wiring", () => {
   });
 
   test("companion tables never restore URL filters over the pin", () => {
-    // The trace and exception companions, like the primary embeds.
-    expect(COMPANION_TABS.split("disableUrlState={true}").length - 1).toBe(2);
+    /*
+     * The trace and exception companions, like the primary embeds — now the
+     * span / exception explorers, so the opt-out is spelled their way.
+     */
+    expect(COMPANION_TABS.split("disableUrlSync={true}").length - 1).toBe(2);
   });
 
   test("the logs companion feeds the viewer's pinned-window mechanism", () => {

--- a/App/Tests/Dashboard/TelemetryPreviewSnapshotWindow.test.ts
+++ b/App/Tests/Dashboard/TelemetryPreviewSnapshotWindow.test.ts
@@ -411,14 +411,30 @@ describe("the incident and alert pages rebuild the window's Date bounds", () => 
     ["incident", INCIDENT_VIEW],
     ["alert", ALERT_VIEW],
   ])(
-    "%s page stops the trace and exception tables restoring a filter over the pin",
+    "%s page stops the span and exception lists restoring a filter over the pin",
     (_name: string, source: string) => {
-      expect(source.split("disableUrlState={true}").length - 1).toBe(2);
+      /*
+       * The two dense tables became the same explorers the /traces and
+       * /exceptions pages use, so the opt-out is spelled the explorers' way
+       * — but the requirement is unchanged: a snapshot pinned to the moment
+       * the monitor fired must not have a filter restored over it from the
+       * host page's query string, and must not write its own state back into
+       * that query string either.
+       */
+      expect(source.split("disableUrlSync={true}").length - 1).toBe(2);
+      expect(source).not.toContain("disableUrlState");
     },
   );
 });
 
 describe("the tables and charts accept the pinned window", () => {
+  /*
+   * The incident / alert snapshot no longer uses these two tables — it embeds
+   * the span and exception explorers instead (see
+   * SnapshotSpanExceptionLists.test.ts). They are still mounted by the
+   * monitor-config previews, the trace detail page and the session-replay
+   * panel, all of which pass a pinned query, so the contract stands.
+   */
   test("trace and exception tables forward a header element and can opt out of URL state", () => {
     for (const source of [TRACE_TABLE, EXCEPTION_TABLE]) {
       expect(source).toContain("rightElement?: ReactElement | undefined;");

--- a/App/Tests/Dashboard/TelemetryQueryFilterValues.test.ts
+++ b/App/Tests/Dashboard/TelemetryQueryFilterValues.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, test } from "@jest/globals";
+import Dictionary from "Common/Types/Dictionary";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import ObjectID from "Common/Types/ObjectID";
+import Search from "Common/Types/BaseDatabase/Search";
+import { JSONObject } from "Common/Types/JSON";
+import JSONFunctions from "Common/Types/JSONFunctions";
+import {
+  TelemetryScopeAttributeValue,
+  getFilterAttributes,
+  getFilterNumberValues,
+  getFilterSearchValue,
+  getFilterStringValues,
+  isEmptyFilterValue,
+} from "../../FeatureSet/Dashboard/src/Utils/TelemetryQueryFilterValues";
+
+/*
+ * These readers sit between a STORED monitor query and every viewer that
+ * hosts one. The shapes they have to cope with are not hypothetical: a
+ * telemetry monitor builds `new Includes([...])`, the worker persists the
+ * blob through JSON.stringify, and whether the reader sees an operator
+ * INSTANCE or the plain `{ _type: "Includes", value: [...] }` object depends
+ * on whether the page ran JSONFunctions.deserialize first. A reader that
+ * handles one and not the other loses an incident's scope on one surface
+ * while keeping it on another — silently, because a scope that fails open
+ * just shows more rows.
+ *
+ * So every case below is asserted in BOTH shapes.
+ */
+
+const SERVICE_ID: string = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+).toString();
+const OTHER_SERVICE_ID: string = new ObjectID(
+  "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+).toString();
+
+/** Persist the way the worker does, restore WITHOUT deserializing. */
+function serialized(value: unknown): unknown {
+  return JSONFunctions.anyObjectToJSONObject({
+    value: value,
+  } as JSONObject)["value"];
+}
+
+/** Persist and restore the way a page that deserializes does. */
+function roundTripped(value: unknown): unknown {
+  return (
+    JSONFunctions.deserialize(
+      JSONFunctions.anyObjectToJSONObject({ value: value } as JSONObject),
+    ) as JSONObject
+  )["value"];
+}
+
+describe("getFilterStringValues", () => {
+  test("reads an Includes of ObjectIDs in both stored shapes", () => {
+    const filter: Includes = new Includes([
+      new ObjectID(SERVICE_ID),
+      new ObjectID(OTHER_SERVICE_ID),
+    ]);
+
+    for (const shape of [filter, serialized(filter), roundTripped(filter)]) {
+      expect(getFilterStringValues(shape)).toEqual([
+        SERVICE_ID,
+        OTHER_SERVICE_ID,
+      ]);
+    }
+  });
+
+  test("reads a bare string, a number and a single ObjectID", () => {
+    expect(getFilterStringValues("checkout")).toEqual(["checkout"]);
+    expect(getFilterStringValues(42)).toEqual(["42"]);
+    expect(getFilterStringValues(new ObjectID(SERVICE_ID))).toEqual([
+      SERVICE_ID,
+    ]);
+    expect(getFilterStringValues(serialized(new ObjectID(SERVICE_ID)))).toEqual(
+      [SERVICE_ID],
+    );
+  });
+
+  test("reads a plain array, and dedupes while preserving order", () => {
+    expect(getFilterStringValues(["b", "a", "b"])).toEqual(["b", "a"]);
+  });
+
+  test("drops blank and non-scalar members rather than emitting empties", () => {
+    expect(getFilterStringValues(["a", "", "   ", null, {}, "b"])).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  test("returns nothing for the shapes it cannot read", () => {
+    expect(getFilterStringValues(null)).toEqual([]);
+    expect(getFilterStringValues(undefined)).toEqual([]);
+    expect(getFilterStringValues(new Search<string>("boom"))).toEqual([]);
+    expect(
+      getFilterStringValues(new InBetween<Date>(new Date(1), new Date(2))),
+    ).toEqual([]);
+  });
+});
+
+describe("isEmptyFilterValue", () => {
+  /*
+   * The distinction this draws is the whole reason it exists: an EMPTY
+   * membership scopes nothing and is a no-op the monitor happened to store,
+   * while an unreadable value is scope we failed to carry and must report.
+   * Conflating them either spams a hint on every incident or hides a real
+   * widening.
+   */
+  test("an empty membership is empty, in both stored shapes", () => {
+    const empty: Includes = new Includes([]);
+
+    expect(isEmptyFilterValue(empty)).toBe(true);
+    expect(isEmptyFilterValue(serialized(empty))).toBe(true);
+    expect(isEmptyFilterValue([])).toBe(true);
+    expect(isEmptyFilterValue("")).toBe(true);
+    expect(isEmptyFilterValue("   ")).toBe(true);
+  });
+
+  test("a populated or unreadable value is not empty", () => {
+    expect(isEmptyFilterValue(new Includes(["a"]))).toBe(false);
+    expect(isEmptyFilterValue("a")).toBe(false);
+    expect(isEmptyFilterValue(new Search<string>("a"))).toBe(false);
+  });
+});
+
+describe("getFilterSearchValue", () => {
+  test("reads a Search in both stored shapes", () => {
+    const filter: Search<string> = new Search<string>("OutOfMemory");
+
+    for (const shape of [filter, serialized(filter), roundTripped(filter)]) {
+      expect(getFilterSearchValue(shape)).toBe("OutOfMemory");
+    }
+  });
+
+  test("is null for anything that is not a Search", () => {
+    /*
+     * The caller uses null to mean "this is an exact-match filter", so a
+     * false positive here would turn a span-name equality into a substring
+     * match and widen an incident's list.
+     */
+    expect(getFilterSearchValue(new Includes(["a"]))).toBeNull();
+    expect(getFilterSearchValue("a")).toBeNull();
+    expect(getFilterSearchValue(null)).toBeNull();
+    expect(getFilterSearchValue(undefined)).toBeNull();
+  });
+
+  test("an empty Search is null, not an empty substring", () => {
+    // `new Search("")` matches everything; reporting it as scope would lie.
+    expect(getFilterSearchValue(new Search<string>(""))).toBeNull();
+    expect(getFilterSearchValue(new Search<string>("   "))).toBeNull();
+  });
+});
+
+describe("getFilterNumberValues", () => {
+  test("reads SpanStatus members through both stored shapes", () => {
+    const filter: Includes = new Includes([1, 2]);
+
+    for (const shape of [filter, serialized(filter), roundTripped(filter)]) {
+      expect(getFilterNumberValues(shape)).toEqual([1, 2]);
+    }
+  });
+
+  test("reads decimal strings, which is what a JSON round trip can leave", () => {
+    expect(getFilterNumberValues(new Includes(["0", "2"]))).toEqual([0, 2]);
+  });
+
+  test("drops non-numeric members rather than coercing them to NaN", () => {
+    // A NaN in the list would compile to a predicate that matches nothing.
+    expect(getFilterNumberValues(new Includes(["2", "error"]))).toEqual([2]);
+  });
+});
+
+describe("getFilterAttributes", () => {
+  test("reads a scalar attribute record, keeping value types", () => {
+    const attributes: Dictionary<TelemetryScopeAttributeValue> =
+      getFilterAttributes({
+        "http.route": "/checkout",
+        "http.status_code": 500,
+        "error.escaped": true,
+      });
+
+    expect(attributes).toEqual({
+      "http.route": "/checkout",
+      "http.status_code": 500,
+      "error.escaped": true,
+    });
+  });
+
+  test("survives the store/load round trip a monitor's attributes take", () => {
+    const stored: unknown = roundTripped({
+      "http.route": "/checkout",
+      "http.status_code": 500,
+    });
+
+    expect(getFilterAttributes(stored)).toEqual({
+      "http.route": "/checkout",
+      "http.status_code": 500,
+    });
+  });
+
+  test("drops non-scalar values and blank keys", () => {
+    expect(
+      getFilterAttributes({
+        good: "yes",
+        nested: { a: 1 },
+        list: ["a"],
+        "  ": "blank key",
+      }),
+    ).toEqual({ good: "yes" });
+  });
+
+  test("is empty for an operator or a non-record", () => {
+    /*
+     * An operator stored under `attributes` is not an attribute map. Reading
+     * its internals as attribute keys would invent filters the monitor never
+     * expressed.
+     */
+    expect(getFilterAttributes(new Includes(["a"]))).toEqual({});
+    expect(getFilterAttributes(new Search<string>("a"))).toEqual({});
+    expect(getFilterAttributes(serialized(new Includes(["a"])))).toEqual({});
+    expect(getFilterAttributes(new ObjectID(SERVICE_ID))).toEqual({});
+    expect(getFilterAttributes(["a"])).toEqual({});
+    expect(getFilterAttributes(null)).toEqual({});
+  });
+});

--- a/App/Tests/Dashboard/TelemetrySnapshot.test.ts
+++ b/App/Tests/Dashboard/TelemetrySnapshot.test.ts
@@ -179,6 +179,6 @@ describe("episode telemetry wiring", () => {
     expect(panel).toContain("TelemetryType.Trace");
     expect(panel).toContain("TelemetryType.Metric");
     expect(panel).toContain("TelemetryType.Exception");
-    expect(panel).toContain("disableUrlState={true}");
+    expect(panel).toContain("disableUrlSync={true}");
   });
 });


### PR DESCRIPTION
## What

The telemetry snapshot on an **alert** or **incident** rendered its spans through a dense `AnalyticsModelTable` and its exceptions through another one — while the Logs branch right beside them embedded the very viewer the `/logs` page uses.

This puts all three signals on the same footing. The Trace branch now mounts **`TracesViewer`** and the Exception branch **`ExceptionsViewer`** — the same explorers `/traces` and `/exceptions` serve — inside a host `Card`, pinned to the window the monitor evaluated over.

Four surfaces move together, because leaving any one behind would put a table and a list on the same card:

| Surface | Why |
|---|---|
| `Pages/Alerts/View/Index.tsx` | the ask |
| `Pages/Incidents/View/Index.tsx` | the ask |
| `Components/Telemetry/TelemetrySnapshotPanel.tsx` | the extracted twin the two **episode** pages mount |
| `Components/Telemetry/TelemetryCompanionSignalTabs.tsx` | renders the Traces / Exceptions tab on all four, and in the AI investigation drawer |

The two dense tables stay. Their five other call sites — the monitor-config previews, the trace detail page, the session-replay panel — are live views rather than event snapshots, and still want a table.

## How

Both explorers had to learn to be hosted, and the interesting part is that one stored query has to reach more than one place at once.

- **`Utils/SpanQueryScope.ts`** reads a stored `Query<Span>` **once** into the list query, the histogram/facet aggregation payload (a different vocabulary — `serviceIds`, `spanNameSearches`, `statusCodes`, …), the read-only chips, and the pinned window. One reading is what stops the chart counting rows the list excludes. Filters the payload cannot express still narrow the **list** and are named on screen rather than dropped.
- **`Utils/ExceptionQueryScope.ts`** has the awkward job: the stored query selects ClickHouse *occurrences* while the explorer lists Postgres *groups*, joined only by `fingerprint`. Rather than bolting a second filter path onto the group query, it feeds the viewer's existing `GROUP BY fingerprint` resolution — which already narrows list, histogram and facet counts together.
- Both viewers gain a **`hostOwnsView`** notion: an embed does not seed state from the host page's URL, does not write state back into it, and does not let a project default saved view apply itself over the pin.

New props: `TracesViewer` — `spanQuery`, `limit`, `emptyMessage`. `ExceptionsViewer` — `exceptionInstanceQuery`, `defaultClassScope`, `limit`, `emptyMessage`, `disableUrlSync`.

`Components/Traces/TracesSearchCompile.ts` is **unchanged from master** — an earlier type widening was reverted once the root cause turned out to be elsewhere (below).

## Two ways this could have shipped looking fine and showing the wrong rows

Both were found by review and are covered by tests.

**1. Exceptions still firing would have vanished.** `ExceptionsViewer` scopes its group list by `lastSeenAt` — a group's last occurrence *anywhere*. AND that with a fixed past window and any exception still firing when you open the incident sits past the window and disappears; the card reads "No exceptions found" for exactly the rows the page exists to show. And it is not an edge case: the **default** exception monitor ("any exception in the last 60 seconds") filters nothing, so its stored query is a window and nothing else. A hosted view now *always* resolves its groups through the instance table — the window itself is the scope — and drops the `lastSeenAt` clause.

**2. A numeric attribute would have narrowed the list but not the chart.** The aggregation endpoint's body parser (`parseAttributeFilterRecord`) keeps strings, string arrays and serialized operators, and **drops a bare number**. A monitor filtering on `http.status_code = 500` would have filtered the list while the histogram and facet counts above it ignored it. Attribute scope values are stringified at the point they are read; the ClickHouse column is `Map(String, String)` either way.

Also fixed from review: the URL *write* guard followed `disableUrlSync` while the *read* followed `hostOwnsView`; a pinned window could be steered by a controlled one; the cross-signal pivot buttons would open the logs explorer project-wide from an incident card; a scope chip stayed on screen after the user overrode that column (including via typed `status:` / `kind:` tokens, which deliberately never become chips); an in-flight fingerprint resolution rendered as "No exceptions found" rather than as loading; and `notCarried` was computed but never rendered.

## Tests

Four new suites in `App/Tests/Dashboard` (**~130 tests**), driven by real `MonitorStep*Util` output taken through the same store/load round trip the pages perform, asserted in **both** the deserialized and raw-JSON shapes:

- `TelemetryQueryFilterValues.test.ts` — the shared readers
- `SpanQueryScope.test.ts` — the span translation, both transports
- `ExceptionQueryScope.test.ts` — the instance→fingerprint→group bridge
- `SnapshotSpanExceptionLists.test.ts` — the wiring the App suite cannot render, including both traps above

Writing them caught two reader bugs, one **latent in code lifted from the existing companion-signal derivation**: an `Includes` of `ObjectID`s read as **empty** when the query had not been deserialized (a scope that fails open), and `Search` having its private field read as an attribute.

Three existing suites were adapted where they pinned the old prop names.

## Verification

- `App/Tests/Dashboard`: **262 suites / 8957 tests green**
- App `tsc --noEmit`: clean
- Dashboard `tsc --noEmit`: **identical to the master baseline** (the package's own deps are not installed in this checkout, so it was diffed against master rather than read absolutely — that diff is what caught a `TS2589` the App typecheck structurally cannot see, since it excludes Dashboard `.tsx`)
- `eslint --fix` on every changed file: clean

The final two edits (a ~15-line guard extension and the lint autofix) landed after the last full-suite run; the 18 directly-affected suites (487 tests) and type-aware lint are green on the final state, and CI's `compile-dashboard` is the authoritative gate for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qH1x6veRRmMSzVuRmuMNP
