### PR TITLE
fix: show human-readable units for metric values in alert and incident emails

### DIFF
--- a/Common/Server/Utils/Monitor/Criteria/CompareCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/CompareCriteria.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../Types/Monitor/CriteriaFilter";
 import Typeof from "../../../../Types/Typeof";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
+import MetricValueFormatter from "../../../../Utils/Monitor/MetricValueFormatter";
 
 export default class CompareCriteria {
   /*
@@ -474,6 +475,15 @@ export default class CompareCriteria {
     criteriaFilter: CriteriaFilter;
     metricDisplayName?: string | undefined;
     unit?: string | undefined;
+    /**
+     * The metric NAME, when there is a real one. Distinct from
+     * metricDisplayName, which is the formula expression for a formula
+     * criteria and is only ever used as a label: this one feeds
+     * ValueFormatter.isFractionMetric, which would read the trailing
+     * `_ratio` of a formula like `a / b_ratio` as a signal to multiply
+     * the value by 100. Callers pass it only for plain metric criteria.
+     */
+    metricName?: string | undefined;
   }): string | null {
     if (data.value === null || data.value === undefined) {
       return null;
@@ -499,6 +509,7 @@ export default class CompareCriteria {
           criteriaFilter: data.criteriaFilter,
           metricDisplayName: data.metricDisplayName,
           unit: data.unit,
+          metricName: data.metricName,
         });
       }
 
@@ -521,6 +532,7 @@ export default class CompareCriteria {
           criteriaFilter: data.criteriaFilter,
           metricDisplayName: data.metricDisplayName,
           unit: data.unit,
+          metricName: data.metricName,
         });
       }
 
@@ -543,6 +555,7 @@ export default class CompareCriteria {
           criteriaFilter: data.criteriaFilter,
           metricDisplayName: data.metricDisplayName,
           unit: data.unit,
+          metricName: data.metricName,
         });
       }
 
@@ -565,6 +578,7 @@ export default class CompareCriteria {
           criteriaFilter: data.criteriaFilter,
           metricDisplayName: data.metricDisplayName,
           unit: data.unit,
+          metricName: data.metricName,
         });
       }
 
@@ -587,6 +601,7 @@ export default class CompareCriteria {
           criteriaFilter: data.criteriaFilter,
           metricDisplayName: data.metricDisplayName,
           unit: data.unit,
+          metricName: data.metricName,
         });
       }
 
@@ -609,6 +624,7 @@ export default class CompareCriteria {
           criteriaFilter: data.criteriaFilter,
           metricDisplayName: data.metricDisplayName,
           unit: data.unit,
+          metricName: data.metricName,
         });
       }
 
@@ -625,6 +641,15 @@ export default class CompareCriteria {
     criteriaFilter: CriteriaFilter;
     metricDisplayName?: string | undefined;
     unit?: string | undefined;
+    /**
+     * The metric NAME, when there is a real one. Distinct from
+     * metricDisplayName, which is the formula expression for a formula
+     * criteria and is only ever used as a label: this one feeds
+     * ValueFormatter.isFractionMetric, which would read the trailing
+     * `_ratio` of a formula like `a / b_ratio` as a signal to multiply
+     * the value by 100. Callers pass it only for plain metric criteria.
+     */
+    metricName?: string | undefined;
   }): string {
     // CPU Percent over the last 5 minutes is 10 which is less than the threshold of 20
     let message: string = "";
@@ -695,30 +720,36 @@ export default class CompareCriteria {
     }
 
     /*
-     * Suppress the units that read as noise — or as a wrong number —
-     * next to a value. OTel's dimensionless "1" marks ratio metrics
-     * whose samples are fractions in [0, 1]; rendering "0.06 1" is both
-     * ugly and misleading (it is not 1% — it is 6%), and a CLS breach
-     * read "is 0.31 1 which is greater than or equal to 0.25 1". UCUM
-     * annotation-only units ("{cpu}", "{packets}", "{errors}") are
-     * descriptive braces, not a unit a reader should be shown. Every
-     * real unit passes through unchanged, so "%" stays "%" and "ms"
-     * stays "ms".
+     * A metric value is written the way the dashboard writes it —
+     * "1.07 GB", "1.5 sec", "25.34%" — rather than as raw digits with a
+     * raw UCUM code glued on. Only two of the ~35 callers pass a unit at
+     * all (MetricMonitorCriteria and DatabaseMonitorCriteria); everything
+     * else carries its unit inside the CheckOn label ("Response Time (in
+     * ms)") and must keep its exact digits, so an absent unit leaves this
+     * sentence byte-for-byte as it was.
      *
-     * The dashboard side already applies the "1" half of this rule in
-     * MonitorCriteriaObservationBuilder.normalizeDisplayUnit, and
-     * ValueFormatter applies both halves when it formats a value. The
-     * email path never picked either up, so the same evaluation rendered
-     * worse in the alert than on the dashboard.
+     * MetricValueFormatter also subsumes the unit-suppression rules this
+     * block used to spell out by hand: OTel's dimensionless "1" (which
+     * made a CLS breach read "is 0.31 1 which is greater than or equal to
+     * 0.25 1") and UCUM's annotation-only "{cpu}" / "{packets}" both
+     * disappear, and a fraction metric still carrying "1" is rendered as
+     * the percentage it means.
+     *
+     * The unit rides each NUMBER instead of the sentence, because
+     * auto-scaling can land two samples in the same sentence on different
+     * scales — "is 900 KB, 1.2 MB" — which one trailing suffix cannot
+     * express.
      */
-    const trimmedUnit: string = (data.unit || "").trim();
-    const annotationOnlyUnitPattern: RegExp = /^\{[^{}]*\}$/;
-    const unitSuffix: string =
-      trimmedUnit &&
-      trimmedUnit !== "1" &&
-      !annotationOnlyUnitPattern.test(trimmedUnit)
-        ? ` ${trimmedUnit}`
-        : "";
+    const withUnit: ((value: number) => string) | undefined =
+      MetricValueFormatter.hasDisplayableUnit(data.unit, data.metricName)
+        ? (value: number): string => {
+            return MetricValueFormatter.format({
+              value: value,
+              unit: data.unit,
+              metricName: data.metricName,
+            });
+          }
+        : undefined;
 
     if (
       data.criteriaFilter.filterType !== FilterType.True &&
@@ -750,10 +781,12 @@ export default class CompareCriteria {
         evaluationType: evaluationType,
       });
 
-      const formattedValues: string =
-        CompareCriteria.formatCriteriaValues(reportedValues);
+      const formattedValues: string = CompareCriteria.formatCriteriaValues(
+        reportedValues,
+        withUnit,
+      );
 
-      message += ` is ${formattedValues}${unitSuffix}`;
+      message += ` is ${formattedValues}`;
 
       message += " which is";
 
@@ -778,22 +811,22 @@ export default class CompareCriteria {
 
     switch (data.criteriaFilter.filterType) {
       case FilterType.GreaterThan:
-        message += ` greater than ${CompareCriteria.formatSingleValue(data.threshold)}${unitSuffix}. `;
+        message += ` greater than ${CompareCriteria.formatSingleValue(data.threshold, withUnit)}. `;
         break;
       case FilterType.GreaterThanOrEqualTo:
-        message += ` greater than or equal to ${CompareCriteria.formatSingleValue(data.threshold)}${unitSuffix}. `;
+        message += ` greater than or equal to ${CompareCriteria.formatSingleValue(data.threshold, withUnit)}. `;
         break;
       case FilterType.LessThan:
-        message += ` less than ${CompareCriteria.formatSingleValue(data.threshold)}${unitSuffix}. `;
+        message += ` less than ${CompareCriteria.formatSingleValue(data.threshold, withUnit)}. `;
         break;
       case FilterType.LessThanOrEqualTo:
-        message += ` less than or equal to ${CompareCriteria.formatSingleValue(data.threshold)}${unitSuffix}. `;
+        message += ` less than or equal to ${CompareCriteria.formatSingleValue(data.threshold, withUnit)}. `;
         break;
       case FilterType.NotEqualTo:
-        message += ` not equal to ${CompareCriteria.formatSingleValue(data.threshold)}${unitSuffix}. `;
+        message += ` not equal to ${CompareCriteria.formatSingleValue(data.threshold, withUnit)}. `;
         break;
       case FilterType.EqualTo:
-        message += ` equal to ${CompareCriteria.formatSingleValue(data.threshold)}${unitSuffix}. `;
+        message += ` equal to ${CompareCriteria.formatSingleValue(data.threshold, withUnit)}. `;
         break;
       case FilterType.Contains:
         message += ` contains ${CompareCriteria.formatSingleValue(data.threshold)}. `;
@@ -918,8 +951,16 @@ export default class CompareCriteria {
     }
   }
 
+  /*
+   * `withUnit`, when supplied, is how a NUMBER is rendered — unit
+   * included. It is threaded down rather than applied to the finished
+   * string because the string is not always one number: a large window
+   * collapses to "N samples between X and Y", and both X and Y need the
+   * unit of their own scale.
+   */
   private static formatCriteriaValues(
     values: Array<number | boolean> | number | boolean | string,
+    withUnit?: ((value: number) => string) | undefined,
   ): string {
     if (Array.isArray(values)) {
       /*
@@ -934,7 +975,7 @@ export default class CompareCriteria {
       if (values.length <= MAX_INLINE) {
         return values
           .map((value: number | boolean) => {
-            return CompareCriteria.formatSingleValue(value);
+            return CompareCriteria.formatSingleValue(value, withUnit);
           })
           .join(", ");
       }
@@ -950,24 +991,26 @@ export default class CompareCriteria {
         const max: number = Math.max(...numericValues);
         return `${numericValues.length} samples between ${CompareCriteria.formatSingleValue(
           min,
-        )} and ${CompareCriteria.formatSingleValue(max)}`;
+          withUnit,
+        )} and ${CompareCriteria.formatSingleValue(max, withUnit)}`;
       }
 
       // Fall back to a truncated list when not all values are numeric
       const head: string = values
         .slice(0, MAX_INLINE)
         .map((value: number | boolean) => {
-          return CompareCriteria.formatSingleValue(value);
+          return CompareCriteria.formatSingleValue(value, withUnit);
         })
         .join(", ");
       return `${head}, … (${values.length} values total)`;
     }
 
-    return CompareCriteria.formatSingleValue(values);
+    return CompareCriteria.formatSingleValue(values, withUnit);
   }
 
   private static formatSingleValue(
     value: number | boolean | string | null | undefined,
+    withUnit?: ((value: number) => string) | undefined,
   ): string {
     if (value === null || value === undefined) {
       return "unknown";
@@ -975,6 +1018,10 @@ export default class CompareCriteria {
 
     if (typeof value === Typeof.Number) {
       const numericValue: number = value as number;
+
+      if (withUnit) {
+        return withUnit(numericValue);
+      }
 
       if (Number.isInteger(numericValue)) {
         return numericValue.toString();

--- a/Common/Server/Utils/Monitor/Criteria/MetricMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/MetricMonitorCriteria.ts
@@ -26,6 +26,7 @@ import {
 } from "../../../../Types/Monitor/CriteriaFilter";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
 import MetricUnitUtil from "../../../../Utils/MetricUnitUtil";
+import MetricValueFormatter from "../../../../Utils/Monitor/MetricValueFormatter";
 import MetricFormulaEvaluator from "../../../../Utils/Metrics/MetricFormulaEvaluator";
 import MetricBaselineService, {
   BaselineSummary,
@@ -369,6 +370,15 @@ export default class MetricMonitorCriteria {
         criteriaFilter: input.criteriaFilter,
         metricDisplayName: metricContext.metricName,
         unit: displayUnit,
+        /*
+         * Only a plain metric criteria has a real metric NAME —
+         * metricContext.metricName is the formula expression when the
+         * criteria targets a formula, and a formula ending in `_ratio`
+         * would trip the fraction heuristic into a 100× render.
+         */
+        metricName: metricContext.isFormula
+          ? undefined
+          : metricContext.metricName,
       });
 
     if (!comparisonMessage) {
@@ -989,13 +999,29 @@ export default class MetricMonitorCriteria {
             : "below";
 
     const sigmaAbs: number = Math.abs(firstBreach.sigma);
-    const unitSuffix: string = metricContext.unit
-      ? ` ${metricContext.unit}`
-      : "";
+
+    /*
+     * Same rendering as the breaching-samples table and the comparison
+     * sentence — an anomaly on a memory metric reads "1.07 GB", not
+     * "1073741824.000 By". σ is a count of standard deviations, not a
+     * quantity in the metric's unit, so it stays a bare number; the
+     * standard deviation itself is in the metric's unit and does not.
+     */
+    const inMetricUnit: (value: number) => string = (value: number): string => {
+      return MetricValueFormatter.format({
+        value: value,
+        unit: metricContext.unit,
+        // Formula expressions are not metric names — see the guard above.
+        metricName: metricContext.isFormula
+          ? undefined
+          : metricContext.metricName,
+      });
+    };
+
     const rootCause: string =
-      `${metricContext.metricName} value ${firstBreach.sample.value.toFixed(3)}${unitSuffix} ` +
+      `${metricContext.metricName} value ${inMetricUnit(firstBreach.sample.value)} ` +
       `is ${sigmaAbs.toFixed(2)}σ ${direction} the same-hour baseline ` +
-      `(mean ${baseline.mean.toFixed(3)}${unitSuffix}, σ ${baseline.stddev.toFixed(3)}${unitSuffix}, ` +
+      `(mean ${inMetricUnit(baseline.mean)}, σ ${inMetricUnit(baseline.stddev)}, ` +
       `${baseline.sampleCount} samples over ${baseline.windowDays} days, sensitivity ${sensitivity}).`;
 
     return {

--- a/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
@@ -100,6 +100,11 @@ import MonitorStepPodmanMonitor from "../../../Types/Monitor/MonitorStepPodmanMo
 import MonitorStepProxmoxMonitor from "../../../Types/Monitor/MonitorStepProxmoxMonitor";
 import MonitorStepCephMonitor from "../../../Types/Monitor/MonitorStepCephMonitor";
 import MonitorStepDockerSwarmMonitor from "../../../Types/Monitor/MonitorStepDockerSwarmMonitor";
+import MetricValueFormatter from "../../../Utils/Monitor/MetricValueFormatter";
+import { getKubernetesMetricByMetricName } from "../../../Types/Monitor/KubernetesMetricCatalog";
+import { getProxmoxMetricByMetricName } from "../../../Types/Monitor/ProxmoxMetricCatalog";
+import { getCephMetricByMetricName } from "../../../Types/Monitor/CephMetricCatalog";
+import { getDockerSwarmMetricByMetricName } from "../../../Types/Monitor/DockerSwarmMetricCatalog";
 
 /**
  * A cross-signal deep link into a telemetry explorer, plus the scope
@@ -1433,13 +1438,28 @@ ${contextBlock}
       return null;
     }
 
+    const unitHeuristicMetricName: string | undefined =
+      MonitorCriteriaEvaluator.metricNameForUnitHeuristics({
+        metricName: ctx.metricName,
+        isFormula: ctx.isFormula,
+      });
+
     const lines: Array<string> = [];
     lines.push(`- Metric: \`${ctx.metricName}\``);
     if (ctx.alias) {
       lines.push(`- Alias: \`${ctx.alias}\``);
     }
-    if (ctx.unit) {
-      lines.push(`- Unit: ${ctx.unit}`);
+    /*
+     * Spell the unit out — "Bytes", not the UCUM "By" the exporter wrote —
+     * and drop the line entirely for units that name no dimension, so a
+     * ratio metric no longer reports the bare "Unit: 1".
+     */
+    const readableUnit: string | null = MetricValueFormatter.getReadableUnit(
+      ctx.unit,
+      unitHeuristicMetricName,
+    );
+    if (readableUnit) {
+      lines.push(`- Unit: ${readableUnit}`);
     }
     if (ctx.aggregationType) {
       lines.push(`- Aggregation: ${ctx.aggregationType}`);
@@ -1459,8 +1479,16 @@ ${contextBlock}
     if (ctx.components && ctx.components.length > 0) {
       const componentLines: Array<string> = ctx.components.map(
         (component: MetricComponent) => {
-          const unitSuffix: string = component.unit
-            ? ` — unit: ${component.unit}`
+          const componentUnit: string | null =
+            MetricValueFormatter.getReadableUnit(
+              component.unit,
+              MonitorCriteriaEvaluator.metricNameForUnitHeuristics({
+                metricName: component.name,
+                isFormula: component.isFormula,
+              }),
+            );
+          const unitSuffix: string = componentUnit
+            ? ` — unit: ${componentUnit}`
             : "";
           const typeSuffix: string = component.isFormula ? " (formula)" : "";
           return `  - \`${component.alias}\` = \`${component.name}\`${typeSuffix}${unitSuffix}`;
@@ -1504,6 +1532,7 @@ ${contextBlock}
           totalSamples: ctx.totalSamplesInWindow,
           unit: ctx.unit,
           metricName: ctx.metricName,
+          unitHeuristicMetricName: unitHeuristicMetricName,
           alias: ctx.alias,
           components: ctx.components || [],
         })}`,
@@ -1575,6 +1604,11 @@ ${contextBlock}
     totalSamples?: number | undefined;
     unit: string | null;
     metricName: string;
+    /**
+     * The metric name to reason about, or undefined for a formula.
+     * See MonitorCriteriaEvaluator.metricNameForUnitHeuristics.
+     */
+    unitHeuristicMetricName: string | undefined;
     alias: string;
     components: Array<MetricComponent>;
   }): string {
@@ -1628,16 +1662,19 @@ ${contextBlock}
       "Value",
     ];
 
+    /*
+     * The component columns carry no unit in their header any more. Each
+     * cell now names the unit it actually landed on, and auto-scaling
+     * means neighbouring rows can land on different ones — a header that
+     * read "a (By)" over cells reading "900 KB" and "1.2 MB" states a
+     * unit that neither row uses. The configured unit is not lost: the
+     * Components bullet list above the table still records it.
+     */
     for (const component of input.components) {
-      const label: string = component.unit
-        ? `${component.alias} (${component.unit})`
-        : component.alias;
-      headerCells.push(label);
+      headerCells.push(component.alias);
     }
 
     headerCells.push(...attrKeys);
-
-    const unitSuffix: string = input.unit ? ` ${input.unit}` : "";
 
     const headerRow: string = `| ${headerCells.join(" | ")} |`;
     const dividerRow: string = `| ${headerCells
@@ -1658,7 +1695,11 @@ ${contextBlock}
           `\`${timestampIso}\``,
           metricCell,
           aliasCell,
-          `${MonitorCriteriaEvaluator.formatNumberForDisplay(s.value)}${unitSuffix}`,
+          MetricValueFormatter.format({
+            value: s.value,
+            unit: input.unit,
+            metricName: input.unitHeuristicMetricName,
+          }),
         ];
 
         for (const component of input.components) {
@@ -1668,11 +1709,24 @@ ${contextBlock}
             return cv.alias === component.alias;
           });
           if (match && typeof match.value === "number") {
-            const componentUnitSuffix: string = component.unit
-              ? ` ${component.unit}`
-              : "";
+            /*
+             * Each component keeps its OWN unit. Component values are
+             * indexed off the per-query series and never go through the
+             * sample→threshold-unit conversion the main Value column
+             * does, so they are in the component's legendUnit — mixing
+             * units across the row is deliberate, and is why every cell
+             * has to say which one it is in.
+             */
             cells.push(
-              `${MonitorCriteriaEvaluator.formatNumberForDisplay(match.value)}${componentUnitSuffix}`,
+              MetricValueFormatter.format({
+                value: match.value,
+                unit: component.unit,
+                metricName:
+                  MonitorCriteriaEvaluator.metricNameForUnitHeuristics({
+                    metricName: component.name,
+                    isFormula: component.isFormula,
+                  }),
+              }),
             );
           } else {
             cells.push("-");
@@ -1720,16 +1774,6 @@ ${contextBlock}
       return `${input.breachingCount} of ${input.totalSamples} samples breached the threshold.`;
     }
     return `${input.breachingCount} sample${input.breachingCount === 1 ? "" : "s"} breached the threshold.`;
-  }
-
-  private static formatNumberForDisplay(value: number): string {
-    if (!Number.isFinite(value)) {
-      return String(value);
-    }
-    if (Number.isInteger(value)) {
-      return value.toString();
-    }
-    return Number(value.toFixed(2)).toString();
   }
 
   private static buildMetricExplorerDeepLink(input: {
@@ -1923,12 +1967,88 @@ ${contextBlock}
     };
   }
 
+  /**
+   * The metric name to hand a unit heuristic, or undefined when there
+   * isn't one.
+   *
+   * `MetricCriteriaContext.metricName` and `MetricComponent.name` are the
+   * FORMULA EXPRESSION when the criteria (or the component) targets a
+   * formula — MetricMonitorCriteria.buildContext falls back to
+   * `metricFormula`. The only thing a name is used for downstream is
+   * ValueFormatter.isFractionMetric, which asks whether the name ends in
+   * `.utilization` / `_ratio` / `_percent` and multiplies a "1"-unit value
+   * by 100 when it does. A formula written as `a / b_ratio` ends in
+   * `_ratio` and would silently be reported at 100× its real value, so a
+   * formula gets no name at all.
+   */
+  private static metricNameForUnitHeuristics(input: {
+    metricName: string | undefined;
+    isFormula: boolean | undefined;
+  }): string | undefined {
+    return input.isFormula ? undefined : input.metricName;
+  }
+
   private static formatScopeDroppedHint(dropped: Array<string>): string {
     if (dropped.length === 0) {
       return "";
     }
 
     return ` _(scope partially carried — not applied: ${dropped.join(", ")})_`;
+  }
+
+  /**
+   * The unit for a value in a per-platform "Affected Resources" table.
+   *
+   * These rows are NOT the same numbers as the criteria's breaching
+   * samples: the worker collects them with a raw `MetricService.findBy`
+   * scan and never runs them through MetricResultUnitConverter, so they
+   * are in the metric's NATIVE unit while the criteria threshold was
+   * compared in the user's chosen display unit. Labelling them with the
+   * query's legendUnit would therefore attach a confidently wrong unit to
+   * a correct number.
+   *
+   * The catalog is the right source precisely because it also declares
+   * the native unit. It is the same lookup, on the same metric name, that
+   * the worker already ran to resolve `metricFriendlyName`, so the unit
+   * shown here can never disagree with the metric name shown beside it.
+   */
+  private static getPlatformMetricUnit(input: {
+    platform: "kubernetes" | "proxmox" | "dockerSwarm" | "ceph";
+    metricName: string;
+  }): string | undefined {
+    switch (input.platform) {
+      case "kubernetes":
+        return getKubernetesMetricByMetricName(input.metricName)?.unit;
+      case "proxmox":
+        return getProxmoxMetricByMetricName(input.metricName)?.unit;
+      case "dockerSwarm":
+        return getDockerSwarmMetricByMetricName(input.metricName)?.unit;
+      case "ceph":
+        return getCephMetricByMetricName(input.metricName)?.unit;
+      default:
+        return undefined;
+    }
+  }
+
+  /**
+   * Render one cell of a platform breakdown table's Value column.
+   *
+   * Bold, because that is how these tables have always drawn the value —
+   * it is the one number in the row a reader scans for.
+   */
+  private static formatPlatformResourceValue(input: {
+    platform: "kubernetes" | "proxmox" | "dockerSwarm" | "ceph";
+    metricName: string;
+    value: number;
+  }): string {
+    return `**${MetricValueFormatter.format({
+      value: input.value,
+      unit: MonitorCriteriaEvaluator.getPlatformMetricUnit({
+        platform: input.platform,
+        metricName: input.metricName,
+      }),
+      metricName: input.metricName,
+    })}**`;
   }
 
   private static async buildKubernetesRootCauseContext(input: {
@@ -2071,7 +2191,13 @@ ${contextBlock}
           cells.push(resource.nodeName ? `\`${resource.nodeName}\`` : "-");
         }
 
-        cells.push(`**${resource.metricValue}**`);
+        cells.push(
+          MonitorCriteriaEvaluator.formatPlatformResourceValue({
+            platform: "kubernetes",
+            metricName: breakdown.metricName,
+            value: resource.metricValue,
+          }),
+        );
 
         resourceLines.push(`| ${cells.join(" | ")} |`);
       }
@@ -2478,7 +2604,13 @@ ${contextBlock}
             : "-";
 
           resourceLines.push(
-            `| ${resourceCell} | ${typeCell} | ${nodeCell} | **${resource.metricValue}** |`,
+            `| ${resourceCell} | ${typeCell} | ${nodeCell} | ${MonitorCriteriaEvaluator.formatPlatformResourceValue(
+              {
+                platform: "proxmox",
+                metricName: breakdown.metricName,
+                value: resource.metricValue,
+              },
+            )} |`,
           );
         }
 
@@ -2640,7 +2772,13 @@ ${contextBlock}
             : "-";
 
           resourceLines.push(
-            `| ${taskCell} | ${serviceCell} | ${nodeCell} | **${resource.metricValue}** |`,
+            `| ${taskCell} | ${serviceCell} | ${nodeCell} | ${MonitorCriteriaEvaluator.formatPlatformResourceValue(
+              {
+                platform: "dockerSwarm",
+                metricName: breakdown.metricName,
+                value: resource.metricValue,
+              },
+            )} |`,
           );
         }
 
@@ -2865,7 +3003,13 @@ ${contextBlock}
             : "-";
 
           resourceLines.push(
-            `| ${daemonCell} | ${poolCell} | ${hostCell} | **${resource.metricValue}** |`,
+            `| ${daemonCell} | ${poolCell} | ${hostCell} | ${MonitorCriteriaEvaluator.formatPlatformResourceValue(
+              {
+                platform: "ceph",
+                metricName: breakdown.metricName,
+                value: resource.metricValue,
+              },
+            )} |`,
           );
         }
 
@@ -2914,6 +3058,27 @@ ${contextBlock}
     const metricName: string = breakdown.metricName;
     const lines: Array<string> = [];
 
+    /*
+     * The top resource's value, in the unit the catalog says the metric
+     * is actually reported in.
+     *
+     * The three "is at N%" sentences below used to hardcode that percent
+     * sign. Two of the three metrics they fire for are not percentages at
+     * all — k8s.node.memory.usage and k8s.node.filesystem.usage are
+     * `bytes`, so a node holding 8 GiB reported "memory usage is at
+     * 8589934592.0%" — and the third, k8s.node.cpu.utilization, is the
+     * kubeletstats cores gauge that four other places in this repo warn
+     * is misnamed, so 1.4 cores in use read as "1.4% CPU utilization".
+     */
+    const topResourceValue: string = MetricValueFormatter.format({
+      value: topResource.metricValue,
+      unit: MonitorCriteriaEvaluator.getPlatformMetricUnit({
+        platform: "kubernetes",
+        metricName: metricName,
+      }),
+      metricName: metricName,
+    });
+
     if (
       metricName === "k8s.container.restarts" ||
       metricName.includes("restart")
@@ -2923,7 +3088,7 @@ ${contextBlock}
       );
       if (topResource.containerName) {
         lines.push(
-          `The container \`${topResource.containerName}\` in pod \`${topResource.podName || "unknown"}\` has restarted **${topResource.metricValue}** times.`,
+          `The container \`${topResource.containerName}\` in pod \`${topResource.podName || "unknown"}\` has restarted **${topResourceValue}** times.`,
         );
       }
       lines.push(
@@ -2959,7 +3124,7 @@ ${contextBlock}
       lines.push(`One or more nodes have transitioned to a NotReady state.`);
       if (topResource.nodeName) {
         lines.push(
-          `Node \`${topResource.nodeName}\` is reporting NotReady (value: ${topResource.metricValue}).`,
+          `Node \`${topResource.nodeName}\` is reporting NotReady (value: ${topResourceValue}).`,
         );
       }
       lines.push(
@@ -2986,7 +3151,7 @@ ${contextBlock}
       lines.push(`Node CPU utilization has exceeded the configured threshold.`);
       if (topResource.nodeName) {
         lines.push(
-          `Node \`${topResource.nodeName}\` is at **${topResource.metricValue.toFixed(1)}%** CPU utilization.`,
+          `Node \`${topResource.nodeName}\` is at **${topResourceValue}** CPU utilization.`,
         );
       }
       lines.push(
@@ -3007,7 +3172,7 @@ ${contextBlock}
       );
       if (topResource.nodeName) {
         lines.push(
-          `Node \`${topResource.nodeName}\` memory usage is at **${topResource.metricValue.toFixed(1)}%**.`,
+          `Node \`${topResource.nodeName}\` memory usage is at **${topResourceValue}**.`,
         );
       }
       lines.push(
@@ -3025,7 +3190,7 @@ ${contextBlock}
       );
       if (topResource.workloadName) {
         lines.push(
-          `${topResource.workloadType || "Deployment"} \`${topResource.workloadName}\` has **${topResource.metricValue}** unavailable replica(s).`,
+          `${topResource.workloadType || "Deployment"} \`${topResource.workloadName}\` has **${topResourceValue}** unavailable replica(s).`,
         );
       }
       lines.push(
@@ -3041,7 +3206,7 @@ ${contextBlock}
       lines.push(`Kubernetes Job has failed pods.`);
       if (topResource.workloadName) {
         lines.push(
-          `Job \`${topResource.workloadName}\` has **${topResource.metricValue}** failed pod(s).`,
+          `Job \`${topResource.workloadName}\` has **${topResourceValue}** failed pod(s).`,
         );
       }
       lines.push(
@@ -3060,7 +3225,7 @@ ${contextBlock}
       );
       if (topResource.nodeName) {
         lines.push(
-          `Node \`${topResource.nodeName}\` filesystem usage is at **${topResource.metricValue.toFixed(1)}%**.`,
+          `Node \`${topResource.nodeName}\` filesystem usage is at **${topResourceValue}**.`,
         );
       }
       lines.push(
@@ -3076,7 +3241,7 @@ ${contextBlock}
       lines.push(`DaemonSet has misscheduled or unavailable nodes.`);
       if (topResource.workloadName) {
         lines.push(
-          `DaemonSet \`${topResource.workloadName}\` has **${topResource.metricValue}** misscheduled node(s).`,
+          `DaemonSet \`${topResource.workloadName}\` has **${topResourceValue}** misscheduled node(s).`,
         );
       }
       lines.push(

--- a/Common/Tests/Server/Utils/Monitor/Criteria/CompareCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/CompareCriteria.test.ts
@@ -774,6 +774,248 @@ describe("CompareCriteria", () => {
       ).toBe("Metric Value is 100 ms which is greater than 50 ms.");
     });
 
+    /*
+     * HUMAN-READABLE UNITS.
+     *
+     * This sentence is the "Filter Conditions Met" line of the alert and
+     * incident email. It used to glue the exporter's raw UCUM code onto
+     * raw digits, so a memory breach the dashboard drew as "1.07 GB"
+     * arrived in the inbox as "1073741824 By".
+     *
+     * The unit rides each NUMBER rather than the sentence, because
+     * auto-scaling can land two samples of one window on different scales
+     * and a single trailing suffix cannot describe both.
+     */
+    test("renders a byte value and its threshold at human scale", () => {
+      const filter: CriteriaFilter = makeFilter({
+        checkOn: CheckOn.MetricValue,
+        filterType: FilterType.GreaterThan,
+      });
+      expect(
+        CompareCriteria.getCompareMessage({
+          values: 1073741824,
+          threshold: 1000000000,
+          criteriaFilter: filter,
+          unit: "By",
+        }),
+      ).toBe("Metric Value is 1.07 GB which is greater than 1 GB.");
+    });
+
+    test("rescales a duration", () => {
+      const filter: CriteriaFilter = makeFilter({
+        checkOn: CheckOn.MetricValue,
+        filterType: FilterType.GreaterThan,
+      });
+      expect(
+        CompareCriteria.getCompareMessage({
+          values: 1500,
+          threshold: 1000,
+          criteriaFilter: filter,
+          unit: "ms",
+        }),
+      ).toBe("Metric Value is 1.5 sec which is greater than 1 sec.");
+    });
+
+    test("gives every listed sample its own scale", () => {
+      const filter: CriteriaFilter = makeFilter({
+        checkOn: CheckOn.MetricValue,
+        filterType: FilterType.GreaterThan,
+        evaluateOverTime: true,
+        evaluateOverTimeOptions: {
+          timeValueInMinutes: 5,
+          evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+        },
+      });
+      expect(
+        CompareCriteria.getCompareMessage({
+          values: [921600, 1258291],
+          threshold: 900000,
+          criteriaFilter: filter,
+          unit: "By",
+        }),
+      ).toBe(
+        "All values of Metric Value over the last 5 minutes is 922 KB, 1.26 MB which is greater than 900 KB.",
+      );
+    });
+
+    test("units ride both ends of the 'N samples between X and Y' summary", () => {
+      const filter: CriteriaFilter = makeFilter({
+        checkOn: CheckOn.MetricValue,
+        filterType: FilterType.GreaterThan,
+        evaluateOverTimeOptions: {
+          timeValueInMinutes: 5,
+          evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+        },
+      });
+      const message: string = CompareCriteria.getCompareMessage({
+        values: [1e9, 2e9, 3e9, 4e9, 5e9, 6e9],
+        threshold: 5e8,
+        criteriaFilter: filter,
+        unit: "By",
+      });
+
+      expect(message).toContain("6 samples between 1 GB and 6 GB");
+      expect(message).toContain("greater than 500 MB");
+    });
+
+    /*
+     * OTel's dimensionless "1" used to be printed: a CLS breach read
+     * "is 0.31 1 which is greater than or equal to 0.25 1".
+     */
+    test("the dimensionless '1' is suppressed on a non-fraction metric", () => {
+      const filter: CriteriaFilter = makeFilter({
+        checkOn: CheckOn.MetricValue,
+        filterType: FilterType.GreaterThanOrEqualTo,
+      });
+      const message: string = CompareCriteria.getCompareMessage({
+        values: 0.31,
+        threshold: 0.25,
+        criteriaFilter: filter,
+        metricDisplayName: "browser.cumulative_layout_shift",
+        metricName: "browser.cumulative_layout_shift",
+        unit: "1",
+      });
+
+      expect(message).toBe(
+        "browser.cumulative_layout_shift is 0.31 which is greater than or equal to 0.25.",
+      );
+      expect(message).not.toContain("0.31 1");
+    });
+
+    test("a fraction metric still carrying '1' reads as a percentage", () => {
+      const filter: CriteriaFilter = makeFilter({
+        checkOn: CheckOn.MetricValue,
+        filterType: FilterType.GreaterThan,
+      });
+      const message: string = CompareCriteria.getCompareMessage({
+        values: 0.0585,
+        threshold: 0.05,
+        criteriaFilter: filter,
+        metricDisplayName: "system.cpu.utilization",
+        metricName: "system.cpu.utilization",
+        unit: "1",
+      });
+
+      expect(message).toBe(
+        "system.cpu.utilization is 5.85% which is greater than 5.00%.",
+      );
+    });
+
+    test("a UCUM annotation-only unit is suppressed", () => {
+      const filter: CriteriaFilter = makeFilter({
+        checkOn: CheckOn.MetricValue,
+        filterType: FilterType.GreaterThan,
+      });
+      const message: string = CompareCriteria.getCompareMessage({
+        values: 512,
+        threshold: 500,
+        criteriaFilter: filter,
+        unit: "{thread}",
+      });
+
+      expect(message).toBe("Metric Value is 512 which is greater than 500.");
+      expect(message).not.toContain("{thread}");
+    });
+
+    /*
+     * THE FORMULA GUARD. metricDisplayName is the formula EXPRESSION for a
+     * formula criteria, and `a / b_ratio` ends in `_ratio` — the suffix
+     * the fraction heuristic keys on. Only `metricName`, which callers
+     * pass exclusively for plain metric criteria, may reach that
+     * heuristic; a formula reported at 100× its value would be a far worse
+     * bug than an unlabelled number.
+     */
+    test("a formula expression is never read as a fraction metric name", () => {
+      const filter: CriteriaFilter = makeFilter({
+        checkOn: CheckOn.MetricValue,
+        filterType: FilterType.GreaterThan,
+      });
+      const message: string = CompareCriteria.getCompareMessage({
+        values: 0.42,
+        threshold: 0.4,
+        criteriaFilter: filter,
+        metricDisplayName: "a / b_ratio",
+        unit: "1",
+      });
+
+      expect(message).toBe("a / b_ratio is 0.42 which is greater than 0.4.");
+      expect(message).not.toContain("42.00%");
+    });
+
+    /*
+     * BACKWARD COMPATIBILITY. Only MetricMonitorCriteria and
+     * DatabaseMonitorCriteria pass a unit; every other monitor type
+     * carries its unit inside the CheckOn label ("Response Time (in ms)")
+     * and must keep byte-identical, unabbreviated output.
+     */
+    test("a message with no unit is unchanged, digits and all", () => {
+      const filter: CriteriaFilter = makeFilter({
+        checkOn: CheckOn.ResponseTime,
+        filterType: FilterType.GreaterThan,
+      });
+
+      const expected: string =
+        "Response Time (in ms) is 5000 which is greater than 4900.";
+
+      expect(
+        CompareCriteria.getCompareMessage({
+          values: 5000,
+          threshold: 4900,
+          criteriaFilter: filter,
+        }),
+      ).toBe(expected);
+      expect(
+        CompareCriteria.getCompareMessage({
+          values: 5000,
+          threshold: 4900,
+          criteriaFilter: filter,
+          unit: undefined,
+        }),
+      ).toBe(expected);
+      expect(
+        CompareCriteria.getCompareMessage({
+          values: 5000,
+          threshold: 4900,
+          criteriaFilter: filter,
+          unit: "",
+        }),
+      ).toBe(expected);
+    });
+
+    test("non-numeric filter types ignore a supplied unit", () => {
+      const filter: CriteriaFilter = makeFilter({
+        checkOn: CheckOn.MetricValue,
+        filterType: FilterType.Contains,
+      });
+
+      const message: string = CompareCriteria.getCompareMessage({
+        values: "abc",
+        threshold: "b",
+        criteriaFilter: filter,
+        unit: "By",
+      });
+
+      expect(message).not.toContain("By");
+      expect(message).not.toContain("GB");
+    });
+
+    test("a non-finite value never reaches the scaling ladder", () => {
+      const filter: CriteriaFilter = makeFilter({
+        checkOn: CheckOn.MetricValue,
+        filterType: FilterType.GreaterThan,
+      });
+
+      const message: string = CompareCriteria.getCompareMessage({
+        values: Infinity,
+        threshold: 1000,
+        criteriaFilter: filter,
+        unit: "By",
+      });
+
+      expect(message).toContain("is Infinity which is");
+      expect(message).not.toContain("InfinityP");
+    });
+
     test("includes the disk path for disk usage checks", () => {
       const withPath: CriteriaFilter = makeFilter({
         checkOn: CheckOn.DiskUsagePercent,

--- a/Common/Tests/Server/Utils/Monitor/Criteria/CompareCriteriaAggregation.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/CompareCriteriaAggregation.test.ts
@@ -312,7 +312,7 @@ describe("CompareCriteria aggregation semantics", () => {
       });
 
       expect(message).toBe(
-        "Any value of CPU is 95, 96, 97 % which is greater than 90 %.",
+        "Any value of CPU is 95.00%, 96.00%, 97.00% which is greater than 90.00%.",
       );
     });
 
@@ -328,7 +328,7 @@ describe("CompareCriteria aggregation semantics", () => {
         unit: "%",
       });
 
-      expect(message).toContain("80, 70");
+      expect(message).toContain("80.00%, 70.00%");
       expect(message).not.toContain("95");
     });
 
@@ -345,7 +345,7 @@ describe("CompareCriteria aggregation semantics", () => {
       });
 
       expect(message).toBe(
-        "All values of CPU is 95, 96 % which is greater than 90 %.",
+        "All values of CPU is 95.00%, 96.00% which is greater than 90.00%.",
       );
     });
 
@@ -513,15 +513,21 @@ describe("CompareCriteria aggregation semantics", () => {
       /*
        * The guard against over-suppression. If this ever goes quiet the
        * fix has widened into a general unit filter.
+       *
+       * The unit now rides each NUMBER at the scale that number landed on,
+       * so a sub-byte value reports "B" and 0.85 ms is written out as the
+       * 850 µs it is. Both halves of the sentence go through the same
+       * renderer, which is the property that matters here: the observed
+       * value and the threshold can never be quoted in different units.
        */
       expect(unitMessage("By")).toBe(
-        "Any value of Metric Value is 0.85 By which is greater than 0.8 By.",
+        "Any value of Metric Value is 0.85 B which is greater than 0.8 B.",
       );
       expect(unitMessage("%")).toBe(
-        "Any value of Metric Value is 0.85 % which is greater than 0.8 %.",
+        "Any value of Metric Value is 0.85% which is greater than 0.80%.",
       );
       expect(unitMessage("ms")).toBe(
-        "Any value of Metric Value is 0.85 ms which is greater than 0.8 ms.",
+        "Any value of Metric Value is 850 µs which is greater than 800 µs.",
       );
       // "1" is suppressed; a unit that merely CONTAINS a 1 is not.
       expect(unitMessage("m/s2")).toContain("0.85 m/s2");
@@ -532,7 +538,7 @@ describe("CompareCriteria aggregation semantics", () => {
       const message: string = unitMessage(" ms ");
 
       expect(message).toBe(
-        "Any value of Metric Value is 0.85 ms which is greater than 0.8 ms.",
+        "Any value of Metric Value is 850 µs which is greater than 800 µs.",
       );
       expect(message).not.toContain("  ");
     });

--- a/Common/Tests/Server/Utils/Monitor/Criteria/MetricMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/MetricMonitorCriteria.test.ts
@@ -111,8 +111,15 @@ describe("MetricMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
       await MetricMonitorCriteria.isMonitorInstanceCriteriaFilterMet(inputs);
 
     expect(message).toBeTruthy();
-    expect(message).toContain("greater than 2000 ms");
-    expect(message).toContain("2500 ms");
+    /*
+     * The COMPARISON happens in the metric's native ms — that is what this
+     * test is about, and the context below pins it. The MESSAGE renders
+     * those same milliseconds at the scale a human reads them at, so 2500
+     * ms is written "2.5 sec"; the threshold gets the same treatment so
+     * the two halves of the sentence cannot disagree.
+     */
+    expect(message).toContain("greater than 2 sec");
+    expect(message).toContain("2.5 sec");
     expect(criteriaFilter.metricCriteriaContext?.unit).toBe("ms");
     expect(criteriaFilter.metricCriteriaContext?.breachingSample?.value).toBe(
       2500,
@@ -228,11 +235,23 @@ describe("MetricMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
       await MetricMonitorCriteria.isMonitorInstanceCriteriaFilterMet(inputs);
 
     /*
-     * No conversion possible, so the displayed unit/values use user's MB
-     * label but values are passed through.
+     * No conversion possible, so the sample value is passed through
+     * untouched and the criteria still speaks the user's chosen MB. Those
+     * two facts are the subject of this test and are asserted directly on
+     * the context.
+     *
+     * The rendered sentence is deliberately NOT asserted on: the user has
+     * mislabelled a 5000 ms sample as 5000 MB, and the renderer takes that
+     * label at its word and reads it out as "5 GB". Any string this
+     * sentence can produce is wrong, because the input is wrong — pinning
+     * one spelling of a wrong answer would only make the misconfiguration
+     * look supported.
      */
     expect(message).toBeTruthy();
-    expect(message).toContain("MB");
+    expect(criteriaFilter.metricCriteriaContext?.unit).toBe("MB");
+    expect(criteriaFilter.metricCriteriaContext?.breachingSample?.value).toBe(
+      5000,
+    );
   });
 
   test("no data + NoDataPolicy.Trigger triggers regardless of threshold", async () => {
@@ -495,7 +514,12 @@ describe("MetricMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
       await MetricMonitorCriteria.isMonitorInstanceCriteriaFilterMet(inputs);
 
     expect(message).toBeTruthy();
-    expect(message).toContain("10 samples between 110 and 200");
+    /*
+     * Both ends of the summary carry the unit, because either end can
+     * land on a different scale than the other once values spread far
+     * enough apart.
+     */
+    expect(message).toContain("10 samples between 110 ms and 200 ms");
     expect(message).toContain("greater than 100 ms");
     // The raw comma-joined dump is no longer in the message
     expect(message).not.toContain("110, 120, 130, 140, 150, 160");

--- a/Common/Tests/Server/Utils/Monitor/Criteria/MetricMonitorCriteriaAnomalyUnits.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/MetricMonitorCriteriaAnomalyUnits.test.ts
@@ -1,0 +1,246 @@
+/*
+ * The baseline lookup is the only thing standing between this test and
+ * ClickHouse. Stub it so the anomaly branch runs against a known baseline
+ * and the assertions are about the SENTENCE, which is what an alert email
+ * shows.
+ */
+jest.mock("../../../../../Server/Services/MetricBaselineService", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "../../../../../Server/Services/MetricBaselineService",
+  ) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: {
+      getBaseline: jest.fn(),
+    },
+  };
+});
+
+import MetricMonitorCriteria from "../../../../../Server/Utils/Monitor/Criteria/MetricMonitorCriteria";
+import MetricBaselineService, {
+  BaselineSummary,
+} from "../../../../../Server/Services/MetricBaselineService";
+import AggregateModel from "../../../../../Types/BaseDatabase/AggregatedModel";
+import AggregatedResult from "../../../../../Types/BaseDatabase/AggregatedResult";
+import {
+  CheckOn,
+  CriteriaFilter,
+  FilterType,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+import MetricAliasData from "../../../../../Types/Metrics/MetricAliasData";
+import MetricQueryConfigData from "../../../../../Types/Metrics/MetricQueryConfigData";
+import MetricQueryData from "../../../../../Types/Metrics/MetricQueryData";
+import MetricsViewConfig from "../../../../../Types/Metrics/MetricsViewConfig";
+import MetricMonitorResponse from "../../../../../Types/Monitor/MetricMonitor/MetricMonitorResponse";
+import MonitorStep from "../../../../../Types/Monitor/MonitorStep";
+import RollingTime from "../../../../../Types/RollingTime/RollingTime";
+import ObjectID from "../../../../../Types/ObjectID";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * THE ANOMALY SENTENCE.
+ *
+ * An anomaly breach produces its own root cause — it never reaches
+ * CompareCriteria — and it used to print `value.toFixed(3)` with the raw
+ * exporter unit glued on:
+ *
+ *   "container.memory.usage value 1073741824.000 By is 4.20σ above ..."
+ *
+ * The quantities in it are now rendered exactly as the Breaching Samples
+ * table renders them. σ is NOT one of those quantities: it is a count of
+ * standard deviations, dimensionless by construction, and must stay a
+ * bare number no matter what unit the metric carries.
+ */
+
+const BASELINE_MEAN: number = 268435456;
+const BASELINE_STDDEV: number = 134217728;
+const BREACHING_VALUE: number = 1073741824;
+
+function baseline(): BaselineSummary {
+  return {
+    sampleCount: 480,
+    mean: BASELINE_MEAN,
+    stddev: BASELINE_STDDEV,
+    median: BASELINE_MEAN,
+    p95: BASELINE_MEAN,
+    minObserved: 0,
+    maxObserved: BREACHING_VALUE,
+    isReliable: true,
+    windowDays: 14,
+    hourOfWeek: 0,
+  } as BaselineSummary;
+}
+
+function buildInputs(input: {
+  metricNativeUnit: string;
+  metricName: string;
+  sampleValue: number;
+}): {
+  criteriaFilter: CriteriaFilter;
+  monitorStep: MonitorStep;
+  dataToProcess: MetricMonitorResponse;
+  projectId: ObjectID;
+} {
+  const aliasData: MetricAliasData = {
+    metricVariable: "a",
+    title: input.metricName,
+    description: undefined,
+    legend: undefined,
+    legendUnit: input.metricNativeUnit,
+  };
+
+  const queryConfig: MetricQueryConfigData = {
+    metricAliasData: aliasData,
+    metricQueryData: {
+      filterData: {
+        metricName: input.metricName,
+      },
+    } as unknown as MetricQueryData,
+  };
+
+  const metricViewConfig: MetricsViewConfig = {
+    queryConfigs: [queryConfig],
+    formulaConfigs: [],
+  };
+
+  const monitorStep: MonitorStep = new MonitorStep();
+  monitorStep.data = {
+    id: ObjectID.generate().toString(),
+    monitorCriteria: { data: undefined } as never,
+  } as unknown as MonitorStep["data"];
+  monitorStep.data!.metricMonitor = {
+    metricViewConfig,
+    rollingTime: RollingTime.Past1Minute,
+  };
+
+  const aggregated: AggregatedResult = {
+    data: [
+      {
+        timestamp: new Date("2026-08-14T10:30:00.000Z"),
+        value: input.sampleValue,
+      } as AggregateModel,
+    ],
+  };
+
+  const projectId: ObjectID = ObjectID.generate();
+
+  return {
+    criteriaFilter: {
+      checkOn: CheckOn.MetricValue,
+      filterType: FilterType.AnomalouslyHigh,
+      metricMonitorOptions: {
+        metricAlias: "a",
+      },
+    } as CriteriaFilter,
+    monitorStep,
+    dataToProcess: {
+      projectId: projectId,
+      metricResult: [aggregated],
+      metricViewConfig,
+      monitorId: ObjectID.generate(),
+    },
+    projectId,
+  };
+}
+
+async function anomalyRootCause(input: {
+  metricNativeUnit: string;
+  metricName: string;
+  sampleValue: number;
+}): Promise<string> {
+  const inputs: ReturnType<typeof buildInputs> = buildInputs(input);
+
+  const message: string | null =
+    await MetricMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+      criteriaFilter: inputs.criteriaFilter,
+      monitorStep: inputs.monitorStep,
+      dataToProcess: inputs.dataToProcess,
+      projectId: inputs.projectId,
+    } as never);
+
+  expect(message).toBeTruthy();
+  return message as string;
+}
+
+describe("MetricMonitorCriteria - anomaly root cause units", () => {
+  beforeEach(() => {
+    (MetricBaselineService.getBaseline as unknown as jest.Mock).mockReset();
+    (
+      MetricBaselineService.getBaseline as unknown as jest.Mock
+    ).mockResolvedValue(baseline() as never);
+  });
+
+  test("value, mean and stddev are all rendered at human scale", async () => {
+    const rootCause: string = await anomalyRootCause({
+      metricName: "container.memory.usage",
+      metricNativeUnit: "By",
+      sampleValue: BREACHING_VALUE,
+    });
+
+    expect(rootCause).toContain("value 1.07 GB");
+    expect(rootCause).toContain("mean 268 MB");
+    expect(rootCause).toContain("σ 134 MB");
+
+    // The old rendering, in full.
+    expect(rootCause).not.toContain("1073741824.000");
+    expect(rootCause).not.toContain("268435456.000");
+    expect(rootCause).not.toContain("By");
+  });
+
+  /*
+   * The σ COUNT is not a quantity in the metric's unit — "6.00σ above the
+   * baseline" is six standard deviations, and rendering it as "6 GB"
+   * would be nonsense. It keeps its own two-decimal format.
+   */
+  test("the sigma count stays a bare number", async () => {
+    const rootCause: string = await anomalyRootCause({
+      metricName: "container.memory.usage",
+      metricNativeUnit: "By",
+      sampleValue: BREACHING_VALUE,
+    });
+
+    expect(rootCause).toMatch(/is \d+\.\d{2}σ above the same-hour baseline/);
+    expect(rootCause).not.toMatch(/is [\d.]+ [A-Za-z]+σ/);
+  });
+
+  test("a metric with no unit keeps its exact digits", async () => {
+    (
+      MetricBaselineService.getBaseline as unknown as jest.Mock
+    ).mockResolvedValue({
+      ...baseline(),
+      mean: 100,
+      stddev: 20,
+    } as never);
+
+    const rootCause: string = await anomalyRootCause({
+      metricName: "http.server.request.count",
+      metricNativeUnit: "",
+      sampleValue: 5000,
+    });
+
+    expect(rootCause).toContain("value 5000 ");
+    expect(rootCause).not.toContain("5K");
+  });
+
+  test("a ratio metric reads as a percentage", async () => {
+    (
+      MetricBaselineService.getBaseline as unknown as jest.Mock
+    ).mockResolvedValue({
+      ...baseline(),
+      mean: 0.2,
+      stddev: 0.05,
+    } as never);
+
+    const rootCause: string = await anomalyRootCause({
+      metricName: "system.cpu.utilization",
+      metricNativeUnit: "1",
+      sampleValue: 0.85,
+    });
+
+    expect(rootCause).toContain("value 85.00%");
+    expect(rootCause).toContain("mean 20.00%");
+    expect(rootCause).not.toContain("0.85 1");
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorCriteriaEvaluator.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorCriteriaEvaluator.test.ts
@@ -117,13 +117,18 @@ function metricResponse(
 describe("MonitorCriteriaEvaluator - Proxmox root cause breakdown", () => {
   test("renders the Resource/Type/Node/Value table: zero rows dropped, worst first", () => {
     const affectedResources: Array<ProxmoxAffectedResource> = [
+      /*
+       * pve_cpu_usage_ratio is a [0, 1] ratio — the catalog says so and
+       * pve-exporter reports it that way — so these are 42% and 97% of a
+       * node's CPU, and the table is expected to say exactly that.
+       */
       {
         resourceId: "qemu/100",
         resourceName: "web-vm",
         resourceType: "qemu",
         scope: "guest",
         nodeName: "pve1",
-        metricValue: 42,
+        metricValue: 0.42,
       },
       {
         resourceId: "qemu/101",
@@ -131,7 +136,7 @@ describe("MonitorCriteriaEvaluator - Proxmox root cause breakdown", () => {
         resourceType: "qemu",
         scope: "guest",
         nodeName: "pve2",
-        metricValue: 97,
+        metricValue: 0.97,
       },
       // Zero-value row — must be dropped from the table.
       {
@@ -164,16 +169,60 @@ describe("MonitorCriteriaEvaluator - Proxmox root cause breakdown", () => {
     expect(context).toContain("- Metric: CPU Usage (`pve_cpu_usage_ratio`)");
 
     expect(context).toContain("| Resource | Type | Node | Value |");
-    // Worst (97) sorts above 42; the zero row is gone entirely.
+    // Worst (0.97) sorts above 0.42; the zero row is gone entirely.
     const dbIndex: number = context!.indexOf("`db-vm` (`qemu/101`)");
     const webIndex: number = context!.indexOf("`web-vm` (`qemu/100`)");
     expect(dbIndex).toBeGreaterThan(-1);
     expect(webIndex).toBeGreaterThan(dbIndex);
     expect(context).not.toContain("idle-vm");
     expect(context).toContain("**Affected Resources** (2 total)");
+
+    /*
+     * The Value column is rendered in the unit the catalog declares for
+     * the metric — a "ratio" on a `_ratio`-suffixed metric is a fraction,
+     * so the reader gets "97.00%" rather than the bare "0.97" they would
+     * otherwise have to recognise as a percentage themselves.
+     */
     expect(context).toContain(
-      "| `db-vm` (`qemu/101`) | qemu | `pve2` | **97** |",
+      "| `db-vm` (`qemu/101`) | qemu | `pve2` | **97.00%** |",
     );
+    expect(context).toContain(
+      "| `web-vm` (`qemu/100`) | qemu | `pve1` | **42.00%** |",
+    );
+  });
+
+  test("renders bytes in the Value column at human scale", () => {
+    const context: string | null = Evaluator.buildProxmoxRootCauseContext({
+      dataToProcess: metricResponse({
+        proxmoxResourceBreakdown: {
+          clusterName: "prod-cluster",
+          metricName: "pve_memory_usage_bytes",
+          metricFriendlyName: "Memory Usage",
+          affectedResources: [
+            {
+              resourceId: "qemu/101",
+              resourceName: "db-vm",
+              resourceType: "qemu",
+              scope: "guest",
+              nodeName: "pve2",
+              metricValue: 8589934592,
+            },
+          ],
+          attributes: {},
+        },
+      }),
+      monitorStep: proxmoxStep(),
+      monitor: new Monitor(),
+    });
+
+    /*
+     * The whole point of the change: an on-call engineer reading this at
+     * 3am should not have to divide by 2^30 in their head.
+     */
+    expect(context).toContain(
+      "| `db-vm` (`qemu/101`) | qemu | `pve2` | **8.59 GB** |",
+    );
+    expect(context).not.toContain("**8589934592**");
   });
 
   test("caps the table at 10 rows, worst first, with an overflow suffix", () => {
@@ -187,12 +236,18 @@ describe("MonitorCriteriaEvaluator - Proxmox root cause breakdown", () => {
       });
     }
 
+    /*
+     * A `count` metric, so the rows render as bare integers and this test
+     * stays about the cap. It doubles as the backward-compatibility pin
+     * for the unitless path: a metric with no dimension to report must
+     * still show its exact digits, never an abbreviated "1.2K".
+     */
     const context: string | null = Evaluator.buildProxmoxRootCauseContext({
       dataToProcess: metricResponse({
         proxmoxResourceBreakdown: {
           clusterName: "prod-cluster",
-          metricName: "pve_cpu_usage_ratio",
-          metricFriendlyName: "CPU Usage",
+          metricName: "pve_replication_failed_syncs",
+          metricFriendlyName: "Failed Replication Syncs",
           affectedResources,
           attributes: {},
         },
@@ -290,8 +345,14 @@ describe("MonitorCriteriaEvaluator - Ceph root cause breakdown", () => {
     );
 
     expect(context).toContain("| Daemon | Pool | Host | Value |");
-    expect(context).toContain("| `osd.3` | - | `ceph-node-1` | **250** |");
-    expect(context).toContain("| - | `rbd` (`2`) | - | **91** |");
+    /*
+     * ceph_osd_apply_latency_ms carries the catalog unit "ms", so the
+     * Value column names it. 250 ms stays "250 ms" rather than scaling to
+     * seconds — the ladder only moves a value when the magnitude asks
+     * for it.
+     */
+    expect(context).toContain("| `osd.3` | - | `ceph-node-1` | **250 ms** |");
+    expect(context).toContain("| - | `rbd` (`2`) | - | **91 ms** |");
     expect(context).not.toContain("osd.5");
     expect(context).toContain("**Affected Resources** (2 total)");
 
@@ -300,6 +361,71 @@ describe("MonitorCriteriaEvaluator - Ceph root cause breakdown", () => {
     const poolIndex: number = context!.indexOf("`rbd` (`2`)");
     expect(osdIndex).toBeGreaterThan(-1);
     expect(poolIndex).toBeGreaterThan(osdIndex);
+  });
+
+  /*
+   * BACKWARD COMPATIBILITY for the platform tables.
+   *
+   * A metric whose catalog unit is "count" or absent has no dimension to
+   * report, and its Value column must keep every digit — never a chart's
+   * abbreviated "1.2K", and never the noise "250 count". ceph_osd_up is
+   * `unit: "count"`; ceph_health_status has no unit at all.
+   */
+  test("a count metric keeps exact bare digits in the Value column", () => {
+    const context: string | null = Evaluator.buildCephRootCauseContext({
+      dataToProcess: metricResponse({
+        cephResourceBreakdown: {
+          clusterName: "prod-cluster",
+          metricName: "ceph_osd_up",
+          metricFriendlyName: "OSD Up",
+          affectedResources: [
+            { daemon: "osd.3", hostname: "ceph-node-1", metricValue: 5000 },
+          ],
+          attributes: {},
+        },
+      }),
+      monitorStep: cephStep(),
+      monitor: new Monitor(),
+    });
+
+    expect(context).toContain("| `osd.3` | - | `ceph-node-1` | **5000** |");
+    expect(context).not.toContain("5K");
+    expect(context).not.toContain("count");
+  });
+
+  /*
+   * ORDERING INVARIANT. The table sorts and filters on the RAW numeric
+   * metricValue and only formats at render time. If a refactor ever sorted
+   * the formatted strings instead, "1.07 GB" would sort below "900 KB" and
+   * the worst-first table would silently invert — putting the healthiest
+   * daemon at the top of an incident.
+   */
+  test("rows still sort worst-first on the raw value, not the formatted string", () => {
+    const context: string | null = Evaluator.buildCephRootCauseContext({
+      dataToProcess: metricResponse({
+        cephResourceBreakdown: {
+          clusterName: "prod-cluster",
+          metricName: "ceph_pool_rd_bytes",
+          metricFriendlyName: "Pool Read Throughput",
+          affectedResources: [
+            { daemon: "osd.smaller", metricValue: 921600 },
+            { daemon: "osd.bigger", metricValue: 1073741824 },
+          ],
+          attributes: {},
+        },
+      }),
+      monitorStep: cephStep(),
+      monitor: new Monitor(),
+    });
+
+    expect(context).toContain("| `osd.bigger` | - | - | **1.07 GB** |");
+    expect(context).toContain("| `osd.smaller` | - | - | **922 KB** |");
+
+    // "1.07 GB" < "922 KB" as strings — the raw numbers must drive this.
+    const biggerIndex: number = context!.indexOf("`osd.bigger`");
+    const smallerIndex: number = context!.indexOf("`osd.smaller`");
+    expect(biggerIndex).toBeGreaterThan(-1);
+    expect(smallerIndex).toBeGreaterThan(biggerIndex);
   });
 
   test("cluster-wide series (ceph_health_status) render no table", () => {
@@ -521,8 +647,8 @@ describe("MonitorCriteriaEvaluator - Ceph affected-resources breach predicate", 
       ],
     });
 
-    expect(context).toContain("| `osd.3` | - | `ceph-node-1` | **250** |");
-    expect(context).toContain("| - | `rbd` (`2`) | - | **91** |");
+    expect(context).toContain("| `osd.3` | - | `ceph-node-1` | **250 ms** |");
+    expect(context).toContain("| - | `rbd` (`2`) | - | **91 ms** |");
     expect(context).not.toContain("osd.5");
     expect(context).toContain("**Affected Resources** (2 total)");
 
@@ -755,5 +881,93 @@ describe("MonitorCriteriaEvaluator - Kubernetes root cause analysis scoping", ()
     });
 
     expect(analysis).toContain("Pods are stuck in Pending phase");
+  });
+
+  /*
+   * REGRESSION: three of these sentences hardcoded a "%" suffix onto
+   * metrics that are not percentages.
+   *
+   * k8s.node.memory.usage and k8s.node.filesystem.usage are BYTES, so a
+   * node holding 8 GiB was reported as "memory usage is at
+   * 8589934592.0%". k8s.node.cpu.utilization is the kubeletstats CORES
+   * gauge that four other places in this repo warn is misnamed, so 1.4
+   * cores in use read as "1.4% CPU utilization" — a number an on-call
+   * engineer would read as "the node is idle".
+   *
+   * Each sentence now takes its unit from the catalog, which is the same
+   * lookup the worker already ran to resolve metricFriendlyName.
+   */
+  describe("unit rendering in the analysis sentences", () => {
+    test("node CPU reports cores, not a percentage", () => {
+      const analysis: string | null = analyse({
+        metricName: "k8s.node.cpu.utilization",
+        topResource: { nodeName: "node-1", metricValue: 1.4 },
+      });
+
+      expect(analysis).toContain(
+        "Node `node-1` is at **1.4 cores** CPU utilization.",
+      );
+      expect(analysis).not.toContain("1.4%");
+    });
+
+    test("node memory reports bytes at human scale, not a percentage", () => {
+      const analysis: string | null = analyse({
+        metricName: "k8s.node.memory.usage",
+        topResource: { nodeName: "node-1", metricValue: 8589934592 },
+      });
+
+      expect(analysis).toContain(
+        "Node `node-1` memory usage is at **8.59 GB**.",
+      );
+      expect(analysis).not.toContain("8589934592");
+      expect(analysis).not.toContain("%");
+    });
+
+    test("node filesystem reports bytes at human scale, not a percentage", () => {
+      const analysis: string | null = analyse({
+        metricName: "k8s.node.filesystem.usage",
+        topResource: { nodeName: "node-1", metricValue: 1099511627776 },
+      });
+
+      expect(analysis).toContain(
+        "Node `node-1` filesystem usage is at **1.1 TB**.",
+      );
+      expect(analysis).not.toContain("%");
+    });
+
+    /*
+     * Counts keep every digit — and stop reporting the raw float an
+     * aggregation hands back, which used to produce "has restarted
+     * **2.3333333333333335** times".
+     */
+    test("restart counts are rounded and carry no unit", () => {
+      const analysis: string | null = analyse({
+        metricName: "k8s.container.restarts",
+        topResource: {
+          podName: "web-7d9f",
+          containerName: "web",
+          metricValue: 2.3333333333333335,
+        },
+      });
+
+      expect(analysis).toContain("has restarted **2.33** times.");
+      expect(analysis).not.toContain("2.3333333333333335");
+      expect(analysis).not.toContain("2.33 count");
+    });
+
+    test("unavailable replicas stay a bare count", () => {
+      const analysis: string | null = analyse({
+        metricName: "k8s.deployment.unavailable_replicas",
+        topResource: {
+          workloadType: "Deployment",
+          workloadName: "web",
+          metricValue: 3,
+        },
+      });
+
+      expect(analysis).toContain(
+        "Deployment `web` has **3** unavailable replica(s).",
+      );
+    });
   });
 });

--- a/Common/Tests/Server/Utils/Monitor/MonitorCriteriaEvaluatorMetricUnits.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorCriteriaEvaluatorMetricUnits.test.ts
@@ -1,0 +1,570 @@
+/*
+ * The evaluator's import chain pulls the native isolated-vm addon
+ * (MonitorCriteriaEvaluator → VMAPI → VMRunner). Nothing under test here
+ * touches the sandbox, and the prebuilt binary cannot always dlopen in the
+ * test environment — so stub the module out before anything imports it.
+ */
+jest.mock("isolated-vm", () => {
+  return {};
+});
+
+import MonitorCriteriaEvaluator from "../../../../Server/Utils/Monitor/MonitorCriteriaEvaluator";
+import CompareCriteria from "../../../../Server/Utils/Monitor/Criteria/CompareCriteria";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import MonitorStep from "../../../../Types/Monitor/MonitorStep";
+import MonitorCriteriaInstance from "../../../../Types/Monitor/MonitorCriteriaInstance";
+import MetricCriteriaContext from "../../../../Types/Monitor/MetricMonitor/MetricCriteriaContext";
+import {
+  CheckOn,
+  CriteriaFilter,
+  FilterType,
+} from "../../../../Types/Monitor/CriteriaFilter";
+import FilterCondition from "../../../../Types/Filter/FilterCondition";
+import ObjectID from "../../../../Types/ObjectID";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * HUMAN-READABLE METRIC VALUES IN THE ROOT CAUSE.
+ *
+ * The metric root cause is what an alert or incident email shows under
+ * "Root Cause" — MonitorCriteriaEvaluator writes it, AlertService and
+ * IncidentService copy it onto the row, and the owner-notification jobs
+ * run it through Markdown.convertToHTML for the email body.
+ *
+ * Before this suite existed, nothing anywhere pinned the Breaching
+ * Samples table or the "- Unit:" line, and both rendered raw digits with
+ * the exporter's raw UCUM code glued on: a memory breach that the
+ * dashboard drew as "1.07 GB" arrived in the inbox as "1073741824 By",
+ * and a ratio metric's Value column read "0.06 1".
+ *
+ * These tests pin:
+ *   - the Value column at human scale, in the unit each row landed on,
+ *   - component columns each in their OWN unit, with no unit in the header
+ *     (auto-scaling means neighbouring rows disagree with any one header),
+ *   - the "- Unit:" line spelled out, and dropped when there is no unit,
+ *   - the formula guard: a formula expression is not a metric name,
+ *   - that the table and the "Filter Conditions Met" sentence in the same
+ *     email render the same sample identically.
+ */
+
+type EvaluatorPrivate = {
+  buildMetricRootCauseContext: (input: {
+    criteriaInstance: MonitorCriteriaInstance;
+    monitor: Monitor;
+    monitorStep?: MonitorStep | undefined;
+  }) => string | null;
+};
+
+const Evaluator: EvaluatorPrivate =
+  MonitorCriteriaEvaluator as unknown as EvaluatorPrivate;
+
+const BREACH_TIME: Date = new Date("2026-08-14T10:30:00.000Z");
+const BREACH_TIME_ISO: string = "2026-08-14T10:30:00.000Z";
+
+function makeContext(
+  overrides: Partial<MetricCriteriaContext> = {},
+): MetricCriteriaContext {
+  return {
+    metricName: "k8s.pod.memory.usage",
+    alias: "a",
+    unit: null,
+    aggregationType: null,
+    isFormula: false,
+    filterAttributes: {},
+    groupBy: [],
+    breachingSamples: [
+      {
+        value: 1073741824,
+        timestamp: BREACH_TIME,
+        attributes: {},
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeCriteriaInstance(
+  ctx: MetricCriteriaContext,
+): MonitorCriteriaInstance {
+  const filter: CriteriaFilter = {
+    checkOn: CheckOn.MetricValue,
+    metricCriteriaContext: ctx,
+  } as CriteriaFilter;
+
+  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+  instance.data = {
+    monitorStatusId: undefined,
+    filterCondition: FilterCondition.All,
+    filters: [filter],
+    incidents: [],
+    alerts: [],
+    name: "Memory breach",
+    description: "Memory breach",
+    id: ObjectID.generate().toString(),
+  };
+  return instance;
+}
+
+function rootCause(ctx: MetricCriteriaContext): string {
+  const context: string | null = Evaluator.buildMetricRootCauseContext({
+    criteriaInstance: makeCriteriaInstance(ctx),
+    monitor: new Monitor(),
+  });
+
+  expect(context).not.toBeNull();
+  return context as string;
+}
+
+/** The one data row of the Breaching Samples table. */
+function sampleRow(context: string): string {
+  const row: string | undefined = context.split("\n").find((line: string) => {
+    return line.includes(BREACH_TIME_ISO);
+  });
+
+  expect(row).toBeDefined();
+  return row as string;
+}
+
+/** The header row of the Breaching Samples table. */
+function headerRow(context: string): string {
+  const row: string | undefined = context.split("\n").find((line: string) => {
+    return line.startsWith("| Timestamp |");
+  });
+
+  expect(row).toBeDefined();
+  return row as string;
+}
+
+describe("MonitorCriteriaEvaluator - Breaching Samples value column", () => {
+  test("renders bytes at human scale instead of raw digits", () => {
+    const context: string = rootCause(makeContext({ unit: "By" }));
+
+    expect(sampleRow(context)).toBe(
+      `| \`${BREACH_TIME_ISO}\` | \`k8s.pod.memory.usage\` | \`a\` | 1.07 GB |`,
+    );
+    expect(context).not.toContain("1073741824");
+  });
+
+  test("renders a duration at human scale", () => {
+    const context: string = rootCause(
+      makeContext({
+        metricName: "http.server.duration",
+        unit: "ms",
+        breachingSamples: [
+          { value: 1500, timestamp: BREACH_TIME, attributes: {} },
+        ],
+      }),
+    );
+
+    expect(sampleRow(context)).toContain("| 1.5 sec |");
+  });
+
+  test("renders a value the user typed a GB threshold against in GB terms", () => {
+    /*
+     * When the criteria carries a thresholdUnit, samples arrive already
+     * converted into it — so ctx.unit is "GB" and the values are counts
+     * of gigabytes. ValueFormatter has no ladder for "GB" on its own;
+     * MetricValueFormatter restates the value in bytes first.
+     */
+    const context: string = rootCause(
+      makeContext({
+        unit: "GB",
+        breachingSamples: [
+          { value: 2500, timestamp: BREACH_TIME, attributes: {} },
+        ],
+      }),
+    );
+
+    expect(sampleRow(context)).toContain("| 2.5 TB |");
+  });
+
+  test("each row names the unit IT landed on", () => {
+    const context: string = rootCause(
+      makeContext({
+        unit: "By",
+        breachingSamples: [
+          {
+            value: 921600,
+            timestamp: new Date("2026-08-14T10:29:00.000Z"),
+            attributes: {},
+          },
+          { value: 1258291, timestamp: BREACH_TIME, attributes: {} },
+        ],
+      }),
+    );
+
+    /*
+     * 922 KB and 1.26 MB in the same table. This is exactly why the unit
+     * rides each cell instead of the column header — no single header
+     * could describe both rows.
+     */
+    expect(context).toContain("| 922 KB |");
+    expect(context).toContain("| 1.26 MB |");
+  });
+
+  test("a ratio metric's fraction is shown as the percentage it means", () => {
+    const context: string = rootCause(
+      makeContext({
+        metricName: "system.cpu.utilization",
+        unit: "1",
+        breachingSamples: [
+          { value: 0.0585, timestamp: BREACH_TIME, attributes: {} },
+        ],
+      }),
+    );
+
+    expect(sampleRow(context)).toContain("| 5.85% |");
+    // The old rendering: a bare "0.06", which reads as 0.06%.
+    expect(context).not.toContain("| 0.06 |");
+    expect(context).not.toContain("0.06 1");
+  });
+
+  test("a UCUM annotation-only unit is dropped rather than printed", () => {
+    const context: string = rootCause(
+      makeContext({
+        metricName: "process.threads",
+        unit: "{thread}",
+        breachingSamples: [
+          { value: 512, timestamp: BREACH_TIME, attributes: {} },
+        ],
+      }),
+    );
+
+    expect(sampleRow(context)).toContain("| 512 |");
+    expect(context).not.toContain("{thread}");
+  });
+
+  /*
+   * BACKWARD COMPATIBILITY. A metric with no unit must keep every digit —
+   * a counter at 5000 is not "5K" in an alert, because the reader may be
+   * scanning the table for the exact value that crossed the threshold.
+   */
+  test("a unitless value keeps its exact digits", () => {
+    const context: string = rootCause(
+      makeContext({
+        metricName: "http.server.request.count",
+        unit: null,
+        breachingSamples: [
+          { value: 5000, timestamp: BREACH_TIME, attributes: {} },
+        ],
+      }),
+    );
+
+    expect(sampleRow(context)).toContain("| 5000 |");
+    expect(context).not.toContain("5K");
+  });
+
+  test("a unitless non-integer is rounded to two decimals", () => {
+    const context: string = rootCause(
+      makeContext({
+        unit: null,
+        breachingSamples: [
+          { value: 2.3333333333333335, timestamp: BREACH_TIME, attributes: {} },
+        ],
+      }),
+    );
+
+    expect(sampleRow(context)).toContain("| 2.33 |");
+  });
+
+  /*
+   * ValueFormatter renders Infinity as "InfinityP PB" — its
+   * formatLargeNumber divides by 1e15, gets Infinity back and appends the
+   * "P". A broken metric must not produce that in an on-call email.
+   */
+  test("a non-finite sample is reported verbatim", () => {
+    const context: string = rootCause(
+      makeContext({
+        unit: "By",
+        breachingSamples: [
+          { value: Infinity, timestamp: BREACH_TIME, attributes: {} },
+        ],
+      }),
+    );
+
+    expect(sampleRow(context)).toContain("| Infinity |");
+    expect(context).not.toContain("InfinityP");
+  });
+
+  test("attribute columns are unaffected", () => {
+    const context: string = rootCause(
+      makeContext({
+        unit: "By",
+        groupBy: ["k8s.pod.name"],
+        breachingSamples: [
+          {
+            value: 1073741824,
+            timestamp: BREACH_TIME,
+            attributes: { "k8s.pod.name": "web-1" },
+          },
+        ],
+      }),
+    );
+
+    expect(headerRow(context)).toBe(
+      "| Timestamp | Metric | Alias | Value | k8s.pod.name |",
+    );
+    expect(sampleRow(context)).toContain("| web-1 |");
+  });
+});
+
+describe("MonitorCriteriaEvaluator - Breaching Samples component columns", () => {
+  function formulaContext(): MetricCriteriaContext {
+    return makeContext({
+      metricName: "a + b",
+      alias: "c",
+      isFormula: true,
+      formulaExpression: "a + b",
+      unit: "By",
+      components: [
+        {
+          alias: "a",
+          name: "container.memory.usage",
+          unit: "By",
+          isFormula: false,
+        },
+        {
+          alias: "b",
+          name: "container.memory.cache",
+          unit: "ms",
+          isFormula: false,
+        },
+      ],
+      breachingSamples: [
+        {
+          value: 1073741824,
+          timestamp: BREACH_TIME,
+          attributes: {},
+          componentValues: [
+            { alias: "a", value: 536870912 },
+            { alias: "b", value: 1500 },
+          ],
+        },
+      ],
+    });
+  }
+
+  test("each component cell is formatted in its own unit", () => {
+    const context: string = rootCause(formulaContext());
+
+    expect(sampleRow(context)).toBe(
+      `| \`${BREACH_TIME_ISO}\` | \`a + b\` | \`c\` | 1.07 GB | 537 MB | 1.5 sec |`,
+    );
+  });
+
+  /*
+   * The header used to read "a (By)". Now that a cell says which scale it
+   * landed on, a header unit is a claim two rows of the same column can
+   * contradict — and the Components bullet list above the table still
+   * records the configured unit, so nothing is lost.
+   */
+  test("component headers carry the alias only, not the configured unit", () => {
+    const context: string = rootCause(formulaContext());
+
+    expect(headerRow(context)).toBe(
+      "| Timestamp | Metric | Alias | Value | a | b |",
+    );
+    expect(context).not.toContain("| a (By) |");
+  });
+
+  test("the Components bullet list spells each component's unit out", () => {
+    const context: string = rootCause(formulaContext());
+
+    expect(context).toContain("- `a` = `container.memory.usage` — unit: Bytes");
+    expect(context).toContain(
+      "- `b` = `container.memory.cache` — unit: Milliseconds",
+    );
+  });
+
+  test("a component with no value for this sample still renders a dash", () => {
+    const ctx: MetricCriteriaContext = formulaContext();
+    ctx.breachingSamples![0]!.componentValues = [
+      { alias: "a", value: 536870912 },
+      { alias: "b", value: null },
+    ];
+
+    expect(sampleRow(rootCause(ctx))).toContain("| 537 MB | - |");
+  });
+});
+
+describe("MonitorCriteriaEvaluator - the Unit line", () => {
+  test("spells the UCUM code out", () => {
+    expect(rootCause(makeContext({ unit: "By" }))).toContain("- Unit: Bytes");
+  });
+
+  test("names the percent a fraction metric carries", () => {
+    const context: string = rootCause(
+      makeContext({ metricName: "system.cpu.utilization", unit: "1" }),
+    );
+
+    expect(context).toContain("- Unit: Percent");
+  });
+
+  /*
+   * The line used to read "- Unit: 1" for every ratio metric — a unit
+   * that names nothing, printed as if it did.
+   */
+  test("is dropped entirely when the unit names no dimension", () => {
+    expect(rootCause(makeContext({ unit: "1" }))).not.toContain("- Unit:");
+    expect(rootCause(makeContext({ unit: "{thread}" }))).not.toContain(
+      "- Unit:",
+    );
+    expect(rootCause(makeContext({ unit: null }))).not.toContain("- Unit:");
+  });
+});
+
+/*
+ * THE FORMULA GUARD.
+ *
+ * MetricCriteriaContext.metricName is the FORMULA EXPRESSION when the
+ * criteria targets a formula. The only use a name has downstream is
+ * ValueFormatter.isFractionMetric, whose regex asks whether the name ends
+ * in `.utilization` / `_ratio` / `_percent`. A formula written as
+ * `a / b_ratio` ends in `_ratio`, so feeding it through would silently
+ * report every value at 100× its real magnitude.
+ */
+describe("MonitorCriteriaEvaluator - formula names are not metric names", () => {
+  test("a formula ending in _ratio is not multiplied by 100", () => {
+    const context: string = rootCause(
+      makeContext({
+        metricName: "a / b_ratio",
+        alias: "c",
+        isFormula: true,
+        formulaExpression: "a / b_ratio",
+        unit: "1",
+        breachingSamples: [
+          { value: 0.42, timestamp: BREACH_TIME, attributes: {} },
+        ],
+      }),
+    );
+
+    expect(sampleRow(context)).toContain("| 0.42 |");
+    expect(context).not.toContain("42.00%");
+    expect(context).not.toContain("- Unit:");
+  });
+
+  test("a formula COMPONENT ending in _ratio is not multiplied by 100 either", () => {
+    const context: string = rootCause(
+      makeContext({
+        metricName: "c",
+        alias: "c",
+        isFormula: true,
+        formulaExpression: "x",
+        unit: null,
+        components: [
+          {
+            alias: "x",
+            name: "p / q_utilization",
+            unit: "1",
+            isFormula: true,
+          },
+        ],
+        breachingSamples: [
+          {
+            value: 1,
+            timestamp: BREACH_TIME,
+            attributes: {},
+            componentValues: [{ alias: "x", value: 0.42 }],
+          },
+        ],
+      }),
+    );
+
+    expect(sampleRow(context)).toContain("| 0.42 |");
+    expect(context).not.toContain("42.00%");
+  });
+
+  /*
+   * A plain metric criteria DOES get the heuristic — this is the control
+   * that shows the guard is narrow rather than a blanket opt-out.
+   */
+  test("a plain metric criteria still gets the fraction heuristic", () => {
+    const context: string = rootCause(
+      makeContext({
+        metricName: "system.memory.utilization",
+        isFormula: false,
+        unit: "1",
+        breachingSamples: [
+          { value: 0.42, timestamp: BREACH_TIME, attributes: {} },
+        ],
+      }),
+    );
+
+    expect(sampleRow(context)).toContain("| 42.00% |");
+  });
+});
+
+/*
+ * ONE EMAIL, ONE ANSWER.
+ *
+ * The unit-suppression rule was hand-rolled three separate times before
+ * this change — in CompareCriteria's "Filter Conditions Met" sentence, in
+ * MonitorCriteriaObservationBuilder, and nowhere at all in the Breaching
+ * Samples table — with the result that a single evaluation read
+ * differently in its own two halves: "0.31" in the sentence and "0.31 1"
+ * in the table directly beneath it.
+ *
+ * Both sections of one email now go through MetricValueFormatter. These
+ * tests assert the two strings are IDENTICAL rather than merely both
+ * plausible, so a fourth copy of the rule cannot quietly appear.
+ */
+describe("MonitorCriteriaEvaluator - the table and the sentence agree", () => {
+  function bothRenderings(input: {
+    value: number;
+    unit: string | null;
+    metricName: string;
+  }): { cell: string; sentence: string } {
+    const ctx: MetricCriteriaContext = makeContext({
+      metricName: input.metricName,
+      unit: input.unit,
+      breachingSamples: [
+        { value: input.value, timestamp: BREACH_TIME, attributes: {} },
+      ],
+    });
+
+    const row: string = sampleRow(rootCause(ctx));
+    const cells: Array<string> = row.split("|").map((cell: string) => {
+      return cell.trim();
+    });
+
+    return {
+      // | ts | metric | alias | VALUE | → index 4 once the leading "" is counted.
+      cell: cells[4] as string,
+      sentence: CompareCriteria.getCompareMessage({
+        values: input.value,
+        threshold: input.value,
+        criteriaFilter: {
+          checkOn: CheckOn.MetricValue,
+          filterType: FilterType.GreaterThan,
+        } as CriteriaFilter,
+        metricDisplayName: input.metricName,
+        metricName: input.metricName,
+        unit: input.unit || undefined,
+      }),
+    };
+  }
+
+  const cases: Array<{
+    value: number;
+    unit: string | null;
+    metricName: string;
+  }> = [
+    { value: 1073741824, unit: "By", metricName: "k8s.pod.memory.usage" },
+    { value: 1500, unit: "ms", metricName: "http.server.duration" },
+    { value: 0.0585, unit: "1", metricName: "system.cpu.utilization" },
+    { value: 0.31, unit: "1", metricName: "browser.cls" },
+    { value: 5000, unit: null, metricName: "http.server.request.count" },
+    { value: 2500, unit: "GB", metricName: "system.filesystem.usage" },
+  ];
+
+  for (const testCase of cases) {
+    test(`${testCase.metricName} @ ${testCase.unit ?? "no unit"} reads the same in both`, () => {
+      const rendered: { cell: string; sentence: string } =
+        bothRenderings(testCase);
+
+      expect(rendered.cell.length).toBeGreaterThan(0);
+      expect(rendered.sentence).toContain(`is ${rendered.cell} which is`);
+      expect(rendered.sentence).toContain(`greater than ${rendered.cell}.`);
+    });
+  }
+});

--- a/Common/Tests/Utils/MetricUnitUtil.test.ts
+++ b/Common/Tests/Utils/MetricUnitUtil.test.ts
@@ -235,6 +235,87 @@ describe("MetricUnitUtil", () => {
     });
   });
 
+  describe("getFamilyBaseUnit", () => {
+    test("returns the family's canonical base for every member", () => {
+      for (const unit of [
+        "B",
+        "b",
+        "By",
+        "bytes",
+        "KB",
+        "kby",
+        "MB",
+        "GB",
+        "TB",
+        "PB",
+      ]) {
+        expect(MetricUnitUtil.getFamilyBaseUnit(unit)).toBe("B");
+      }
+
+      for (const unit of [
+        "ns",
+        "µs",
+        "us",
+        "ms",
+        "s",
+        "sec",
+        "seconds",
+        "min",
+        "hours",
+        "d",
+        "days",
+      ]) {
+        expect(MetricUnitUtil.getFamilyBaseUnit(unit)).toBe("sec");
+      }
+
+      for (const unit of ["%", "percent", "1"]) {
+        expect(MetricUnitUtil.getFamilyBaseUnit(unit)).toBe("%");
+      }
+
+      for (const unit of ["bit", "bits", "kbit", "mbit", "gbit"]) {
+        expect(MetricUnitUtil.getFamilyBaseUnit(unit)).toBe("bit");
+      }
+    });
+
+    test("is case- and whitespace-insensitive", () => {
+      expect(MetricUnitUtil.getFamilyBaseUnit("  GB  ")).toBe("B");
+      expect(MetricUnitUtil.getFamilyBaseUnit("MS")).toBe("sec");
+    });
+
+    test("returns null for an unknown or empty unit", () => {
+      expect(MetricUnitUtil.getFamilyBaseUnit(undefined)).toBeNull();
+      expect(MetricUnitUtil.getFamilyBaseUnit("")).toBeNull();
+      expect(MetricUnitUtil.getFamilyBaseUnit("   ")).toBeNull();
+      expect(MetricUnitUtil.getFamilyBaseUnit("cores")).toBeNull();
+      expect(MetricUnitUtil.getFamilyBaseUnit("widgets")).toBeNull();
+      // Binary prefixes are deliberately not in any family here.
+      expect(MetricUnitUtil.getFamilyBaseUnit("KiBy")).toBeNull();
+    });
+
+    /*
+     * The base is the unit every other member converts into with the
+     * family's own converter — this is the contract MetricValueFormatter
+     * relies on when it restates "2500 GB" as bytes before scaling.
+     */
+    test("the base it names round-trips through convertToMetricUnit", () => {
+      expect(
+        MetricUnitUtil.convertToMetricUnit({
+          value: 2500,
+          fromUnit: "GB",
+          metricUnit: MetricUnitUtil.getFamilyBaseUnit("GB") as string,
+        }),
+      ).toBe(2.5e12);
+
+      expect(
+        MetricUnitUtil.convertToMetricUnit({
+          value: 36,
+          fromUnit: "hours",
+          metricUnit: MetricUnitUtil.getFamilyBaseUnit("hours") as string,
+        }),
+      ).toBe(129600);
+    });
+  });
+
   describe("hasCompatibleUnitFamily", () => {
     test("true for known families", () => {
       expect(MetricUnitUtil.hasCompatibleUnitFamily("bytes")).toBe(true);

--- a/Common/Tests/Utils/Monitor/MetricValueFormatter.test.ts
+++ b/Common/Tests/Utils/Monitor/MetricValueFormatter.test.ts
@@ -1,0 +1,546 @@
+import MetricValueFormatter from "../../../Utils/Monitor/MetricValueFormatter";
+import ValueFormatter from "../../../Utils/ValueFormatter";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * How a metric value is written into an alert or incident.
+ *
+ * The behaviour has three tiers and every test below belongs to one:
+ *
+ *   1. The unit names a SCALE LADDER (bytes, seconds and their prefixed
+ *      members) — the value is rescaled the way the dashboard rescales it,
+ *      so 1073741824 By reads "1.07 GB".
+ *   2. The unit names a dimension but NO ladder (cores, Celsius, ops) —
+ *      the unit symbol is appended and the digits are left alone,
+ *      because an
+ *      alert reader needs to tell 1500 restarts from 1549 and "1.5K" does
+ *      not let them.
+ *   3. The unit names NO dimension ("", "1" on a counter, "{restarts}",
+ *      the catalogs' "count") — the number stands on its own.
+ */
+describe("MetricValueFormatter", () => {
+  describe("format — units with a scale ladder", () => {
+    test("scales bytes the way the dashboard does", () => {
+      expect(MetricValueFormatter.format({ value: 0, unit: "By" })).toBe("0 B");
+      expect(MetricValueFormatter.format({ value: 512, unit: "By" })).toBe(
+        "512 B",
+      );
+      expect(MetricValueFormatter.format({ value: 1000, unit: "By" })).toBe(
+        "1 KB",
+      );
+      expect(
+        MetricValueFormatter.format({ value: 1048576, unit: "bytes" }),
+      ).toBe("1.05 MB");
+      expect(
+        MetricValueFormatter.format({ value: 1073741824, unit: "By" }),
+      ).toBe("1.07 GB");
+      expect(
+        MetricValueFormatter.format({ value: 1099511627776, unit: "bytes" }),
+      ).toBe("1.1 TB");
+    });
+
+    test("scales time units", () => {
+      expect(MetricValueFormatter.format({ value: 750, unit: "ms" })).toBe(
+        "750 ms",
+      );
+      expect(MetricValueFormatter.format({ value: 1500, unit: "ms" })).toBe(
+        "1.5 sec",
+      );
+      expect(
+        MetricValueFormatter.format({ value: 3661, unit: "seconds" }),
+      ).toBe("1.02 hours");
+      expect(MetricValueFormatter.format({ value: 1500, unit: "ns" })).toBe(
+        "1.5 µs",
+      );
+      expect(MetricValueFormatter.format({ value: 0, unit: "seconds" })).toBe(
+        "0 sec",
+      );
+    });
+
+    /*
+     * A user who types a threshold in "GB" makes every sample arrive
+     * carrying the unit "GB". ValueFormatter has a ladder for "bytes" but
+     * not for "GB", so on its own it rendered 2500 of them as "2.5K GB".
+     * The value is restated in the family's base unit first.
+     */
+    test("rescales a PREFIXED unit through its family base", () => {
+      expect(MetricValueFormatter.format({ value: 2500, unit: "GB" })).toBe(
+        "2.5 TB",
+      );
+      expect(MetricValueFormatter.format({ value: 2, unit: "GB" })).toBe(
+        "2 GB",
+      );
+      expect(MetricValueFormatter.format({ value: 0.5, unit: "MB" })).toBe(
+        "500 KB",
+      );
+      expect(MetricValueFormatter.format({ value: 1500, unit: "KB" })).toBe(
+        "1.5 MB",
+      );
+      expect(MetricValueFormatter.format({ value: 36, unit: "hours" })).toBe(
+        "1.5 days",
+      );
+      expect(MetricValueFormatter.format({ value: 5, unit: "min" })).toBe(
+        "5 min",
+      );
+      expect(MetricValueFormatter.format({ value: 90, unit: "min" })).toBe(
+        "1.5 hours",
+      );
+    });
+
+    test("scales the numerator of a rate unit and keeps the denominator", () => {
+      expect(
+        MetricValueFormatter.format({ value: 1500000, unit: "By/s" }),
+      ).toBe("1.5 MB/s");
+      expect(MetricValueFormatter.format({ value: 2.5, unit: "GB/s" })).toBe(
+        "2.5 GB/s",
+      );
+      expect(MetricValueFormatter.format({ value: 2000, unit: "GB/s" })).toBe(
+        "2 TB/s",
+      );
+    });
+
+    test("a rate whose numerator has no ladder keeps its digits", () => {
+      expect(
+        MetricValueFormatter.format({ value: 1500, unit: "requests/s" }),
+      ).toBe("1500 requests/s");
+    });
+
+    test("negatives keep their sign through the ladder", () => {
+      expect(MetricValueFormatter.format({ value: -2048, unit: "bytes" })).toBe(
+        "-2.05 KB",
+      );
+      expect(MetricValueFormatter.format({ value: -1500, unit: "ms" })).toBe(
+        "-1.5 sec",
+      );
+    });
+  });
+
+  describe("format — percent and fraction metrics", () => {
+    test("percent units render inline with two decimals", () => {
+      expect(MetricValueFormatter.format({ value: 87.5, unit: "%" })).toBe(
+        "87.50%",
+      );
+      expect(MetricValueFormatter.format({ value: 100, unit: "percent" })).toBe(
+        "100.00%",
+      );
+      expect(MetricValueFormatter.format({ value: 2.04, unit: "pct" })).toBe(
+        "2.04%",
+      );
+    });
+
+    /*
+     * The flagship case: a ratio metric whose samples are fractions in
+     * [0, 1] carrying OTel's dimensionless "1". The alert used to say
+     * "0.06 1"; the dashboard has always said "5.85%".
+     */
+    test("a [0,1] fraction on a ratio metric becomes a percentage", () => {
+      expect(
+        MetricValueFormatter.format({
+          value: 0.0585,
+          unit: "1",
+          metricName: "system.cpu.utilization",
+        }),
+      ).toBe("5.85%");
+      expect(
+        MetricValueFormatter.format({
+          value: 0.2534,
+          unit: "1",
+          metricName: "db.client.connection.usage_ratio",
+        }),
+      ).toBe("25.34%");
+    });
+
+    /*
+     * kubeletstats reports these two as CPU CORES despite the
+     * `.utilization` name, and ValueFormatter.isFractionMetric excludes
+     * them by exact name. Four other places in the repo depend on that
+     * exclusion; this pins that the alert path honours it too, so 0.18
+     * cores never reads as "18.31%".
+     */
+    test("the kubeletstats cores gauges are NOT treated as fractions", () => {
+      expect(
+        MetricValueFormatter.format({
+          value: 0.1831,
+          unit: "1",
+          metricName: "k8s.pod.cpu.utilization",
+        }),
+      ).toBe("0.18");
+      expect(
+        MetricValueFormatter.format({
+          value: 0.1831,
+          unit: "1",
+          metricName: "k8s.node.cpu.utilization",
+        }),
+      ).toBe("0.18");
+    });
+
+    test("a fraction unit with no metric name stays a bare number", () => {
+      expect(MetricValueFormatter.format({ value: 0.25, unit: "1" })).toBe(
+        "0.25",
+      );
+    });
+
+    /*
+     * The catalogs spell the dimensionless fraction "ratio". It means what
+     * "1" means, so it needs the same metric-name signal before it can be
+     * shown as a percentage.
+     */
+    test("the catalogs' 'ratio' behaves exactly like '1'", () => {
+      expect(
+        MetricValueFormatter.format({
+          value: 0.97,
+          unit: "ratio",
+          metricName: "pve_cpu_usage_ratio",
+        }),
+      ).toBe("97.00%");
+      expect(MetricValueFormatter.format({ value: 0.97, unit: "ratio" })).toBe(
+        "0.97",
+      );
+    });
+
+    /*
+     * Values reaching this formatter have ALREADY been converted into the
+     * threshold unit by MetricMonitorCriteria, so a ratio metric whose
+     * threshold is in "%" arrives pre-multiplied. Re-applying the fraction
+     * heuristic there would report 6% as 600%.
+     */
+    test("does not double-scale a value already converted into percent", () => {
+      expect(
+        MetricValueFormatter.format({
+          value: 6,
+          unit: "%",
+          metricName: "system.cpu.utilization",
+        }),
+      ).toBe("6.00%");
+    });
+  });
+
+  describe("format — units with a dimension but no ladder", () => {
+    test("appends the unit symbol and leaves every digit alone", () => {
+      expect(MetricValueFormatter.format({ value: 0.42, unit: "cores" })).toBe(
+        "0.42 cores",
+      );
+      expect(
+        MetricValueFormatter.format({ value: 1234567, unit: "cores" }),
+      ).toBe("1234567 cores");
+      expect(MetricValueFormatter.format({ value: 95, unit: "Cel" })).toBe(
+        "95 °C",
+      );
+      expect(MetricValueFormatter.format({ value: 1500, unit: "kbit" })).toBe(
+        "1500 kbit",
+      );
+      expect(MetricValueFormatter.format({ value: 1024, unit: "KiBy" })).toBe(
+        "1024 KiB",
+      );
+      expect(MetricValueFormatter.format({ value: 4200, unit: "ops" })).toBe(
+        "4200 ops",
+      );
+    });
+
+    /*
+     * This is the whole reason the formatter is not a bare call to
+     * ValueFormatter: on a chart axis "1.23M cores" is right, in an alert
+     * the exact count is the thing the reader came for.
+     */
+    test("does NOT abbreviate large numbers the way a chart axis would", () => {
+      expect(ValueFormatter.formatValue(1234567, "cores")).toBe("1.23M cores");
+      expect(
+        MetricValueFormatter.format({ value: 1234567, unit: "cores" }),
+      ).toBe("1234567 cores");
+    });
+
+    test("rounds a non-integer to two decimals", () => {
+      expect(MetricValueFormatter.format({ value: 3.14159, unit: "ops" })).toBe(
+        "3.14 ops",
+      );
+      expect(MetricValueFormatter.format({ value: 2.5, unit: "ops" })).toBe(
+        "2.5 ops",
+      );
+    });
+  });
+
+  describe("format — units that name no dimension", () => {
+    test("no unit at all leaves the number exactly as it was", () => {
+      expect(MetricValueFormatter.format({ value: 97 })).toBe("97");
+      expect(MetricValueFormatter.format({ value: 5000 })).toBe("5000");
+      expect(MetricValueFormatter.format({ value: 250, unit: "" })).toBe("250");
+      expect(MetricValueFormatter.format({ value: 12, unit: null })).toBe("12");
+      expect(MetricValueFormatter.format({ value: 12, unit: "   " })).toBe(
+        "12",
+      );
+    });
+
+    test("rounds a bare non-integer to two decimals", () => {
+      // A count metric arrives as a float from an aggregation.
+      expect(MetricValueFormatter.format({ value: 2.3333333333333335 })).toBe(
+        "2.33",
+      );
+      expect(MetricValueFormatter.format({ value: 0.9712 })).toBe("0.97");
+      // Trailing zeros are dropped: 1.50 reads "1.5".
+      expect(MetricValueFormatter.format({ value: 1.5 })).toBe("1.5");
+    });
+
+    test("UCUM annotation-only units are dropped", () => {
+      expect(
+        MetricValueFormatter.format({ value: 1500, unit: "{restarts}" }),
+      ).toBe("1500");
+      expect(MetricValueFormatter.format({ value: 42, unit: "{cpu}" })).toBe(
+        "42",
+      );
+      expect(MetricValueFormatter.format({ value: 7, unit: "{packets}" })).toBe(
+        "7",
+      );
+    });
+
+    test("the catalogs' 'count' is dropped like the dimensionless '1'", () => {
+      expect(MetricValueFormatter.format({ value: 250, unit: "count" })).toBe(
+        "250",
+      );
+      expect(MetricValueFormatter.format({ value: 12, unit: "COUNT" })).toBe(
+        "12",
+      );
+    });
+
+    test("the dimensionless '1' on a counter is dropped", () => {
+      expect(
+        MetricValueFormatter.format({
+          value: 0.31,
+          unit: "1",
+          metricName: "browser.cumulative_layout_shift",
+        }),
+      ).toBe("0.31");
+    });
+  });
+
+  /*
+   * Three Proxmox catalog entries declare `unit: "seconds"` for a value
+   * that is a Unix epoch, not a duration. Run through the time ladder,
+   * an epoch of 1750000000 renders "20.25K days" — which does not just
+   * fail to help, it actively misleads: a replication job that synced a
+   * minute ago reads as 55 years stale.
+   */
+  describe("format — metrics whose 'seconds' is a point in time", () => {
+    test("epoch timestamps keep their digits instead of becoming durations", () => {
+      for (const metricName of [
+        "pve_replication_last_sync_timestamp_seconds",
+        "pve_replication_last_try_timestamp_seconds",
+        "pve_replication_next_sync_timestamp_seconds",
+      ]) {
+        expect(
+          MetricValueFormatter.format({
+            value: 1750000000,
+            unit: "seconds",
+            metricName: metricName,
+          }),
+        ).toBe("1750000000 s");
+      }
+    });
+
+    test("the ladder is what would otherwise mislead", () => {
+      expect(ValueFormatter.formatValue(1750000000, "seconds")).toBe(
+        "20.25K days",
+      );
+    });
+
+    test("recognises the shapes a timestamp metric name takes", () => {
+      expect(
+        MetricValueFormatter.isAbsoluteTimestampMetric(
+          "pve_replication_last_sync_timestamp_seconds",
+        ),
+      ).toBe(true);
+      expect(
+        MetricValueFormatter.isAbsoluteTimestampMetric(
+          "process.start.timestamp",
+        ),
+      ).toBe(true);
+      expect(
+        MetricValueFormatter.isAbsoluteTimestampMetric("build_timestamps"),
+      ).toBe(true);
+    });
+
+    /*
+     * Narrow on purpose. A genuine duration whose name merely mentions
+     * time must still scale — this is the control that stops the carve-out
+     * from swallowing the common case.
+     */
+    test("does not swallow genuine durations", () => {
+      expect(
+        MetricValueFormatter.isAbsoluteTimestampMetric(
+          "http.server.request.duration",
+        ),
+      ).toBe(false);
+      expect(
+        MetricValueFormatter.isAbsoluteTimestampMetric(
+          "timestamp_delta_seconds",
+        ),
+      ).toBe(false);
+      expect(MetricValueFormatter.isAbsoluteTimestampMetric(undefined)).toBe(
+        false,
+      );
+
+      expect(
+        MetricValueFormatter.format({
+          value: 3661,
+          unit: "seconds",
+          metricName: "http.server.request.duration",
+        }),
+      ).toBe("1.02 hours");
+    });
+
+    test("only suppresses the ladder, not the unit label", () => {
+      expect(
+        MetricValueFormatter.getReadableUnit(
+          "seconds",
+          "pve_replication_last_sync_timestamp_seconds",
+        ),
+      ).toBe("Seconds");
+    });
+  });
+
+  describe("format — non-finite values", () => {
+    /*
+     * ValueFormatter has no non-finite guard outside its percent branch:
+     * formatLargeNumber divides Infinity by 1e15, gets Infinity, and
+     * appends the "P" suffix. Anything routed through it would report a
+     * broken metric as "InfinityP PB" in an on-call email.
+     */
+    test("are reported verbatim, never through the scaling ladder", () => {
+      expect(ValueFormatter.formatValue(Infinity, "By")).toBe("InfinityP PB");
+
+      expect(MetricValueFormatter.format({ value: NaN, unit: "By" })).toBe(
+        "NaN",
+      );
+      expect(MetricValueFormatter.format({ value: Infinity, unit: "By" })).toBe(
+        "Infinity",
+      );
+      expect(
+        MetricValueFormatter.format({ value: -Infinity, unit: "seconds" }),
+      ).toBe("-Infinity");
+      expect(MetricValueFormatter.format({ value: NaN })).toBe("NaN");
+      expect(MetricValueFormatter.format({ value: NaN, unit: "%" })).toBe(
+        "NaN",
+      );
+    });
+  });
+
+  describe("hasDisplayableUnit", () => {
+    test("true for units that name a dimension", () => {
+      for (const unit of [
+        "By",
+        "bytes",
+        "GB",
+        "ms",
+        "seconds",
+        "%",
+        "percent",
+        "cores",
+        "Cel",
+        "ops",
+        "By/s",
+      ]) {
+        expect(MetricValueFormatter.hasDisplayableUnit(unit)).toBe(true);
+      }
+    });
+
+    test("false for units that do not", () => {
+      for (const unit of [
+        undefined,
+        null,
+        "",
+        "   ",
+        "1",
+        "count",
+        "counts",
+        "{restarts}",
+        "{}",
+      ]) {
+        expect(MetricValueFormatter.hasDisplayableUnit(unit)).toBe(false);
+      }
+    });
+
+    test("'1' and 'ratio' become displayable on a fraction metric", () => {
+      expect(
+        MetricValueFormatter.hasDisplayableUnit("1", "system.cpu.utilization"),
+      ).toBe(true);
+      expect(
+        MetricValueFormatter.hasDisplayableUnit("ratio", "pve_cpu_usage_ratio"),
+      ).toBe(true);
+      expect(
+        MetricValueFormatter.hasDisplayableUnit(
+          "1",
+          "k8s.node.cpu.utilization",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("getReadableUnit", () => {
+    test("spells UCUM codes out", () => {
+      expect(MetricValueFormatter.getReadableUnit("By")).toBe("Bytes");
+      expect(MetricValueFormatter.getReadableUnit("ms")).toBe("Milliseconds");
+      expect(MetricValueFormatter.getReadableUnit("s")).toBe("Seconds");
+      expect(MetricValueFormatter.getReadableUnit("Cel")).toBe("Celsius");
+      expect(MetricValueFormatter.getReadableUnit("%")).toBe("Percent");
+      expect(MetricValueFormatter.getReadableUnit("By/s")).toBe(
+        "Bytes per Second",
+      );
+    });
+
+    test("echoes a unit it does not recognise", () => {
+      expect(MetricValueFormatter.getReadableUnit("cores")).toBe("cores");
+      expect(MetricValueFormatter.getReadableUnit("widgets")).toBe("widgets");
+    });
+
+    /*
+     * Returning null rather than "" is what lets the caller drop the whole
+     * "- Unit:" line instead of emitting the noise "- Unit: 1".
+     */
+    test("returns null when there is no dimension to name", () => {
+      expect(MetricValueFormatter.getReadableUnit(undefined)).toBeNull();
+      expect(MetricValueFormatter.getReadableUnit(null)).toBeNull();
+      expect(MetricValueFormatter.getReadableUnit("")).toBeNull();
+      expect(MetricValueFormatter.getReadableUnit("1")).toBeNull();
+      expect(MetricValueFormatter.getReadableUnit("count")).toBeNull();
+      expect(MetricValueFormatter.getReadableUnit("{restarts}")).toBeNull();
+    });
+
+    test("names the percent a fraction metric really carries", () => {
+      expect(
+        MetricValueFormatter.getReadableUnit("1", "system.cpu.utilization"),
+      ).toBe("Percent");
+      expect(
+        MetricValueFormatter.getReadableUnit("ratio", "pve_cpu_usage_ratio"),
+      ).toBe("Percent");
+      expect(
+        MetricValueFormatter.getReadableUnit("1", "k8s.node.cpu.utilization"),
+      ).toBeNull();
+    });
+  });
+
+  describe("agreement with the dashboard", () => {
+    /*
+     * The point of reusing ValueFormatter is that an email and the metric
+     * explorer say the same thing about the same sample. Where a ladder
+     * applies, the two must be byte-identical.
+     */
+    test("matches ValueFormatter exactly for every ladder unit", () => {
+      const cases: Array<[number, string]> = [
+        [1073741824, "By"],
+        [1048576, "bytes"],
+        [512, "By"],
+        [1500, "ms"],
+        [3661, "seconds"],
+        [1500, "ns"],
+        [1500000, "By/s"],
+        [87.5, "%"],
+        [0, "bytes"],
+      ];
+
+      for (const [value, unit] of cases) {
+        expect(MetricValueFormatter.format({ value: value, unit: unit })).toBe(
+          ValueFormatter.formatValue(value, unit),
+        );
+      }
+    });
+  });
+});

--- a/Common/Utils/MetricUnitUtil.ts
+++ b/Common/Utils/MetricUnitUtil.ts
@@ -298,6 +298,40 @@ export default class MetricUnitUtil {
   }
 
   /*
+   * The canonical base of the family this unit belongs to — "B" for any
+   * data unit, "sec" for any time unit, "%" for percent, "bit" for bits.
+   * Null when the unit belongs to no known family.
+   *
+   * Distinct from getCanonicalUnitValue, which answers "what should the
+   * threshold dropdown default to for this metric" and returns the unit
+   * itself for a known family member. This answers "what is the one unit
+   * every member of this family can be converted into", which is what a
+   * formatter needs before it can pick a human-readable scale: a value
+   * carrying the unit "GB" has to become bytes before a bytes ladder can
+   * decide that 2500 of them read best as "2.5 TB".
+   */
+  public static getFamilyBaseUnit(
+    metricUnit: string | undefined,
+  ): string | null {
+    if (!metricUnit || !metricUnit.trim()) {
+      return null;
+    }
+
+    const family: Array<UnitDefinition> | null = findFamily(metricUnit);
+    if (!family) {
+      return null;
+    }
+
+    const base: UnitDefinition | undefined = family.find(
+      (u: UnitDefinition) => {
+        return u.toCanonical === 1;
+      },
+    );
+
+    return base?.value || null;
+  }
+
+  /*
    * Convenience: does the metric unit belong to a family we can offer
    * conversions for? When false, the UI should still render a dropdown,
    * but with just the raw unit.

--- a/Common/Utils/Monitor/MetricValueFormatter.ts
+++ b/Common/Utils/Monitor/MetricValueFormatter.ts
@@ -1,0 +1,342 @@
+import MetricUnitUtil from "../MetricUnitUtil";
+import ValueFormatter from "../ValueFormatter";
+
+/*
+ * How a metric sample is written into alert / incident notification text.
+ *
+ * The dashboard has always scaled metric values before showing them —
+ * `ValueFormatter` turns 1073741824 bytes into "1.07 GB" for every chart,
+ * gauge and value tile. The notification path never did. The same memory
+ * breach that reads "1.07 GB" on the monitor page arrived in the on-call
+ * engineer's inbox as the bare digits "1073741824 By", and in the
+ * "Affected Resources" tables as a Value column with no unit at all — a
+ * column of ten-digit numbers the reader has to divide by 2^30 in their
+ * head at 3am to find out whether the pod is anywhere near its limit.
+ *
+ * This module is the single place that decides how a (value, unit) pair
+ * is rendered for a notification, so the breaching-samples table, the
+ * "Filter Conditions Met" sentence, the observation summary and the
+ * per-platform resource tables cannot drift apart inside one email.
+ *
+ * WHY IT WRAPS ValueFormatter RATHER THAN BEING A CALL TO IT.
+ *
+ * Three things differ between a chart axis and an alert body:
+ *
+ *  1. ABBREVIATION. `ValueFormatter` shortens any number over 1000 to
+ *     "1.5K" — right for a tick label, which has no horizontal room, and
+ *     wrong for an alert, where "restarted 1.5K times" hides the
+ *     difference between 1500 and 1549 that the reader opened the table
+ *     to find. Here, only a unit that names an actual SCALE LADDER
+ *     (bytes → KB → MB, seconds → min → hours) may rescale a number.
+ *     Everything else keeps its digits and simply gets its unit spelled
+ *     out: "1234567 cores", not "1.23M cores".
+ *
+ *  2. PREFIXED UNITS. A user who typed a threshold in "GB" makes every
+ *     sample arrive carrying the unit "GB", and ValueFormatter has a
+ *     ladder for "bytes" but not for "GB" — so 2500 of them rendered
+ *     "2.5K GB" instead of "2.5 TB". Anything in a MetricUnitUtil family
+ *     is converted to that family's base before the ladder runs.
+ *
+ *  3. UNITS WORTH HIDING. OTel's dimensionless "1" and UCUM's
+ *     annotation-only units ("{restarts}", "{packets}") are not
+ *     dimensions, and printing them produces the "0.06 1" that
+ *     CompareCriteria and MonitorCriteriaObservationBuilder each grew
+ *     their own guard against. That rule lives here now.
+ */
+export default class MetricValueFormatter {
+  /*
+   * UCUM annotation-only units — "{thread}", "{packets}", "{errors}".
+   * The braces describe what is being counted; the value is a plain
+   * count and the text inside them is not a unit a reader should see.
+   */
+  private static readonly annotationOnlyUnitPattern: RegExp = /^\{[^{}]*\}$/;
+
+  /*
+   * The per-platform metric catalogs (Kubernetes, Ceph, Proxmox, Docker
+   * Swarm) were written for humans reading a metric picker, so they spell
+   * two dimensionless concepts in English rather than in UCUM. "count"
+   * appears on 43 catalog entries and means exactly what UCUM's "1" means
+   * on a counter — printing it gives "15 count", which reads as a typo.
+   * "ratio" means what UCUM's "1" means on a fraction metric: a value in
+   * [0, 1] that a reader wants as a percentage.
+   *
+   * Rewriting them here rather than in each catalog keeps the catalogs
+   * legible to the people who edit them and still gives every consumer of
+   * this formatter one vocabulary.
+   */
+  private static readonly informalUnitAliases: Record<string, string> = {
+    count: "",
+    counts: "",
+    ratio: "1",
+    fraction: "1",
+  };
+
+  /*
+   * Metrics whose unit says "seconds" but whose VALUE is a POINT in time
+   * rather than a length of one.
+   *
+   * Proxmox has three: pve_replication_last_sync_timestamp_seconds,
+   * _last_try_ and _next_sync_ — all carrying `unit: "seconds"`, all
+   * holding a Unix epoch. Sent through the duration ladder, an epoch of
+   * 1750000000 renders "20.25K days", which is not merely unhelpful: it
+   * READS as a duration, so a replication job that synced a minute ago
+   * looks 55 years stale. The bare number at least cannot be misread as
+   * something it is not.
+   *
+   * Same shape as ValueFormatter's kubeletstats exclusion: a narrow,
+   * name-anchored carve-out for a unit the exporter declared wrongly.
+   */
+  private static readonly absoluteTimestampMetricPattern: RegExp =
+    /(^|[._])timestamps?([._]seconds?)?$/i;
+
+  /**
+   * Whether `unit` names a real dimension for `metricName` — i.e. whether
+   * it is worth attaching to a number at all. False for the empty unit,
+   * for the dimensionless "1" on a non-fraction metric, and for
+   * annotation-only units.
+   */
+  public static hasDisplayableUnit(
+    unit: string | null | undefined,
+    metricName?: string | null | undefined,
+  ): boolean {
+    const trimmed: string = MetricValueFormatter.canonicalizeUnit(unit);
+
+    if (!trimmed) {
+      return false;
+    }
+
+    /*
+     * "1" is OTel's dimensionless marker. On a `.utilization` / `.ratio`
+     * metric it means "this is a [0, 1] fraction", which IS a scale (× 100
+     * into a percent) and is why the fraction case is excluded here rather
+     * than folded in. On anything else it is noise: "0.06 1" is not just
+     * ugly, it reads as 1% when the value is 6%.
+     */
+    if (trimmed === "1") {
+      return ValueFormatter.isFractionMetric(metricName || undefined);
+    }
+
+    return !MetricValueFormatter.annotationOnlyUnitPattern.test(trimmed);
+  }
+
+  /**
+   * Format one metric sample for a notification.
+   *
+   * Units with a scale ladder are rescaled, exactly as the dashboard does:
+   *   format({ value: 1073741824, unit: "By" })            → "1.07 GB"
+   *   format({ value: 2500, unit: "GB" })                  → "2.5 TB"
+   *   format({ value: 1500, unit: "ms" })                  → "1.5 sec"
+   *   format({ value: 3661, unit: "seconds" })             → "1.02 hours"
+   *   format({ value: 1500000, unit: "By/s" })             → "1.5 MB/s"
+   *   format({ value: 0.2534, unit: "1",
+   *            metricName: "system.cpu.utilization" })     → "25.34%"
+   *   format({ value: 87.5, unit: "%" })                   → "87.50%"
+   *
+   * Units without one keep every digit and are merely labelled:
+   *   format({ value: 1234567, unit: "cores" })            → "1234567 cores"
+   *   format({ value: 95, unit: "Cel" })                   → "95 Celsius"
+   *
+   * A value with no dimension to report is left bare:
+   *   format({ value: 1500 })                              → "1500"
+   *   format({ value: 1500, unit: "{restarts}" })          → "1500"
+   *   format({ value: 3.14159 })                           → "3.14"
+   */
+  public static format(input: {
+    value: number;
+    unit?: string | null | undefined;
+    metricName?: string | null | undefined;
+  }): string {
+    if (!Number.isFinite(input.value)) {
+      return String(input.value);
+    }
+
+    const unit: string = MetricValueFormatter.canonicalizeUnit(input.unit);
+    const metricName: string | undefined = input.metricName || undefined;
+
+    if (!MetricValueFormatter.hasDisplayableUnit(unit, metricName)) {
+      return MetricValueFormatter.formatBareNumber(input.value);
+    }
+
+    const formatOptions: { metricName?: string } = metricName
+      ? { metricName: metricName }
+      : {};
+
+    /*
+     * Percent first. ValueFormatter renders "%" and the fraction-metric
+     * "1" as a two-decimal percentage, and neither is reachable through
+     * the ladder path below (there is no percent threshold table, and the
+     * percent family's base unit "%" has no ladder either).
+     */
+    if (
+      ValueFormatter.isPercentUnit(unit) ||
+      (unit === "1" && ValueFormatter.isFractionMetric(metricName))
+    ) {
+      return ValueFormatter.formatValue(input.value, unit, formatOptions);
+    }
+
+    const scalable: { value: number; unit: string } | null =
+      MetricValueFormatter.isAbsoluteTimestampMetric(metricName)
+        ? null
+        : MetricValueFormatter.toScalableUnit(input.value, unit);
+
+    if (scalable) {
+      return ValueFormatter.formatValue(
+        scalable.value,
+        scalable.unit,
+        formatOptions,
+      );
+    }
+
+    /*
+     * No ladder for this unit: label the number, leave its digits alone.
+     *
+     * The SYMBOL rather than the spelled-out name, because this suffix
+     * sits directly against a number, where the ladder path also emits
+     * symbols ("1.07 GB", "1.5 sec"). getReadableUnit is for the "Unit:"
+     * label line, where a name reads better than a code — and it is
+     * actively wrong here for compound units, which it rewrites: "m/s2"
+     * becomes "m per s2" and "10*3/uL" becomes "10*3 per uL", both longer
+     * and less recognisable than what the exporter wrote. getCompactUnit
+     * keeps the slash and still expands what is worth expanding
+     * ("Cel" → "°C", "KiBy" → "KiB").
+     */
+    const unitSymbol: string =
+      ValueFormatter.getCompactUnit(unit, formatOptions) || unit;
+
+    return `${MetricValueFormatter.formatBareNumber(input.value)} ${unitSymbol}`;
+  }
+
+  /**
+   * The spelled-out name of a unit, for the "Unit:" line of a root cause —
+   * "Bytes" rather than the UCUM "By" the exporter wrote. Returns null when
+   * the unit names no dimension, so the caller can drop the line entirely
+   * instead of printing the noise "Unit: 1".
+   */
+  public static getReadableUnit(
+    unit: string | null | undefined,
+    metricName?: string | null | undefined,
+  ): string | null {
+    if (!MetricValueFormatter.hasDisplayableUnit(unit, metricName)) {
+      return null;
+    }
+
+    const readable: string = ValueFormatter.getReadableUnit(
+      MetricValueFormatter.canonicalizeUnit(unit),
+      metricName ? { metricName: metricName } : {},
+    );
+
+    return readable.trim() ? readable : null;
+  }
+
+  /*
+   * Trim the unit and rewrite the catalogs' English spellings of "no
+   * dimension" into the UCUM ones the rest of the pipeline understands.
+   * Anything else is returned untouched — including its casing, which
+   * matters because an unrecognised unit is echoed verbatim next to the
+   * value ("5 widgets", not "5 Widgets").
+   */
+  private static canonicalizeUnit(unit: string | null | undefined): string {
+    const trimmed: string = (unit || "").trim();
+
+    if (!trimmed) {
+      return "";
+    }
+
+    const alias: string | undefined =
+      MetricValueFormatter.informalUnitAliases[trimmed.toLowerCase()];
+
+    return alias === undefined ? trimmed : alias;
+  }
+
+  /**
+   * Whether this metric's value is a point in time rather than a quantity,
+   * and so must never be run through a scale ladder. See
+   * absoluteTimestampMetricPattern.
+   */
+  public static isAbsoluteTimestampMetric(
+    metricName: string | null | undefined,
+  ): boolean {
+    if (!metricName) {
+      return false;
+    }
+
+    return MetricValueFormatter.absoluteTimestampMetricPattern.test(
+      metricName.trim(),
+    );
+  }
+
+  /*
+   * Restate (value, unit) in a unit ValueFormatter has a scale ladder for,
+   * or return null when no ladder can apply.
+   *
+   * Three ways a unit gets there:
+   *   - it already has one ("bytes", "ms", "s", "ns");
+   *   - it is a rate whose NUMERATOR does ("By/s" → scale the bytes, keep
+   *     the "/s"), which is how 1500000 By/s reads "1.5 MB/s";
+   *   - it is a prefixed member of a MetricUnitUtil family ("GB", "hours"),
+   *     in which case the value is converted into that family's base first.
+   */
+  private static toScalableUnit(
+    value: number,
+    unit: string,
+  ): { value: number; unit: string } | null {
+    if (!unit) {
+      return null;
+    }
+
+    if (ValueFormatter.isScalableUnit(unit)) {
+      return { value: value, unit: unit };
+    }
+
+    if (unit.includes("/")) {
+      const [numerator, ...denominatorParts] = unit.split("/");
+      const denominator: string = denominatorParts.join("/").trim();
+
+      if (!numerator || !numerator.trim() || !denominator) {
+        return null;
+      }
+
+      const scaledNumerator: { value: number; unit: string } | null =
+        MetricValueFormatter.toScalableUnit(value, numerator.trim());
+
+      if (!scaledNumerator) {
+        return null;
+      }
+
+      return {
+        value: scaledNumerator.value,
+        unit: `${scaledNumerator.unit}/${denominator}`,
+      };
+    }
+
+    const baseUnit: string | null = MetricUnitUtil.getFamilyBaseUnit(unit);
+
+    if (!baseUnit || !ValueFormatter.isScalableUnit(baseUnit)) {
+      return null;
+    }
+
+    return {
+      value: MetricUnitUtil.convertToMetricUnit({
+        value: value,
+        fromUnit: unit,
+        metricUnit: baseUnit,
+      }),
+      unit: baseUnit,
+    };
+  }
+
+  /*
+   * The unscaled rendering: integers verbatim, everything else rounded to
+   * two decimals with trailing zeros dropped (1.50 → "1.5"). This is the
+   * behaviour the root-cause tables had before units arrived, and every
+   * value without a scale ladder keeps it exactly, so a counter's digits
+   * survive the trip to the inbox.
+   */
+  private static formatBareNumber(value: number): string {
+    if (Number.isInteger(value)) {
+      return value.toString();
+    }
+
+    return Number(value.toFixed(2)).toString();
+  }
+}


### PR DESCRIPTION
## The problem

A metric monitor's alert and incident emails printed metric values as raw digits with the exporter's raw UCUM code glued on — or, in the per-platform tables, with no unit at all.

The same memory breach the dashboard drew as **1.07 GB** arrived in the on-call engineer's inbox as **1073741824 By**. The "Affected Resources" tables showed a `Value` column of ten-digit numbers with nothing to say what they measured, at 3am, to someone deciding whether to get out of bed.

## What changed

Every metric value in the root cause now renders the way `ValueFormatter` already renders it for every chart, gauge and value tile on the dashboard.

| Section | Before | After |
| --- | --- | --- |
| Breaching Samples · Value | `1073741824 By` | `1.07 GB` |
| Breaching Samples · Value | `0.06 1` | `5.85%` |
| Filter Conditions Met | `is 1073741824 By which is greater than 1000000000 By` | `is 1.07 GB which is greater than 1 GB` |
| Affected Resources · Value | `**8589934592**` | `**8.59 GB**` |
| Metric Details · Unit | `Unit: By` / `Unit: 1` | `Unit: Bytes` / *(line dropped)* |
| Anomaly root cause | `1073741824.000 By` | `1.07 GB` |

Three Kubernetes root-cause sentences were **worse than unlabelled**: they hardcoded a `%` onto metrics whose catalog units are `bytes` and `cores`. A node holding 8 GiB reported *"memory usage is at 8589934592.0%"*, and 1.4 cores in use read as *"1.4% CPU utilization"* — a number an on-call engineer would read as "the node is idle". They now take their unit from the same catalog lookup the worker already ran to resolve the metric's friendly name.

## Design notes

**One place decides this.** New `Common/Utils/Monitor/MetricValueFormatter` delegates to `ValueFormatter` and replaces the two hand-rolled *partial* copies of the unit-suppression rule that had grown in `CompareCriteria` and `MonitorCriteriaObservationBuilder` — which is why a single evaluation could read `0.31` in one section of an email and `0.31 1` in the table directly beneath it. A test asserts the table cell and the sentence render one sample **identically**, so a third copy cannot quietly appear.

**Why it wraps `ValueFormatter` rather than calling it.** Four things differ between a chart axis and an alert body:

1. **Abbreviation.** `formatValue` shortens anything ≥1000 to `1.5K` — right for a tick label with no horizontal room, wrong for *"restarted 1.5K times"* when the reader opened the table to find whether it was 1500 or 1549. Only units that own a real scale ladder may rescale a number here.
2. **Prefixed units.** A threshold typed in `GB` makes every sample arrive labelled `GB`, and `ValueFormatter` has a ladder for `bytes` but not `GB` — so 2500 of them rendered `2.5K GB` instead of `2.5 TB`.
3. **Non-finite values.** `ValueFormatter.formatValue(Infinity, "By")` returns the nonsense `InfinityP PB`. The helper it replaced guarded this; the new one reinstates the guard.
4. **Units worth hiding.** OTel's dimensionless `1`, UCUM's `{restarts}`, and the catalogs' English `count`.

**The unit rides each number, not the column header or the sentence.** Auto-scaling means neighbouring rows land on different scales — `922 KB` and `1.26 MB` in one column — so a header unit would state something neither row uses. The configured unit is still recorded in the Metric Details bullet list.

**Two deliberate carve-outs, both pinned by tests.**

- A **formula expression is never fed to the fraction heuristic**. `MetricCriteriaContext.metricName` *is* the formula for a formula criteria, and `a / b_ratio` ends in `_ratio` — the exact suffix `isFractionMetric` keys on. Without the guard every value would be reported at 100× its magnitude.
- The three Proxmox replication metrics that declare `unit: "seconds"` while holding a **Unix epoch** keep their exact digits. Through the duration ladder, `1750000000` renders `20.25K days` — not merely unhelpful but actively misleading, since a job that synced a minute ago would read as 55 years stale. Same shape as the existing kubeletstats cores-gauge exclusion.

**Backward compatibility.** Only `MetricMonitorCriteria` and `DatabaseMonitorCriteria` pass a unit to `CompareCriteria`; every other monitor type carries its unit inside the `CheckOn` label (*"Response Time (in ms)"*) and its sentence is byte-identical to before — a regression test pins that, digits and all.

## Deliberately out of scope

`MonitorCriteriaObservationBuilder` / `MonitorCriteriaMessageFormatter` build the *"recorded latest 5000.00 ms"* sentence. That path runs **only for filters that did NOT match**, so it reaches the dashboard's Evaluation Logs, never an alert email. Bringing it in line would mean rewriting four whole-string `toBe` test files for a surface this issue is not about — worth a follow-up, not this PR.

Also noted while tracing the delivery chain, not fixed here:
- the on-call `Acknowledge*.hbs` emails receive **raw markdown** (literal `**Filter Conditions Met**:` and pipe rows);
- the email markdown renderer emits an unstyled `<table>` nested inside a `<p>`.

## Testing

**1788 tests pass** across `Common/Tests/Server/Utils/Monitor` (83 suites), plus `Common/Tests/Utils`. New coverage:

- **34** `MetricValueFormatter` cases — every ladder, prefixed units, rates, percent/fraction, the kubeletstats exclusion, the timestamp carve-out, non-finite values, negatives, zero, and a table asserting the ladder path is byte-identical to what the dashboard shows.
- **26** evaluator cases — the Value column, per-component columns in their own units, the Unit line, the formula guard, and the cross-section agreement tests.
- **4** anomaly-sentence cases, including that **σ stays a bare number** (it counts standard deviations; rendering it as "6 GB" would be nonsense).
- Backward-compat pins that a `count`-unit or unitless metric still renders exact bare digits, and that the tables still sort worst-first on the **raw** value — `"1.07 GB" < "922 KB"` as strings, so sorting formatted output would silently invert the ordering.

Existing assertions that moved were updated deliberately rather than loosened; each carries a comment saying why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yEwmjVLY8YNvgEnNSnLx2
