### PR TITLE
feat: let a monitor template default its monitors' custom fields (#3548)

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Create.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Create.tsx
@@ -4,6 +4,7 @@ import PageComponentProps from "../PageComponentProps";
 import Route from "Common/Types/API/Route";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import MonitorTemplate from "Common/Models/DatabaseModels/MonitorTemplate";
+import MonitorTemplateCustomFieldUtil from "Common/Utils/Monitor/MonitorTemplateCustomFieldUtil";
 import Label from "Common/Models/DatabaseModels/Label";
 import React, {
   Fragment,
@@ -241,6 +242,21 @@ const MonitorCreate: FunctionComponent<
   const bindToNetworkDeviceId: MutableRefObject<ObjectID | null> =
     useRef<ObjectID | null>(null);
   const [isBinding, setIsBinding] = useState<boolean>(false);
+
+  /*
+   * The template's custom field defaults, carried to onBeforeCreate.
+   *
+   * Every other template default reaches the new monitor through a form field
+   * seeded from initialValues, but custom fields have no input on this form —
+   * they are edited on the monitor's own Custom Fields page after it exists —
+   * so a value put in initialValues would simply never be submitted. Applying
+   * it at create time instead is what makes a monitor a person makes from a
+   * template carry the same defaults as one an auto-import rule provisions
+   * from it (issue #3548). A ref for the same reason as the bind above:
+   * nothing renders from it.
+   */
+  const templateCustomFields: MutableRefObject<JSONObject | null> =
+    useRef<JSONObject | null>(null);
 
   const loadProbes: () => Promise<void> = async (): Promise<void> => {
     try {
@@ -924,11 +940,14 @@ const MonitorCreate: FunctionComponent<
             monitorType: true,
             monitorSteps: true,
             monitoringInterval: true,
+            customFields: true,
             labels: true,
           },
         });
 
       if (template) {
+        templateCustomFields.current = template.customFields || null;
+
         const templateJSON: JSONObject = BaseModel.toJSONObject(
           template,
           MonitorTemplate,
@@ -1207,6 +1226,11 @@ const MonitorCreate: FunctionComponent<
               onBeforeCreate={async (item: Monitor): Promise<Monitor> => {
                 if (monitorTemplateId) {
                   item.monitorTemplateId = new ObjectID(monitorTemplateId);
+                }
+                if (templateCustomFields.current) {
+                  item.customFields = MonitorTemplateCustomFieldUtil.clone(
+                    templateCustomFields.current,
+                  );
                 }
                 return item;
               }}

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplatesView.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplatesView.tsx
@@ -15,6 +15,7 @@ import { JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import ModelDelete from "Common/UI/Components/ModelDelete/ModelDelete";
+import CustomFieldsDetail from "Common/UI/Components/CustomFields/CustomFieldsDetail";
 import CardModelDetail from "Common/UI/Components/ModelDetail/CardModelDetail";
 import ConfirmModal from "Common/UI/Components/Modal/ConfirmModal";
 import {
@@ -35,7 +36,9 @@ import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import Navigation from "Common/UI/Utils/Navigation";
 import Label from "Common/Models/DatabaseModels/Label";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
+import MonitorCustomField from "Common/Models/DatabaseModels/MonitorCustomField";
 import MonitorTemplate from "Common/Models/DatabaseModels/MonitorTemplate";
+import MonitorTemplateCustomFieldUtil from "Common/Utils/Monitor/MonitorTemplateCustomFieldUtil";
 import MonitorStepsType from "Common/Types/Monitor/MonitorSteps";
 import MonitorType, {
   MonitorTypeHelper,
@@ -127,6 +130,20 @@ const MonitorTemplatesView: FunctionComponent<
     useState<boolean>(false);
   const [isSyncingLabels, setIsSyncingLabels] = useState<boolean>(false);
   const [labelsSyncError, setLabelsSyncError] = useState<string>("");
+
+  const [showCustomFieldsSyncModal, setShowCustomFieldsSyncModal] =
+    useState<boolean>(false);
+  const [isSyncingCustomFields, setIsSyncingCustomFields] =
+    useState<boolean>(false);
+  const [customFieldsSyncError, setCustomFieldsSyncError] =
+    useState<string>("");
+  /*
+   * Reported by the Custom Field Defaults card itself rather than fetched
+   * here, so it reflects an edit made on this page without a second read.
+   */
+  const [templateCustomFields, setTemplateCustomFields] = useState<JSONObject>(
+    {},
+  );
 
   const [singleSyncMonitor, setSingleSyncMonitor] = useState<Monitor | null>(
     null,
@@ -325,6 +342,60 @@ const MonitorTemplatesView: FunctionComponent<
     }
   };
 
+  /*
+   * The backfill half of custom field defaults (issue #3548). Setting defaults
+   * on the template only reaches monitors provisioned AFTER the edit, and the
+   * fleet that made this a problem — a thousand devices an auto-import rule
+   * already imported — is entirely on the other side of that line. This is
+   * what reaches them.
+   *
+   * Scoped to `customFields` by name because an unscoped sync deliberately
+   * leaves them alone: see DEFAULT_SYNCABLE_FIELDS in MonitorTemplateService.
+   */
+  const onSyncCustomFieldsSubmit: () => Promise<void> =
+    async (): Promise<void> => {
+      setIsSyncingCustomFields(true);
+      setCustomFieldsSyncError("");
+      try {
+        const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+          await API.post<JSONObject>({
+            url: URL.fromString(APP_API_URL.toString()).addRoute(
+              `/monitor-template/${modelId.toString()}/sync-to-linked-monitors`,
+            ),
+            data: {
+              fields: ["customFields"],
+            },
+            headers: ModelAPI.getCommonHeaders(),
+          });
+
+        if (response.isFailure()) {
+          setCustomFieldsSyncError(API.getFriendlyMessage(response));
+          setIsSyncingCustomFields(false);
+          return;
+        }
+
+        const synced: number = (response.data["syncedMonitors"] as number) || 0;
+        const total: number =
+          (response.data["totalLinkedMonitors"] as number) || 0;
+
+        const summary: SyncResultSummary = buildSyncResultSummary({
+          subject: "custom field defaults",
+          syncedMonitors: synced,
+          totalLinkedMonitors: total,
+        });
+
+        setSyncResultTitle(summary.title);
+        setSyncResultMessage(summary.message);
+        setShowCustomFieldsSyncModal(false);
+        setIsSyncingCustomFields(false);
+        fetchLinkedMonitorCount();
+        setTableRefreshToggle(Math.random().toString());
+      } catch (e) {
+        setCustomFieldsSyncError(API.getFriendlyMessage(e));
+        setIsSyncingCustomFields(false);
+      }
+    };
+
   const onSingleSyncSubmit: () => Promise<void> = async (): Promise<void> => {
     if (!singleSyncMonitor || !singleSyncMonitor.id) {
       return;
@@ -515,6 +586,24 @@ const MonitorTemplatesView: FunctionComponent<
     linkedMonitorCount === null
       ? "Sync Labels to Linked Monitors"
       : `Sync Labels to ${linkedMonitorCount} Linked Monitor${linkedMonitorCount === 1 ? "" : "s"}`;
+
+  const syncCustomFieldsButtonTitle: string =
+    linkedMonitorCount === null
+      ? "Sync Custom Fields to Linked Monitors"
+      : `Sync Custom Fields to ${linkedMonitorCount} Linked Monitor${linkedMonitorCount === 1 ? "" : "s"}`;
+
+  /*
+   * A template with no defaults set has nothing to push, and a sync that
+   * writes nothing comes back as "0 of N synced" — which the summary reads as
+   * a permissions problem and tells the operator to run it again as somebody
+   * else. Say what is actually wrong instead, on a button that stays visible
+   * so the sentence has somewhere to hang.
+   */
+  const customFieldDefaultNames: Array<string> = Object.keys(
+    MonitorTemplateCustomFieldUtil.getDefaults(templateCustomFields),
+  );
+
+  const hasCustomFieldDefaults: boolean = customFieldDefaultNames.length > 0;
 
   /*
    * The count goes in the title rather than only inside the sync buttons: "how
@@ -977,9 +1066,47 @@ const MonitorTemplatesView: FunctionComponent<
         }}
       />
 
+      {/*
+       * Custom field defaults (issue #3548). Written onto every monitor this
+       * template provisions — including the ones an auto-import rule creates
+       * from a discovery scan, which is the case where filling them in by hand
+       * afterwards means opening a thousand monitors one at a time.
+       *
+       * `hideIfEmpty` for the same reason the resource overview pages use it:
+       * a project that has defined no Monitor Custom Fields has nothing to
+       * default, and reading the schema is gated on a billing plan besides.
+       */}
+      <CustomFieldsDetail
+        title="Custom Field Defaults"
+        description="Custom field values written onto every monitor created from this template — including monitors provisioned automatically by auto-import rules and alert policies. Fields left blank here are not defaulted."
+        modelType={MonitorTemplate}
+        customFieldType={MonitorCustomField}
+        name="Monitor Template Custom Field Defaults"
+        projectId={ProjectUtil.getCurrentProject()!.id!}
+        modelId={modelId}
+        hideIfEmpty={true}
+        onValuesLoaded={setTemplateCustomFields}
+        additionalButtons={[
+          {
+            title: syncCustomFieldsButtonTitle,
+            icon: IconProp.Refresh,
+            buttonStyle: ButtonStyleType.NORMAL,
+            disabled: linkedMonitorCount === 0 || !hasCustomFieldDefaults,
+            tooltip: hasCustomFieldDefaults
+              ? undefined
+              : "Set at least one default above before syncing.",
+            onClick: () => {
+              setSyncResultMessage("");
+              setCustomFieldsSyncError("");
+              setShowCustomFieldsSyncModal(true);
+            },
+          },
+        ]}
+      />
+
       <MonitorsTable
         title={linkedMonitorsTitle}
-        description="Monitors created from or linked to this template. Use the sync buttons on the cards above to push the template's criteria, monitoring interval, or labels onto every linked monitor."
+        description="Monitors created from or linked to this template. Use the sync buttons on the cards above to push the template's criteria, monitoring interval, labels, or custom field defaults onto every linked monitor."
         noItemsMessage="No monitors are linked to this template yet."
         disableCreate={true}
         query={linkedMonitorsQuery}
@@ -1068,7 +1195,7 @@ const MonitorTemplatesView: FunctionComponent<
           title="Sync Criteria to Linked Monitors"
           description={
             <span>
-              {`This will overwrite ONLY the monitor criteria on ${linkedMonitorCount} monitor${linkedMonitorCount === 1 ? "" : "s"} created from this template. Monitoring interval, minimum probe agreement, name, description, and labels will be left alone. This cannot be undone.`}
+              {`This will overwrite ONLY the monitor criteria on ${linkedMonitorCount} monitor${linkedMonitorCount === 1 ? "" : "s"} created from this template. Monitoring interval, minimum probe agreement, name, description, labels, and custom field values will be left alone. This cannot be undone.`}
             </span>
           }
           submitButtonText="Sync Criteria"
@@ -1088,7 +1215,7 @@ const MonitorTemplatesView: FunctionComponent<
           title="Sync Interval to Linked Monitors"
           description={
             <span>
-              {`This will overwrite the monitoring interval and minimum probe agreement on ${linkedMonitorCount} monitor${linkedMonitorCount === 1 ? "" : "s"} created from this template. Criteria, name, description, and labels will be left alone. This cannot be undone.`}
+              {`This will overwrite the monitoring interval and minimum probe agreement on ${linkedMonitorCount} monitor${linkedMonitorCount === 1 ? "" : "s"} created from this template. Criteria, name, description, labels, and custom field values will be left alone. This cannot be undone.`}
             </span>
           }
           submitButtonText="Sync Interval"
@@ -1108,7 +1235,7 @@ const MonitorTemplatesView: FunctionComponent<
           title="Sync Labels to Linked Monitors"
           description={
             <span>
-              {`This will overwrite ONLY the labels on ${linkedMonitorCount} monitor${linkedMonitorCount === 1 ? "" : "s"} created from this template. Criteria, monitoring interval, minimum probe agreement, name, and description will be left alone. This cannot be undone.`}
+              {`This will overwrite ONLY the labels on ${linkedMonitorCount} monitor${linkedMonitorCount === 1 ? "" : "s"} created from this template. Criteria, monitoring interval, minimum probe agreement, name, description, and custom field values will be left alone. This cannot be undone.`}
             </span>
           }
           submitButtonText="Sync Labels"
@@ -1123,12 +1250,32 @@ const MonitorTemplatesView: FunctionComponent<
         />
       )}
 
+      {showCustomFieldsSyncModal && (
+        <ConfirmModal
+          title="Sync Custom Fields to Linked Monitors"
+          description={
+            <span>
+              {`This will overwrite the ${customFieldDefaultNames.length} custom field${customFieldDefaultNames.length === 1 ? "" : "s"} this template defaults (${customFieldDefaultNames.join(", ")}) on ${linkedMonitorCount} monitor${linkedMonitorCount === 1 ? "" : "s"} created from this template, replacing any value entered on those monitors. Custom fields this template leaves blank are not touched, and neither are criteria, monitoring interval, labels, name, or description. This cannot be undone.`}
+            </span>
+          }
+          submitButtonText="Sync Custom Fields"
+          submitButtonType={ButtonStyleType.PRIMARY}
+          isLoading={isSyncingCustomFields}
+          error={customFieldsSyncError}
+          onSubmit={onSyncCustomFieldsSubmit}
+          onClose={() => {
+            setShowCustomFieldsSyncModal(false);
+            setCustomFieldsSyncError("");
+          }}
+        />
+      )}
+
       {singleSyncMonitor && (
         <ConfirmModal
           title="Sync Monitor from Template"
           description={
             <span>
-              {`This will overwrite the criteria, monitoring interval, minimum probe agreement, and labels on "${singleSyncMonitor.name || "this monitor"}" with the template's current values. Name and description will be left alone. This cannot be undone.`}
+              {`This will overwrite the criteria, monitoring interval, minimum probe agreement, and labels on "${singleSyncMonitor.name || "this monitor"}" with the template's current values. Name, description, and custom field values will be left alone. This cannot be undone.`}
             </span>
           }
           submitButtonText="Sync Now"

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/AutoImportRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/AutoImportRules.tsx
@@ -476,8 +476,15 @@ const NetworkDeviceAutoImportRulesPage: FunctionComponent<
                   fetchDropdownOptions: fetchNetworkDeviceMonitorTemplates,
                   required: false,
                   placeholder: "Import device only (no monitor)",
+                  /*
+                   * The custom fields half names where they are SET, because
+                   * that is what issue #3548 could not find: the values were
+                   * always copied from the template onto every imported
+                   * device's monitor, and the template had nowhere to enter
+                   * them until the Custom Field Defaults card existed.
+                   */
                   description:
-                    "Alert criteria, interval, minimum probe agreement, custom fields and monitor labels are copied from this template. Health OIDs and other polling settings remain on the Network Device. Matching rules that select different templates can create multiple monitors per device.",
+                    "Alert criteria, interval, minimum probe agreement, monitor labels and custom field defaults (set on the template's own Custom Field Defaults card) are copied from this template onto every monitor it creates. Health OIDs and other polling settings remain on the Network Device. Matching rules that select different templates can create multiple monitors per device.",
                   showIf: canSelectAutoImportMonitorTemplate,
                 },
               ]

--- a/App/FeatureSet/Docs/Content/en/monitor/network-device-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/network-device-monitor.md
@@ -449,6 +449,19 @@ Or by hand:
 
 Network Device monitors have no polling interval of their own: they are evaluated server-side every time the device's poll results arrive, and every time a matching trap arrives.
 
+### Custom Field Defaults
+
+If your project defines Monitor Custom Fields (**Monitors** -> **Settings** -> **Custom Fields**) — Vendor, Configuration Item, owning service, whatever your CMDB needs — a monitor template can fill them in for you. **Monitors** -> **Settings** -> **Templates** -> open a template -> **Custom Field Defaults**.
+
+Every monitor made from that template afterwards is created carrying those values — the ones a person creates with **Create Monitor from Template**, and, the case this exists for, the ones an auto-import rule creates when a [discovery scan](#discovering-devices-with-a-network-scan) brings in a thousand devices at once. Without defaults, those thousand monitors arrive with every custom field empty and the only way to fill them is one monitor at a time.
+
+Two things to know:
+
+- **A field left blank on the template is not a default.** A blank leaves each monitor to answer that field for itself, so a template can default Vendor across a whole switch fleet while Configuration Item stays a per-device answer.
+- **Defaults apply at creation time.** They do not reach monitors that already exist — which is exactly the fleet you have if you set them up after a scan has already run. **Sync Custom Fields to Linked Monitors**, on that same card, is what pushes them onto the existing fleet. It overwrites the fields the template defaults, including values somebody typed in by hand, and the confirmation names those fields before it runs. Fields the template leaves blank are still left alone, so a sync can never blank a value.
+
+Custom field defaults are the one thing a plain **Sync from Template** leaves alone: pushing criteria or an interval never rewrites the values on your monitors.
+
 ## Monitoring Criteria
 
 You can set up criteria to check poll results and trigger alerts or incidents.

--- a/App/Tests/Dashboard/MonitorTemplateCustomFieldDefaults.test.ts
+++ b/App/Tests/Dashboard/MonitorTemplateCustomFieldDefaults.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * ISSUE #3548 — a monitor template's custom fields are the DEFAULTS the
+ * monitors made from it are born with.
+ *
+ * The server half of that is covered by unit tests
+ * (MonitorTemplateServiceCustomFieldSync, MonitorTemplateCustomFieldUtil). What
+ * those cannot see is the dashboard, and the dashboard is where the feature is
+ * easiest to lose silently:
+ *
+ *   - the template read on the monitor CREATE page has an explicit `select`.
+ *     Drop `customFields` from it and the page still renders, still creates
+ *     monitors, and quietly stops carrying the defaults — the create form has
+ *     no custom field input to make the loss visible;
+ *   - `customFields` is not a form field, so it is not submitted with the rest
+ *     of the form. It reaches the new monitor only through `onBeforeCreate`;
+ *   - the template view's sync button must scope its push BY NAME. An
+ *     unscoped sync deliberately leaves custom fields alone (see
+ *     DEFAULT_SYNCABLE_FIELDS in MonitorTemplateService), so a call that
+ *     forgets `fields` would silently do nothing at all.
+ *
+ * Both files are React pages with no extractable logic and the App suite runs
+ * in a plain Node environment with no renderer, so this reads the source the
+ * same way the sibling MonitorTemplateSyncTenantHeader test does.
+ */
+
+const DASHBOARD_PAGES: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Pages",
+  "Monitor",
+);
+
+const MONITOR_CREATE: string = path.join(DASHBOARD_PAGES, "Create.tsx");
+const MONITOR_TEMPLATES_VIEW: string = path.join(
+  DASHBOARD_PAGES,
+  "Settings",
+  "MonitorTemplatesView.tsx",
+);
+
+/*
+ * Comments are stripped so the prose above a call (which names both
+ * `customFields` and the endpoint) cannot satisfy an assertion about the code,
+ * and whitespace is squashed so prettier re-wrapping a call cannot turn a real
+ * regression check into a red herring.
+ */
+function readCode(file: string): string {
+  return fs
+    .readFileSync(file, "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/.*$/gm, " ")
+    .replace(/\s+/g, " ");
+}
+
+/*
+ * The argument object of every call to `name(`, as source text. Brace-matched
+ * rather than regex-matched so a nested object does not truncate the capture.
+ */
+function getCallArguments(code: string, name: string): Array<string> {
+  const calls: Array<string> = [];
+  const marker: RegExp = new RegExp(
+    `(?<![A-Za-z])${name}(?:<[^>]*>)?\\(\\s*\\{`,
+    "g",
+  );
+
+  let match: RegExpExecArray | null = marker.exec(code);
+
+  while (match !== null) {
+    const openIndex: number = code.indexOf("{", match.index);
+    let depth: number = 0;
+    let end: number = -1;
+
+    for (let i: number = openIndex; i < code.length; i++) {
+      if (code[i] === "{") {
+        depth++;
+      } else if (code[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+
+    if (end === -1) {
+      break;
+    }
+
+    calls.push(code.substring(openIndex, end + 1));
+    marker.lastIndex = end;
+    match = marker.exec(code);
+  }
+
+  return calls;
+}
+
+describe("Monitor template custom field defaults reach the monitor create page", () => {
+  const code: string = readCode(MONITOR_CREATE);
+
+  test("the template read selects customFields", () => {
+    const templateReads: Array<string> = getCallArguments(
+      code,
+      "ModelAPI.getItem",
+    ).filter((call: string): boolean => {
+      return call.includes("modelType: MonitorTemplate");
+    });
+
+    expect(templateReads).toHaveLength(1);
+    expect(templateReads[0]).toContain("customFields: true");
+  });
+
+  /*
+   * ModelForm submits only the keys of its declared form fields, so a value
+   * merely seeded into initialValues is dropped. onBeforeCreate is the one
+   * hook that reaches the model actually sent to the API.
+   */
+  test("the defaults are applied in onBeforeCreate, not left to the form", () => {
+    expect(code).toMatch(
+      /onBeforeCreate=\{async \(item: Monitor\)[\s\S]*?item\.customFields =/,
+    );
+    expect(code).toContain("MonitorTemplateCustomFieldUtil.clone(");
+  });
+});
+
+describe("The monitor template view syncs custom fields by name", () => {
+  const code: string = readCode(MONITOR_TEMPLATES_VIEW);
+
+  const syncCalls: Array<string> = getCallArguments(code, "API.post").filter(
+    (call: string): boolean => {
+      return call.includes("sync-to-linked-monitors");
+    },
+  );
+
+  test("every sync from this page scopes itself to named fields", () => {
+    expect(syncCalls.length).toBeGreaterThan(0);
+
+    for (const call of syncCalls) {
+      expect(call).toMatch(/data: \{ fields: \[/);
+    }
+  });
+
+  test("one of them pushes exactly customFields", () => {
+    const customFieldSyncs: Array<string> = syncCalls.filter(
+      (call: string): boolean => {
+        return call.includes('fields: ["customFields"]');
+      },
+    );
+
+    expect(customFieldSyncs).toHaveLength(1);
+  });
+
+  /*
+   * The card is what makes the defaults settable at all — the column has
+   * existed on MonitorTemplate since the model was written and was reachable
+   * from nothing, which is the whole of issue #3548. It has to point at the
+   * Monitor custom field schema (not the template's own, which does not
+   * exist), or the operator is offered the wrong list of fields.
+   */
+  test("the Custom Field Defaults card edits MonitorTemplate against the Monitor schema", () => {
+    expect(code).toContain("<CustomFieldsDetail");
+    expect(code).toContain("modelType={MonitorTemplate}");
+    expect(code).toContain("customFieldType={MonitorCustomField}");
+  });
+});

--- a/App/Tests/Dashboard/MonitorTemplateSyncTenantHeader.test.ts
+++ b/App/Tests/Dashboard/MonitorTemplateSyncTenantHeader.test.ts
@@ -20,7 +20,9 @@ import path from "path";
  * of these permissions: Project Owner, ..." — a message that sends project
  * owners hunting for a role they already hold.
  *
- * All six calls shipped without the header. This pins every one of them: the
+ * All six calls the page had at the time shipped without the header, and the
+ * count below moves with the page as sync buttons are added — a new post is
+ * exactly the thing that reintroduces this. This pins every one of them: the
  * component is a React page with no extractable logic, and the App suite runs
  * in a plain Node environment with no renderer, so this reads the source the
  * same way the sibling *Invariants tests do.
@@ -104,7 +106,7 @@ describe("Monitor Template sync/link endpoints send the tenant header", () => {
      */
     const calls: Array<string> = getApiPostArguments(code);
 
-    expect(calls.length).toBe(6);
+    expect(calls.length).toBe(7);
     expect(code).toContain("/sync-to-linked-monitors");
     expect(code).toContain("/sync-to-monitor/");
     expect(code).toContain("/link-monitor/");

--- a/Common/Server/Services/MonitorTemplateService.ts
+++ b/Common/Server/Services/MonitorTemplateService.ts
@@ -22,6 +22,7 @@ import PositiveNumber from "../../Types/PositiveNumber";
 import Model from "../../Models/DatabaseModels/MonitorTemplate";
 import Monitor from "../../Models/DatabaseModels/Monitor";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import MonitorTemplateCustomFieldUtil from "../../Utils/Monitor/MonitorTemplateCustomFieldUtil";
 import NetworkDeviceMonitorTemplateUtil from "../../Utils/Monitor/NetworkDeviceMonitorTemplateUtil";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import ModelPermission from "../Types/Database/Permissions/Index";
@@ -41,9 +42,31 @@ export type SyncableTemplateField =
   | "monitorSteps"
   | "monitoringInterval"
   | "minimumProbeAgreement"
-  | "labels";
+  | "labels"
+  | "customFields";
 
-const ALL_SYNCABLE_FIELDS: ReadonlyArray<SyncableTemplateField> = [
+const SYNCABLE_FIELDS: ReadonlyArray<SyncableTemplateField> = [
+  "monitorSteps",
+  "monitoringInterval",
+  "minimumProbeAgreement",
+  "labels",
+  "customFields",
+];
+
+/*
+ * What an UNSCOPED sync pushes — every syncable field except custom field
+ * defaults.
+ *
+ * Custom fields are the one syncable thing whose per-monitor value is
+ * ordinarily typed in by hand: a monitor's Configuration Item or Vendor is
+ * about that device, not about the template. A caller that names no fields is
+ * saying "push the template", not "and also rewrite every operator-entered
+ * value in the fleet", so custom fields ship only when asked for by name —
+ * which is what the dedicated button on the template's Custom Field Defaults
+ * card does. The dashboard always scopes its syncs, so this only decides what
+ * an API caller gets by default.
+ */
+const DEFAULT_SYNCABLE_FIELDS: ReadonlyArray<SyncableTemplateField> = [
   "monitorSteps",
   "monitoringInterval",
   "minimumProbeAgreement",
@@ -309,10 +332,10 @@ export class Service extends DatabaseService<Model> {
     fields: Array<string> | undefined,
   ): Array<SyncableTemplateField> {
     if (!fields || fields.length === 0) {
-      return [...ALL_SYNCABLE_FIELDS];
+      return [...DEFAULT_SYNCABLE_FIELDS];
     }
 
-    const allowed: Set<string> = new Set(ALL_SYNCABLE_FIELDS);
+    const allowed: Set<string> = new Set(SYNCABLE_FIELDS);
     for (const field of fields) {
       if (!allowed.has(field)) {
         throw new BadDataException(
@@ -323,6 +346,16 @@ export class Service extends DatabaseService<Model> {
     return fields as Array<SyncableTemplateField>;
   }
 
+  /*
+   * The part of the push that is identical for every linked monitor, so it can
+   * ride a single bulk update.
+   *
+   * `customFields` is deliberately absent: a template's custom fields are
+   * DEFAULTS overlaid on whatever the monitor already holds, which is a
+   * different value per monitor and therefore cannot be one shared payload.
+   * The two sync entry points below compute it per monitor instead — see
+   * buildCustomFieldsUpdate.
+   */
   private buildUpdateData(
     template: Model,
     fields: Array<SyncableTemplateField>,
@@ -330,6 +363,10 @@ export class Service extends DatabaseService<Model> {
     const updateData: Partial<Monitor> = {};
 
     for (const field of fields) {
+      if (field === "customFields") {
+        continue;
+      }
+
       const value: unknown = (template as unknown as Record<string, unknown>)[
         field
       ];
@@ -342,13 +379,46 @@ export class Service extends DatabaseService<Model> {
     return updateData;
   }
 
+  /*
+   * Does this push carry custom field defaults that are worth a write?
+   *
+   * A template whose bag is absent, empty, or holds nothing but blanks has no
+   * defaults to give, and saying so here is what stops a custom-fields-only
+   * sync from taking the per-monitor path (and reporting a fleet-wide write)
+   * to push nothing at all.
+   */
+  private hasCustomFieldDefaultsToSync(
+    template: Model,
+    fields: Array<SyncableTemplateField>,
+  ): boolean {
+    return (
+      fields.includes("customFields") &&
+      MonitorTemplateCustomFieldUtil.hasDefaults(template.customFields)
+    );
+  }
+
+  /*
+   * One monitor's custom field bag after the template's defaults are laid over
+   * it: the template wins every field it actually defaults, and every other
+   * value the operator entered on that monitor survives untouched.
+   */
+  private buildCustomFieldsUpdate(data: {
+    template: Model;
+    monitor: Monitor;
+  }): JSONObject {
+    return MonitorTemplateCustomFieldUtil.applyDefaults({
+      templateCustomFields: data.template.customFields,
+      monitorCustomFields: data.monitor.customFields,
+    });
+  }
+
   /**
    * Push the template's current configuration onto every monitor that was
    * created from it. Sync is intentionally explicit (button-triggered) so a
    * config tweak doesn't silently re-deploy across the whole fleet.
    *
    * Pass `fields` to scope the sync — e.g. `["monitorSteps"]` to push only the
-   * criteria. If omitted, every syncable field is pushed.
+   * criteria. If omitted, DEFAULT_SYNCABLE_FIELDS is pushed.
    */
   @CaptureSpan()
   public async syncLinkedMonitors(data: {
@@ -369,6 +439,7 @@ export class Service extends DatabaseService<Model> {
         monitorSteps: true,
         monitoringInterval: true,
         minimumProbeAgreement: true,
+        customFields: true,
         labels: {
           _id: true,
         },
@@ -398,7 +469,17 @@ export class Service extends DatabaseService<Model> {
 
     const updateData: Partial<Monitor> = this.buildUpdateData(template, fields);
 
-    if (Object.keys(updateData).length === 0) {
+    /*
+     * Custom field defaults never ride in updateData — the value written
+     * depends on what each monitor already holds — so they are their own
+     * reason for this push to have work to do.
+     */
+    const syncCustomFields: boolean = this.hasCustomFieldDefaultsToSync(
+      template,
+      fields,
+    );
+
+    if (Object.keys(updateData).length === 0 && !syncCustomFields) {
       return {
         totalLinkedMonitors,
         syncedMonitors: 0,
@@ -412,10 +493,16 @@ export class Service extends DatabaseService<Model> {
      * those rows individually and rebind cloned template steps to each
      * monitor's current (or provenance-backed) device instead.
      */
-    if (
+    const rebindMonitorSteps: boolean =
       template.monitorType === MonitorType.NetworkDevice &&
-      fields.includes("monitorSteps")
-    ) {
+      fields.includes("monitorSteps");
+
+    /*
+     * Custom field defaults take the same row-at-a-time path for their own
+     * reason: they are overlaid on the monitor's existing bag, so the payload
+     * is read from the row being written and cannot be shared.
+     */
+    if (rebindMonitorSteps || syncCustomFields) {
       let syncedMonitors: number = 0;
       const linkedMonitorQuery: Query<Monitor> = {
         monitorTemplateId: template.id!,
@@ -428,12 +515,20 @@ export class Service extends DatabaseService<Model> {
        * label scope order-dependent: accessible rows could update before a
        * later hidden row threw. This is the same permission-narrowed subset
        * the ordinary bulk update path applies atomically.
+       *
+       * The probe names `customFields` when this push writes them — the
+       * per-monitor values are not known yet, and only the KEYS decide the
+       * column check — so a caller who may not update that column is refused
+       * up front rather than on an arbitrary row partway through the fleet.
        */
       const authorizedMonitorQuery: Query<Monitor> =
         await ModelPermission.checkUpdateQueryPermissions(
           Monitor,
           linkedMonitorQuery,
-          updateData as any,
+          {
+            ...updateData,
+            ...(syncCustomFields ? { customFields: {} } : {}),
+          } as any,
           data.props,
         );
       const monitorsToSync: Array<Monitor> = [];
@@ -444,6 +539,7 @@ export class Service extends DatabaseService<Model> {
           select: {
             _id: true,
             monitorSteps: true,
+            customFields: true,
             autoProvisionedNetworkDeviceId: true,
           },
           sort: { createdAt: SortOrder.Ascending, _id: SortOrder.Ascending },
@@ -468,15 +564,27 @@ export class Service extends DatabaseService<Model> {
           monitor,
           data: {
             ...updateData,
-            monitorSteps: monitor.autoProvisionedNetworkDeviceId
-              ? NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps({
-                  monitorSteps: template.monitorSteps,
-                  networkDeviceId: monitor.autoProvisionedNetworkDeviceId,
-                })
-              : NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
-                  templateMonitorSteps: template.monitorSteps,
-                  currentMonitorSteps: monitor.monitorSteps,
-                }),
+            ...(rebindMonitorSteps
+              ? {
+                  monitorSteps: monitor.autoProvisionedNetworkDeviceId
+                    ? NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps({
+                        monitorSteps: template.monitorSteps,
+                        networkDeviceId: monitor.autoProvisionedNetworkDeviceId,
+                      })
+                    : NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
+                        templateMonitorSteps: template.monitorSteps,
+                        currentMonitorSteps: monitor.monitorSteps,
+                      }),
+                }
+              : {}),
+            ...(syncCustomFields
+              ? {
+                  customFields: this.buildCustomFieldsUpdate({
+                    template,
+                    monitor,
+                  }),
+                }
+              : {}),
           },
         };
       });
@@ -642,6 +750,7 @@ export class Service extends DatabaseService<Model> {
         monitorSteps: true,
         monitoringInterval: true,
         minimumProbeAgreement: true,
+        customFields: true,
         labels: {
           _id: true,
         },
@@ -664,6 +773,7 @@ export class Service extends DatabaseService<Model> {
         projectId: true,
         monitorTemplateId: true,
         monitorSteps: true,
+        customFields: true,
         autoProvisionedNetworkDeviceId: true,
       },
       props: { isRoot: true },
@@ -704,6 +814,17 @@ export class Service extends DatabaseService<Model> {
             templateMonitorSteps: template.monitorSteps,
             currentMonitorSteps: monitor.monitorSteps,
           });
+    }
+
+    /*
+     * Overlaid on this monitor's own bag, so a value the operator entered on
+     * a field the template does not default survives the push.
+     */
+    if (this.hasCustomFieldDefaultsToSync(template, fields)) {
+      updateData.customFields = this.buildCustomFieldsUpdate({
+        template,
+        monitor,
+      });
     }
 
     if (Object.keys(updateData).length === 0) {

--- a/Common/Tests/Server/Services/MonitorTemplateServiceCustomFieldSync.test.ts
+++ b/Common/Tests/Server/Services/MonitorTemplateServiceCustomFieldSync.test.ts
@@ -1,0 +1,502 @@
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorTemplate from "../../../Models/DatabaseModels/MonitorTemplate";
+import MonitorService from "../../../Server/Services/MonitorService";
+import MonitorTemplateService, {
+  SyncLinkedMonitorsResult,
+} from "../../../Server/Services/MonitorTemplateService";
+import FindBy from "../../../Server/Types/Database/FindBy";
+import Query from "../../../Server/Types/Database/Query";
+import Select from "../../../Server/Types/Database/Select";
+import ModelPermission from "../../../Server/Types/Database/Permissions/Index";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import type { SpyInstance } from "jest-mock";
+
+/*
+ * Contract under test — pushing a monitor template's CUSTOM FIELD DEFAULTS
+ * onto the monitors already made from it (issue #3548).
+ *
+ * Provisioning has always copied a template's `customFields` onto the monitors
+ * it creates, so setting defaults on a template covers everything imported
+ * after the edit. The fleet that makes this a problem is on the other side of
+ * that line: a thousand devices an auto-import rule already turned into
+ * monitors with every custom field empty. Sync is what reaches them, and three
+ * things about it are easy to get wrong and impossible to undo:
+ *
+ *   - it OVERLAYS. A template holds a key for every custom field the project
+ *     has defined the moment its edit form is saved, so an assignment would
+ *     blank every field the template happens not to default across the whole
+ *     fleet;
+ *   - it is per-monitor, because the value written depends on what that
+ *     monitor already holds — which rules out the bulk `updateBy` every other
+ *     syncable field rides;
+ *   - it is opt-in by name. An unscoped sync pushes criteria, interval and
+ *     labels and deliberately leaves operator-entered custom field values
+ *     alone.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const TEMPLATE_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+function buildTemplate(data?: {
+  customFields?: JSONObject | undefined;
+  monitorType?: MonitorType | undefined;
+}): MonitorTemplate {
+  const template: MonitorTemplate = new MonitorTemplate();
+  template.id = TEMPLATE_ID;
+  template.projectId = PROJECT_ID;
+  /*
+   * Ping rather than Network Device, so nothing but custom fields can push a
+   * sync onto the per-monitor path.
+   */
+  template.monitorType = data?.monitorType || MonitorType.Ping;
+  template.monitoringInterval = "*/10 * * * *";
+  template.minimumProbeAgreement = 2;
+  const customFields: JSONObject | undefined =
+    data && "customFields" in data
+      ? data.customFields
+      : {
+          Vendor: "Cisco",
+          "Configuration Item": "",
+        };
+  if (customFields) {
+    template.customFields = customFields;
+  }
+  return template;
+}
+
+function buildLinkedMonitor(customFields?: JSONObject | undefined): Monitor {
+  const monitor: Monitor = new Monitor();
+  monitor.id = ObjectID.generate();
+  monitor.projectId = PROJECT_ID;
+  monitor.monitorType = MonitorType.Ping;
+  monitor.monitorTemplateId = TEMPLATE_ID;
+  if (customFields) {
+    monitor.customFields = customFields;
+  }
+  return monitor;
+}
+
+interface MockedSync {
+  updateOneSpy: SpyInstance<typeof MonitorService.updateOneById>;
+  bulkUpdateSpy: SpyInstance<typeof MonitorService.updateBy>;
+  findBySpy: SpyInstance<typeof MonitorService.findBy>;
+  permissionSpy: SpyInstance<
+    typeof ModelPermission.checkUpdateQueryPermissions
+  >;
+}
+
+function mockSync(data: {
+  template: MonitorTemplate;
+  monitors: Array<Monitor>;
+}): MockedSync {
+  jest
+    .spyOn(MonitorTemplateService, "findOneById")
+    .mockResolvedValue(data.template);
+  jest
+    .spyOn(MonitorTemplateService, "countLinkedMonitors")
+    .mockResolvedValue(data.monitors.length);
+
+  return {
+    updateOneSpy: jest
+      .spyOn(MonitorService, "updateOneById")
+      .mockResolvedValue(1),
+    bulkUpdateSpy: jest.spyOn(MonitorService, "updateBy").mockResolvedValue(0),
+    findBySpy: jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue(data.monitors),
+    permissionSpy: jest
+      .spyOn(ModelPermission, "checkUpdateQueryPermissions")
+      .mockImplementation(
+        async (
+          _modelType: any,
+          query: Query<Monitor>,
+        ): Promise<Query<Monitor>> => {
+          return query;
+        },
+      ) as SpyInstance<typeof ModelPermission.checkUpdateQueryPermissions>,
+  };
+}
+
+function writtenCustomFields(
+  updateOneSpy: SpyInstance<typeof MonitorService.updateOneById>,
+  callIndex: number,
+): JSONObject {
+  return updateOneSpy.mock.calls[callIndex]![0].data
+    .customFields as unknown as JSONObject;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("MonitorTemplateService custom field default synchronization", () => {
+  it("is not pushed by an unscoped sync", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    const monitor: Monitor = buildLinkedMonitor({ Vendor: "Juniper" });
+    const mocks: MockedSync = mockSync({ template, monitors: [monitor] });
+
+    const result: SyncLinkedMonitorsResult =
+      await MonitorTemplateService.syncLinkedMonitors({
+        monitorTemplateId: TEMPLATE_ID,
+        props: { isRoot: true },
+      });
+
+    expect(result).toEqual({ totalLinkedMonitors: 1, syncedMonitors: 0 });
+
+    /*
+     * The bulk path, and the payload it carries has no customFields key at
+     * all — not an empty one, which would still clear the column. (`labels` is
+     * absent because this template has none, not because it is unsyncable.)
+     */
+    expect(mocks.updateOneSpy).not.toHaveBeenCalled();
+    expect(mocks.bulkUpdateSpy).toHaveBeenCalledTimes(1);
+
+    const bulkPayloadKeys: Array<string> = Object.keys(
+      mocks.bulkUpdateSpy.mock.calls[0]![0].data as unknown as JSONObject,
+    );
+    expect(bulkPayloadKeys).not.toContain("customFields");
+    expect(bulkPayloadKeys).toEqual([
+      "monitoringInterval",
+      "minimumProbeAgreement",
+    ]);
+  });
+
+  it("is accepted as a scoped field, and an unknown field still is not", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    mockSync({ template, monitors: [buildLinkedMonitor()] });
+
+    await expect(
+      MonitorTemplateService.syncLinkedMonitors({
+        monitorTemplateId: TEMPLATE_ID,
+        fields: ["customFields"],
+        props: { isRoot: true },
+      }),
+    ).resolves.toEqual({ totalLinkedMonitors: 1, syncedMonitors: 1 });
+
+    await expect(
+      MonitorTemplateService.syncLinkedMonitors({
+        monitorTemplateId: TEMPLATE_ID,
+        fields: ["name"],
+        props: { isRoot: true },
+      }),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  /*
+   * The behaviour the whole feature turns on: only the fields the template
+   * actually defaults are written, and every other value on the monitor —
+   * including one on a field the template holds an empty string for — survives.
+   */
+  it("overlays the template's defaults and leaves every other value on the monitor alone", async () => {
+    const template: MonitorTemplate = buildTemplate({
+      customFields: {
+        Vendor: "Cisco",
+        Duration: 30,
+        "Configuration Item": "",
+        Services: [],
+      },
+    });
+    const monitor: Monitor = buildLinkedMonitor({
+      Vendor: "Juniper",
+      "Configuration Item": "CI-4417",
+      Services: ["billing"],
+      Notes: "replaced 2026-01-04",
+    });
+    const mocks: MockedSync = mockSync({ template, monitors: [monitor] });
+
+    const result: SyncLinkedMonitorsResult =
+      await MonitorTemplateService.syncLinkedMonitors({
+        monitorTemplateId: TEMPLATE_ID,
+        fields: ["customFields"],
+        props: { isRoot: true },
+      });
+
+    expect(result).toEqual({ totalLinkedMonitors: 1, syncedMonitors: 1 });
+    expect(writtenCustomFields(mocks.updateOneSpy, 0)).toEqual({
+      Vendor: "Cisco",
+      Duration: 30,
+      "Configuration Item": "CI-4417",
+      Services: ["billing"],
+      Notes: "replaced 2026-01-04",
+    });
+
+    // Scoped to custom fields, so nothing else about the monitor is rewritten.
+    expect(
+      Object.keys(
+        mocks.updateOneSpy.mock.calls[0]![0].data as unknown as JSONObject,
+      ),
+    ).toEqual(["customFields"]);
+  });
+
+  /*
+   * Each monitor's payload is computed from that monitor's own bag, which is
+   * exactly why this cannot ride the shared bulk update the other syncable
+   * fields use.
+   */
+  it("writes a different payload per monitor, one row at a time", async () => {
+    const template: MonitorTemplate = buildTemplate({
+      customFields: { Vendor: "Cisco" },
+    });
+    const alreadyTagged: Monitor = buildLinkedMonitor({
+      Vendor: "Juniper",
+      "Configuration Item": "CI-1",
+    });
+    const untouched: Monitor = buildLinkedMonitor();
+    const mocks: MockedSync = mockSync({
+      template,
+      monitors: [alreadyTagged, untouched],
+    });
+
+    const result: SyncLinkedMonitorsResult =
+      await MonitorTemplateService.syncLinkedMonitors({
+        monitorTemplateId: TEMPLATE_ID,
+        fields: ["customFields"],
+        props: { isRoot: true },
+      });
+
+    expect(result).toEqual({ totalLinkedMonitors: 2, syncedMonitors: 2 });
+    expect(mocks.bulkUpdateSpy).not.toHaveBeenCalled();
+    expect(mocks.updateOneSpy).toHaveBeenCalledTimes(2);
+
+    expect(writtenCustomFields(mocks.updateOneSpy, 0)).toEqual({
+      Vendor: "Cisco",
+      "Configuration Item": "CI-1",
+    });
+    expect(writtenCustomFields(mocks.updateOneSpy, 1)).toEqual({
+      Vendor: "Cisco",
+    });
+  });
+
+  /*
+   * Whatever else it pushes, a per-monitor sync has to READ the column it is
+   * about to overlay — a select that omits it hands the merge an undefined bag
+   * and turns the overlay into an assignment, silently blanking the fields the
+   * template does not default.
+   */
+  it("reads each monitor's existing custom fields before overlaying them", async () => {
+    const template: MonitorTemplate = buildTemplate({
+      customFields: { Vendor: "Cisco" },
+    });
+    const mocks: MockedSync = mockSync({
+      template,
+      monitors: [buildLinkedMonitor()],
+    });
+
+    await MonitorTemplateService.syncLinkedMonitors({
+      monitorTemplateId: TEMPLATE_ID,
+      fields: ["customFields"],
+      props: { isRoot: true },
+    });
+
+    const select: Select<Monitor> = (
+      mocks.findBySpy.mock.calls[0]![0] as FindBy<Monitor>
+    ).select as Select<Monitor>;
+    expect((select as JSONObject)["customFields"]).toBe(true);
+  });
+
+  /*
+   * The read of the template itself, for the same reason. Selecting the column
+   * is what makes the difference between "this template defaults nothing" and
+   * "nobody asked for the column", and the two are indistinguishable
+   * afterwards.
+   */
+  it("selects customFields on the template it reads", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    mockSync({ template, monitors: [buildLinkedMonitor()] });
+    const templateReadSpy: SpyInstance<
+      typeof MonitorTemplateService.findOneById
+    > = jest.spyOn(MonitorTemplateService, "findOneById");
+
+    await MonitorTemplateService.syncLinkedMonitors({
+      monitorTemplateId: TEMPLATE_ID,
+      fields: ["customFields"],
+      props: { isRoot: true },
+    });
+
+    expect(
+      (templateReadSpy.mock.calls[0]![0].select as JSONObject)["customFields"],
+    ).toBe(true);
+  });
+
+  /*
+   * A caller who may not update Monitor.customFields must be refused before
+   * the first write, not on whichever row the loop happens to reach when the
+   * column check finally runs. The per-monitor values are not known at that
+   * point and only the KEYS decide a column check, so the probe names the
+   * column with an empty bag.
+   */
+  it("names customFields in the up-front column permission probe", async () => {
+    const template: MonitorTemplate = buildTemplate({
+      customFields: { Vendor: "Cisco" },
+    });
+    const mocks: MockedSync = mockSync({
+      template,
+      monitors: [buildLinkedMonitor()],
+    });
+
+    await MonitorTemplateService.syncLinkedMonitors({
+      monitorTemplateId: TEMPLATE_ID,
+      fields: ["customFields"],
+      props: { isRoot: true },
+    });
+
+    expect(mocks.permissionSpy).toHaveBeenCalledTimes(1);
+    expect(
+      Object.keys(mocks.permissionSpy.mock.calls[0]![2] as JSONObject),
+    ).toContain("customFields");
+  });
+
+  /*
+   * "0 of 200 synced" is the summary the dashboard reads as a permissions
+   * problem and tells the operator to run the sync again as somebody else. A
+   * template with nothing to push must therefore write nothing and say so,
+   * rather than walk the fleet.
+   */
+  it.each([
+    ["an absent bag", undefined],
+    ["an empty bag", {}],
+    ["a bag holding only blanks", { Vendor: "", Services: [], Duration: null }],
+  ])(
+    "writes nothing when the template has %s",
+    async (
+      _label: string,
+      customFields: JSONObject | undefined,
+    ): Promise<void> => {
+      const template: MonitorTemplate = buildTemplate({ customFields });
+      const mocks: MockedSync = mockSync({
+        template,
+        monitors: [buildLinkedMonitor({ Vendor: "Juniper" })],
+      });
+
+      const result: SyncLinkedMonitorsResult =
+        await MonitorTemplateService.syncLinkedMonitors({
+          monitorTemplateId: TEMPLATE_ID,
+          fields: ["customFields"],
+          props: { isRoot: true },
+        });
+
+      expect(result).toEqual({ totalLinkedMonitors: 1, syncedMonitors: 0 });
+      expect(mocks.updateOneSpy).not.toHaveBeenCalled();
+      expect(mocks.bulkUpdateSpy).not.toHaveBeenCalled();
+      expect(mocks.findBySpy).not.toHaveBeenCalled();
+    },
+  );
+
+  /*
+   * Custom fields ride alongside the other per-monitor field rather than
+   * displacing it: a Network Device template pushing criteria AND defaults has
+   * to rebind the steps to each monitor's own device in the same write.
+   */
+  it("carries a Network Device criteria rebind and the defaults in one write", async () => {
+    const template: MonitorTemplate = buildTemplate({
+      monitorType: MonitorType.NetworkDevice,
+      customFields: { Vendor: "Cisco" },
+    });
+    const monitor: Monitor = buildLinkedMonitor({ Duration: 30 });
+    const mocks: MockedSync = mockSync({ template, monitors: [monitor] });
+
+    const result: SyncLinkedMonitorsResult =
+      await MonitorTemplateService.syncLinkedMonitors({
+        monitorTemplateId: TEMPLATE_ID,
+        fields: ["customFields", "monitoringInterval"],
+        props: { isRoot: true },
+      });
+
+    expect(result).toEqual({ totalLinkedMonitors: 1, syncedMonitors: 1 });
+    expect(mocks.updateOneSpy).toHaveBeenCalledTimes(1);
+    expect(
+      Object.keys(
+        mocks.updateOneSpy.mock.calls[0]![0].data as unknown as JSONObject,
+      ).sort(),
+    ).toEqual(["customFields", "monitoringInterval"]);
+    expect(writtenCustomFields(mocks.updateOneSpy, 0)).toEqual({
+      Vendor: "Cisco",
+      Duration: 30,
+    });
+  });
+
+  describe("syncToMonitor", () => {
+    it("overlays the defaults onto that one monitor's values", async () => {
+      const template: MonitorTemplate = buildTemplate({
+        customFields: { Vendor: "Cisco", "Configuration Item": "" },
+      });
+      const monitor: Monitor = buildLinkedMonitor({
+        Vendor: "Juniper",
+        "Configuration Item": "CI-4417",
+      });
+
+      jest
+        .spyOn(MonitorTemplateService, "findOneById")
+        .mockResolvedValue(template);
+      jest.spyOn(MonitorService, "findOneById").mockResolvedValue(monitor);
+      const updateOneSpy: SpyInstance<typeof MonitorService.updateOneById> =
+        jest.spyOn(MonitorService, "updateOneById").mockResolvedValue(1);
+
+      await MonitorTemplateService.syncToMonitor({
+        monitorTemplateId: TEMPLATE_ID,
+        monitorId: monitor.id!,
+        fields: ["customFields"],
+        props: { isRoot: true },
+      });
+
+      expect(writtenCustomFields(updateOneSpy, 0)).toEqual({
+        Vendor: "Cisco",
+        "Configuration Item": "CI-4417",
+      });
+    });
+
+    it("reads the monitor's existing custom fields before overlaying them", async () => {
+      const template: MonitorTemplate = buildTemplate({
+        customFields: { Vendor: "Cisco" },
+      });
+      const monitor: Monitor = buildLinkedMonitor();
+
+      jest
+        .spyOn(MonitorTemplateService, "findOneById")
+        .mockResolvedValue(template);
+      const monitorReadSpy: SpyInstance<typeof MonitorService.findOneById> =
+        jest.spyOn(MonitorService, "findOneById").mockResolvedValue(monitor);
+      jest.spyOn(MonitorService, "updateOneById").mockResolvedValue(1);
+
+      await MonitorTemplateService.syncToMonitor({
+        monitorTemplateId: TEMPLATE_ID,
+        monitorId: monitor.id!,
+        fields: ["customFields"],
+        props: { isRoot: true },
+      });
+
+      expect(
+        (monitorReadSpy.mock.calls[0]![0].select as JSONObject)["customFields"],
+      ).toBe(true);
+    });
+
+    it("writes nothing when the template defaults nothing", async () => {
+      const template: MonitorTemplate = buildTemplate({ customFields: {} });
+      const monitor: Monitor = buildLinkedMonitor({ Vendor: "Juniper" });
+
+      jest
+        .spyOn(MonitorTemplateService, "findOneById")
+        .mockResolvedValue(template);
+      jest.spyOn(MonitorService, "findOneById").mockResolvedValue(monitor);
+      const updateOneSpy: SpyInstance<typeof MonitorService.updateOneById> =
+        jest.spyOn(MonitorService, "updateOneById").mockResolvedValue(1);
+
+      await MonitorTemplateService.syncToMonitor({
+        monitorTemplateId: TEMPLATE_ID,
+        monitorId: monitor.id!,
+        fields: ["customFields"],
+        props: { isRoot: true },
+      });
+
+      expect(updateOneSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Tests/Server/Services/NetworkDeviceAutoImportRuleEngineService.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceAutoImportRuleEngineService.test.ts
@@ -139,6 +139,7 @@ import NetworkDeviceDiscoveryScan, {
 } from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import { DiscoveryScanSnmpConfig } from "../../../Utils/NetworkDiscovery/SnmpScanConfigUtil";
 import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
 import OneUptimeDate from "../../../Types/Date";
 import MonitorSteps from "../../../Types/Monitor/MonitorSteps";
@@ -811,6 +812,66 @@ describe("NetworkDeviceAutoImportRuleEngineService.processCompletedScan", () => 
         template.monitorSteps?.data?.monitorStepsInstanceArray[0]?.data
           ?.networkDeviceMonitor?.networkDeviceId,
       ).toBe(TEMPLATE_DEVICE_ID);
+    });
+
+    /*
+     * ISSUE #3548. A template's custom fields are the DEFAULTS its monitors
+     * are born with, and this is the path that made that worth having: a
+     * discovery scan importing a thousand devices used to leave a thousand
+     * monitors with every custom field empty, fillable only one monitor at a
+     * time.
+     *
+     * Driven through the engine rather than the builder alone for the same
+     * reason as the name test above — the values only reach the create call if
+     * `customFields` is still in this service's template select, and a dropped
+     * select column is indistinguishable from a template nobody set defaults
+     * on. Two hosts, because the cached template serves the whole estate: a
+     * shallow copy would hand every monitor in the run the same jsonb object,
+     * so one later edit would reach the rest of the fleet and the template.
+     */
+    it("gives every monitor in one run its own copy of the template's custom field defaults", async () => {
+      const template: MonitorTemplate = makeTemplate({
+        customFields: { Vendor: "Cisco", Thresholds: { cpu: 80 } },
+      });
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({
+          discoveredDevices: [
+            makeHost(),
+            makeHost({ ipAddress: "10.0.0.6", sysName: "core-switch-02" }),
+          ],
+        }),
+      );
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([template]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result).toMatchObject({ devicesCreated: 2, monitorsCreated: 2 });
+
+      const firstMonitor: Monitor = provisionedMonitor(0);
+      const secondMonitor: Monitor = provisionedMonitor(1);
+
+      for (const monitor of [firstMonitor, secondMonitor]) {
+        expect(monitor.customFields).toEqual({
+          Vendor: "Cisco",
+          Thresholds: { cpu: 80 },
+        });
+      }
+
+      expect(firstMonitor.customFields).not.toBe(secondMonitor.customFields);
+      expect(firstMonitor.customFields?.["Thresholds"]).not.toBe(
+        secondMonitor.customFields?.["Thresholds"],
+      );
+
+      (firstMonitor.customFields!["Thresholds"] as JSONObject)["cpu"] = 10;
+      expect(
+        (secondMonitor.customFields!["Thresholds"] as JSONObject)["cpu"],
+      ).toBe(80);
+      expect((template.customFields!["Thresholds"] as JSONObject)["cpu"]).toBe(
+        80,
+      );
     });
 
     /*

--- a/Common/Tests/UI/Components/CustomFields/CustomFieldsDetail.test.tsx
+++ b/Common/Tests/UI/Components/CustomFields/CustomFieldsDetail.test.tsx
@@ -78,7 +78,9 @@ import CustomFieldsDetail from "../../../../UI/Components/CustomFields/CustomFie
 import BaseModel from "../../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import Incident from "../../../../Models/DatabaseModels/Incident";
 import IncidentCustomField from "../../../../Models/DatabaseModels/IncidentCustomField";
+import { CardButtonSchema } from "../../../../UI/Components/Card/Card";
 import CustomFieldType from "../../../../Types/CustomField/CustomFieldType";
+import IconProp from "../../../../Types/Icon/IconProp";
 import { JSONObject } from "../../../../Types/JSON";
 import ObjectID from "../../../../Types/ObjectID";
 
@@ -153,6 +155,8 @@ const resolveListWith: ResolveListFunction = (data: Array<BaseModel>): void => {
 interface RenderOptions {
   hideIfEmpty?: boolean | undefined;
   isEditable?: boolean | undefined;
+  additionalButtons?: Array<CardButtonSchema> | undefined;
+  onValuesLoaded?: ((customFields: JSONObject) => void) | undefined;
 }
 
 type RenderCardFunction = (options?: RenderOptions) => void;
@@ -169,6 +173,8 @@ const renderCard: RenderCardFunction = (options?: RenderOptions): void => {
       modelId={INCIDENT_ID}
       hideIfEmpty={options?.hideIfEmpty}
       isEditable={options?.isEditable}
+      additionalButtons={options?.additionalButtons}
+      onValuesLoaded={options?.onValuesLoaded}
     />,
   );
 };
@@ -715,5 +721,159 @@ describe("CustomFieldsDetail - a rejected save", () => {
     });
 
     expect(container).toBeEmptyDOMElement();
+  });
+});
+
+/*
+ * Both props exist for the Monitor Template's Custom Field Defaults card
+ * (issue #3548), which needs a second button — "Sync Custom Fields to Linked
+ * Monitors" — and needs to word and enable that button from the values this
+ * card has actually loaded.
+ */
+describe("CustomFieldsDetail - additionalButtons", () => {
+  const buildSyncButton: (onClick: () => void) => CardButtonSchema = (
+    onClick: () => void,
+  ): CardButtonSchema => {
+    return {
+      title: "Sync Custom Fields",
+      icon: IconProp.Refresh,
+      onClick: onClick,
+    };
+  };
+
+  test("renders beside the edit button and calls back when clicked", async () => {
+    const onSyncClick: MockFunction = getJestMockFunction();
+    resolveListWith(buildSchema([{ name: "Vendor" }]));
+    getItemMock.mockResolvedValue(buildIncident({ Vendor: "Cisco" }) as never);
+
+    renderCard({
+      additionalButtons: [
+        buildSyncButton(() => {
+          onSyncClick();
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Edit Fields")).toBeInTheDocument();
+    const syncButton: HTMLElement = screen.getByText("Sync Custom Fields");
+
+    fireEvent.click(syncButton);
+
+    expect(onSyncClick).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * A disabled extra button stays on screen: its tooltip is where the reason
+   * lives ("Set at least one default above before syncing"), and a button that
+   * vanishes takes the explanation with it.
+   */
+  test("honours disabled without removing the button", async () => {
+    const onSyncClick: MockFunction = getJestMockFunction();
+    resolveListWith(buildSchema([{ name: "Vendor" }]));
+    getItemMock.mockResolvedValue(buildIncident(undefined) as never);
+
+    renderCard({
+      additionalButtons: [
+        {
+          ...buildSyncButton(() => {
+            onSyncClick();
+          }),
+          disabled: true,
+        },
+      ],
+    });
+
+    fireEvent.click(await screen.findByText("Sync Custom Fields"));
+
+    expect(onSyncClick).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The gating on "Edit Fields" is about whether there is anything to edit
+   * here. Whether a push to OTHER records is worth offering is the caller's
+   * question, and it still has an answer on a record with no values — that is
+   * exactly when the caller wants to say why the push is unavailable.
+   */
+  test("renders even when there is no edit button to sit beside", async () => {
+    resolveListWith([]);
+    getItemMock.mockResolvedValue(buildIncident(undefined) as never);
+
+    renderCard({
+      additionalButtons: [
+        buildSyncButton(() => {
+          // Nothing: this test is about the button existing.
+        }),
+      ],
+    });
+
+    expect(await screen.findByText(NO_FIELDS_MESSAGE)).toBeInTheDocument();
+    expect(screen.queryByText("Edit Fields")).not.toBeInTheDocument();
+    expect(screen.getByText("Sync Custom Fields")).toBeInTheDocument();
+  });
+});
+
+describe("CustomFieldsDetail - onValuesLoaded", () => {
+  test("reports the record's stored bag once the load settles", async () => {
+    const onValuesLoaded: MockFunction = getJestMockFunction();
+    resolveListWith(buildSchema([{ name: "Vendor" }]));
+    getItemMock.mockResolvedValue(buildIncident({ Vendor: "Cisco" }) as never);
+
+    renderCard({
+      onValuesLoaded: (customFields: JSONObject): void => {
+        onValuesLoaded(customFields);
+      },
+    });
+
+    await waitFor(() => {
+      expect(onValuesLoaded).toHaveBeenCalledWith({ Vendor: "Cisco" });
+    });
+  });
+
+  // A record with nothing stored is a value, not a missing callback.
+  test("reports an empty bag for a record with no custom fields", async () => {
+    const onValuesLoaded: MockFunction = getJestMockFunction();
+    resolveListWith(buildSchema([{ name: "Vendor" }]));
+    getItemMock.mockResolvedValue(buildIncident(undefined) as never);
+
+    renderCard({
+      onValuesLoaded: (customFields: JSONObject): void => {
+        onValuesLoaded(customFields);
+      },
+    });
+
+    await waitFor(() => {
+      expect(onValuesLoaded).toHaveBeenCalledWith({});
+    });
+  });
+
+  /*
+   * The reason this is a callback rather than something the caller fetches
+   * itself: an edit made in this card has to reach the caller, or its extra
+   * button goes on explaining a state that is two saves out of date.
+   */
+  test("reports again with the new values after a save", async () => {
+    const onValuesLoaded: MockFunction = getJestMockFunction();
+    resolveListWith(buildSchema([{ name: "Vendor" }]));
+    getItemMock.mockResolvedValue(buildIncident(undefined) as never);
+    updateByIdMock.mockResolvedValue(undefined as never);
+
+    renderCard({
+      onValuesLoaded: (customFields: JSONObject): void => {
+        onValuesLoaded(customFields);
+      },
+    });
+
+    await waitFor(() => {
+      expect(onValuesLoaded).toHaveBeenCalledWith({});
+    });
+
+    getItemMock.mockResolvedValue(buildIncident({ Vendor: "Cisco" }) as never);
+
+    fireEvent.click(await screen.findByText("Edit Fields"));
+    fireEvent.click(await screen.findByText("Save"));
+
+    await waitFor(() => {
+      expect(onValuesLoaded).toHaveBeenCalledWith({ Vendor: "Cisco" });
+    });
   });
 });

--- a/Common/Tests/Utils/Monitor/MonitorTemplateCustomFieldUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/MonitorTemplateCustomFieldUtil.test.ts
@@ -1,0 +1,218 @@
+import MonitorTemplateCustomFieldUtil from "../../../Utils/Monitor/MonitorTemplateCustomFieldUtil";
+import { JSONObject } from "../../../Types/JSON";
+import OneUptimeDate from "../../../Types/Date";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test — what a monitor template's `customFields` bag MEANS
+ * (issue #3548), which is the difference between the two things that read it:
+ *
+ *   - provisioning takes the whole bag, because the monitor it is building has
+ *     no values to protect;
+ *   - sync OVERLAYS it, because the monitors it is pushing onto already carry
+ *     values somebody typed in.
+ *
+ * The interesting half is what counts as a default. A template's bag holds a
+ * key for every custom field the project has defined the moment the edit form
+ * is saved — the form submits its whole values object — so most keys in a
+ * freshly saved template hold nothing at all. If those counted, one operator
+ * defaulting Vendor would blank Configuration Item across the fleet the next
+ * time anybody pressed Sync.
+ */
+describe("MonitorTemplateCustomFieldUtil", () => {
+  describe("getDefaults", () => {
+    it("keeps only the fields the template actually defaults", () => {
+      const defaults: JSONObject = MonitorTemplateCustomFieldUtil.getDefaults({
+        Vendor: "Cisco",
+        "Configuration Item": "",
+        Services: "   ",
+        Duration: null,
+        Owner: undefined,
+        Tags: [],
+      });
+
+      expect(defaults).toEqual({ Vendor: "Cisco" });
+    });
+
+    /*
+     * The two values most likely to be mistaken for "unset". A Boolean custom
+     * field defaulting to false and a Number defaulting to 0 are both things an
+     * operator means, and dropping them would make those two field types
+     * impossible to default at all.
+     */
+    it("treats false and zero as values, not blanks", () => {
+      expect(
+        MonitorTemplateCustomFieldUtil.getDefaults({
+          "Is Critical": false,
+          Duration: 0,
+        }),
+      ).toEqual({ "Is Critical": false, Duration: 0 });
+    });
+
+    it("keeps a non-empty multi-select and drops an emptied one", () => {
+      expect(
+        MonitorTemplateCustomFieldUtil.getDefaults({
+          Services: ["billing", "checkout"],
+          Regions: [],
+        }),
+      ).toEqual({ Services: ["billing", "checkout"] });
+    });
+
+    it("answers an absent, null or empty bag with an empty bag", () => {
+      expect(MonitorTemplateCustomFieldUtil.getDefaults(undefined)).toEqual({});
+      expect(MonitorTemplateCustomFieldUtil.getDefaults(null)).toEqual({});
+      expect(MonitorTemplateCustomFieldUtil.getDefaults({})).toEqual({});
+    });
+
+    /*
+     * The bag is jsonb handed to a whole fleet. Returning a live reference
+     * would let one monitor's write reach the template object every other
+     * monitor in the same run is still reading from.
+     */
+    it("returns a deep copy, so a caller's edit cannot reach the template", () => {
+      const templateCustomFields: JSONObject = {
+        Vendor: "Cisco",
+        Thresholds: { cpu: 80, memory: 90 },
+        Services: ["billing"],
+      };
+
+      const defaults: JSONObject =
+        MonitorTemplateCustomFieldUtil.getDefaults(templateCustomFields);
+
+      (defaults["Thresholds"] as JSONObject)["cpu"] = 10;
+      (defaults["Services"] as Array<string>).push("checkout");
+
+      expect((templateCustomFields["Thresholds"] as JSONObject)["cpu"]).toBe(
+        80,
+      );
+      expect(templateCustomFields["Services"]).toEqual(["billing"]);
+    });
+
+    it("carries a Date custom field through the clone as a Date", () => {
+      const reviewedOn: Date = OneUptimeDate.fromString(
+        "2026-02-03T04:05:06.000Z",
+      );
+
+      const defaults: JSONObject = MonitorTemplateCustomFieldUtil.getDefaults({
+        "Reviewed On": reviewedOn,
+      });
+
+      expect(defaults["Reviewed On"]).toBeInstanceOf(Date);
+      expect((defaults["Reviewed On"] as Date).toISOString()).toBe(
+        reviewedOn.toISOString(),
+      );
+    });
+  });
+
+  describe("hasDefaults", () => {
+    it("is false for a bag that holds nothing but blanks", () => {
+      expect(
+        MonitorTemplateCustomFieldUtil.hasDefaults({
+          Vendor: "",
+          Services: [],
+          Duration: null,
+        }),
+      ).toBe(false);
+    });
+
+    it("is false for an absent or empty bag and true once a value is set", () => {
+      expect(MonitorTemplateCustomFieldUtil.hasDefaults(undefined)).toBe(false);
+      expect(MonitorTemplateCustomFieldUtil.hasDefaults({})).toBe(false);
+      expect(MonitorTemplateCustomFieldUtil.hasDefaults({ Duration: 0 })).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("applyDefaults", () => {
+    /*
+     * The single most important behaviour here: a sync must not turn the
+     * fields this template says nothing about into blanks. That is the whole
+     * reason sync overlays instead of assigning.
+     */
+    it("leaves a monitor's own value alone when the template does not default that field", () => {
+      expect(
+        MonitorTemplateCustomFieldUtil.applyDefaults({
+          templateCustomFields: { Vendor: "Cisco", "Configuration Item": "" },
+          monitorCustomFields: {
+            Vendor: "Juniper",
+            "Configuration Item": "CI-4417",
+            Duration: 30,
+          },
+        }),
+      ).toEqual({
+        Vendor: "Cisco",
+        "Configuration Item": "CI-4417",
+        Duration: 30,
+      });
+    });
+
+    it("fills a monitor that has no custom fields at all", () => {
+      expect(
+        MonitorTemplateCustomFieldUtil.applyDefaults({
+          templateCustomFields: { Vendor: "Cisco", Duration: 30 },
+          monitorCustomFields: undefined,
+        }),
+      ).toEqual({ Vendor: "Cisco", Duration: 30 });
+    });
+
+    it("returns the monitor's values unchanged when the template defaults nothing", () => {
+      expect(
+        MonitorTemplateCustomFieldUtil.applyDefaults({
+          templateCustomFields: {},
+          monitorCustomFields: { Vendor: "Juniper" },
+        }),
+      ).toEqual({ Vendor: "Juniper" });
+    });
+
+    it("mutates neither input", () => {
+      const templateCustomFields: JSONObject = {
+        Thresholds: { cpu: 80 },
+      };
+      const monitorCustomFields: JSONObject = {
+        Vendor: "Juniper",
+        Notes: { owner: "network-team" },
+      };
+
+      const merged: JSONObject = MonitorTemplateCustomFieldUtil.applyDefaults({
+        templateCustomFields,
+        monitorCustomFields,
+      });
+
+      (merged["Thresholds"] as JSONObject)["cpu"] = 10;
+      (merged["Notes"] as JSONObject)["owner"] = "someone-else";
+      merged["Vendor"] = "Arista";
+
+      expect((templateCustomFields["Thresholds"] as JSONObject)["cpu"]).toBe(
+        80,
+      );
+      expect((monitorCustomFields["Notes"] as JSONObject)["owner"]).toBe(
+        "network-team",
+      );
+      expect(monitorCustomFields["Vendor"]).toBe("Juniper");
+    });
+  });
+
+  describe("clone", () => {
+    /*
+     * Provisioning's copy, which differs from getDefaults on purpose: a
+     * monitor being created has nothing underneath, so a blank default and an
+     * absent one look identical on it, and copying the bag as written keeps
+     * "what the template says" and "what the new monitor got" the same object.
+     */
+    it("copies the bag verbatim, blanks included, without sharing structure", () => {
+      const templateCustomFields: JSONObject = {
+        Vendor: "Cisco",
+        "Configuration Item": "",
+        Thresholds: { cpu: 80 },
+      };
+
+      const cloned: JSONObject =
+        MonitorTemplateCustomFieldUtil.clone(templateCustomFields);
+
+      expect(cloned).toEqual(templateCustomFields);
+      expect(cloned).not.toBe(templateCustomFields);
+      expect(cloned["Thresholds"]).not.toBe(templateCustomFields["Thresholds"]);
+    });
+  });
+});

--- a/Common/UI/Components/CustomFields/CustomFieldsDetail.tsx
+++ b/Common/UI/Components/CustomFields/CustomFieldsDetail.tsx
@@ -5,7 +5,7 @@ import PermissionGate, {
   PermissionGateResult,
 } from "../../Utils/PermissionGate";
 import { ButtonStyleType } from "../Button/Button";
-import Card from "../Card/Card";
+import Card, { CardButtonSchema } from "../Card/Card";
 import ComponentLoader from "../ComponentLoader/ComponentLoader";
 import Detail from "../Detail/Detail";
 import { DropdownOption } from "../Dropdown/Dropdown";
@@ -79,6 +79,22 @@ export interface ComponentProps {
    * real reason.
    */
   hideIfEmpty?: boolean | undefined;
+  /*
+   * Card buttons that belong beside "Edit Fields" rather than on a card of
+   * their own — the Monitor Template's "Sync Custom Fields to Linked Monitors"
+   * being the one that exists. They render after the edit button and are not
+   * touched by the gating above: whether a push to other records is offered is
+   * the caller's decision, not this card's.
+   */
+  additionalButtons?: Array<CardButtonSchema> | undefined;
+  /*
+   * The record's stored bag, handed back after every load — including the
+   * reload that follows a save — so a caller whose extra button acts on those
+   * values can enable and word it from what is actually stored, rather than
+   * re-reading the record behind this card's back and going stale the moment
+   * somebody edits it here.
+   */
+  onValuesLoaded?: ((customFields: JSONObject) => void) | undefined;
 }
 
 const CustomFieldsDetail: FunctionComponent<ComponentProps> = (
@@ -219,6 +235,12 @@ const CustomFieldsDetail: FunctionComponent<ComponentProps> = (
       setSchemaList(schemaList.data);
       setModel(item);
 
+      if (props.onValuesLoaded) {
+        props.onValuesLoaded(
+          ((item as any)?.["customFields"] as JSONObject) || {},
+        );
+      }
+
       setIsLoading(false);
     } catch (err) {
       setIsLoading(false);
@@ -313,30 +335,33 @@ const CustomFieldsDetail: FunctionComponent<ComponentProps> = (
   const showEditButton: boolean =
     canEdit && (updateGate.isAllowed || Boolean(updateGate.disabledReason));
 
+  const cardButtons: Array<CardButtonSchema> = [
+    ...(showEditButton
+      ? [
+          {
+            title: "Edit Fields",
+            buttonStyle: ButtonStyleType.NORMAL,
+            disabled: !updateGate.isAllowed,
+            tooltip: updateGate.disabledReason,
+            onClick: () => {
+              if (!updateGate.isAllowed) {
+                return;
+              }
+
+              setShowModelForm(true);
+            },
+            icon: IconProp.Edit,
+          } as CardButtonSchema,
+        ]
+      : []),
+    ...(props.additionalButtons || []),
+  ];
+
   return (
     <Card
       title={props.title}
       description={props.description}
-      buttons={
-        showEditButton
-          ? [
-              {
-                title: "Edit Fields",
-                buttonStyle: ButtonStyleType.NORMAL,
-                disabled: !updateGate.isAllowed,
-                tooltip: updateGate.disabledReason,
-                onClick: () => {
-                  if (!updateGate.isAllowed) {
-                    return;
-                  }
-
-                  setShowModelForm(true);
-                },
-                icon: IconProp.Edit,
-              },
-            ]
-          : []
-      }
+      buttons={cardButtons}
     >
       <div className="border-t border-gray-200 px-4 py-5 sm:px-6 -m-6 -mt-2">
         {isLoading && !loadError && <ComponentLoader />}

--- a/Common/Utils/Monitor/MonitorTemplateCustomFieldUtil.ts
+++ b/Common/Utils/Monitor/MonitorTemplateCustomFieldUtil.ts
@@ -1,0 +1,124 @@
+import { JSONObject, JSONValue } from "../../Types/JSON";
+import JSONFunctions from "../../Types/JSONFunctions";
+
+/*
+ * WHAT A MONITOR TEMPLATE'S CUSTOM FIELDS MEAN, in one place.
+ *
+ * A template's `customFields` bag is a set of DEFAULTS for the monitors made
+ * from it — the answer to issue #3548, where an auto-import rule turned a
+ * thousand discovered devices into a thousand monitors whose Vendor, Services
+ * and Configuration Item fields were all empty and could only be filled in one
+ * monitor at a time.
+ *
+ * Two callers need the same answer and would drift apart if each wrote its
+ * own:
+ *
+ *   - PROVISIONING (NetworkDeviceMonitorTemplateUtil.buildMonitor, reached
+ *     from the auto-import engine and the alert-policy engine) starts from a
+ *     monitor with no values at all, so it takes the whole bag.
+ *   - SYNC (MonitorTemplateService) pushes the template onto monitors that
+ *     already exist and may already carry values an operator typed in, so it
+ *     OVERLAYS instead: every field the template actually gives a default for
+ *     wins, and every other field on the monitor is left exactly as it is.
+ *
+ * Both go through a deep clone, because a jsonb bag handed to several monitors
+ * by reference is one nested edit away from leaking across the fleet — and
+ * back onto the template itself.
+ */
+export default class MonitorTemplateCustomFieldUtil {
+  /*
+   * A defaults bag is only worth writing when there is a value in it, so
+   * "template has no defaults" and "template has an empty bag" are the same
+   * answer to every caller here. This is what keeps a sync scoped to custom
+   * fields alone from reporting that it wrote to a fleet it did not touch.
+   */
+  public static hasDefaults(
+    customFields: JSONObject | undefined | null,
+  ): boolean {
+    return Object.keys(this.getDefaults(customFields)).length > 0;
+  }
+
+  /*
+   * The template's defaults, deep-cloned, with the fields it does not actually
+   * default DROPPED.
+   *
+   * A template carries a key for every custom field the project has defined
+   * the moment somebody saves the edit form — the form submits its whole
+   * values object — so most keys in a freshly saved bag hold nothing. Left in,
+   * they would make a sync overwrite real per-monitor values with blanks: a
+   * template that only defaults Vendor would silently clear Configuration Item
+   * on every monitor in the fleet.
+   *
+   * `false` and `0` are values, not blanks — a Boolean custom field defaulting
+   * to false and a Number defaulting to 0 are both things an operator means.
+   */
+  public static getDefaults(
+    customFields: JSONObject | undefined | null,
+  ): JSONObject {
+    if (!customFields) {
+      return {};
+    }
+
+    const defaults: JSONObject = {};
+
+    for (const key of Object.keys(customFields)) {
+      const value: JSONValue = customFields[key] as JSONValue;
+
+      if (this.isBlank(value)) {
+        continue;
+      }
+
+      defaults[key] = value;
+    }
+
+    return this.clone(defaults);
+  }
+
+  /*
+   * Overlay the template's defaults onto the values a monitor already has.
+   * Returns a new bag; neither input is mutated.
+   */
+  public static applyDefaults(data: {
+    templateCustomFields: JSONObject | undefined | null;
+    monitorCustomFields: JSONObject | undefined | null;
+  }): JSONObject {
+    return {
+      ...this.clone(data.monitorCustomFields || {}),
+      ...this.getDefaults(data.templateCustomFields),
+    };
+  }
+
+  /*
+   * The whole bag, verbatim apart from being deep-cloned — blanks included.
+   *
+   * Provisioning uses this rather than getDefaults because there is nothing
+   * underneath to protect: a monitor being created has no values of its own,
+   * so a blank default and an absent one look identical on the monitor, and
+   * copying the bag as written keeps "what the template says" and "what the
+   * new monitor got" literally the same object.
+   */
+  public static clone(customFields: JSONObject): JSONObject {
+    return JSONFunctions.deserialize(JSONFunctions.serialize(customFields));
+  }
+
+  /*
+   * Nothing an operator would call a default. An empty multi-select arrives as
+   * [], a cleared text field as "" (or as spaces, from a form nobody trimmed),
+   * and a field never touched as null or undefined.
+   */
+  private static isBlank(value: JSONValue): boolean {
+    if (value === undefined || value === null) {
+      return true;
+    }
+
+    if (typeof value === "string") {
+      return value.trim() === "";
+    }
+
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    }
+
+    return false;
+  }
+}

--- a/Common/Utils/Monitor/NetworkDeviceMonitorTemplateUtil.ts
+++ b/Common/Utils/Monitor/NetworkDeviceMonitorTemplateUtil.ts
@@ -3,10 +3,10 @@ import MonitorTemplate from "../../Models/DatabaseModels/MonitorTemplate";
 import NetworkDevice from "../../Models/DatabaseModels/NetworkDevice";
 import BadDataException from "../../Types/Exception/BadDataException";
 import { JSONObject } from "../../Types/JSON";
-import JSONFunctions from "../../Types/JSONFunctions";
 import MonitorSteps from "../../Types/Monitor/MonitorSteps";
 import MonitorType from "../../Types/Monitor/MonitorType";
 import ObjectID from "../../Types/ObjectID";
+import MonitorTemplateCustomFieldUtil from "./MonitorTemplateCustomFieldUtil";
 
 /*
  * Materialises a project MonitorTemplate for one discovered NetworkDevice.
@@ -379,7 +379,12 @@ export default class NetworkDeviceMonitorTemplateUtil {
     return truncated;
   }
 
+  /*
+   * Delegated so "what a template's custom fields mean" is written down once
+   * — provisioning takes the bag whole, sync overlays it. See
+   * MonitorTemplateCustomFieldUtil.
+   */
   private static cloneCustomFields(customFields: JSONObject): JSONObject {
-    return JSONFunctions.deserialize(JSONFunctions.serialize(customFields));
+    return MonitorTemplateCustomFieldUtil.clone(customFields);
   }
 }


### PR DESCRIPTION
Closes #3548.

## Should we build this? Mostly it was already built

The issue asks for default custom field values in one of two places — on the **Monitor Template** (preferred) or as a **Custom Fields step on the Auto Import Rule**. Investigating the first one turned up something worth saying out loud:

- `MonitorTemplate.customFields` has existed since the model was first written (`1777201966799-AddMonitorTemplate` creates the jsonb column).
- Both provisioning engines already `SELECT` it — `NetworkDeviceAutoImportRuleEngineService.loadMonitorTemplates` and `NetworkAlertPolicyEngineService`.
- `NetworkDeviceMonitorTemplateUtil.buildMonitor` already deep-clones it onto every monitor it creates, and a test already pinned that it does.

The column was simply **unreachable**. No form, card or page in the product ever wrote to it, so it has been dead since the day it shipped. That is the whole of the bug: the reporter's thousand imported monitors were always going to inherit whatever the template said, and there was nowhere to say anything.

**So this exposes the template column and does not add the Auto Import Rule step.** A per-rule bag would be:

- dead config for any rule without a monitor template — no monitor is created at all, and `NetworkDevice` has no `customFields` column of its own, so there is nothing on the device to fill;
- a second place to configure the same thing, with no defined answer when two rules point at one template.

The issue itself prefers the template ("keeps configuration centralized in one place"), and the rule form's template field already advertised that custom fields come from the template — it just could not say where to enter them. It now names the card.

## What is new

**Custom Field Defaults card** on the monitor template page (**Monitors → Settings → Templates →** open one), mounting the same `CustomFieldsDetail` every other resource uses, against the project's Monitor Custom Field schema. `hideIfEmpty`, matching the resource overview pages: a project that defines no monitor custom fields has nothing to default, and reading the schema is billing-gated besides.

**Sync Custom Fields to Linked Monitors**, on that same card. Defaults only reach monitors created *after* the edit — and the fleet that makes this a problem (a thousand devices a scan already imported) is entirely on the other side of that line, so this is the backfill path. Three deliberate choices:

- **It overlays, it does not assign.** Every field the template actually defaults wins; every other value on the monitor survives. This matters because a template carries a key for *every* custom field the project has defined the moment its edit form is saved — the form submits its whole values object — so an assignment would have blanked Configuration Item across the fleet for a template that only defaults Vendor.
- **It is opt-in by name.** An unscoped `sync-to-linked-monitors` still pushes criteria, interval and labels and leaves operator-entered custom field values alone (`DEFAULT_SYNCABLE_FIELDS`), so no existing caller — including the page's own per-monitor **Sync from Template** — starts rewriting them. The other sync modals' "will be left alone" lists now say so.
- **It says what it will do.** The confirmation names the fields it is about to overwrite, and the button explains itself rather than disappearing when the template defaults nothing (a sync with nothing to push comes back "0 of N synced", which the shared summary reads as a permissions problem and tells the operator to try again as somebody else).

**Create Monitor from Template** now carries the defaults too. It was the one path that dropped them: `customFields` has no input on the create form, so `ModelForm` never submits it — a value seeded into `initialValues` is filtered out by `getSelectFields()`. Applied in `onBeforeCreate` instead, so a monitor a person makes from a template matches one an auto-import rule provisions from it.

`MonitorTemplateCustomFieldUtil` states in one place what a template's custom fields mean, since provisioning and sync read the same bag differently: provisioning takes it whole (there is nothing underneath to protect, and a blank default and an absent one are indistinguishable on a new monitor), sync overlays the non-blank subset. `false` and `0` are values an operator means; `""`, whitespace, `null` and `[]` are not.

**No migration** — the column is already there.

## Tests

| Suite | What it pins |
| --- | --- |
| `Common/Tests/Utils/Monitor/MonitorTemplateCustomFieldUtil.test.ts` | What counts as a default (`false`/`0` in, `""`/`[]`/whitespace out), overlay semantics, deep-clone isolation in both directions, a Date custom field surviving the clone |
| `Common/Tests/Server/Services/MonitorTemplateServiceCustomFieldSync.test.ts` | 14 cases: not pushed by an unscoped sync (and no empty `customFields` key in the bulk payload either), accepted when named, overlay leaves the monitor's other values alone, a different payload per monitor, the two `select`s that make the overlay possible, `customFields` in the up-front column permission probe, no write at all for an absent/empty/all-blank bag, and a Network Device criteria rebind riding in the same write |
| `Common/Tests/Server/Services/NetworkDeviceAutoImportRuleEngineService.test.ts` | End to end: two hosts in one run each get their own copy, and neither the sibling monitor nor the cached template can be reached through a nested edit |
| `App/Tests/Dashboard/MonitorTemplateCustomFieldDefaults.test.ts` | The dashboard wiring a clean `tsc` cannot see — the template read's `select`, the `onBeforeCreate` apply, every sync on the page scoping itself by name, and the card's model types |
| `Common/Tests/UI/Components/CustomFields/CustomFieldsDetail.test.tsx` | `additionalButtons` (rendered, clickable, disabled-but-still-visible, present with no edit button beside it) and `onValuesLoaded` (including the report after a save) |

Verified locally: `Common` and `App` `tsc` clean; the changed Dashboard `.tsx` type-checked against the Dashboard's own compiler (App's `tsconfig` excludes `FeatureSet/Dashboard`); eslint clean on every changed file; and every suite that imports `MonitorTemplateService`, `CustomFieldsDetail` or `NetworkDeviceMonitorTemplateUtil` re-run green (35 suites, ~1150 tests).

## Docs

A **Custom Field Defaults** section in `monitor/network-device-monitor.md`, under Alerting: where to set them, that a blank is not a default, and that they apply at creation time with sync as the backfill.

## What a reviewer might want to push back on

- **Sync overwrites hand-entered values for the fields the template defaults.** The alternative — fill only where empty — is safer but leaves no way to correct a wrong default across a fleet. Overwrite matches every other sync button on the page, it is button-triggered behind a confirmation that names the fields, and blank fields are still never touched. Happy to flip it if you would rather this be a pure backfill.
- **`customFields` is excluded from the unscoped sync's default set.** That makes `SYNCABLE_FIELDS` (allowed) and `DEFAULT_SYNCABLE_FIELDS` (used when the caller names none) diverge. The dashboard always scopes its syncs, so this only decides what an API caller gets by default — and silently rewriting a fleet's operator-entered values seemed like the wrong default for a call that just says "push the template".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Gxvk3C8weeszRQZZU5Rzr
