### PR TITLE
feat(dashboards): filter Monitor Lists with project label variables

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/ArgumentsForm.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/ArgumentsForm.tsx
@@ -49,6 +49,8 @@ import Button, {
 } from "Common/UI/Components/Button/Button";
 import IconProp from "Common/Types/Icon/IconProp";
 import EntityFilterDropdown from "./EntityFilterDropdown";
+import ProjectLabelVariableDropdown from "./ProjectLabelVariableDropdown";
+import DashboardVariable from "Common/Types/Dashboard/DashboardVariable";
 import TraceChartQueryEditor from "./TraceChartQueryEditor";
 import LogChartQueryEditor from "./LogChartQueryEditor";
 import DataSourceQueryEditor from "./DataSourceQueryEditor";
@@ -62,6 +64,7 @@ export interface ComponentProps {
     telemetryAttributes: string[];
   };
   component: DashboardBaseComponent;
+  variables?: Array<DashboardVariable> | undefined;
   onHasFormValidationErrors?:
     | ((values: Dictionary<boolean>) => void)
     | undefined;
@@ -76,6 +79,7 @@ interface SectionGroup {
 const ArgumentsForm: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  const variables: Array<DashboardVariable> | undefined = props.variables;
   const formRefs: React.MutableRefObject<
     Record<string, FormProps<FormValues<JSONObject>> | null>
   > = useRef({});
@@ -486,6 +490,23 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
     | undefined => {
     if (arg.type === ComponentInputType.MetricsQueryConfig) {
       return getMetricsQueryConfigForm(arg);
+    }
+    if (arg.type === ComponentInputType.ProjectLabelVariable) {
+      // eslint-disable-next-line react/display-name
+      return (
+        value: FormValues<JSONObject>,
+        componentProps: CustomElementProps,
+      ): ReactElement => {
+        return (
+          <ProjectLabelVariableDropdown
+            variables={variables}
+            value={value[arg.id as string] as string | undefined}
+            onChange={(next: string) => {
+              return componentProps.onChange?.(next);
+            }}
+          />
+        );
+      };
     }
     if (arg.type === ComponentInputType.EntityDropdown) {
       return getEntityDropdownForm(arg, false);

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/ComponentInputTypeToFormFieldType.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/ComponentInputTypeToFormFieldType.tsx
@@ -85,6 +85,10 @@ export default class ComponentInputTypeToFormFieldType {
       };
     }
 
+    if (componentInputType === ComponentInputType.ProjectLabelVariable) {
+      return { fieldType: FormFieldSchemaType.CustomComponent };
+    }
+
     if (componentInputType === ComponentInputType.EntityDropdown) {
       return {
         fieldType: FormFieldSchemaType.CustomComponent,

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/ComponentSettingsModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/ComponentSettingsModal.tsx
@@ -1,3 +1,4 @@
+import DashboardVariable from "Common/Types/Dashboard/DashboardVariable";
 import DashboardViewConfig from "Common/Types/Dashboard/DashboardViewConfig";
 import IconProp from "Common/Types/Icon/IconProp";
 import ObjectID from "Common/Types/ObjectID";
@@ -27,6 +28,7 @@ export interface ComponentProps {
   onComponentDuplicate: (component: DashboardBaseComponent) => void;
   componentId: ObjectID;
   dashboardViewConfig: DashboardViewConfig;
+  variables?: Array<DashboardVariable> | undefined;
   dashboardStartAndEndDate: RangeStartAndEndDateTime;
   totalCurrentDashboardWidthInPx: number;
   metrics: {
@@ -178,6 +180,7 @@ const ComponentSettingsModal: FunctionComponent<ComponentProps> = (
                   }}
                 >
                   <DashboardBaseComponentElement
+                    variables={props.variables}
                     componentId={props.componentId}
                     isEditMode={false}
                     isSelected={false}
@@ -213,6 +216,7 @@ const ComponentSettingsModal: FunctionComponent<ComponentProps> = (
               Settings
             </h4>
             <ArgumentsForm
+              variables={props.variables}
               component={component}
               onFormChange={(component: DashboardBaseComponent) => {
                 props.onComponentUpdate(component);

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/Index.tsx
@@ -401,6 +401,7 @@ const DashboardCanvas: FunctionComponent<ComponentProps> = (
       </div>
       {props.selectedComponentId && props.isEditMode && (
         <ComponentSettingsModal
+          variables={props.variables}
           title="Component Settings"
           description="Edit the settings of this component"
           dashboardViewConfig={props.dashboardViewConfig}

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/ProjectLabelVariableDropdown.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/ProjectLabelVariableDropdown.tsx
@@ -1,0 +1,67 @@
+import React, { FunctionComponent, ReactElement } from "react";
+import DashboardVariable, {
+  DashboardVariableType,
+} from "Common/Types/Dashboard/DashboardVariable";
+
+export interface ComponentProps {
+  variables?: Array<DashboardVariable> | undefined;
+  value?: string | undefined;
+  onChange: (value: string) => void;
+}
+
+const ProjectLabelVariableDropdown: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const variables: Array<DashboardVariable> = (props.variables || []).filter(
+    (variable: DashboardVariable) => {
+      return variable.type === DashboardVariableType.ProjectLabel;
+    },
+  );
+  const selected: DashboardVariable | undefined = variables.find(
+    (variable: DashboardVariable) => {
+      return variable.id === props.value;
+    },
+  );
+  const missing: boolean = Boolean(props.value && !selected);
+  return (
+    <div>
+      <select
+        aria-label="Label Variable"
+        className="w-full text-sm border border-gray-200 rounded-md px-2 py-1.5 bg-white text-gray-700"
+        value={props.value || ""}
+        onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+          return props.onChange(e.target.value);
+        }}
+      >
+        <option value="">None</option>
+        {missing && <option value={props.value}>Unavailable variable</option>}
+        {variables.map((variable: DashboardVariable) => {
+          return (
+            <option key={variable.id} value={variable.id}>
+              {variable.label && variable.label !== variable.name
+                ? `${variable.label} (${variable.name})`
+                : variable.name}
+            </option>
+          );
+        })}
+      </select>
+      {missing ? (
+        <p role="alert" className="text-xs text-red-600 mt-1">
+          This label variable was removed or its source changed. Choose a
+          Project Labels variable or clear the binding.
+        </p>
+      ) : selected && !selected.labelOptions?.length ? (
+        <p role="alert" className="text-xs text-red-600 mt-1">
+          Choose allowed labels for this variable in Dashboard Variables.
+        </p>
+      ) : variables.length === 0 ? (
+        <p className="text-xs text-gray-500 mt-1">
+          Add a Project Labels variable from the dashboard toolbar to use it
+          here.
+        </p>
+      ) : null}
+    </div>
+  );
+};
+
+export default ProjectLabelVariableDropdown;

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardMonitorListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardMonitorListComponent.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactElement,
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import DashboardMonitorListComponent from "Common/Types/Dashboard/DashboardComponents/DashboardMonitorListComponent";
@@ -28,6 +29,7 @@ import AppLink from "../../AppLink/AppLink";
 import Route from "Common/Types/API/Route";
 import ObjectID from "Common/Types/ObjectID";
 import Color from "Common/Types/Color";
+import DashboardLabelVariable from "Common/Utils/Dashboard/LabelVariable";
 
 export interface ComponentProps extends DashboardBaseComponentProps {
   component: DashboardMonitorListComponent;
@@ -45,6 +47,7 @@ const DashboardMonitorListComponentElement: FunctionComponent<
   const [monitors, setMonitors] = useState<Array<Monitor>>([]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const requestVersion: React.MutableRefObject<number> = useRef<number>(0);
 
   const maxRows: number = props.component.arguments.maxRows || 25;
   const viewMode: ResourceListViewMode =
@@ -57,12 +60,15 @@ const DashboardMonitorListComponentElement: FunctionComponent<
     props.component.arguments.monitorTypes;
   const labelIds: Array<string> | undefined =
     props.component.arguments.labelIds;
+  const labelVariableId: string | undefined =
+    props.component.arguments.labelVariableId;
 
   const monitorStatusIdsKey: string = (monitorStatusIds || []).join(",");
   const monitorTypesKey: string = (monitorTypes || []).join(",");
   const labelIdsKey: string = (labelIds || []).join(",");
 
   const fetchMonitors: () => Promise<void> = useCallback(async () => {
+    const version: number = ++requestVersion.current;
     setIsLoading(true);
 
     const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
@@ -98,8 +104,14 @@ const DashboardMonitorListComponentElement: FunctionComponent<
         );
       }
 
-      if (labelIds && labelIds.length > 0) {
-        (query as Record<string, unknown>)["labels"] = new Includes(labelIds);
+      const labelFilter: ReturnType<typeof DashboardLabelVariable.getFilter> =
+        DashboardLabelVariable.getFilter({
+          labelIds,
+          labelVariableId,
+          variables: props.variables,
+        });
+      if (labelFilter) {
+        (query as Record<string, unknown>)["labels"] = labelFilter;
       }
 
       const listResult: ListResult<Monitor> = await ModelAPI.getList<Monitor>({
@@ -125,9 +137,15 @@ const DashboardMonitorListComponentElement: FunctionComponent<
         },
       });
 
+      if (version !== requestVersion.current) {
+        return;
+      }
       setMonitors(listResult.data);
       setError(null);
     } catch (err: unknown) {
+      if (version !== requestVersion.current) {
+        return;
+      }
       setError(API.getFriendlyErrorMessage(err as Error));
     }
 
@@ -138,12 +156,17 @@ const DashboardMonitorListComponentElement: FunctionComponent<
     monitorStatusIdsKey,
     monitorTypesKey,
     labelIdsKey,
+    labelVariableId,
     props.componentId,
     props.variables,
   ]);
 
   useEffect(() => {
     fetchMonitors();
+    return () => {
+      // A slower request for the previous unit must not replace this selection.
+      requestVersion.current++;
+    };
   }, [fetchMonitors, props.refreshTick]);
 
   const honeycombTiles: Array<HoneycombTile> = monitors.map(
@@ -233,7 +256,10 @@ const DashboardMonitorListComponentElement: FunctionComponent<
 
   return (
     <DashboardResourceListBase
-      title={props.component.arguments.title}
+      title={DashboardLabelVariable.interpolateTitle(
+        props.component.arguments.title,
+        props.variables,
+      )}
       pluralLabel="monitors"
       columns={COLUMNS}
       count={monitors.length}
@@ -256,6 +282,7 @@ function arePropsEqual(prev: ComponentProps, next: ComponentProps): boolean {
     prev.refreshTick !== next.refreshTick ||
     prev.isEditMode !== next.isEditMode ||
     prev.isSelected !== next.isSelected ||
+    !JSONFunctions.deepEqual(prev.variables, next.variables) ||
     prev.dashboardComponentWidthInPx !== next.dashboardComponentWidthInPx ||
     prev.dashboardComponentHeightInPx !== next.dashboardComponentHeightInPx
   ) {

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx
@@ -83,7 +83,10 @@ import useDashboardTimeRangeZoom, {
 } from "Common/UI/Utils/UseDashboardTimeRangeZoom";
 import TimeRange from "Common/Types/Time/TimeRange";
 import MetricType from "Common/Models/DatabaseModels/MetricType";
-import DashboardVariable from "Common/Types/Dashboard/DashboardVariable";
+import DashboardVariable, {
+  DashboardVariableOption,
+  DashboardVariableType,
+} from "Common/Types/Dashboard/DashboardVariable";
 import DashboardVariableUrlState from "Common/Utils/Dashboard/VariableUrlState";
 import PermissionGate, {
   ModelAction,
@@ -644,6 +647,37 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
           const next: Array<DashboardVariable> = updated.map(
             (v: DashboardVariable) => {
               const prior: DashboardVariable | undefined = priorById.get(v.id);
+              if (
+                prior?.type !== v.type ||
+                Boolean(prior?.isMultiSelect) !== Boolean(v.isMultiSelect)
+              ) {
+                return {
+                  ...v,
+                  selectedValue: undefined,
+                  selectedValues: undefined,
+                };
+              }
+              if (v.type === DashboardVariableType.ProjectLabel) {
+                const allowed: Set<string> = new Set(
+                  (v.labelOptions || []).map(
+                    (option: DashboardVariableOption) => {
+                      return option.value;
+                    },
+                  ),
+                );
+                return {
+                  ...v,
+                  selectedValue:
+                    prior.selectedValue && !allowed.has(prior.selectedValue)
+                      ? ""
+                      : prior.selectedValue,
+                  selectedValues: prior.selectedValues?.filter(
+                    (value: string) => {
+                      return allowed.has(value);
+                    },
+                  ),
+                };
+              }
               return {
                 ...v,
                 selectedValue: prior?.selectedValue,

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardVariableSelector.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardVariableSelector.tsx
@@ -2,7 +2,6 @@ import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
-  useRef,
   useState,
 } from "react";
 import DashboardVariable, {
@@ -10,10 +9,11 @@ import DashboardVariable, {
 } from "Common/Types/Dashboard/DashboardVariable";
 import MetricUtil from "../../Metrics/Utils/Metrics";
 
-export interface VariableValueChange {
-  selectedValue?: string | undefined;
-  selectedValues?: Array<string> | undefined;
-}
+import DashboardVariableControl, {
+  VariableValueChange,
+} from "Common/UI/Components/Dashboard/DashboardVariableControl";
+
+export type { VariableValueChange } from "Common/UI/Components/Dashboard/DashboardVariableControl";
 
 export interface ComponentProps {
   variables: Array<DashboardVariable>;
@@ -30,124 +30,6 @@ interface SingleVariableSelectorProps {
     change: VariableValueChange,
   ) => void;
 }
-
-const MultiSelectPopover: FunctionComponent<{
-  options: Array<string>;
-  selected: Array<string>;
-  label: string;
-  isLoading: boolean;
-  onChange: (next: Array<string>) => void;
-}> = ({
-  options,
-  selected,
-  label,
-  isLoading,
-  onChange,
-}: {
-  options: Array<string>;
-  selected: Array<string>;
-  label: string;
-  isLoading: boolean;
-  onChange: (next: Array<string>) => void;
-}): ReactElement => {
-  const [open, setOpen] = useState<boolean>(false);
-  const wrapRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) {
-      return undefined;
-    }
-    const onDocClick: (e: MouseEvent) => void = (e: MouseEvent): void => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", onDocClick);
-    return () => {
-      document.removeEventListener("mousedown", onDocClick);
-    };
-  }, [open]);
-
-  const buttonText: string =
-    selected.length === 0
-      ? isLoading
-        ? "Loading…"
-        : "All"
-      : selected.length === 1
-        ? (selected[0] as string)
-        : `${selected.length} selected`;
-
-  const toggle: (value: string) => void = (value: string): void => {
-    if (selected.includes(value)) {
-      onChange(
-        selected.filter((v: string) => {
-          return v !== value;
-        }),
-      );
-    } else {
-      onChange([...selected, value]);
-    }
-  };
-
-  return (
-    <div className="relative" ref={wrapRef}>
-      <button
-        type="button"
-        className="text-xs border border-gray-200 rounded-md px-2.5 py-1.5 bg-white text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-300 transition-colors flex items-center gap-1"
-        disabled={isLoading}
-        onClick={() => {
-          setOpen(!open);
-        }}
-        title={label}
-      >
-        <span className="truncate max-w-[10rem]">{buttonText}</span>
-        <span className="text-gray-400">▾</span>
-      </button>
-      {open && (
-        <div className="absolute z-30 mt-1 right-0 w-56 max-h-72 overflow-auto rounded-md border border-gray-200 bg-white shadow-lg py-1">
-          <div className="flex items-center justify-between px-3 py-1.5 border-b border-gray-100 text-[11px] text-gray-500">
-            <span>{selected.length} selected</span>
-            <button
-              type="button"
-              className="text-blue-600 hover:underline disabled:text-gray-300"
-              disabled={selected.length === 0}
-              onClick={() => {
-                onChange([]);
-              }}
-            >
-              Clear
-            </button>
-          </div>
-          {options.length === 0 ? (
-            <div className="px-3 py-2 text-xs text-gray-400">
-              {isLoading ? "Loading options…" : "No options available"}
-            </div>
-          ) : (
-            options.map((option: string) => {
-              const checked: boolean = selected.includes(option);
-              return (
-                <label
-                  key={option}
-                  className="flex items-center gap-2 px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50 cursor-pointer"
-                >
-                  <input
-                    type="checkbox"
-                    className="h-3.5 w-3.5"
-                    checked={checked}
-                    onChange={() => {
-                      toggle(option);
-                    }}
-                  />
-                  <span className="truncate">{option}</span>
-                </label>
-              );
-            })
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
 
 const SingleVariableSelector: FunctionComponent<SingleVariableSelectorProps> = (
   props: SingleVariableSelectorProps,
@@ -185,96 +67,21 @@ const SingleVariableSelector: FunctionComponent<SingleVariableSelectorProps> = (
           }
           setIsLoadingOptions(false);
         });
+    } else {
+      setIsLoadingOptions(false);
     }
     return () => {
       cancelled = true;
     };
   }, [variable.type, variable.attributeKey]);
 
-  const isTelemetryAttribute: boolean =
-    variable.type === DashboardVariableType.TelemetryAttribute;
-  const isCustomList: boolean =
-    variable.type === DashboardVariableType.CustomList ||
-    Boolean(variable.customListValues);
-
-  const customListOptions: Array<string> = variable.customListValues
-    ? variable.customListValues.split(",").map((v: string) => {
-        return v.trim();
-      })
-    : [];
-
-  const options: Array<string> = isTelemetryAttribute
-    ? dynamicOptions
-    : customListOptions;
-
-  const useSelect: boolean = isTelemetryAttribute || isCustomList;
-  const label: string = variable.label || variable.name;
-
   return (
-    <div className="flex items-center gap-1.5">
-      <label className="text-xs font-medium text-gray-400 uppercase tracking-wide">
-        {label}
-      </label>
-      {useSelect && variable.isMultiSelect ? (
-        /*
-         * `selectedValues` only — never defaultValue. The popover renders
-         * "All" for an empty list, and DashboardVariableInterpolation
-         * resolves an empty list to no predicate, so the two agree. Seeding
-         * this from defaultValue would put a filter behind a control that
-         * reads "All".
-         */
-        <MultiSelectPopover
-          options={options}
-          selected={variable.selectedValues || []}
-          label={label}
-          isLoading={isLoadingOptions}
-          onChange={(next: Array<string>) => {
-            props.onVariableValueChange(variable.id, { selectedValues: next });
-          }}
-        />
-      ) : useSelect ? (
-        <select
-          className="text-xs border border-gray-200 rounded-md px-2.5 py-1.5 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-300 transition-colors"
-          /*
-           * `??`, not `||`: picking "All" stores selectedValue as "", which is
-           * a real selection and must not collapse back to defaultValue. Only
-           * an unset (undefined) selection falls through to the default — the
-           * same rule the query side applies in
-           * Common/Utils/Dashboard/VariableInterpolation.ts, so what the
-           * toolbar shows and what the widgets are filtered by stay in step.
-           */
-          value={variable.selectedValue ?? variable.defaultValue ?? ""}
-          disabled={isLoadingOptions}
-          onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
-            props.onVariableValueChange(variable.id, {
-              selectedValue: e.target.value,
-            });
-          }}
-        >
-          <option value="">{isLoadingOptions ? "Loading…" : "All"}</option>
-          {options.map((option: string) => {
-            return (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            );
-          })}
-        </select>
-      ) : (
-        <input
-          type="text"
-          className="text-xs border border-gray-200 rounded-md px-2.5 py-1.5 bg-white text-gray-700 w-28 focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-300 transition-colors"
-          // `??` so clearing the box stays cleared. See the select above.
-          value={variable.selectedValue ?? variable.defaultValue ?? ""}
-          placeholder={variable.name}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            props.onVariableValueChange(variable.id, {
-              selectedValue: e.target.value,
-            });
-          }}
-        />
-      )}
-    </div>
+    <DashboardVariableControl
+      variable={variable}
+      dynamicOptions={dynamicOptions}
+      isLoadingOptions={isLoadingOptions}
+      onVariableValueChange={props.onVariableValueChange}
+    />
   );
 };
 

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardVariablesModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardVariablesModal.tsx
@@ -1,6 +1,7 @@
 import React, {
   FunctionComponent,
   ReactElement,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -14,8 +15,18 @@ import Icon from "Common/UI/Components/Icon/Icon";
 import AutocompleteTextInput from "Common/UI/Components/AutocompleteTextInput/AutocompleteTextInput";
 import DashboardVariable, {
   DashboardVariableType,
+  DashboardVariableOption,
 } from "Common/Types/Dashboard/DashboardVariable";
 import ObjectID from "Common/Types/ObjectID";
+import Label from "Common/Models/DatabaseModels/Label";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "Common/UI/Utils/Project";
+import API from "Common/UI/Utils/API/API";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import Dropdown, {
+  DropdownOption,
+  DropdownValue,
+} from "Common/UI/Components/Dropdown/Dropdown";
 
 export interface ComponentProps {
   variables: Array<DashboardVariable>;
@@ -30,9 +41,135 @@ interface VariableRowProps {
   onChange: (variable: DashboardVariable) => void;
   onDelete: () => void;
   nameError?: string | undefined;
+  labelError?: string | undefined;
 }
 
 const RESERVED_NAME_PATTERN: RegExp = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+interface LabelChoicesProps {
+  variable: DashboardVariable;
+  onChange: (variable: DashboardVariable) => void;
+}
+
+const LabelChoices: FunctionComponent<LabelChoicesProps> = (
+  props: LabelChoicesProps,
+): ReactElement => {
+  const [options, setOptions] = useState<Array<DashboardVariableOption>>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    let cancelled: boolean = false;
+    const load: () => Promise<void> = async (): Promise<void> => {
+      try {
+        const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+        if (!projectId) {
+          throw new Error("Select a project to choose labels.");
+        }
+        const choices: Array<DashboardVariableOption> = [];
+        let skip: number = 0;
+        while (!cancelled) {
+          const result: ListResult<Label> = await ModelAPI.getList<Label>({
+            modelType: Label,
+            query: { projectId },
+            select: { _id: true, name: true },
+            sort: { name: SortOrder.Ascending },
+            skip,
+            limit: 1000,
+          });
+          for (const label of result.data) {
+            if (label._id && label.name) {
+              choices.push({ label: label.name, value: label._id.toString() });
+            }
+          }
+          skip += result.data.length;
+          if (result.data.length === 0 || skip >= result.count) {
+            break;
+          }
+        }
+        if (!cancelled) {
+          setOptions(choices);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(API.getFriendlyErrorMessage(err as Error));
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const savedOptions: Array<DashboardVariableOption> =
+    props.variable.labelOptions || [];
+  const allOptions: Array<DashboardVariableOption> = [
+    ...options,
+    ...savedOptions.filter((saved: DashboardVariableOption) => {
+      return !options.some((option: DashboardVariableOption) => {
+        return option.value === saved.value;
+      });
+    }),
+  ];
+
+  return (
+    <div>
+      {isLoading ? (
+        <p className="text-xs text-gray-500">Loading project labels…</p>
+      ) : error ? (
+        <p role="alert" className="text-xs text-red-600">
+          {error}
+        </p>
+      ) : (
+        <Dropdown
+          ariaLabel="Allowed project labels"
+          isMultiSelect={true}
+          placeholder="Choose labels for this variable"
+          options={allOptions}
+          value={savedOptions}
+          onChange={(values: DropdownValue | Array<DropdownValue> | null) => {
+            const selected: Array<string> = Array.isArray(values)
+              ? values.map((value: DropdownValue) => {
+                  return value.toString();
+                })
+              : [];
+            const labelOptions: Array<DashboardVariableOption> =
+              allOptions.filter((option: DashboardVariableOption) => {
+                return selected.includes(option.value);
+              });
+            props.onChange({
+              ...props.variable,
+              labelOptions,
+              defaultValue: selected.includes(props.variable.defaultValue || "")
+                ? props.variable.defaultValue
+                : "",
+              selectedValue: selected.includes(
+                props.variable.selectedValue || "",
+              )
+                ? props.variable.selectedValue
+                : "",
+              selectedValues: (props.variable.selectedValues || []).filter(
+                (value: string) => {
+                  return selected.includes(value);
+                },
+              ),
+            });
+          }}
+        />
+      )}
+      <p className="text-[11px] text-gray-500 mt-1">
+        Choose up to 1,000 labels. Their names appear in the toolbar and on
+        shared dashboards. Bind this variable in a Monitor List widget’s Label
+        Variable setting.
+      </p>
+    </div>
+  );
+};
 
 const VariableRow: FunctionComponent<VariableRowProps> = (
   props: VariableRowProps,
@@ -89,26 +226,66 @@ const VariableRow: FunctionComponent<VariableRowProps> = (
            * applies, so it is disabled instead of quietly ignored. The
            * stored value is kept so unticking the box restores it.
            */}
-          <input
-            type="text"
-            className="w-full text-sm border border-gray-200 rounded-md px-2 py-1.5 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-100 disabled:bg-gray-50 disabled:text-gray-400"
-            placeholder={variable.isMultiSelect ? "All" : "(none)"}
-            value={variable.defaultValue || ""}
-            disabled={Boolean(variable.isMultiSelect)}
-            title={
-              variable.isMultiSelect
-                ? "Multi-select variables start on All and do not use a default."
-                : undefined
-            }
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              props.onChange({ ...variable, defaultValue: e.target.value });
-            }}
-          />
+          {variable.type === DashboardVariableType.ProjectLabel ? (
+            <select
+              aria-label="Default label"
+              className="w-full text-sm border border-gray-200 rounded-md px-2 py-1.5 bg-white text-gray-700 disabled:bg-gray-50"
+              value={variable.defaultValue || ""}
+              disabled={Boolean(variable.isMultiSelect)}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                return props.onChange({
+                  ...variable,
+                  defaultValue: e.target.value,
+                });
+              }}
+            >
+              <option value="">All</option>
+              {variable.defaultValue &&
+                !variable.labelOptions?.some(
+                  (option: DashboardVariableOption) => {
+                    return option.value === variable.defaultValue;
+                  },
+                ) && (
+                  <option value={variable.defaultValue}>
+                    Unavailable label
+                  </option>
+                )}
+              {(variable.labelOptions || []).map(
+                (option: DashboardVariableOption) => {
+                  return (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  );
+                },
+              )}
+            </select>
+          ) : (
+            <input
+              type="text"
+              className="w-full text-sm border border-gray-200 rounded-md px-2 py-1.5 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-100 disabled:bg-gray-50 disabled:text-gray-400"
+              placeholder={variable.isMultiSelect ? "All" : "(none)"}
+              value={variable.defaultValue || ""}
+              disabled={Boolean(variable.isMultiSelect)}
+              title={
+                variable.isMultiSelect
+                  ? "Multi-select variables start on All and do not use a default."
+                  : undefined
+              }
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                props.onChange({ ...variable, defaultValue: e.target.value });
+              }}
+            />
+          )}
           <label className="mt-2 flex items-center gap-1.5 text-[11px] text-gray-500">
             <input
               type="checkbox"
               className="h-3.5 w-3.5"
               checked={Boolean(variable.isMultiSelect)}
+              disabled={
+                variable.type === DashboardVariableType.TextInput ||
+                variable.type === DashboardVariableType.Query
+              }
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 props.onChange({
                   ...variable,
@@ -133,25 +310,124 @@ const VariableRow: FunctionComponent<VariableRowProps> = (
 
         <div className="col-span-12">
           <label className="text-[11px] font-medium text-gray-500 uppercase tracking-wide block mb-1">
-            Attribute Key
+            Source
           </label>
-          <AutocompleteTextInput
-            value={variable.attributeKey || ""}
-            placeholder="e.g. k8s.cluster.name"
-            suggestions={props.telemetryAttributeOptions}
-            className="w-full text-sm border border-gray-200 rounded-md px-2 py-1.5 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-100 font-mono"
-            outerDivClassName="relative w-full"
-            onChange={(value: string) => {
-              props.onChange({ ...variable, attributeKey: value });
+          <Dropdown
+            ariaLabel="Variable source"
+            options={[
+              DashboardVariableType.TelemetryAttribute,
+              DashboardVariableType.ProjectLabel,
+              DashboardVariableType.CustomList,
+              DashboardVariableType.TextInput,
+              ...(variable.type === DashboardVariableType.Query
+                ? [DashboardVariableType.Query]
+                : []),
+            ].map((type: DashboardVariableType): DropdownOption => {
+              return {
+                label: type,
+                value: type,
+              };
+            })}
+            value={{ label: variable.type, value: variable.type }}
+            onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
+              if (typeof value === "string" && value !== variable.type) {
+                props.onChange({
+                  ...variable,
+                  type: value as DashboardVariableType,
+                  attributeKey:
+                    value === DashboardVariableType.TelemetryAttribute
+                      ? variable.attributeKey
+                      : undefined,
+                  labelOptions:
+                    value === DashboardVariableType.ProjectLabel
+                      ? variable.labelOptions
+                      : undefined,
+                  customListValues:
+                    value === DashboardVariableType.CustomList
+                      ? variable.customListValues
+                      : undefined,
+                  query:
+                    value === DashboardVariableType.Query
+                      ? variable.query
+                      : undefined,
+                  isMultiSelect:
+                    value === DashboardVariableType.TextInput
+                      ? false
+                      : variable.isMultiSelect,
+                  defaultValue: "",
+                  selectedValue: "",
+                  selectedValues: [],
+                });
+              }
             }}
           />
-          <p className="text-[11px] text-gray-400 mt-1">
-            Widgets that filter on this attribute will be scoped to the selected
-            value. Choosing &quot;All&quot; leaves widgets unfiltered
-            {variable.isMultiSelect
-              ? " — a multi-select with nothing picked is All."
-              : "."}
-          </p>
+        </div>
+        <div className="col-span-12">
+          {variable.type === DashboardVariableType.TelemetryAttribute ? (
+            <>
+              <label className="text-[11px] font-medium text-gray-500 uppercase tracking-wide block mb-1">
+                Attribute Key
+              </label>
+              <AutocompleteTextInput
+                value={variable.attributeKey || ""}
+                placeholder="e.g. k8s.cluster.name"
+                suggestions={props.telemetryAttributeOptions}
+                className="w-full text-sm border border-gray-200 rounded-md px-2 py-1.5 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-100 font-mono"
+                outerDivClassName="relative w-full"
+                onChange={(value: string) => {
+                  return props.onChange({ ...variable, attributeKey: value });
+                }}
+              />
+              <p className="text-[11px] text-gray-400 mt-1">
+                Widgets that support this attribute will be scoped to the
+                selected value. Choosing &quot;All&quot; removes this attribute
+                filter
+                {variable.isMultiSelect
+                  ? " — a multi-select with nothing picked is All."
+                  : "."}
+              </p>
+            </>
+          ) : variable.type === DashboardVariableType.ProjectLabel ? (
+            <>
+              <label className="text-[11px] font-medium text-gray-500 uppercase tracking-wide block mb-1">
+                Allowed Labels
+              </label>
+              <LabelChoices variable={variable} onChange={props.onChange} />
+              {props.labelError && (
+                <p role="alert" className="text-xs text-red-600 mt-1">
+                  {props.labelError}
+                </p>
+              )}
+            </>
+          ) : variable.type === DashboardVariableType.CustomList ? (
+            <>
+              <label className="text-[11px] font-medium text-gray-500 uppercase tracking-wide block mb-1">
+                Values
+              </label>
+              <input
+                aria-label="Custom list values"
+                className="w-full text-sm border border-gray-200 rounded-md px-2 py-1.5"
+                placeholder="prod, staging"
+                value={variable.customListValues || ""}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  return props.onChange({
+                    ...variable,
+                    customListValues: e.target.value,
+                  });
+                }}
+              />
+              <p className="text-[11px] text-gray-500 mt-1">
+                Comma-separated values for text and query placeholders. Use
+                Project Labels to filter Monitor Lists.
+              </p>
+            </>
+          ) : (
+            <p className="text-[11px] text-gray-500">
+              {variable.type === DashboardVariableType.Query
+                ? "This legacy query variable is preserved. Query option loading is not supported."
+                : "Viewers enter a value for text and query placeholders. Use Project Labels to filter Monitor Lists."}
+            </p>
+          )}
         </div>
       </div>
     </div>
@@ -190,7 +466,25 @@ const DashboardVariablesModal: FunctionComponent<ComponentProps> = (
     return errors;
   }, [variables]);
 
-  const hasErrors: boolean = Object.keys(nameErrors).length > 0;
+  const labelErrors: Record<string, string> = {};
+  for (const variable of variables) {
+    if (variable.type === DashboardVariableType.ProjectLabel) {
+      const count: number = variable.labelOptions?.length || 0;
+      if (count === 0 || count > 1000) {
+        labelErrors[variable.id] = "Choose between 1 and 1,000 allowed labels.";
+      } else if (
+        variable.defaultValue &&
+        !variable.labelOptions?.some((option: DashboardVariableOption) => {
+          return option.value === variable.defaultValue;
+        })
+      ) {
+        labelErrors[variable.id] =
+          "Choose a default from the allowed labels or select All.";
+      }
+    }
+  }
+  const hasErrors: boolean =
+    Object.keys(nameErrors).length > 0 || Object.keys(labelErrors).length > 0;
 
   const addVariable: () => void = () => {
     const newVar: DashboardVariable = {
@@ -222,13 +516,26 @@ const DashboardVariablesModal: FunctionComponent<ComponentProps> = (
   return (
     <Modal
       title="Dashboard Variables"
-      description="Add variables to filter every widget on this dashboard by an attribute (for example, cluster or namespace). Selectors appear on the toolbar in view mode."
+      description="Add toolbar selectors for supported telemetry attributes or explicitly bind project labels to Monitor List widgets."
       modalWidth={ModalWidth.Large}
       onClose={props.onClose}
       onSubmit={() => {
+        if (hasErrors) {
+          return;
+        }
         const normalized: Array<DashboardVariable> = variables.map(
           (v: DashboardVariable) => {
-            return { ...v, name: (v.name || "").trim() };
+            const definition: DashboardVariable = {
+              ...v,
+              name: (v.name || "").trim(),
+            };
+            /*
+             * Toolbar choices belong to the current viewer. Publishing them
+             * would override the configured default for subsequent viewers.
+             */
+            delete definition.selectedValue;
+            delete definition.selectedValues;
+            return definition;
           },
         );
         props.onSave(normalized);
@@ -246,7 +553,7 @@ const DashboardVariablesModal: FunctionComponent<ComponentProps> = (
             />
             <p className="text-sm text-gray-500 mb-1">No variables yet</p>
             <p className="text-xs text-gray-400">
-              Add a variable to filter all widgets by a shared attribute.
+              Add a variable, then configure the widgets it should filter.
             </p>
           </div>
         ) : (
@@ -261,6 +568,7 @@ const DashboardVariablesModal: FunctionComponent<ComponentProps> = (
                   deleteVariable(variable.id);
                 }}
                 nameError={nameErrors[variable.id]}
+                labelError={labelErrors[variable.id]}
               />
             );
           })

--- a/App/FeatureSet/Docs/Content/en/dashboards/variables.md
+++ b/App/FeatureSet/Docs/Content/en/dashboards/variables.md
@@ -14,9 +14,7 @@ Use it when: the choices are small and fixed. `environment` with values `prod, s
 
 ### Query
 
-The options come from a query against your data.
-
-Use it when: the choices change over time and you want the dropdown to keep up. "Every customer ID seen in the past 24 hours." The query runs against your project's data and the results become the dropdown.
+Existing query variable definitions are preserved, but loading dropdown options from a custom query is not supported. Use **Telemetry Attribute** for choices discovered from telemetry, or **Project Labels** for monitor label choices.
 
 ### Text Input
 
@@ -32,19 +30,31 @@ Configure the **attribute key** (for example, `service.name`, `host.name`, `k8s.
 
 Use it when: the choices match the tags you already send with your telemetry. This is the most common type because it updates automatically — when you ship a new service tagged `service.name = inventory`, that name appears in the dropdown without you editing the dashboard.
 
+### Project Labels
+
+Choose existing project labels to offer as a dashboard dropdown. For example, create a variable named `UNIT`, set its source to **Project Labels**, and choose the labels `0660` and `0661`.
+
+The dashboard saves the chosen label IDs and display names. Filtering uses IDs, so renaming a project label does not break its binding. Display names are saved with the dashboard; reselect a renamed label in the variable editor to update its displayed name. Public dashboards show these same saved choices.
+
+In a **Monitor List** widget, open **Filters → Label Variable** and select `UNIT`. Selecting `0660` now shows monitors carrying that label. Other widgets are unaffected unless they explicitly support and bind the variable.
+
+Fixed widget filters remain in effect. For example, with a fixed `network` label and `UNIT` set to `0660`, a monitor must carry both labels. Multiple selected units match any selected unit. Choosing **All** removes only the variable condition, keeping fixed label, status, and monitor-type filters.
+
+A missing variable or a selection outside its configured choices shows an error. A selected label with no matching monitors shows the empty list. Remove the widget binding explicitly when it is no longer needed.
+
 ## Multi-select
 
-Each variable can allow multiple selections. When on, the viewer can pick one or more values; the dashboard filters to any of them.
+Custom List, Telemetry Attribute, and Project Labels variables can allow multiple selections. When on, the viewer can pick one or more values; the dashboard filters to any of them. An empty selection means **All**.
 
 Use multi-select when: you want to compare "checkout and payments together" without leaving the dashboard. Avoid it when the math doesn't work across selected values (for example, averaging averages).
 
 ## Default values
 
-Every variable can have a default. The dashboard renders with the default until the viewer changes it. For public dashboards, the default is what visitors see first.
+Single-select variables can have a default. The dashboard renders with the default until the viewer changes it. Multi-select variables start on **All** and do not use a default. A shared URL's explicit selection takes precedence, including an explicit **All**.
 
 ## How to use a variable in a widget
 
-Anywhere a widget takes a filter — a metric's `WHERE`, a list's filter, a log stream's attribute match — you can use `{{variable_name}}`.
+Variable support depends on the widget and filter. Telemetry attribute variables bind to their configured attribute key; Monitor List label filters use the explicit **Label Variable** setting described above.
 
 For example, a chart filtered by service:
 
@@ -55,6 +65,8 @@ service.name = '{{service}}'
 When the dropdown is set to `checkout`, the chart filters to the checkout service. When the viewer switches to `payments`, the chart re-renders for payments.
 
 For **Telemetry Attribute** variables, OneUptime knows which attribute the variable maps to and applies the filter to every widget that uses the same attribute — you don't have to edit each widget by hand.
+
+Monitor List titles also support `{{variable_name}}`. For example, `{{UNIT}} NETWORK` displays `0660 NETWORK`, `0660, 0661 NETWORK`, or `All NETWORK`. A title controls displayed text; configure **Label Variable** to filter the monitor query.
 
 ## Time range
 

--- a/App/FeatureSet/PublicDashboard/src/Pages/DashboardView/DashboardVariableSelector.tsx
+++ b/App/FeatureSet/PublicDashboard/src/Pages/DashboardView/DashboardVariableSelector.tsx
@@ -13,16 +13,25 @@ import URL from "Common/Types/API/URL";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 import { JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
+import DashboardVariableControl, {
+  VariableValueChange,
+} from "Common/UI/Components/Dashboard/DashboardVariableControl";
 
 export interface ComponentProps {
   variables: Array<DashboardVariable>;
-  onVariableValueChange: (variableId: string, value: string) => void;
+  onVariableValueChange: (
+    variableId: string,
+    change: VariableValueChange,
+  ) => void;
   dashboardId: ObjectID;
 }
 
 interface SingleVariableSelectorProps {
   variable: DashboardVariable;
-  onVariableValueChange: (variableId: string, value: string) => void;
+  onVariableValueChange: (
+    variableId: string,
+    change: VariableValueChange,
+  ) => void;
   dashboardId: ObjectID;
 }
 
@@ -68,73 +77,21 @@ const SingleVariableSelector: FunctionComponent<SingleVariableSelectorProps> = (
           }
           setIsLoadingOptions(false);
         });
+    } else {
+      setIsLoadingOptions(false);
     }
     return () => {
       cancelled = true;
     };
   }, [variable.type, variable.attributeKey, props.dashboardId]);
 
-  const isTelemetryAttribute: boolean =
-    variable.type === DashboardVariableType.TelemetryAttribute;
-  const isCustomList: boolean =
-    variable.type === DashboardVariableType.CustomList ||
-    Boolean(variable.customListValues);
-
-  const customListOptions: Array<string> = variable.customListValues
-    ? variable.customListValues.split(",").map((v: string) => {
-        return v.trim();
-      })
-    : [];
-
-  const options: Array<string> = isTelemetryAttribute
-    ? dynamicOptions
-    : customListOptions;
-
-  const useSelect: boolean = isTelemetryAttribute || isCustomList;
-
   return (
-    <div className="flex items-center gap-1.5">
-      <label className="text-xs font-medium text-gray-500">
-        {variable.name}:
-      </label>
-      {useSelect ? (
-        <select
-          className="text-xs border border-gray-200 rounded px-2 py-1 bg-white text-gray-700"
-          /*
-           * `??`, not `||`: picking "All" stores selectedValue as "", which is
-           * a real selection and must not collapse back to defaultValue. Only
-           * an unset (undefined) selection falls through to the default — the
-           * same rule the query side applies in
-           * Common/Utils/Dashboard/VariableInterpolation.ts, so what this
-           * toolbar shows and what the widgets are filtered by stay in step.
-           */
-          value={variable.selectedValue ?? variable.defaultValue ?? ""}
-          disabled={isLoadingOptions}
-          onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
-            props.onVariableValueChange(variable.id, e.target.value);
-          }}
-        >
-          <option value="">{isLoadingOptions ? "Loading…" : "All"}</option>
-          {options.map((option: string) => {
-            return (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            );
-          })}
-        </select>
-      ) : (
-        <input
-          type="text"
-          className="text-xs border border-gray-200 rounded px-2 py-1 bg-white text-gray-700 w-24"
-          // `??` so clearing the box stays cleared. See the select above.
-          value={variable.selectedValue ?? variable.defaultValue ?? ""}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            props.onVariableValueChange(variable.id, e.target.value);
-          }}
-        />
-      )}
-    </div>
+    <DashboardVariableControl
+      variable={variable}
+      dynamicOptions={dynamicOptions}
+      isLoadingOptions={isLoadingOptions}
+      onVariableValueChange={props.onVariableValueChange}
+    />
   );
 };
 

--- a/App/FeatureSet/PublicDashboard/src/Pages/DashboardView/DashboardViewPage.tsx
+++ b/App/FeatureSet/PublicDashboard/src/Pages/DashboardView/DashboardViewPage.tsx
@@ -37,6 +37,7 @@ import MoreMenuItem from "Common/UI/Components/MoreMenu/MoreMenuItem";
 import IconProp from "Common/Types/Icon/IconProp";
 import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import DashboardVariableSelector from "./DashboardVariableSelector";
+import { VariableValueChange } from "Common/UI/Components/Dashboard/DashboardVariableControl";
 import MetricUtil from "../../../../Dashboard/src/Components/Metrics/Utils/Metrics";
 import { setPublicDashboardContext } from "../../../../Dashboard/src/Components/Dashboard/Utils/PublicDashboardContext";
 import MetricType from "Common/Models/DatabaseModels/MetricType";
@@ -401,12 +402,19 @@ const DashboardViewPage: FunctionComponent<ComponentProps> = (
                     dashboardId={props.dashboardId}
                     onVariableValueChange={(
                       variableId: string,
-                      value: string,
+                      change: VariableValueChange,
                     ) => {
                       const updated: Array<DashboardVariable> =
                         dashboardVariables.map((v: DashboardVariable) => {
                           if (v.id === variableId) {
-                            return { ...v, selectedValue: value };
+                            return {
+                              ...v,
+                              selectedValue:
+                                change.selectedValues !== undefined
+                                  ? undefined
+                                  : change.selectedValue,
+                              selectedValues: change.selectedValues,
+                            };
                           }
                           return v;
                         });

--- a/Common/Server/Types/Database/Permissions/ReadPermission.ts
+++ b/Common/Server/Types/Database/Permissions/ReadPermission.ts
@@ -1,6 +1,7 @@
 import DatabaseRequestType from "../../BaseDatabase/DatabaseRequestType";
 import Query from "../Query";
 import QueryHelper from "../QueryHelper";
+import QueryUtil from "../QueryUtil";
 import RelationSelect from "../RelationSelect";
 import Select from "../Select";
 import SelectUtil from "../SelectUtil";
@@ -12,8 +13,11 @@ import DatabaseCommonInteractionPropsUtil, {
   PermissionType,
 } from "../../../../Types/BaseDatabase/DatabaseCommonInteractionPropsUtil";
 import ObjectID from "../../../../Types/ObjectID";
+import BadDataException from "../../../../Types/Exception/BadDataException";
 import Permission, { UserPermission } from "../../../../Types/Permission";
 import CaptureSpan from "../../../Utils/Telemetry/CaptureSpan";
+import { combineWithPrivacyClause } from "../../../Utils/PrivacyFilterUtil";
+import { FindOperator } from "typeorm";
 
 export interface CheckReadPermissionType<TBaseModel extends BaseModel>
   extends CheckPermissionBaseInterface<TBaseModel> {
@@ -119,13 +123,49 @@ export default class ReadPermission {
       }
     }
 
-    // now add these to query
-
     const model: TBaseModel = new modelType();
+    const accessControlColumn: string | null = model.getAccessControlColumn();
+    const manyToManyMeta: ReturnType<
+      typeof QueryUtil.getManyToManyRelationMetadata
+    > = accessControlColumn
+      ? QueryUtil.getManyToManyRelationMetadata(modelType, accessControlColumn)
+      : null;
 
-    (query as any)[model.getAccessControlColumn() as string] = {
-      _id: QueryHelper.notInOrNull(labelIds),
-    };
+    if (!manyToManyMeta) {
+      throw new BadDataException(
+        "Cannot apply read label restrictions without access-control relation metadata.",
+      );
+    }
+
+    const idQuery: Query<TBaseModel> = QueryUtil.serializeQuery(modelType, {
+      _id: query._id,
+    } as Query<TBaseModel>);
+    const existingIdFilter: unknown = idQuery._id;
+    if (
+      existingIdFilter !== undefined &&
+      typeof existingIdFilter !== "string" &&
+      !(existingIdFilter instanceof FindOperator)
+    ) {
+      throw new BadDataException(
+        "Cannot combine read label restrictions with an unsupported ID filter.",
+      );
+    }
+
+    /*
+     * Keep the caller's label selection intact. Blocking labels is a separate
+     * condition on the owner: it must have none of the blocked label links.
+     * Applying that condition to _id also lets grouped dashboard label filters
+     * and existing record selectors reach QueryUtil without being replaced.
+     * Serialize the ID condition first because QueryUtil does not descend into
+     * the database AND operator to convert application query operators later.
+     */
+    (query as any)._id = combineWithPrivacyClause(
+      existingIdFilter,
+      QueryHelper.noneEntitiesInManyToMany({
+        values: labelIds,
+        ...manyToManyMeta,
+      }),
+    );
 
     return { query };
   }

--- a/Common/Server/Types/Database/QueryUtil.ts
+++ b/Common/Server/Types/Database/QueryUtil.ts
@@ -7,6 +7,7 @@ import GreaterThanOrEqual from "../../../Types/BaseDatabase/GreaterThanOrEqual";
 import InBetween from "../../../Types/BaseDatabase/InBetween";
 import Includes from "../../../Types/BaseDatabase/Includes";
 import IncludesAll from "../../../Types/BaseDatabase/IncludesAll";
+import IncludesAnyOfGroups from "../../../Types/BaseDatabase/IncludesAnyOfGroups";
 import IncludesNone from "../../../Types/BaseDatabase/IncludesNone";
 import StartsWith from "../../../Types/BaseDatabase/StartsWith";
 import EndsWith from "../../../Types/BaseDatabase/EndsWith";
@@ -24,6 +25,7 @@ import { TableColumnMetadata } from "../../../Types/Database/TableColumn";
 import TableColumnType from "../../../Types/Database/TableColumnType";
 import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
+import BadDataException from "../../../Types/Exception/BadDataException";
 import Typeof from "../../../Types/Typeof";
 import { And, DataSource } from "typeorm";
 import { FindOperator } from "typeorm/find-options/FindOperator";
@@ -45,6 +47,7 @@ export default class QueryUtil {
     const model: BaseModel = new modelType();
 
     query = query as Query<TBaseModel>;
+    const groupedRelationFilters: Array<FindOperator<unknown>> = [];
 
     /*
      * Multi-field text search:
@@ -125,6 +128,37 @@ export default class QueryUtil {
     for (const key in query) {
       const tableColumnMetadata: TableColumnMetadata =
         model.getTableColumnMetadata(key);
+
+      if (query[key] instanceof IncludesAnyOfGroups) {
+        if (tableColumnMetadata?.type !== TableColumnType.EntityArray) {
+          throw new BadDataException(
+            "IncludesAnyOfGroups requires a many-to-many entity relation.",
+          );
+        }
+
+        const relation: {
+          joinTableName: string;
+          ownerColumnName: string;
+          relationColumnName: string;
+        } | null = QueryUtil.getManyToManyRelationMetadata(modelType, key);
+
+        if (!relation) {
+          throw new BadDataException(
+            "IncludesAnyOfGroups requires available many-to-many relation metadata.",
+          );
+        }
+
+        for (const group of (query[key] as IncludesAnyOfGroups).groups) {
+          groupedRelationFilters.push(
+            QueryHelper.anyOfEntitiesInManyToMany({
+              ...relation,
+              values: group,
+            }) as FindOperator<unknown>,
+          );
+        }
+        delete query[key];
+        continue;
+      }
 
       if (tableColumnMetadata && query[key] === null) {
         query[key] = QueryHelper.isNull();
@@ -632,6 +666,28 @@ export default class QueryUtil {
           }
         }
       }
+    }
+
+    if (groupedRelationFilters.length > 0) {
+      /*
+       * Apply these only after scalar operators have been serialized, so an
+       * existing id condition survives regardless of the query's key order.
+       */
+      const existingIdFilter: unknown = query._id;
+      if (existingIdFilter !== undefined) {
+        if (existingIdFilter instanceof FindOperator) {
+          groupedRelationFilters.unshift(existingIdFilter);
+        } else if (typeof existingIdFilter === "string") {
+          groupedRelationFilters.unshift(
+            QueryHelper.equalTo(existingIdFilter) as FindOperator<unknown>,
+          );
+        } else {
+          throw new BadDataException(
+            "IncludesAnyOfGroups cannot combine an unsupported id filter.",
+          );
+        }
+      }
+      query._id = And(...groupedRelationFilters) as any;
     }
 
     return query;

--- a/Common/Server/Utils/Dashboard/PublicDashboardResourceListPolicy.ts
+++ b/Common/Server/Utils/Dashboard/PublicDashboardResourceListPolicy.ts
@@ -21,6 +21,7 @@ import DashboardModelQueryInterpolation, {
   AttributeToColumnMap,
 } from "../../../Utils/Dashboard/ModelQueryVariableInterpolation";
 import DashboardVariableInterpolation from "../../../Utils/Dashboard/VariableInterpolation";
+import DashboardLabelVariable from "../../../Utils/Dashboard/LabelVariable";
 
 export interface PublicDashboardResourceListPolicyResult {
   resourceType: string;
@@ -180,6 +181,7 @@ export default class PublicDashboardResourceListPolicy {
       componentType: componentType as DashboardComponentType,
       argumentsObject,
       requestedQuery: data.requestedQuery,
+      variables,
     });
 
     let query: Record<string, unknown> = draft.query;
@@ -505,8 +507,9 @@ export default class PublicDashboardResourceListPolicy {
     componentType: DashboardComponentType;
     argumentsObject: Record<string, unknown>;
     requestedQuery: unknown;
+    variables: Array<DashboardVariable>;
   }): PolicyDraft {
-    const { componentType, argumentsObject, requestedQuery } = data;
+    const { componentType, argumentsObject, requestedQuery, variables } = data;
 
     switch (componentType) {
       case DashboardComponentType.IncidentList:
@@ -520,6 +523,7 @@ export default class PublicDashboardResourceListPolicy {
       case DashboardComponentType.MonitorList:
         return PublicDashboardResourceListPolicy.buildMonitorPolicy(
           argumentsObject,
+          variables,
         );
       case DashboardComponentType.NetworkMap:
         return PublicDashboardResourceListPolicy.buildNetworkMapPolicy(
@@ -814,6 +818,7 @@ export default class PublicDashboardResourceListPolicy {
 
   private static buildMonitorPolicy(
     argumentsObject: Record<string, unknown>,
+    variables: Array<DashboardVariable>,
   ): PolicyDraft {
     const query: Record<string, unknown> = {};
     const statusFilter: string | undefined =
@@ -841,12 +846,22 @@ export default class PublicDashboardResourceListPolicy {
       argumentsObject,
       argumentKey: "monitorTypes",
     });
-    PublicDashboardResourceListPolicy.addIncludesFromArgument({
-      query,
-      queryKey: "labels",
-      argumentsObject,
-      argumentKey: "labelIds",
-    });
+    const labels: ReturnType<typeof DashboardLabelVariable.getFilter> =
+      DashboardLabelVariable.getFilter({
+        labelIds: PublicDashboardResourceListPolicy.optionalStringArray(
+          argumentsObject,
+          "labelIds",
+        ),
+        labelVariableId: PublicDashboardResourceListPolicy.optionalString(
+          argumentsObject,
+          "labelVariableId",
+          false,
+        ),
+        variables,
+      });
+    if (labels) {
+      query["labels"] = labels;
+    }
 
     return PublicDashboardResourceListPolicy.listDraft({
       resourceType: "monitor",
@@ -1653,19 +1668,19 @@ export default class PublicDashboardResourceListPolicy {
           storedValue,
           "Stored dashboard variable",
         );
-      if (stored["type"] !== DashboardVariableType.TelemetryAttribute) {
+      const type: unknown = stored["type"];
+      if (
+        type !== DashboardVariableType.TelemetryAttribute &&
+        type !== DashboardVariableType.ProjectLabel
+      ) {
         continue;
       }
 
       const id: unknown = stored["id"];
-      const attributeKey: unknown = stored["attributeKey"];
       if (
         typeof id !== "string" ||
         id.length === 0 ||
-        id.length > MAX_VARIABLE_ID_LENGTH ||
-        typeof attributeKey !== "string" ||
-        attributeKey.trim().length === 0 ||
-        attributeKey.length > MAX_VARIABLE_VALUE_LENGTH
+        id.length > MAX_VARIABLE_ID_LENGTH
       ) {
         throw new BadDataException("Stored dashboard variable is malformed.");
       }
@@ -1700,11 +1715,10 @@ export default class PublicDashboardResourceListPolicy {
       const name: unknown = stored["name"];
       const storedIsMultiSelect: boolean = isMultiSelect === true;
 
-      variables.push({
+      const variable: DashboardVariable = {
         id,
         name: typeof name === "string" ? name : "",
-        type: DashboardVariableType.TelemetryAttribute,
-        attributeKey: attributeKey.trim(),
+        type,
         isMultiSelect: storedIsMultiSelect,
         defaultValue:
           typeof defaultValue === "string" ? defaultValue : undefined,
@@ -1716,10 +1730,61 @@ export default class PublicDashboardResourceListPolicy {
           storedIsMultiSelect && Array.isArray(selectedValues)
             ? (selectedValues as Array<string>)
             : undefined,
-      });
+      };
+
+      if (type === DashboardVariableType.ProjectLabel) {
+        variable.labelOptions =
+          PublicDashboardResourceListPolicy.readLabelOptions(stored);
+      } else {
+        const attributeKey: unknown = stored["attributeKey"];
+        if (
+          typeof attributeKey !== "string" ||
+          attributeKey.trim().length === 0 ||
+          attributeKey.length > MAX_VARIABLE_VALUE_LENGTH
+        ) {
+          throw new BadDataException("Stored dashboard variable is malformed.");
+        }
+        variable.attributeKey = attributeKey.trim();
+      }
+
+      variables.push(variable);
     }
 
     return variables;
+  }
+
+  private static readLabelOptions(
+    stored: Record<string, unknown>,
+  ): NonNullable<DashboardVariable["labelOptions"]> {
+    const value: unknown = stored["labelOptions"];
+    if (!Array.isArray(value)) {
+      throw new BadDataException(
+        "Stored dashboard label options are malformed.",
+      );
+    }
+
+    return value.map((entry: unknown): { label: string; value: string } => {
+      const option: Record<string, unknown> =
+        PublicDashboardResourceListPolicy.requireObject(
+          entry,
+          "Stored dashboard label option",
+        );
+      const label: unknown = option["label"];
+      const labelId: unknown = option["value"];
+      if (
+        typeof label !== "string" ||
+        label.length === 0 ||
+        label.length > MAX_VARIABLE_VALUE_LENGTH ||
+        typeof labelId !== "string" ||
+        labelId.length === 0 ||
+        labelId.length > MAX_VARIABLE_VALUE_LENGTH
+      ) {
+        throw new BadDataException(
+          "Stored dashboard label options are malformed.",
+        );
+      }
+      return { label, value: labelId };
+    });
   }
 
   private static validateRequestedVariableSelections(

--- a/Common/Tests/App/Dashboard/DashboardLabelVariables.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardLabelVariables.test.tsx
@@ -1,0 +1,580 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import DashboardVariable, {
+  DashboardVariableOption,
+  DashboardVariableType,
+} from "../../../Types/Dashboard/DashboardVariable";
+import ObjectID from "../../../Types/ObjectID";
+import { VariableValueChange } from "../../../UI/Components/Dashboard/DashboardVariableControl";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import PrivateSelector from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardVariableSelector";
+import PublicSelector from "../../../../App/FeatureSet/PublicDashboard/src/Pages/DashboardView/DashboardVariableSelector";
+import DashboardVariablesModal from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardVariablesModal";
+import ProjectLabelVariableDropdown from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/ProjectLabelVariableDropdown";
+import ComponentInputTypeToFormFieldType from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/ComponentInputTypeToFormFieldType";
+import { ComponentInputType } from "../../../Types/Dashboard/DashboardComponents/ComponentArgument";
+import FormFieldSchemaType from "../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import DashboardVariableUrlState from "../../../Utils/Dashboard/VariableUrlState";
+import DashboardVariableInterpolation from "../../../Utils/Dashboard/VariableInterpolation";
+
+const getListMock: MockFunction = getJestMockFunction();
+const telemetryMock: MockFunction = getJestMockFunction();
+const publicPostMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<unknown>): unknown => {
+        return getListMock(...args);
+      },
+    },
+  };
+});
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: (): string => {
+        return "44444444-4444-4444-8444-444444444444";
+      },
+    },
+  };
+});
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/Utils/Metrics",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        getTelemetryAttributeValues: (...args: Array<unknown>): unknown => {
+          return telemetryMock(...args);
+        },
+      },
+    };
+  },
+);
+jest.mock("../../../../App/FeatureSet/PublicDashboard/src/Utils/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      post: (...args: Array<unknown>): unknown => {
+        return publicPostMock(...args);
+      },
+    },
+  };
+});
+
+const OPTIONS: Array<DashboardVariableOption> = [
+  { label: "0660", value: "11111111-1111-4111-8111-111111111111" },
+  { label: "0661", value: "22222222-2222-4222-8222-222222222222" },
+];
+const FIRST: string = OPTIONS[0]!.value;
+const SECOND: string = OPTIONS[1]!.value;
+const DASHBOARD_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+function labelVariable(
+  overrides: Partial<DashboardVariable> = {},
+): DashboardVariable {
+  return {
+    id: "unit",
+    name: "UNIT",
+    label: "Unit",
+    type: DashboardVariableType.ProjectLabel,
+    labelOptions: OPTIONS,
+    ...overrides,
+  };
+}
+
+interface SelectorState {
+  variable: DashboardVariable;
+  changes: Array<VariableValueChange>;
+}
+
+function renderSelector(
+  isPublic: boolean,
+  variable: DashboardVariable,
+): SelectorState {
+  const state: SelectorState = { variable, changes: [] };
+  const Harness: React.FunctionComponent = (): React.ReactElement => {
+    const [current, setCurrent] = React.useState<DashboardVariable>(variable);
+    const onChange: (id: string, change: VariableValueChange) => void = (
+      _id: string,
+      change: VariableValueChange,
+    ): void => {
+      const next: DashboardVariable = {
+        ...current,
+        selectedValue: change.selectedValue,
+        selectedValues: change.selectedValues,
+      };
+      state.variable = next;
+      state.changes.push(change);
+      setCurrent(next);
+    };
+    return isPublic ? (
+      <PublicSelector
+        variables={[current]}
+        dashboardId={DASHBOARD_ID}
+        onVariableValueChange={onChange}
+      />
+    ) : (
+      <PrivateSelector variables={[current]} onVariableValueChange={onChange} />
+    );
+  };
+  render(<Harness />);
+  return state;
+}
+
+beforeEach(() => {
+  getListMock.mockReset();
+  getListMock.mockResolvedValue({
+    data: OPTIONS.map((option: DashboardVariableOption) => {
+      return {
+        _id: option.value,
+        name: option.label,
+      };
+    }),
+    count: 2,
+    skip: 0,
+    limit: 1000,
+  });
+  telemetryMock.mockReset();
+  publicPostMock.mockReset();
+});
+afterEach(cleanup);
+
+describe.each([false, true])(
+  "Project Labels selector (public=%s)",
+  (isPublic: boolean) => {
+    test("shows names with leading zeroes and sends stable label IDs without a labels request", () => {
+      const state: SelectorState = renderSelector(isPublic, labelVariable());
+      expect(screen.getByRole("option", { name: "0660" })).toHaveValue(FIRST);
+      fireEvent.change(screen.getByRole("combobox", { name: "Unit" }), {
+        target: { value: FIRST },
+      });
+      expect(state.variable.selectedValue).toBe(FIRST);
+      expect(screen.getByRole("combobox", { name: "Unit" })).toHaveValue(FIRST);
+      expect(getListMock).not.toHaveBeenCalled();
+      expect(telemetryMock).not.toHaveBeenCalled();
+      expect(publicPostMock).not.toHaveBeenCalled();
+    });
+
+    test("All remains selected after clearing a configured default", () => {
+      const state: SelectorState = renderSelector(
+        isPublic,
+        labelVariable({ defaultValue: FIRST }),
+      );
+      const select: HTMLElement = screen.getByRole("combobox", {
+        name: "Unit",
+      });
+      expect(select).toHaveValue(FIRST);
+      fireEvent.change(select, { target: { value: "" } });
+      expect(state.variable.selectedValue).toBe("");
+      expect(select).toHaveValue("");
+    });
+
+    test("multiple choices and Clear update selectedValues and remove stale scalar state", () => {
+      const state: SelectorState = renderSelector(
+        isPublic,
+        labelVariable({
+          isMultiSelect: true,
+          selectedValue: FIRST,
+          defaultValue: FIRST,
+        }),
+      );
+      const button: HTMLElement = screen.getByRole("button", {
+        name: /^Unit:/,
+      });
+      expect(button).toHaveTextContent("All");
+      fireEvent.click(button);
+      fireEvent.click(screen.getByRole("checkbox", { name: "0660" }));
+      expect(button).toHaveTextContent("0660");
+      fireEvent.click(screen.getByRole("checkbox", { name: "0661" }));
+      expect(state.variable.selectedValues).toEqual([FIRST, SECOND]);
+      expect(state.variable.selectedValue).toBeUndefined();
+      fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+      expect(state.variable.selectedValues).toEqual([]);
+      expect(button).toHaveTextContent("All");
+    });
+
+    test("a deleted or disallowed selected ID is visibly unavailable instead of appearing as All", () => {
+      renderSelector(isPublic, labelVariable({ selectedValue: "missing" }));
+      expect(
+        screen.getByRole("option", { name: "Unavailable label" }),
+      ).toHaveValue("missing");
+      expect(screen.getByRole("combobox", { name: "Unit" })).toHaveValue(
+        "missing",
+      );
+    });
+
+    test("limits explicit multi-selection to 100 labels", () => {
+      const options: Array<DashboardVariableOption> = Array.from(
+        { length: 101 },
+        (_unused: unknown, index: number) => {
+          return {
+            label: `Unit ${index}`,
+            value: `label-${index}`,
+          };
+        },
+      );
+      renderSelector(
+        isPublic,
+        labelVariable({
+          isMultiSelect: true,
+          labelOptions: options,
+          selectedValues: options
+            .slice(0, 100)
+            .map((option: DashboardVariableOption) => {
+              return option.value;
+            }),
+        }),
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Unit:/ }));
+      expect(screen.getByRole("checkbox", { name: "Unit 100" })).toBeDisabled();
+      expect(
+        screen.getByRole("checkbox", { name: "Unit 0" }),
+      ).not.toBeDisabled();
+      expect(screen.getByText("Choose up to 100 labels.")).toBeInTheDocument();
+    });
+  },
+);
+
+function renderEditor(
+  variable: DashboardVariable,
+): Array<Array<DashboardVariable>> {
+  const saved: Array<Array<DashboardVariable>> = [];
+  render(
+    <DashboardVariablesModal
+      variables={[variable]}
+      telemetryAttributeOptions={["host.name"]}
+      onSave={(values: Array<DashboardVariable>) => {
+        saved.push(values);
+      }}
+      onClose={() => {}}
+    />,
+  );
+  return saved;
+}
+
+function chooseDropdown(name: string, option: string): void {
+  fireEvent.keyDown(screen.getByRole("combobox", { name }), {
+    key: "ArrowDown",
+  });
+  fireEvent.click(screen.getByRole("option", { name: option }));
+}
+
+describe("Project Labels variable authoring", () => {
+  test("switching sources clears incompatible settings and preserves the variable ID", () => {
+    const saved: Array<Array<DashboardVariable>> = renderEditor(
+      labelVariable({
+        type: DashboardVariableType.CustomList,
+        customListValues: "0660, 0661",
+        isMultiSelect: true,
+        selectedValues: ["0660"],
+      }),
+    );
+    chooseDropdown("Variable source", "Text Input");
+    fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+    expect(saved[0]?.[0]).toMatchObject({
+      id: "unit",
+      type: DashboardVariableType.TextInput,
+      isMultiSelect: false,
+    });
+    expect(saved[0]?.[0]).not.toHaveProperty("selectedValue");
+    expect(saved[0]?.[0]).not.toHaveProperty("selectedValues");
+    expect(saved[0]?.[0]?.customListValues).toBeUndefined();
+    expect(saved[0]?.[0]?.labelOptions).toBeUndefined();
+    expect(getListMock).not.toHaveBeenCalled();
+  });
+
+  test("clears a default and selection when its label is removed from the allowlist", async () => {
+    const saved: Array<Array<DashboardVariable>> = renderEditor(
+      labelVariable({ defaultValue: SECOND, selectedValue: SECOND }),
+    );
+    await screen.findByRole("combobox", { name: "Allowed project labels" });
+    fireEvent.keyDown(
+      screen.getByRole("combobox", { name: "Allowed project labels" }),
+      { key: "Backspace", keyCode: 8 },
+    );
+    expect(screen.getByRole("combobox", { name: "Default label" })).toHaveValue(
+      "",
+    );
+    fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+    expect(saved[0]?.[0]).toMatchObject({
+      labelOptions: [OPTIONS[0]],
+      defaultValue: "",
+    });
+    expect(saved[0]?.[0]).not.toHaveProperty("selectedValue");
+    expect(saved[0]?.[0]).not.toHaveProperty("selectedValues");
+  });
+
+  test("shows an invalid saved default and requires an explicit valid choice", async () => {
+    renderEditor(labelVariable({ defaultValue: "missing" }));
+    await screen.findByRole("combobox", { name: "Allowed project labels" });
+    const select: HTMLElement = screen.getByRole("combobox", {
+      name: "Default label",
+    });
+    expect(select).toHaveValue("missing");
+    expect(screen.getByTestId("modal-footer-submit-button")).toBeDisabled();
+    fireEvent.change(select, { target: { value: "" } });
+    expect(screen.getByTestId("modal-footer-submit-button")).not.toBeDisabled();
+  });
+
+  test("creates an explicit allowlist and saves display labels separately from IDs", async () => {
+    const saved: Array<Array<DashboardVariable>> = renderEditor(
+      labelVariable({
+        type: DashboardVariableType.TelemetryAttribute,
+        labelOptions: undefined,
+      }),
+    );
+    expect(getListMock).not.toHaveBeenCalled();
+    chooseDropdown("Variable source", "Project Labels");
+    expect(screen.getByTestId("modal-footer-submit-button")).toBeDisabled();
+    await screen.findByRole("combobox", { name: "Allowed project labels" });
+    chooseDropdown("Allowed project labels", "0660");
+    fireEvent.change(screen.getByRole("combobox", { name: "Default label" }), {
+      target: { value: FIRST },
+    });
+    fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+    expect(saved[0]?.[0]).toMatchObject({
+      id: "unit",
+      type: DashboardVariableType.ProjectLabel,
+      labelOptions: [OPTIONS[0]],
+      defaultValue: FIRST,
+    });
+    expect(getListMock.mock.calls[0]?.[0]).toMatchObject({
+      query: { projectId: "44444444-4444-4444-8444-444444444444" },
+      select: { _id: true, name: true },
+      limit: 1000,
+    });
+  });
+
+  test("keeps a saved label snapshot when no currently available project label has its ID", async () => {
+    getListMock.mockResolvedValue({ data: [], count: 0, skip: 0, limit: 1000 });
+    const saved: Array<Array<DashboardVariable>> = renderEditor(
+      labelVariable({ defaultValue: FIRST }),
+    );
+    await screen.findByRole("combobox", { name: "Allowed project labels" });
+    fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+    expect(saved[0]?.[0]?.labelOptions).toEqual(OPTIONS);
+    expect(saved[0]?.[0]?.defaultValue).toBe(FIRST);
+  });
+
+  test.each([false, true])(
+    "a newly configured default applies after a clean reload (public=%s)",
+    async (isPublic: boolean) => {
+      const saved: Array<Array<DashboardVariable>> = renderEditor(
+        labelVariable({
+          type: DashboardVariableType.TelemetryAttribute,
+          labelOptions: undefined,
+        }),
+      );
+      chooseDropdown("Variable source", "Project Labels");
+      await screen.findByRole("combobox", { name: "Allowed project labels" });
+      chooseDropdown("Allowed project labels", "0660");
+      fireEvent.change(
+        screen.getByRole("combobox", { name: "Default label" }),
+        {
+          target: { value: FIRST },
+        },
+      );
+      fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+      expect(saved[0]?.[0]).not.toHaveProperty("selectedValue");
+      expect(saved[0]?.[0]).not.toHaveProperty("selectedValues");
+
+      // Reload the JSON definition without any viewer-specific URL selection.
+      const stored: Array<DashboardVariable> = JSON.parse(
+        JSON.stringify(saved[0]),
+      );
+      const [restored]: Array<DashboardVariable> =
+        DashboardVariableUrlState.applyUrlToVariables(
+          stored,
+          DashboardVariableUrlState.parseFromSearch(""),
+        );
+      cleanup();
+      renderSelector(isPublic, restored!);
+      expect(screen.getByRole("combobox", { name: "Unit" })).toHaveValue(FIRST);
+      expect(DashboardVariableInterpolation.resolveValue(restored!)).toEqual({
+        scalar: FIRST,
+      });
+    },
+  );
+
+  test.each([false, true])(
+    "saving definition edits does not publish runtime selections (multi=%s)",
+    async (isMultiSelect: boolean) => {
+      const original: DashboardVariable = labelVariable({
+        isMultiSelect,
+        defaultValue: FIRST,
+        selectedValue: SECOND,
+        selectedValues: [SECOND],
+      });
+      const saved: Array<Array<DashboardVariable>> = renderEditor(original);
+      await screen.findByRole("combobox", { name: "Allowed project labels" });
+      fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+      expect(saved[0]?.[0]).not.toHaveProperty("selectedValue");
+      expect(saved[0]?.[0]).not.toHaveProperty("selectedValues");
+      expect(original.selectedValue).toBe(SECOND);
+      expect(original.selectedValues).toEqual([SECOND]);
+
+      const stored: Array<DashboardVariable> = JSON.parse(
+        JSON.stringify(saved[0]),
+      );
+      expect(DashboardVariableInterpolation.resolveValue(stored[0]!)).toEqual(
+        isMultiSelect ? undefined : { scalar: FIRST },
+      );
+    },
+  );
+
+  test("loads additional project label pages so choices beyond the first page are available", async () => {
+    getListMock.mockResolvedValueOnce({
+      data: [{ _id: FIRST, name: "0660" }],
+      count: 2,
+      skip: 0,
+      limit: 1000,
+    });
+    getListMock.mockResolvedValueOnce({
+      data: [{ _id: SECOND, name: "0661" }],
+      count: 2,
+      skip: 1,
+      limit: 1000,
+    });
+    renderEditor(labelVariable({ labelOptions: [] }));
+    await screen.findByRole("combobox", { name: "Allowed project labels" });
+    chooseDropdown("Allowed project labels", "0661");
+    expect(getListMock).toHaveBeenCalledTimes(2);
+    expect(getListMock.mock.calls[1]?.[0]).toMatchObject({ skip: 1 });
+    expect(screen.getByRole("option", { name: "0661" })).toHaveValue(SECOND);
+  });
+
+  test("reports a labels loading failure and prevents saving an empty allowlist", async () => {
+    getListMock.mockRejectedValue(new Error("Labels could not be loaded"));
+    const saved: Array<Array<DashboardVariable>> = renderEditor(
+      labelVariable({ labelOptions: [] }),
+    );
+    await waitFor(() => {
+      return expect(screen.queryByText("Loading project labels…")).toBeNull();
+    });
+    expect(
+      screen.getByText("Choose between 1 and 1,000 allowed labels."),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("modal-footer-submit-button")).toBeDisabled();
+    expect(saved).toEqual([]);
+  });
+
+  test("disables a single default for multi-select label variables", async () => {
+    renderEditor(labelVariable({ isMultiSelect: true, defaultValue: FIRST }));
+    await screen.findByRole("combobox", { name: "Allowed project labels" });
+    expect(
+      screen.getByRole("combobox", { name: "Default label" }),
+    ).toBeDisabled();
+  });
+
+  test("preserves legacy custom-list source and values when saving unrelated edits", () => {
+    const saved: Array<Array<DashboardVariable>> = renderEditor(
+      labelVariable({
+        type: DashboardVariableType.CustomList,
+        labelOptions: undefined,
+        customListValues: "0660, 0661",
+        defaultValue: "0660",
+      }),
+    );
+    fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+    expect(saved[0]?.[0]).toMatchObject({
+      type: DashboardVariableType.CustomList,
+      customListValues: "0660, 0661",
+      defaultValue: "0660",
+    });
+    expect(getListMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("Monitor List variable binding editor", () => {
+  test("offers only label variables and persists their stable IDs across renames", () => {
+    const changes: Array<string> = [];
+    const { rerender } = render(
+      <ProjectLabelVariableDropdown
+        variables={[
+          labelVariable(),
+          labelVariable({
+            id: "telemetry",
+            name: "host",
+            type: DashboardVariableType.TelemetryAttribute,
+          }),
+        ]}
+        onChange={(value: string) => {
+          changes.push(value);
+        }}
+      />,
+    );
+    expect(screen.queryByRole("option", { name: "host" })).toBeNull();
+    fireEvent.change(screen.getByRole("combobox", { name: "Label Variable" }), {
+      target: { value: "unit" },
+    });
+    expect(changes).toEqual(["unit"]);
+    rerender(
+      <ProjectLabelVariableDropdown
+        variables={[labelVariable({ name: "LOCATION" })]}
+        value="unit"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole("combobox")).toHaveValue("unit");
+    expect(
+      screen.getByRole("option", { name: "Unit (LOCATION)" }),
+    ).toBeInTheDocument();
+  });
+
+  test("flags a deleted binding and lets the author explicitly clear it", () => {
+    const changes: Array<string> = [];
+    render(
+      <ProjectLabelVariableDropdown
+        variables={[]}
+        value="missing"
+        onChange={(value: string) => {
+          changes.push(value);
+        }}
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "removed or its source changed",
+    );
+    expect(screen.getByRole("combobox")).toHaveValue("missing");
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "" } });
+    expect(changes).toEqual([""]);
+  });
+
+  test("explains how to create a variable when none exists", () => {
+    render(<ProjectLabelVariableDropdown onChange={() => {}} />);
+    expect(
+      screen.getByText(
+        "Add a Project Labels variable from the dashboard toolbar to use it here.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("registers the binding as a custom control instead of a free-text field", () => {
+    expect(
+      ComponentInputTypeToFormFieldType.getFormFieldTypeByComponentInputType(
+        ComponentInputType.ProjectLabelVariable,
+      ).fieldType,
+    ).toBe(FormFieldSchemaType.CustomComponent);
+  });
+});

--- a/Common/Tests/App/Dashboard/DashboardMonitorLabelVariable.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardMonitorLabelVariable.test.tsx
@@ -1,0 +1,438 @@
+import "@testing-library/jest-dom";
+import React, { act } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import DashboardMonitorListComponentElement, {
+  ComponentProps,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardMonitorListComponent";
+import DashboardVariableSelector from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardVariableSelector";
+import { setPublicDashboardContext } from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/PublicDashboardContext";
+import DashboardMonitorListComponentUtil from "../../../Utils/Dashboard/Components/DashboardMonitorListComponent";
+import DashboardVariable, {
+  DashboardVariableType,
+} from "../../../Types/Dashboard/DashboardVariable";
+import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import IncludesAnyOfGroups from "../../../Types/BaseDatabase/IncludesAnyOfGroups";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { ObjectType } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import TimeRange from "../../../Types/Time/TimeRange";
+import URL from "../../../Types/API/URL";
+import { VariableValueChange } from "../../../UI/Components/Dashboard/DashboardVariableControl";
+
+const listMock: jest.Mock = jest.fn();
+const PROJECT_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const DASHBOARD_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const UNIT_660: string = "06600000-0000-4000-8000-000000000000";
+const UNIT_661: string = "06610000-0000-4000-8000-000000000000";
+const NETWORK: string = "00000000-0000-4000-8000-000000000001";
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<unknown>) => {
+        return listMock(...args);
+      },
+    },
+  };
+});
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: () => {
+        return PROJECT_ID;
+      },
+    },
+  };
+});
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      getFriendlyErrorMessage: (error: Error) => {
+        return error.message;
+      },
+    },
+  };
+});
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/AppLink/AppLink",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: { children: React.ReactNode }) => {
+        return <span>{props.children}</span>;
+      },
+    };
+  },
+);
+jest.mock("../../../../App/FeatureSet/Dashboard/src/Utils/RouteMap", () => {
+  return {
+    __esModule: true,
+    default: {},
+    RouteUtil: {
+      populateRouteParams: () => {
+        return {
+          toString: () => {
+            return "/monitor";
+          },
+        };
+      },
+    },
+  };
+});
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/Utils/Metrics",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        getTelemetryAttributeValues: () => {
+          return Promise.resolve([]);
+        },
+      },
+    };
+  },
+);
+
+function variable(
+  overrides: Partial<DashboardVariable> = {},
+): DashboardVariable {
+  return {
+    id: "unit",
+    name: "UNIT",
+    type: DashboardVariableType.ProjectLabel,
+    labelOptions: [
+      { label: "0660", value: UNIT_660 },
+      { label: "0661", value: UNIT_661 },
+    ],
+    ...overrides,
+  };
+}
+
+const dashboardViewConfig: DashboardViewConfig = {
+  _type: ObjectType.DashboardViewConfig,
+  components: [],
+  heightInDashboardUnits: 12,
+};
+
+function props(overrides: Partial<ComponentProps> = {}): ComponentProps {
+  const component: ComponentProps["component"] =
+    DashboardMonitorListComponentUtil.getDefaultComponent();
+  component.arguments = {
+    title: "{{UNIT}} NETWORK",
+    labelVariableId: "unit",
+    maxRows: 25,
+  };
+  return {
+    component,
+    componentId: component.componentId,
+    key: "monitors",
+    isEditMode: false,
+    isSelected: false,
+    onComponentUpdate: () => {},
+    totalCurrentDashboardWidthInPx: 1200,
+    dashboardCanvasTopInPx: 0,
+    dashboardCanvasLeftInPx: 0,
+    dashboardCanvasWidthInPx: 1200,
+    dashboardCanvasHeightInPx: 800,
+    dashboardComponentHeightInPx: 320,
+    dashboardComponentWidthInPx: 480,
+    dashboardViewConfig,
+    dashboardStartAndEndDate: { range: TimeRange.PAST_ONE_HOUR },
+    metricTypes: [],
+    refreshTick: 0,
+    variables: [variable()],
+    ...overrides,
+  };
+}
+
+function response(name: string): {
+  data: Array<Record<string, unknown>>;
+  count: number;
+} {
+  return {
+    data: [
+      {
+        _id: UNIT_660,
+        name,
+        monitorType: "Manual",
+        currentMonitorStatus: { name: "Operational" },
+      },
+    ],
+    count: 1,
+  };
+}
+
+beforeEach(() => {
+  listMock.mockReset();
+  listMock.mockResolvedValue(response("All unit monitors"));
+  setPublicDashboardContext(null);
+});
+afterEach(() => {
+  cleanup();
+  setPublicDashboardContext(null);
+});
+
+describe("MonitorList project label variables", () => {
+  test("changing the real UNIT selector changes the query, rows and title without a refresh tick", async () => {
+    const initial: ComponentProps = props();
+    function Dashboard(): React.ReactElement {
+      const [variables, setVariables] = React.useState<
+        Array<DashboardVariable>
+      >([variable()]);
+      return (
+        <>
+          <DashboardVariableSelector
+            variables={variables}
+            onVariableValueChange={(
+              _id: string,
+              change: VariableValueChange,
+            ) => {
+              return setVariables([
+                { ...(variables[0] as DashboardVariable), ...change },
+              ]);
+            }}
+          />
+          <DashboardMonitorListComponentElement
+            {...initial}
+            variables={variables}
+          />
+        </>
+      );
+    }
+    render(<Dashboard />);
+    expect(await screen.findByText("All unit monitors")).toBeInTheDocument();
+    expect(screen.getByText("All NETWORK")).toBeInTheDocument();
+
+    listMock.mockResolvedValue(response("0660 router"));
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: UNIT_660 },
+    });
+    expect(await screen.findByText("0660 router")).toBeInTheDocument();
+    expect(screen.queryByText("All unit monitors")).not.toBeInTheDocument();
+    expect(screen.getByText("0660 NETWORK")).toBeInTheDocument();
+    expect(listMock.mock.calls[1][0].query.labels).toEqual(
+      new Includes([UNIT_660]),
+    );
+
+    listMock.mockResolvedValue(response("0661 switch"));
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: UNIT_661 },
+    });
+    expect(await screen.findByText("0661 switch")).toBeInTheDocument();
+    expect(screen.queryByText("0660 router")).not.toBeInTheDocument();
+    expect(listMock.mock.calls[2][0].query.labels).toEqual(
+      new Includes([UNIT_661]),
+    );
+
+    listMock.mockResolvedValue(response("All unit monitors"));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "" } });
+    expect(await screen.findByText("All unit monitors")).toBeInTheDocument();
+    expect(listMock.mock.calls[3][0].query.labels).toBeUndefined();
+  });
+
+  test("retains project, fixed labels, status, monitor type and row limit", async () => {
+    const input: ComponentProps = props({
+      variables: [variable({ selectedValue: UNIT_660 })],
+    });
+    input.component.arguments = {
+      ...input.component.arguments,
+      labelIds: [NETWORK],
+      statusFilter: "operational",
+      monitorStatusIds: [NETWORK],
+      monitorTypes: ["Manual"],
+      maxRows: 7,
+    };
+    render(<DashboardMonitorListComponentElement {...input} />);
+    await waitFor(() => {
+      return expect(listMock).toHaveBeenCalledTimes(1);
+    });
+    expect(listMock.mock.calls[0][0]).toMatchObject({
+      query: {
+        projectId: PROJECT_ID,
+        labels: new IncludesAnyOfGroups([[NETWORK], [UNIT_660]]),
+        currentMonitorStatus: { isOperationalState: true },
+        currentMonitorStatusId: new Includes([NETWORK]),
+        monitorType: new Includes(["Manual"]),
+      },
+      limit: 7,
+      skip: 0,
+      sort: { name: SortOrder.Ascending },
+    });
+    expect(await screen.findByText("0660 NETWORK")).toBeInTheDocument();
+  });
+
+  test("All retains fixed labels even when a default is configured", async () => {
+    const input: ComponentProps = props({
+      variables: [variable({ selectedValue: "", defaultValue: UNIT_660 })],
+    });
+    input.component.arguments.labelIds = [NETWORK];
+    render(<DashboardMonitorListComponentElement {...input} />);
+    await screen.findByText("All NETWORK");
+    expect(listMock.mock.calls[0][0].query.labels).toEqual(
+      new Includes([NETWORK]),
+    );
+  });
+
+  test("a deleted label returns the ordinary empty state", async () => {
+    listMock.mockResolvedValue({ data: [], count: 0 });
+    render(
+      <DashboardMonitorListComponentElement
+        {...props({ variables: [variable({ selectedValue: UNIT_660 })] })}
+      />,
+    );
+    expect(await screen.findByText("No monitors found")).toBeInTheDocument();
+    expect(listMock.mock.calls[0][0].query.labels).toEqual(
+      new Includes([UNIT_660]),
+    );
+  });
+
+  test("a removed binding produces a configuration error without fetching all monitors", async () => {
+    render(
+      <DashboardMonitorListComponentElement {...props({ variables: [] })} />,
+    );
+    expect(
+      await screen.findByText(/label variable is missing/),
+    ).toBeInTheDocument();
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  test("a selection absent from published options is an error", async () => {
+    render(
+      <DashboardMonitorListComponentElement
+        {...props({ variables: [variable({ selectedValue: NETWORK })] })}
+      />,
+    );
+    expect(
+      await screen.findByText(/offered by this dashboard variable/),
+    ).toBeInTheDocument();
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  test("late responses for the previous unit cannot replace the latest results", async () => {
+    let resolvePrevious: (
+      result: ReturnType<typeof response>,
+    ) => void = () => {};
+    listMock.mockImplementationOnce(() => {
+      return new Promise<ReturnType<typeof response>>(
+        (
+          resolve: (
+            result:
+              | ReturnType<typeof response>
+              | PromiseLike<ReturnType<typeof response>>,
+          ) => void,
+        ) => {
+          resolvePrevious = resolve;
+        },
+      );
+    });
+    const initial: ComponentProps = props({
+      variables: [variable({ selectedValue: UNIT_660 })],
+    });
+    const view: ReturnType<typeof render> = render(
+      <DashboardMonitorListComponentElement {...initial} />,
+    );
+    await waitFor(() => {
+      return expect(listMock).toHaveBeenCalledTimes(1);
+    });
+    listMock.mockResolvedValue(response("0661 switch"));
+    view.rerender(
+      <DashboardMonitorListComponentElement
+        {...initial}
+        variables={[variable({ selectedValue: UNIT_661 })]}
+      />,
+    );
+    expect(await screen.findByText("0661 switch")).toBeInTheDocument();
+    await act(async () => {
+      resolvePrevious(response("0660 router"));
+    });
+    expect(screen.queryByText("0660 router")).not.toBeInTheDocument();
+    expect(screen.getByText("0661 switch")).toBeInTheDocument();
+    expect(screen.getByText("0661 NETWORK")).toBeInTheDocument();
+  });
+
+  test("late errors for a previous selection do not hide the latest rows", async () => {
+    let rejectPrevious: (error: Error) => void = () => {};
+    listMock.mockImplementationOnce(() => {
+      return new Promise<ReturnType<typeof response>>(
+        (
+          _resolve: (
+            result:
+              | ReturnType<typeof response>
+              | PromiseLike<ReturnType<typeof response>>,
+          ) => void,
+          reject: (error?: unknown) => void,
+        ) => {
+          rejectPrevious = reject;
+        },
+      );
+    });
+    const initial: ComponentProps = props({
+      variables: [variable({ selectedValue: UNIT_660 })],
+    });
+    const view: ReturnType<typeof render> = render(
+      <DashboardMonitorListComponentElement {...initial} />,
+    );
+    await waitFor(() => {
+      return expect(listMock).toHaveBeenCalledTimes(1);
+    });
+    listMock.mockResolvedValue(response("0661 switch"));
+    view.rerender(
+      <DashboardMonitorListComponentElement
+        {...initial}
+        variables={[variable({ selectedValue: UNIT_661 })]}
+      />,
+    );
+    await screen.findByText("0661 switch");
+    await act(async () => {
+      rejectPrevious(new Error("Old request failed"));
+    });
+    expect(screen.queryByText("Old request failed")).not.toBeInTheDocument();
+    expect(screen.getByText("0661 switch")).toBeInTheDocument();
+  });
+
+  test("public requests send component identity and selection IDs to the dashboard endpoint", async () => {
+    setPublicDashboardContext({
+      dashboardId: DASHBOARD_ID,
+      apiUrl: URL.fromString("https://dev.oneuptime.com/public-dashboard-api"),
+      postJSON: async () => {
+        throw new Error("Unexpected public request");
+      },
+    });
+    const input: ComponentProps = props({
+      variables: [
+        variable({ isMultiSelect: true, selectedValues: [UNIT_660, UNIT_661] }),
+      ],
+    });
+    render(<DashboardMonitorListComponentElement {...input} />);
+    await screen.findByText("0660, 0661 NETWORK");
+    const options: Record<string, any> =
+      listMock.mock.calls[0][0].requestOptions;
+    expect(options["overrideRequestUrl"].toString()).toContain(
+      `/resource-list/${DASHBOARD_ID.toString()}/monitor`,
+    );
+    expect(options["additionalRequestBody"]).toEqual({
+      componentId: input.componentId.toString(),
+      variables: [
+        {
+          id: "unit",
+          selectedValue: null,
+          selectedValues: [UNIT_660, UNIT_661],
+        },
+      ],
+    });
+  });
+});

--- a/Common/Tests/App/Dashboard/DashboardVariableAllContract.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardVariableAllContract.test.tsx
@@ -439,8 +439,11 @@ describe("dashboard variable All contract", () => {
         React.createElement(PublicDashboardVariableSelector, {
           variables: [variable],
           dashboardId: new ObjectID("11111111-1111-4111-8111-111111111111"),
-          onVariableValueChange: (_id: string, value: string): void => {
-            values.push(value);
+          onVariableValueChange: (
+            _id: string,
+            change: VariableValueChange,
+          ): void => {
+            values.push(change.selectedValue || "");
           },
         }),
       );

--- a/Common/Tests/App/PublicDashboard/DashboardVariableSelector.test.tsx
+++ b/Common/Tests/App/PublicDashboard/DashboardVariableSelector.test.tsx
@@ -55,6 +55,7 @@ import DashboardVariable, {
 import DashboardVariableInterpolation, {
   ResolvedVariableValue,
 } from "../../../Utils/Dashboard/VariableInterpolation";
+import { VariableValueChange } from "../../../UI/Components/Dashboard/DashboardVariableControl";
 import ObjectID from "../../../Types/ObjectID";
 
 const DASHBOARD_ID: ObjectID = new ObjectID(
@@ -127,11 +128,19 @@ const ViewerHarness: React.FunctionComponent<HarnessProps> = (
     <DashboardVariableSelector
       variables={variables}
       dashboardId={DASHBOARD_ID}
-      onVariableValueChange={(variableId: string, value: string) => {
+      onVariableValueChange={(
+        variableId: string,
+        change: VariableValueChange,
+      ) => {
+        const value: string = change.selectedValue || "";
         const updated: Array<DashboardVariable> = variables.map(
           (v: DashboardVariable): DashboardVariable => {
             if (v.id === variableId) {
-              return { ...v, selectedValue: value };
+              return {
+                ...v,
+                selectedValue: change.selectedValue,
+                selectedValues: change.selectedValues,
+              };
             }
             return v;
           },
@@ -436,8 +445,8 @@ describe("Public dashboard variable selector", () => {
     test("each is labelled with its variable name", () => {
       renderViewer([customListVariable({}), textVariable({})]);
 
-      expect(screen.getByText("region:")).toBeInTheDocument();
-      expect(screen.getByText("service:")).toBeInTheDocument();
+      expect(screen.getByText("region")).toBeInTheDocument();
+      expect(screen.getByText("service")).toBeInTheDocument();
     });
 
     test('picking "All" on one leaves the others on their defaults', async () => {

--- a/Common/Tests/Server/API/DashboardPublicResourceListAPI.test.ts
+++ b/Common/Tests/Server/API/DashboardPublicResourceListAPI.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../../../Server/Utils/Express";
 import InBetween from "../../../Types/BaseDatabase/InBetween";
 import Includes from "../../../Types/BaseDatabase/Includes";
+import IncludesAnyOfGroups from "../../../Types/BaseDatabase/IncludesAnyOfGroups";
 import SortOrder from "../../../Types/BaseDatabase/SortOrder";
 import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
 import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
@@ -878,6 +879,134 @@ describe("DashboardAPI public resource-list", () => {
         "query"
       ] as JSONObject;
       expect(query["kind"]).toBe("Pod");
+    });
+
+    describe("published monitor label variable selections", () => {
+      const firstLabelId: string = ObjectID.generate().toString();
+      const secondLabelId: string = ObjectID.generate().toString();
+      const fixedLabelId: string = ObjectID.generate().toString();
+      const labelVariable: JSONObject = {
+        id: "unit",
+        name: "UNIT",
+        type: DashboardVariableType.ProjectLabel,
+        labelOptions: [
+          { label: "Payments", value: firstLabelId },
+          { label: "Support", value: secondLabelId },
+        ],
+        defaultValue: firstLabelId,
+      };
+
+      it("applies the chosen label while preserving stored monitor policy and project", async () => {
+        const monitor: BuiltWidget = buildWidget({
+          componentType: DashboardComponentType.MonitorList,
+          argumentsObject: {
+            labelVariableId: "unit",
+            labelIds: [fixedLabelId],
+            statusFilter: "operational",
+            monitorTypes: ["Ping"],
+            maxRows: 6,
+          },
+        });
+        setDashboardWidgets([monitor.widget], [labelVariable]);
+
+        await callRoute({
+          resourceType: "monitor",
+          body: {
+            componentId: monitor.componentId.toString(),
+            variables: [{ id: "unit", selectedValue: secondLabelId }],
+          },
+        });
+
+        expect(nextFunction).not.toHaveBeenCalled();
+        const findBy: JSONObject = getFindByArgs(MonitorService);
+        expect(findBy["query"]).toEqual({
+          projectId,
+          currentMonitorStatus: { isOperationalState: true },
+          monitorType: new Includes(["Ping"]),
+          labels: new IncludesAnyOfGroups([[fixedLabelId], [secondLabelId]]),
+        });
+        expect(findBy["limit"]).toBe(6);
+        expect(findBy["sort"]).toEqual({ name: SortOrder.Ascending });
+        expect(findBy["select"]).toEqual({
+          _id: true,
+          name: true,
+          monitorType: true,
+          currentMonitorStatus: { name: true, color: true },
+        });
+      });
+
+      it("retains fixed labels when the public viewer chooses All", async () => {
+        const monitor: BuiltWidget = buildWidget({
+          componentType: DashboardComponentType.MonitorList,
+          argumentsObject: {
+            labelVariableId: "unit",
+            labelIds: [fixedLabelId],
+          },
+        });
+        setDashboardWidgets([monitor.widget], [labelVariable]);
+
+        await callRoute({
+          resourceType: "monitor",
+          body: {
+            componentId: monitor.componentId.toString(),
+            variables: [{ id: "unit", selectedValue: "" }],
+          },
+        });
+
+        expect(nextFunction).not.toHaveBeenCalled();
+        expect(getFindByArgs(MonitorService)["query"]).toEqual({
+          projectId,
+          labels: new Includes([fixedLabelId]),
+        });
+      });
+
+      it("accepts several published label IDs for a saved multi-select", async () => {
+        const monitor: BuiltWidget = buildWidget({
+          componentType: DashboardComponentType.MonitorList,
+          argumentsObject: { labelVariableId: "unit" },
+        });
+        setDashboardWidgets(
+          [monitor.widget],
+          [{ ...labelVariable, isMultiSelect: true }],
+        );
+
+        await callRoute({
+          resourceType: "monitor",
+          body: {
+            componentId: monitor.componentId.toString(),
+            variables: [
+              { id: "unit", selectedValues: [firstLabelId, secondLabelId] },
+            ],
+          },
+        });
+
+        expect(nextFunction).not.toHaveBeenCalled();
+        expect(getFindByArgs(MonitorService)["query"]).toEqual({
+          projectId,
+          labels: new Includes([firstLabelId, secondLabelId]),
+        });
+      });
+
+      it("reports an invalid selection before reading monitors when a choice was removed", async () => {
+        const monitor: BuiltWidget = buildWidget({
+          componentType: DashboardComponentType.MonitorList,
+          argumentsObject: { labelVariableId: "unit" },
+        });
+        setDashboardWidgets([monitor.widget], [labelVariable]);
+
+        await callRoute({
+          resourceType: "monitor",
+          body: {
+            componentId: monitor.componentId.toString(),
+            variables: [
+              { id: "unit", selectedValue: ObjectID.generate().toString() },
+            ],
+          },
+        });
+
+        expect(getThrownError()).toBeInstanceOf(BadDataException);
+        expectNothingListed();
+      });
     });
 
     it("passes only dynamic time and bounded variable selections into policy", async () => {

--- a/Common/Tests/Server/Types/Database/Permissions/ReadBlockPermission.test.ts
+++ b/Common/Tests/Server/Types/Database/Permissions/ReadBlockPermission.test.ts
@@ -1,20 +1,48 @@
 import ReadPermission from "../../../../../Server/Types/Database/Permissions/ReadPermission";
+import QueryUtil from "../../../../../Server/Types/Database/QueryUtil";
 import Incident from "../../../../../Models/DatabaseModels/Incident";
 import Monitor from "../../../../../Models/DatabaseModels/Monitor";
 import DatabaseCommonInteractionProps from "../../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Includes from "../../../../../Types/BaseDatabase/Includes";
+import IncludesAnyOfGroups from "../../../../../Types/BaseDatabase/IncludesAnyOfGroups";
+import IncludesNone from "../../../../../Types/BaseDatabase/IncludesNone";
+import EqualTo from "../../../../../Types/BaseDatabase/EqualTo";
+import NotEqual from "../../../../../Types/BaseDatabase/NotEqual";
+import Search from "../../../../../Types/BaseDatabase/Search";
+import BadDataException from "../../../../../Types/Exception/BadDataException";
 import NotAuthorizedException from "../../../../../Types/Exception/NotAuthorizedException";
 import ObjectID from "../../../../../Types/ObjectID";
 import Permission, {
   UserPermission,
   UserTenantAccessPermission,
 } from "../../../../../Types/Permission";
-import { FindOperator } from "typeorm";
+import { FindOperator, In } from "typeorm";
 
 describe("ReadPermission.checkReadBlockPermission", () => {
   const projectId: ObjectID = ObjectID.generate();
   const userId: ObjectID = ObjectID.generate();
   const blockedLabelA: ObjectID = ObjectID.generate();
   const blockedLabelB: ObjectID = ObjectID.generate();
+
+  beforeEach(() => {
+    jest
+      .spyOn(QueryUtil, "getManyToManyRelationMetadata")
+      .mockImplementation((modelType: any, column: string) => {
+        if (column !== "labels") {
+          return null;
+        }
+        return {
+          joinTableName:
+            modelType === Monitor ? "MonitorLabel" : "IncidentLabel",
+          ownerColumnName: modelType === Monitor ? "monitorId" : "incidentId",
+          relationColumnName: "labelId",
+        };
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
   function makeProps(
     permissions: Array<UserPermission>,
@@ -59,18 +87,21 @@ describe("ReadPermission.checkReadBlockPermission", () => {
   }
 
   /*
-   * The rewrite has to SUBTRACT the blocked labels, not restrict the read to
-   * them. Asserting only that some FindOperator landed on the column would
-   * pass just as happily if notInOrNull() were swapped for its including
-   * counterpart, so read the rendered SQL back and return the ids it denies.
+   * Read the owner-row exclusion predicate, including the relation table it
+   * uses, so the test checks that label blocks are composed independently of
+   * the caller's relation filters.
    */
-  function deniedLabelIds(operator: any): Array<string> {
+  function deniedLabelIds(
+    operator: any,
+    joinTableName: string = "IncidentLabel",
+  ): Array<string> {
     expect(operator).toBeInstanceOf(FindOperator);
     expect(operator.type).toBe("raw");
 
-    const sql: string = operator.getSql("labelId");
-    expect(sql).toContain("NOT IN");
-    expect(sql).toContain("IS NULL");
+    const sql: string = operator.getSql("ownerId");
+    expect(sql).toContain("ownerId NOT IN (SELECT");
+    expect(sql).toContain(`FROM "${joinTableName}"`);
+    expect(sql).toContain(`WHERE "${joinTableName}"."labelId" IN (`);
 
     return Object.values(
       operator.objectLiteralParameters as Record<string, Array<string>>,
@@ -136,8 +167,8 @@ describe("ReadPermission.checkReadBlockPermission", () => {
       makeProps([blockPermission(Permission.ProjectMember, [blockedLabelA])]),
     );
 
-    expect(result.query.labels).toBeDefined();
-    expect(deniedLabelIds(result.query.labels._id)).toEqual([
+    expect(result.query.labels).toBeUndefined();
+    expect(deniedLabelIds(result.query._id)).toEqual([
       blockedLabelA.toString(),
     ]);
     // The caller's own filters survive the rewrite.
@@ -156,7 +187,7 @@ describe("ReadPermission.checkReadBlockPermission", () => {
       ]),
     );
 
-    expect(deniedLabelIds(result.query.labels._id)).toEqual([
+    expect(deniedLabelIds(result.query._id)).toEqual([
       blockedLabelA.toString(),
       blockedLabelB.toString(),
     ]);
@@ -204,9 +235,225 @@ describe("ReadPermission.checkReadBlockPermission", () => {
       makeProps([blockPermission(Permission.ProjectMember, [blockedLabelA])]),
     );
 
-    expect(result.query.labels).toBeDefined();
-    expect(deniedLabelIds(result.query.labels._id)).toEqual([
+    expect(result.query.labels).toBeUndefined();
+    expect(deniedLabelIds(result.query._id, "MonitorLabel")).toEqual([
       blockedLabelA.toString(),
     ]);
+  });
+
+  it("preserves an existing label selection while adding the block condition", async () => {
+    const labels: Includes = new Includes([ObjectID.generate().toString()]);
+    const query: any = { projectId, labels };
+
+    const result: any = await ReadPermission.checkReadBlockPermission(
+      Monitor,
+      query,
+      makeProps([blockPermission(Permission.ProjectMember, [blockedLabelA])]),
+    );
+
+    expect(result.query.labels).toBe(labels);
+    expect(result.query.projectId).toBe(projectId);
+    expect(deniedLabelIds(result.query._id, "MonitorLabel")).toEqual([
+      blockedLabelA.toString(),
+    ]);
+  });
+
+  it("preserves grouped dashboard labels, project, status, and the selected record through query serialization", async () => {
+    const monitorId: ObjectID = ObjectID.generate();
+    const fixedLabelId: string = ObjectID.generate().toString();
+    const selectedLabelId: string = ObjectID.generate().toString();
+    const labels: IncludesAnyOfGroups = new IncludesAnyOfGroups([
+      [fixedLabelId],
+      [selectedLabelId],
+    ]);
+    const currentMonitorStatusId: ObjectID = ObjectID.generate();
+    const query: any = {
+      projectId,
+      _id: monitorId,
+      labels,
+      currentMonitorStatusId,
+    };
+
+    const result: any = await ReadPermission.checkReadBlockPermission(
+      Monitor,
+      query,
+      makeProps([blockPermission(Permission.ProjectMember, [blockedLabelA])]),
+    );
+
+    expect(result.query.labels).toBe(labels);
+    expect(result.query.projectId).toBe(projectId);
+    expect(result.query.currentMonitorStatusId).toBe(currentMonitorStatusId);
+    expect(result.query._id.type).toBe("and");
+    expect(result.query._id.value[0].type).toBe("raw");
+    expect(
+      Object.values(result.query._id.value[0].objectLiteralParameters),
+    ).toEqual([monitorId.toString()]);
+    expect(deniedLabelIds(result.query._id.value[1], "MonitorLabel")).toEqual([
+      blockedLabelA.toString(),
+    ]);
+
+    const recordAndBlockCondition: FindOperator<any> = result.query._id;
+    const serialized: any = QueryUtil.serializeQuery(Monitor, result.query);
+    expect(serialized.labels).toBeUndefined();
+    expect(serialized._id.type).toBe("and");
+    const clauses: Array<FindOperator<any>> = serialized._id.value;
+    expect(clauses).toHaveLength(3);
+    expect(clauses[0]).toBe(recordAndBlockCondition);
+    expect(Object.values(clauses[1]!.objectLiteralParameters || {})).toEqual([
+      [fixedLabelId],
+    ]);
+    expect(Object.values(clauses[2]!.objectLiteralParameters || {})).toEqual([
+      [selectedLabelId],
+    ]);
+    expect(Object.values(serialized.projectId.objectLiteralParameters)).toEqual(
+      [projectId.toString()],
+    );
+    expect(
+      Object.values(serialized.currentMonitorStatusId.objectLiteralParameters),
+    ).toEqual([currentMonitorStatusId.toString()]);
+  });
+
+  it("combines with an existing database ID condition without replacing it", async () => {
+    const idFilter: FindOperator<string> = In([ObjectID.generate().toString()]);
+    const query: any = { projectId, _id: idFilter };
+
+    const result: any = await ReadPermission.checkReadBlockPermission(
+      Incident,
+      query,
+      makeProps([blockPermission(Permission.ProjectMember, [blockedLabelA])]),
+    );
+
+    expect(result.query._id.type).toBe("and");
+    expect(result.query._id.value[0]).toBe(idFilter);
+    expect(deniedLabelIds(result.query._id.value[1])).toEqual([
+      blockedLabelA.toString(),
+    ]);
+  });
+
+  const requestedId: string = ObjectID.generate().toString();
+
+  it.each([
+    {
+      name: "EqualTo",
+      idFilter: new EqualTo(requestedId),
+      expectedSql: "Monitor._id = :",
+      expectedParameters: [requestedId],
+    },
+    {
+      name: "IncludesNone",
+      idFilter: new IncludesNone([new ObjectID(requestedId)]),
+      expectedSql: "Monitor._id NOT IN (",
+      expectedParameters: [[requestedId]],
+    },
+    {
+      name: "NotEqual",
+      idFilter: new NotEqual(requestedId),
+      expectedSql: "Monitor._id != :",
+      expectedParameters: [requestedId],
+    },
+    {
+      name: "Search",
+      idFilter: new Search(requestedId),
+      expectedSql: "CAST(Monitor._id AS TEXT) ILIKE",
+      expectedParameters: [`%${requestedId}%`],
+    },
+    {
+      name: "Includes",
+      idFilter: new Includes([requestedId]),
+      expectedSql: "Monitor._id IN (",
+      expectedParameters: [[requestedId]],
+    },
+  ])(
+    "preserves the $name ID filter when composing read label restrictions",
+    async ({
+      idFilter,
+      expectedSql,
+      expectedParameters,
+    }: {
+      idFilter: unknown;
+      expectedSql: string;
+      expectedParameters: Array<unknown>;
+    }): Promise<void> => {
+      const labels: IncludesAnyOfGroups = new IncludesAnyOfGroups([
+        [ObjectID.generate().toString()],
+        [ObjectID.generate().toString()],
+      ]);
+      const query: any = { projectId, _id: idFilter, labels };
+
+      const result: any = await ReadPermission.checkReadBlockPermission(
+        Monitor,
+        query,
+        makeProps([blockPermission(Permission.ProjectMember, [blockedLabelA])]),
+      );
+
+      expect(result.query.labels).toBe(labels);
+      expect(result.query._id.type).toBe("and");
+      const callerCondition: FindOperator<unknown> = result.query._id.value[0];
+      expect(callerCondition.type).toBe("raw");
+      expect(callerCondition.getSql?.("Monitor._id")).toContain(expectedSql);
+      expect(
+        Object.values(callerCondition.objectLiteralParameters || {}),
+      ).toEqual(expectedParameters);
+      expect(deniedLabelIds(result.query._id.value[1], "MonitorLabel")).toEqual(
+        [blockedLabelA.toString()],
+      );
+
+      const recordAndBlockCondition: FindOperator<unknown> = result.query._id;
+      const serialized: any = QueryUtil.serializeQuery(Monitor, result.query);
+      expect(serialized._id.value[0]).toBe(recordAndBlockCondition);
+      expect(serialized._id.value).toHaveLength(3);
+    },
+  );
+
+  it("rejects an unsupported ID condition before changing the caller's query", async () => {
+    const idFilter: Record<string, unknown> = { comparison: "unsupported" };
+    const labels: Includes = new Includes([ObjectID.generate().toString()]);
+    const query: any = { projectId, _id: idFilter, labels };
+
+    await expect(
+      ReadPermission.checkReadBlockPermission(
+        Monitor,
+        query,
+        makeProps([blockPermission(Permission.ProjectMember, [blockedLabelA])]),
+      ),
+    ).rejects.toThrow("unsupported ID filter");
+    expect(query).toEqual({ projectId, _id: idFilter, labels });
+  });
+
+  it("reports missing relation metadata without changing the caller's filters", async () => {
+    jest
+      .spyOn(QueryUtil, "getManyToManyRelationMetadata")
+      .mockReturnValue(null);
+    const labels: IncludesAnyOfGroups = new IncludesAnyOfGroups([
+      [ObjectID.generate().toString()],
+      [ObjectID.generate().toString()],
+    ]);
+    const monitorId: ObjectID = ObjectID.generate();
+    const query: any = { projectId, labels, _id: monitorId };
+
+    await expect(
+      ReadPermission.checkReadBlockPermission(
+        Monitor,
+        query,
+        makeProps([blockPermission(Permission.ProjectMember, [blockedLabelA])]),
+      ),
+    ).rejects.toThrow(BadDataException);
+    expect(query).toEqual({ projectId, labels, _id: monitorId });
+  });
+
+  it("reports an unavailable access-control column before composing label restrictions", async () => {
+    jest
+      .spyOn(Monitor.prototype, "getAccessControlColumn")
+      .mockReturnValue(null);
+    const query: any = { projectId };
+
+    await expect(
+      ReadPermission.checkReadBlockPermission(
+        Monitor,
+        query,
+        makeProps([blockPermission(Permission.ProjectMember, [blockedLabelA])]),
+      ),
+    ).rejects.toThrow("access-control relation metadata");
+    expect(query).toEqual({ projectId });
   });
 });

--- a/Common/Tests/Server/Types/Database/QueryUtilIncludesAnyOfGroups.test.ts
+++ b/Common/Tests/Server/Types/Database/QueryUtilIncludesAnyOfGroups.test.ts
@@ -1,0 +1,169 @@
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import QueryUtil from "../../../../Server/Types/Database/QueryUtil";
+import IncludesAnyOfGroups from "../../../../Types/BaseDatabase/IncludesAnyOfGroups";
+import Includes from "../../../../Types/BaseDatabase/Includes";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import ObjectID from "../../../../Types/ObjectID";
+import { FindOperator, In } from "typeorm";
+
+const relation: {
+  joinTableName: string;
+  ownerColumnName: string;
+  relationColumnName: string;
+} = {
+  joinTableName: "MonitorLabel",
+  ownerColumnName: "monitorId",
+  relationColumnName: "labelId",
+};
+
+describe("QueryUtil — grouped relation membership", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(QueryUtil, "getManyToManyRelationMetadata")
+      .mockReturnValue(relation);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("ANDs independent ANY groups without joining the relation into the row set", () => {
+    const result: Record<string, any> = QueryUtil.serializeQuery(Monitor, {
+      labels: new IncludesAnyOfGroups([
+        ["network", "router"],
+        ["0660", "0661"],
+      ]),
+    });
+    expect(result["labels"]).toBeUndefined();
+    const filter: FindOperator<FindOperator<unknown>[]> = result["_id"];
+    expect(filter.type).toBe("and");
+    expect(filter.value).toHaveLength(2);
+    expect(
+      filter.value.map((child: FindOperator<unknown>) => {
+        return Object.values(child.objectLiteralParameters || {});
+      }),
+    ).toEqual([[["network", "router"]], [["0660", "0661"]]]);
+    for (const child of filter.value) {
+      expect(child.getSql?.("Monitor._id")).toContain(
+        'Monitor._id IN (SELECT "MonitorLabel"."monitorId"',
+      );
+    }
+    const parameterNames: Array<string> = filter.value.flatMap(
+      (child: FindOperator<unknown>) => {
+        return Object.keys(child.objectLiteralParameters || {});
+      },
+    );
+    expect(new Set(parameterNames).size).toBe(2);
+  });
+
+  test("an empty group contributes a false condition", () => {
+    const result: Record<string, any> = QueryUtil.serializeQuery(Monitor, {
+      labels: new IncludesAnyOfGroups([["network"], []]),
+    });
+    expect(result["_id"].value[1].getSql("Monitor._id")).toBe("TRUE = FALSE");
+  });
+
+  test.each(["before", "after"])(
+    "preserves an ObjectID filter placed %s the relation key",
+    (position: string) => {
+      const id: ObjectID = ObjectID.generate();
+      const labels: IncludesAnyOfGroups = new IncludesAnyOfGroups([
+        ["network"],
+        ["0660"],
+      ]);
+      const query: Record<string, unknown> =
+        position === "before" ? { _id: id, labels } : { labels, _id: id };
+      const result: Record<string, any> = QueryUtil.serializeQuery(
+        Monitor,
+        query as any,
+      );
+      expect(result["_id"].type).toBe("and");
+      expect(result["_id"].value).toHaveLength(3);
+      expect(
+        Object.values(result["_id"].value[0].objectLiteralParameters),
+      ).toEqual([id.toString()]);
+    },
+  );
+
+  test.each(["before", "after"])(
+    "preserves an Includes id filter placed %s the relation key",
+    (position: string) => {
+      const ids: Array<string> = [
+        ObjectID.generate().toString(),
+        ObjectID.generate().toString(),
+      ];
+      const labels: IncludesAnyOfGroups = new IncludesAnyOfGroups([
+        ["network"],
+        ["0660"],
+      ]);
+      const query: Record<string, unknown> =
+        position === "before"
+          ? { _id: new Includes(ids), labels }
+          : { labels, _id: new Includes(ids) };
+      const result: Record<string, any> = QueryUtil.serializeQuery(
+        Monitor,
+        query as any,
+      );
+      expect(result["_id"].value[0].type).toBe("raw");
+      expect(
+        Object.values(result["_id"].value[0].objectLiteralParameters),
+      ).toEqual([ids]);
+    },
+  );
+
+  test("preserves existing string and TypeORM id conditions", () => {
+    const id: string = ObjectID.generate().toString();
+    const stringResult: Record<string, any> = QueryUtil.serializeQuery(
+      Monitor,
+      {
+        _id: id,
+        labels: new IncludesAnyOfGroups([["network"], ["0660"]]),
+      },
+    );
+    expect(
+      Object.values(stringResult["_id"].value[0].objectLiteralParameters),
+    ).toEqual([id]);
+    const idFilter: FindOperator<string> = In([id]);
+    const operatorResult: Record<string, any> = QueryUtil.serializeQuery(
+      Monitor,
+      {
+        _id: idFilter as any,
+        labels: new IncludesAnyOfGroups([["network"], ["0660"]]),
+      },
+    );
+    expect(operatorResult["_id"].value[0]).toBe(idFilter);
+  });
+
+  test("retains the project and other widget conditions", () => {
+    const projectId: ObjectID = ObjectID.generate();
+    const result: Record<string, any> = QueryUtil.serializeQuery(Monitor, {
+      projectId,
+      disableActiveMonitoring: false,
+      labels: new IncludesAnyOfGroups([["network"], ["0660"]]),
+    });
+    expect(Object.values(result["projectId"].objectLiteralParameters)).toEqual([
+      projectId.toString(),
+    ]);
+    expect(result["disableActiveMonitoring"]).toBe(false);
+  });
+
+  test.each(["name", "customFields", "project", "missingColumn"])(
+    "rejects the operator on the unsupported %s column",
+    (column: string) => {
+      expect(() => {
+        return QueryUtil.serializeQuery(Monitor, {
+          [column]: new IncludesAnyOfGroups([["network"]]),
+        });
+      }).toThrow(BadDataException);
+    },
+  );
+
+  test("fails clearly when the many-to-many relation cannot be resolved", () => {
+    jest.mocked(QueryUtil.getManyToManyRelationMetadata).mockReturnValue(null);
+    expect(() => {
+      return QueryUtil.serializeQuery(Monitor, {
+        labels: new IncludesAnyOfGroups([["network"], ["0660"]]),
+      });
+    }).toThrow("available many-to-many relation metadata");
+  });
+});

--- a/Common/Tests/Server/Types/Database/QueryUtilIncludesAnyOfGroupsPostgres.test.ts
+++ b/Common/Tests/Server/Types/Database/QueryUtilIncludesAnyOfGroupsPostgres.test.ts
@@ -1,0 +1,297 @@
+import Entities from "../../../../Models/DatabaseModels/Index";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import PostgresAppInstance from "../../../../Server/Infrastructure/PostgresDatabase";
+import Query from "../../../../Server/Types/Database/Query";
+import QueryUtil from "../../../../Server/Types/Database/QueryUtil";
+import Includes from "../../../../Types/BaseDatabase/Includes";
+import IncludesAnyOfGroups from "../../../../Types/BaseDatabase/IncludesAnyOfGroups";
+import { JSONObject } from "../../../../Types/JSON";
+import JSONFunctions from "../../../../Types/JSONFunctions";
+import ObjectID from "../../../../Types/ObjectID";
+import { DataSource, FindOptionsWhere } from "typeorm";
+
+/*
+ * Run with RUN_POSTGRES_DASHBOARD_LABEL_TESTS=true and config.env loaded.
+ * All rows and cloned production tables live in a unique temporary schema.
+ * Uses the local development database on port 5400 unless overridden below.
+ */
+const describePostgres: typeof describe =
+  process.env["RUN_POSTGRES_DASHBOARD_LABEL_TESTS"] === "true"
+    ? describe
+    : describe.skip;
+
+describePostgres("dashboard label groups against Postgres", () => {
+  const schema: string = `dashboard_labels_${ObjectID.generate().toString().replace(/-/g, "")}`;
+  const projectId: string = ObjectID.generate().toString();
+  const otherProjectId: string = ObjectID.generate().toString();
+  const statusId: string = ObjectID.generate().toString();
+  const network: string = ObjectID.generate().toString();
+  const router: string = ObjectID.generate().toString();
+  const unit0660: string = ObjectID.generate().toString();
+  const unit0661: string = ObjectID.generate().toString();
+  const monitorIds: Record<string, string> = {};
+  let database: DataSource;
+
+  beforeAll(async () => {
+    database = new DataSource({
+      type: "postgres",
+      host: process.env["DASHBOARD_LABEL_TEST_DATABASE_HOST"] || "localhost",
+      port: Number(process.env["DASHBOARD_LABEL_TEST_DATABASE_PORT"] || "5400"),
+      username: process.env["DATABASE_USERNAME"] || "postgres",
+      password: process.env["DATABASE_PASSWORD"] || "password",
+      database: process.env["DATABASE_NAME"] || "oneuptimedb",
+      entities: Entities,
+      schema,
+      synchronize: false,
+      extra: { options: `-c search_path=${schema},public` },
+    });
+    await database.initialize();
+    await database.query(`CREATE SCHEMA "${schema}"`);
+    for (const table of ["Monitor", "Label", "MonitorLabel"]) {
+      await database.query(
+        `CREATE TABLE "${schema}"."${table}" (LIKE public."${table}" INCLUDING ALL)`,
+      );
+    }
+    /*
+     * LIKE does not copy foreign keys. Retain the production relation's
+     * cascade behavior so deleting a label exercises the real join lifecycle.
+     */
+    await database.query(
+      `ALTER TABLE "${schema}"."MonitorLabel" ADD FOREIGN KEY ("labelId") REFERENCES "${schema}"."Label" ("_id") ON UPDATE CASCADE ON DELETE CASCADE`,
+    );
+    await database.query(
+      `ALTER TABLE "${schema}"."MonitorLabel" ADD FOREIGN KEY ("monitorId") REFERENCES "${schema}"."Monitor" ("_id") ON UPDATE CASCADE ON DELETE CASCADE`,
+    );
+    expect(
+      (await database.query("SELECT current_schema()"))[0].current_schema,
+    ).toBe(schema);
+    jest.spyOn(PostgresAppInstance, "isConnected").mockReturnValue(true);
+    jest.spyOn(PostgresAppInstance, "getDataSource").mockReturnValue(database);
+
+    for (const [id, name] of [
+      [network, "network"],
+      [router, "router"],
+      [unit0660, "0660"],
+      [unit0661, "0661"],
+    ]) {
+      await database.query(
+        `INSERT INTO "Label" ("_id", "version", "projectId", "name", "slug", "color") VALUES ($1, 1, $2, $3, $3, '#000000')`,
+        [id, projectId, name],
+      );
+    }
+    await seedMonitor("network-0660", [network, unit0660]);
+    await seedMonitor("network-0661", [network, unit0661]);
+    await seedMonitor("router-0661", [router, unit0661]);
+    await seedMonitor("both-units", [network, router, unit0660, unit0661]);
+    await seedMonitor("network-no-unit", [network]);
+    await seedMonitor("unit-only", [unit0660]);
+    await seedMonitor("no-labels", []);
+    await seedMonitor("other-project", [network, unit0660], otherProjectId);
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    if (database?.isInitialized) {
+      await database.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+      await database.destroy();
+    }
+  });
+
+  async function seedMonitor(
+    name: string,
+    labels: Array<string>,
+    monitorProjectId: string = projectId,
+  ): Promise<void> {
+    const id: string = ObjectID.generate().toString();
+    monitorIds[name] = id;
+    await database.query(
+      `INSERT INTO "Monitor" ("_id", "version", "projectId", "name", "slug", "monitorType", "currentMonitorStatusId") VALUES ($1, 1, $2, $3, $3, 'Manual', $4)`,
+      [id, monitorProjectId, name, statusId],
+    );
+    for (const labelId of labels) {
+      await database.query(
+        `INSERT INTO "MonitorLabel" ("monitorId", "labelId") VALUES ($1, $2)`,
+        [id, labelId],
+      );
+    }
+  }
+
+  async function findNames(query: Query<Monitor>): Promise<Array<string>> {
+    const serialized: Query<Monitor> = QueryUtil.serializeQuery(Monitor, {
+      projectId: new ObjectID(projectId),
+      ...query,
+    });
+    const monitors: Array<Monitor> = await database
+      .getRepository(Monitor)
+      .find({
+        select: { _id: true, name: true },
+        where: serialized as unknown as FindOptionsWhere<Monitor>,
+        order: { name: "ASC" },
+      });
+    return monitors.map((monitor: Monitor) => {
+      return monitor.name!;
+    });
+  }
+
+  test("requires a category label and the selected unit on the same monitor", async () => {
+    expect(
+      await findNames({
+        labels: new IncludesAnyOfGroups([[network, router], [unit0660]]),
+      }),
+    ).toEqual(["both-units", "network-0660"]);
+  });
+
+  test("switching the selected unit changes the actual matching rows", async () => {
+    expect(
+      await findNames({
+        labels: new IncludesAnyOfGroups([[network, router], [unit0661]]),
+      }),
+    ).toEqual(["both-units", "network-0661", "router-0661"]);
+  });
+
+  test("matches any selected unit without duplicating monitors carrying both", async () => {
+    expect(
+      await findNames({
+        labels: new IncludesAnyOfGroups([[network], [unit0660, unit0661]]),
+      }),
+    ).toEqual(["both-units", "network-0660", "network-0661"]);
+  });
+
+  test("three independent conditions remain conjunctive", async () => {
+    expect(
+      await findNames({
+        labels: new IncludesAnyOfGroups([
+          [network],
+          [router],
+          [unit0660, unit0661],
+        ]),
+      }),
+    ).toEqual(["both-units"]);
+  });
+
+  test("All can omit just the unit condition while retaining the fixed labels", async () => {
+    expect(
+      await findNames({ labels: new Includes([network, router]) }),
+    ).toEqual([
+      "both-units",
+      "network-0660",
+      "network-0661",
+      "network-no-unit",
+      "router-0661",
+    ]);
+  });
+
+  test("empty and missing-label groups return no monitors", async () => {
+    expect(
+      await findNames({ labels: new IncludesAnyOfGroups([[network], []]) }),
+    ).toEqual([]);
+    expect(
+      await findNames({
+        labels: new IncludesAnyOfGroups([
+          [network],
+          [ObjectID.generate().toString()],
+        ]),
+      }),
+    ).toEqual([]);
+  });
+
+  test.each(["before", "after"])(
+    "retains the explicit monitor id %s labels",
+    async (position: string) => {
+      const id: ObjectID = new ObjectID(monitorIds["network-0660"]!);
+      const labels: IncludesAnyOfGroups = new IncludesAnyOfGroups([
+        [network],
+        [unit0660],
+      ]);
+      expect(
+        await findNames(
+          position === "before" ? { _id: id, labels } : { labels, _id: id },
+        ),
+      ).toEqual(["network-0660"]);
+      expect(
+        await findNames({
+          labels: new IncludesAnyOfGroups([[network], [unit0661]]),
+          _id: id,
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  test("retains other widget filters", async () => {
+    expect(
+      await findNames({
+        currentMonitorStatusId: new ObjectID(ObjectID.generate().toString()),
+        labels: new IncludesAnyOfGroups([[network], [unit0660]]),
+      }),
+    ).toEqual([]);
+  });
+
+  test("API serialization keeps the same database behavior", async () => {
+    const payload: JSONObject = JSON.parse(
+      JSON.stringify(
+        JSONFunctions.serialize({
+          labels: new IncludesAnyOfGroups([[network, router], [unit0661]]),
+        }),
+      ),
+    );
+    expect(
+      await findNames(JSONFunctions.deserialize(payload) as Query<Monitor>),
+    ).toEqual(["both-units", "network-0661", "router-0661"]);
+  });
+
+  test("count and pagination operate on unique monitors", async () => {
+    const where: FindOptionsWhere<Monitor> = QueryUtil.serializeQuery(Monitor, {
+      projectId: new ObjectID(projectId),
+      labels: new IncludesAnyOfGroups([
+        [network, router],
+        [unit0660, unit0661],
+      ]),
+    }) as unknown as FindOptionsWhere<Monitor>;
+    const [rows, count]: [Array<Monitor>, number] = await database
+      .getRepository(Monitor)
+      .findAndCount({
+        where,
+        select: { _id: true, name: true },
+        order: { name: "ASC" },
+        skip: 1,
+        take: 2,
+      });
+    expect(count).toBe(4);
+    expect(
+      rows.map((monitor: Monitor) => {
+        return monitor.name;
+      }),
+    ).toEqual(["network-0660", "network-0661"]);
+  });
+
+  test("a deleted selected label produces no results while retaining the fixed condition", async () => {
+    const deletedLabel: string = ObjectID.generate().toString();
+    await database.query(
+      `INSERT INTO "Label" ("_id", "version", "projectId", "name", "slug", "color") VALUES ($1, 1, $2, 'removed-unit', 'removed-unit', '#000000')`,
+      [deletedLabel, projectId],
+    );
+    await seedMonitor("deleted-label-monitor", [network, deletedLabel]);
+    try {
+      expect(
+        await findNames({
+          labels: new IncludesAnyOfGroups([[network], [deletedLabel]]),
+        }),
+      ).toEqual(["deleted-label-monitor"]);
+      await database.query(`DELETE FROM "Label" WHERE "_id" = $1`, [
+        deletedLabel,
+      ]);
+      expect(
+        await findNames({
+          labels: new IncludesAnyOfGroups([[network], [deletedLabel]]),
+        }),
+      ).toEqual([]);
+    } finally {
+      await database.query(`DELETE FROM "Monitor" WHERE "_id" = $1`, [
+        monitorIds["deleted-label-monitor"],
+      ]);
+      await database.query(`DELETE FROM "Label" WHERE "_id" = $1`, [
+        deletedLabel,
+      ]);
+    }
+  });
+});

--- a/Common/Tests/Server/Utils/Dashboard/PublicDashboardResourceListPolicy.test.ts
+++ b/Common/Tests/Server/Utils/Dashboard/PublicDashboardResourceListPolicy.test.ts
@@ -3,6 +3,7 @@ import PublicDashboardResourceListPolicy, {
 } from "../../../../Server/Utils/Dashboard/PublicDashboardResourceListPolicy";
 import InBetween from "../../../../Types/BaseDatabase/InBetween";
 import Includes from "../../../../Types/BaseDatabase/Includes";
+import IncludesAnyOfGroups from "../../../../Types/BaseDatabase/IncludesAnyOfGroups";
 import Search from "../../../../Types/BaseDatabase/Search";
 import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
 import { LIMIT_PER_PROJECT } from "../../../../Types/Database/LimitMax";
@@ -1035,6 +1036,219 @@ describe("PublicDashboardResourceListPolicy", () => {
           ],
         });
       }).toThrow(BadDataException);
+    });
+  });
+
+  describe("monitor project label variables", () => {
+    const firstLabelId: string = ObjectID.generate().toString();
+    const secondLabelId: string = ObjectID.generate().toString();
+    const fixedLabelId: string = ObjectID.generate().toString();
+    const labelVariable: JSONObject = {
+      id: "unit",
+      name: "UNIT",
+      type: DashboardVariableType.ProjectLabel,
+      labelOptions: [
+        { label: "Payments", value: firstLabelId },
+        { label: "Support", value: secondLabelId },
+      ],
+      defaultValue: firstLabelId,
+    };
+
+    it("filters by the saved variable's default when no selection was sent", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.MonitorList,
+        argumentsObject: { labelVariableId: "unit" },
+        storedVariables: [labelVariable],
+      });
+
+      expect(result.query).toEqual({ labels: new Includes([firstLabelId]) });
+    });
+
+    it("uses the selected label ID while retaining the saved widget filters", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.MonitorList,
+        argumentsObject: {
+          labelVariableId: "unit",
+          statusFilter: "operational",
+          monitorTypes: ["Ping"],
+          monitorStatusIds: ["status"],
+          maxRows: 7,
+        },
+        storedVariables: [labelVariable],
+        requestedVariables: [{ id: "unit", selectedValue: secondLabelId }],
+      });
+
+      expect(result.query).toEqual({
+        labels: new Includes([secondLabelId]),
+        currentMonitorStatus: { isOperationalState: true },
+        monitorType: new Includes(["Ping"]),
+        currentMonitorStatusId: new Includes(["status"]),
+      });
+      expect(result.limit).toBe(7);
+      expect(result.sort).toEqual({ name: SortOrder.Ascending });
+      expect(result.select).toEqual({
+        _id: true,
+        name: true,
+        monitorType: true,
+        currentMonitorStatus: { name: true, color: true },
+      });
+    });
+
+    it("requires both a fixed label group and the selected variable group", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.MonitorList,
+        argumentsObject: {
+          labelVariableId: "unit",
+          labelIds: [fixedLabelId],
+        },
+        storedVariables: [labelVariable],
+        requestedVariables: [{ id: "unit", selectedValue: secondLabelId }],
+      });
+
+      expect(result.query["labels"]).toEqual(
+        new IncludesAnyOfGroups([[fixedLabelId], [secondLabelId]]),
+      );
+    });
+
+    it("lets All clear only the variable filter and preserves fixed labels", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.MonitorList,
+        argumentsObject: {
+          labelVariableId: "unit",
+          labelIds: [fixedLabelId],
+        },
+        storedVariables: [labelVariable],
+        requestedVariables: [{ id: "unit", selectedValue: "" }],
+      });
+
+      expect(result.query["labels"]).toEqual(new Includes([fixedLabelId]));
+    });
+
+    it("leaves the label filter absent when All is selected without fixed labels", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.MonitorList,
+        argumentsObject: { labelVariableId: "unit" },
+        storedVariables: [labelVariable],
+        requestedVariables: [{ id: "unit", selectedValue: "" }],
+      });
+
+      expect(result.query["labels"]).toBeUndefined();
+    });
+
+    it("matches either selected label for a multi-select", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.MonitorList,
+        argumentsObject: { labelVariableId: "unit" },
+        storedVariables: [{ ...labelVariable, isMultiSelect: true }],
+        requestedVariables: [
+          { id: "unit", selectedValues: [firstLabelId, secondLabelId] },
+        ],
+      });
+
+      expect(result.query["labels"]).toEqual(
+        new Includes([firstLabelId, secondLabelId]),
+      );
+    });
+
+    it("treats an empty multi-select as All even when a default or stale scalar exists", () => {
+      for (const requestedVariables of [
+        [],
+        [{ id: "unit", selectedValue: firstLabelId, selectedValues: [] }],
+      ]) {
+        const result: PublicDashboardResourceListPolicyResult = build({
+          componentType: DashboardComponentType.MonitorList,
+          argumentsObject: {
+            labelVariableId: "unit",
+            labelIds: [fixedLabelId],
+          },
+          storedVariables: [{ ...labelVariable, isMultiSelect: true }],
+          requestedVariables,
+        });
+
+        expect(result.query["labels"]).toEqual(new Includes([fixedLabelId]));
+      }
+    });
+
+    it("ignores stale multi-select values for a saved single-select", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.MonitorList,
+        argumentsObject: { labelVariableId: "unit" },
+        storedVariables: [labelVariable],
+        requestedVariables: [
+          {
+            id: "unit",
+            selectedValue: firstLabelId,
+            selectedValues: [secondLabelId],
+          },
+        ],
+      });
+
+      expect(result.query["labels"]).toEqual(new Includes([firstLabelId]));
+    });
+
+    it("does not apply a label variable to an unbound widget", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.MonitorList,
+        argumentsObject: { labelIds: [fixedLabelId] },
+        storedVariables: [labelVariable],
+        requestedVariables: [{ id: "unit", selectedValue: secondLabelId }],
+      });
+
+      expect(result.query["labels"]).toEqual(new Includes([fixedLabelId]));
+    });
+
+    it("rejects a selection that is no longer among the published choices", () => {
+      expect(() => {
+        return build({
+          componentType: DashboardComponentType.MonitorList,
+          argumentsObject: { labelVariableId: "unit" },
+          storedVariables: [labelVariable],
+          requestedVariables: [
+            { id: "unit", selectedValue: ObjectID.generate().toString() },
+          ],
+        });
+      }).toThrow(BadDataException);
+    });
+
+    it("rejects a missing or incompatible saved variable binding", () => {
+      for (const storedVariables of [
+        [],
+        [
+          {
+            id: "unit",
+            name: "UNIT",
+            type: DashboardVariableType.TelemetryAttribute,
+            attributeKey: "unit",
+          },
+        ],
+      ]) {
+        expect(() => {
+          return build({
+            componentType: DashboardComponentType.MonitorList,
+            argumentsObject: { labelVariableId: "unit" },
+            storedVariables,
+          });
+        }).toThrow(BadDataException);
+      }
+    });
+
+    it("rejects malformed saved label choices", () => {
+      for (const labelOptions of [
+        null,
+        "Payments",
+        [null],
+        [{ value: firstLabelId }],
+        [{ label: "Payments", value: 42 }],
+        [{ label: "", value: firstLabelId }],
+      ]) {
+        expect(() => {
+          return build({
+            componentType: DashboardComponentType.MonitorList,
+            argumentsObject: { labelVariableId: "unit" },
+            storedVariables: [{ ...labelVariable, labelOptions }],
+          });
+        }).toThrow(BadDataException);
+      }
     });
   });
 

--- a/Common/Tests/Types/Database/IncludesAnyOfGroups.test.ts
+++ b/Common/Tests/Types/Database/IncludesAnyOfGroups.test.ts
@@ -1,0 +1,106 @@
+import IncludesAnyOfGroups from "../../../Types/BaseDatabase/IncludesAnyOfGroups";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject, ObjectType } from "../../../Types/JSON";
+import JSONFunctions from "../../../Types/JSONFunctions";
+import SerializableObjectDictionary from "../../../Types/SerializableObjectDictionary";
+
+describe("IncludesAnyOfGroups", () => {
+  test("preserves group boundaries and removes duplicate ids within a group", () => {
+    const value: IncludesAnyOfGroups = new IncludesAnyOfGroups([
+      ["network", "router", "network"],
+      ["0660", "0661"],
+    ]);
+    expect(value.groups).toEqual([
+      ["network", "router"],
+      ["0660", "0661"],
+    ]);
+  });
+
+  test("retains empty groups so they can match nothing", () => {
+    expect(new IncludesAnyOfGroups([["network"], []]).groups).toEqual([
+      ["network"],
+      [],
+    ]);
+  });
+
+  test("owns its data and does not expose mutable validated groups", () => {
+    const groups: Array<Array<string>> = [["network"], ["0660"]];
+    const value: IncludesAnyOfGroups = new IncludesAnyOfGroups(groups);
+    groups[0]!.push("router");
+    value.groups[1]!.push("0661");
+    (value.toJSON()["value"] as Array<Array<string>>)[0]!.push("other");
+    expect(value.groups).toEqual([["network"], ["0660"]]);
+  });
+
+  test("round trips through the API JSON registry with leading zeros intact", () => {
+    const value: IncludesAnyOfGroups = new IncludesAnyOfGroups([
+      ["network"],
+      ["0660", "0661"],
+    ]);
+    const serialized: JSONObject = JSONFunctions.serialize({ labels: value });
+    expect(serialized["labels"]).toEqual({
+      _type: ObjectType.IncludesAnyOfGroups,
+      value: [["network"], ["0660", "0661"]],
+    });
+    const result: JSONObject = JSONFunctions.deserialize(
+      JSON.parse(JSON.stringify(serialized)),
+    ) as JSONObject;
+    expect(SerializableObjectDictionary[ObjectType.IncludesAnyOfGroups]).toBe(
+      IncludesAnyOfGroups,
+    );
+    expect(result["labels"]).toBeInstanceOf(IncludesAnyOfGroups);
+    expect((result["labels"] as IncludesAnyOfGroups).groups).toEqual(
+      value.groups,
+    );
+  });
+
+  test.each(
+    [
+      undefined,
+      null,
+      [],
+      "network",
+      ["network"],
+      [null],
+      [[null]],
+      [[1]],
+      [[{}]],
+      [[""]],
+      [["a".repeat(257)]],
+      Array.from({ length: 33 }, () => {
+        return ["id"];
+      }),
+      [
+        Array.from({ length: 1001 }, () => {
+          return "id";
+        }),
+      ],
+      Array.from({ length: 11 }, () => {
+        return Array.from({ length: 1000 }, () => {
+          return "id";
+        });
+      }),
+    ].map((groups: unknown) => {
+      return [groups];
+    }),
+  )("rejects invalid or oversized group data %#", (groups: unknown) => {
+    expect(() => {
+      return new IncludesAnyOfGroups(groups as Array<Array<string>>);
+    }).toThrow(BadDataException);
+    expect(() => {
+      return IncludesAnyOfGroups.fromJSON({
+        _type: ObjectType.IncludesAnyOfGroups,
+        value: groups,
+      } as JSONObject);
+    }).toThrow(BadDataException);
+  });
+
+  test("rejects a different operator type", () => {
+    expect(() => {
+      return IncludesAnyOfGroups.fromJSON({
+        _type: ObjectType.Includes,
+        value: [["network"]],
+      });
+    }).toThrow(BadDataException);
+  });
+});

--- a/Common/Tests/UI/ReactRouterSingletonBuild.test.ts
+++ b/Common/Tests/UI/ReactRouterSingletonBuild.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, describe, expect, test } from "@jest/globals";
+import childProcess from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const REPOSITORY_ROOT: string = path.resolve(__dirname, "..", "..", "..");
+const COMMON_MODULES: string = path.join(
+  REPOSITORY_ROOT,
+  "Common",
+  "node_modules",
+);
+const ESBUILD_CONFIG: string = path.join(
+  REPOSITORY_ROOT,
+  "Common",
+  "UI",
+  "esbuild-config.js",
+);
+const APP_LINK: string = path.join(
+  REPOSITORY_ROOT,
+  "App/FeatureSet/Dashboard/src/Components/AppLink/AppLink.tsx",
+);
+const temporaryRoots: Array<string> = [];
+
+interface RenderResult {
+  html: string;
+  error: string;
+}
+
+/*
+ * PublicDashboard mounts its own router but reuses Dashboard widgets and their
+ * AppLink. Separate package installations otherwise create two router contexts.
+ * A mocked AppLink or Jest's react-router-dom module mapper hides that failure,
+ * so bundle the actual link source against two physical router installations.
+ */
+function renderSharedLink(nodeEnv: string): RenderResult {
+  const root: string = fs.mkdtempSync(
+    path.join(os.tmpdir(), "oneuptime-router-"),
+  );
+  temporaryRoots.push(root);
+  fs.symlinkSync(COMMON_MODULES, path.join(root, "node_modules"), "dir");
+
+  for (const packageName of ["public", "shared"]) {
+    const moduleDirectory: string = path.join(
+      root,
+      packageName,
+      "node_modules",
+    );
+    fs.mkdirSync(moduleDirectory, { recursive: true });
+    for (const dependency of ["react-router", "react-router-dom"]) {
+      fs.cpSync(
+        path.join(COMMON_MODULES, dependency),
+        path.join(moduleDirectory, dependency),
+        { recursive: true, dereference: true },
+      );
+    }
+  }
+
+  fs.copyFileSync(APP_LINK, path.join(root, "shared", "AppLink.tsx"));
+  const entry: string = path.join(root, "public", "Entry.tsx");
+  fs.writeFileSync(
+    entry,
+    `
+      import React from "react";
+      import { MemoryRouter } from "react-router-dom";
+      import { renderToStaticMarkup } from "react-dom/server";
+      import AppLink from "../shared/AppLink";
+
+      globalThis.routerFixtureMarkup = renderToStaticMarkup(
+        <MemoryRouter initialEntries={["/public-dashboard"]}>
+          <AppLink to={{ toString: () => "/dashboard/monitors/example" }}>
+            Unit 0660 monitor
+          </AppLink>
+        </MemoryRouter>,
+      );
+    `,
+  );
+
+  const script: string = `
+    const path = require("path");
+    const configModule = require(${JSON.stringify(ESBUILD_CONFIG)});
+    const esbuild = require(require.resolve("esbuild", {
+      paths: [${JSON.stringify(COMMON_MODULES)}],
+    }));
+    const config = configModule.createConfig({
+      serviceName: "PublicDashboard",
+      publicPath: "/public-dashboard/dist/",
+      entryPoint: ${JSON.stringify(entry)},
+    });
+    config.write = false;
+    config.splitting = false;
+    config.format = "cjs";
+    config.sourcemap = false;
+    config.logLevel = "silent";
+
+    esbuild.build(config).then((result) => {
+      const output = result.outputFiles[0].text;
+      new Function("require", "module", "exports", output)(require, { exports: {} }, {});
+      console.log(JSON.stringify({ html: globalThis.routerFixtureMarkup, error: "" }));
+    }).catch((error) => {
+      console.log(JSON.stringify({ html: "", error: String(error) }));
+    });
+  `;
+
+  return JSON.parse(
+    childProcess.execFileSync(process.execPath, ["-e", script], {
+      cwd: REPOSITORY_ROOT,
+      env: { ...process.env, NODE_ENV: nodeEnv },
+      encoding: "utf8",
+      timeout: 120000,
+      maxBuffer: 1024 * 1024,
+    }),
+  ) as RenderResult;
+}
+
+afterAll(() => {
+  for (const root of temporaryRoots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("shared public dashboard router context", () => {
+  test.each(["production", "development"])(
+    "renders the real shared AppLink inside the public router in %s",
+    (nodeEnv: string) => {
+      const result: RenderResult = renderSharedLink(nodeEnv);
+      expect(result.error).toBe("");
+      expect(result.html).toContain('href="/dashboard/monitors/example"');
+      expect(result.html).toContain("Unit 0660 monitor");
+    },
+    180000,
+  );
+});

--- a/Common/Tests/Utils/Dashboard/Components/DashboardMonitorListComponent.test.ts
+++ b/Common/Tests/Utils/Dashboard/Components/DashboardMonitorListComponent.test.ts
@@ -55,6 +55,7 @@ const EXPECTED_ARGUMENT_IDS: Array<ArgumentId> = [
   "monitorStatusIds",
   "monitorTypes",
   "labelIds",
+  "labelVariableId",
 ];
 
 const DISPLAY_SECTION_ARGUMENT_IDS: Array<ArgumentId> = [
@@ -68,6 +69,7 @@ const FILTER_SECTION_ARGUMENT_IDS: Array<ArgumentId> = [
   "monitorStatusIds",
   "monitorTypes",
   "labelIds",
+  "labelVariableId",
 ];
 
 const VALID_INPUT_TYPES: Set<string> = new Set<string>(
@@ -157,6 +159,7 @@ describe("DashboardMonitorListComponentUtil", () => {
       expect(component.arguments.monitorStatusIds).toBeUndefined();
       expect(component.arguments.monitorTypes).toBeUndefined();
       expect(component.arguments.labelIds).toBeUndefined();
+      expect(component.arguments.labelVariableId).toBeUndefined();
     });
 
     test("uses the same default row count that the maxRows field shows as its placeholder", () => {
@@ -188,7 +191,7 @@ describe("DashboardMonitorListComponentUtil", () => {
   });
 
   describe("getComponentConfigArguments", () => {
-    test("declares exactly the seven documented arguments, in form order", () => {
+    test("declares the documented arguments, in form order", () => {
       expect(
         getArguments().map((arg: MonitorListArgument) => {
           return arg.id;
@@ -341,6 +344,13 @@ describe("DashboardMonitorListComponentUtil", () => {
       expect(arg.entityFilterModelType).toBe(EntityFilterModelType.Label);
       expect(arg.placeholder).toBe("All labels");
       expect(arg.dropdownOptions).toBeUndefined();
+    });
+
+    test("declares a dedicated project-label variable binding alongside fixed labels", () => {
+      const arg: MonitorListArgument = getArgumentById("labelVariableId");
+      expect(arg.type).toBe(ComponentInputType.ProjectLabelVariable);
+      expect(arg.required).toBe(false);
+      expect(arg.entityFilterModelType).toBeUndefined();
     });
 
     test("renders the monitor-type filter as a static multi-select, not an entity lookup", () => {

--- a/Common/Tests/Utils/Dashboard/LabelVariable.test.ts
+++ b/Common/Tests/Utils/Dashboard/LabelVariable.test.ts
@@ -1,0 +1,257 @@
+import Includes from "../../../Types/BaseDatabase/Includes";
+import IncludesAnyOfGroups from "../../../Types/BaseDatabase/IncludesAnyOfGroups";
+import DashboardVariable, {
+  DashboardVariableType,
+} from "../../../Types/Dashboard/DashboardVariable";
+import JSONFunctions from "../../../Types/JSONFunctions";
+import DashboardLabelVariable from "../../../Utils/Dashboard/LabelVariable";
+
+const UNIT_660: string = "06600000-0000-4000-8000-000000000000";
+const UNIT_661: string = "06610000-0000-4000-8000-000000000000";
+const NETWORK: string = "00000000-0000-4000-8000-000000000001";
+
+function variable(
+  overrides: Partial<DashboardVariable> = {},
+): DashboardVariable {
+  return {
+    id: "unit",
+    name: "UNIT",
+    type: DashboardVariableType.ProjectLabel,
+    labelOptions: [
+      { label: "0660", value: UNIT_660 },
+      { label: "0661", value: UNIT_661 },
+    ],
+    ...overrides,
+  };
+}
+
+function filter(
+  overrides: Partial<DashboardVariable> = {},
+  labelIds?: Array<string>,
+): ReturnType<typeof DashboardLabelVariable.getFilter> {
+  return DashboardLabelVariable.getFilter({
+    labelVariableId: "unit",
+    labelIds,
+    variables: [variable(overrides)],
+  });
+}
+
+describe("project label dashboard variable filters", () => {
+  test("keeps existing widgets with fixed labels unchanged", () => {
+    expect(DashboardLabelVariable.getFilter({ labelIds: [NETWORK] })).toEqual(
+      new Includes([NETWORK]),
+    );
+    expect(DashboardLabelVariable.getFilter({})).toBeUndefined();
+  });
+
+  test("a title or an unbound variable does not change the query", () => {
+    expect(
+      DashboardLabelVariable.getFilter({
+        variables: [variable({ selectedValue: UNIT_660 })],
+      }),
+    ).toBeUndefined();
+  });
+
+  test.each([UNIT_660, UNIT_661])(
+    "filters by selected label ID %s",
+    (id: string) => {
+      expect(filter({ selectedValue: id })).toEqual(new Includes([id]));
+    },
+  );
+
+  test("uses an absent selection's default", () => {
+    expect(filter({ defaultValue: UNIT_660 })).toEqual(
+      new Includes([UNIT_660]),
+    );
+  });
+
+  test("All overrides a default and retains the fixed label condition", () => {
+    expect(
+      filter({ defaultValue: UNIT_660, selectedValue: "" }, [NETWORK]),
+    ).toEqual(new Includes([NETWORK]));
+    expect(filter({ selectedValue: "" })).toBeUndefined();
+  });
+
+  test("multi-select is OR within units and AND with fixed labels", () => {
+    expect(
+      filter({ isMultiSelect: true, selectedValues: [UNIT_660, UNIT_661] }, [
+        NETWORK,
+      ]),
+    ).toEqual(new IncludesAnyOfGroups([[NETWORK], [UNIT_660, UNIT_661]]));
+  });
+
+  test("empty multi-select ignores a stale scalar and default", () => {
+    expect(
+      filter(
+        {
+          isMultiSelect: true,
+          selectedValues: [],
+          selectedValue: UNIT_660,
+          defaultValue: UNIT_661,
+        },
+        [NETWORK],
+      ),
+    ).toEqual(new Includes([NETWORK]));
+  });
+
+  test("does not mutate saved configuration and deduplicates repeated picks", () => {
+    const saved: DashboardVariable = variable({
+      isMultiSelect: true,
+      selectedValues: [UNIT_660, UNIT_660],
+    });
+    const before: string = JSON.stringify(saved);
+    const fixed: Array<string> = [NETWORK, NETWORK];
+    expect(
+      DashboardLabelVariable.getFilter({
+        labelIds: fixed,
+        labelVariableId: saved.id,
+        variables: [saved],
+      }),
+    ).toEqual(new IncludesAnyOfGroups([[NETWORK], [UNIT_660]]));
+    expect(JSON.stringify(saved)).toBe(before);
+    expect(fixed).toEqual([NETWORK, NETWORK]);
+  });
+
+  test("binding survives a variable rename and display name changes", () => {
+    expect(
+      filter({
+        name: "BRANCH",
+        selectedValue: UNIT_660,
+        labelOptions: [{ label: "Renamed unit", value: UNIT_660 }],
+      }),
+    ).toEqual(new Includes([UNIT_660]));
+  });
+
+  test("missing, duplicate, or incompatible variable definitions are errors", () => {
+    for (const variables of [
+      [],
+      [variable(), variable()],
+      [variable({ type: DashboardVariableType.CustomList })],
+    ]) {
+      expect(() => {
+        return DashboardLabelVariable.getFilter({
+          labelVariableId: "unit",
+          variables,
+        });
+      }).toThrow(/label variable/);
+    }
+  });
+
+  test.each(["0660", NETWORK])(
+    "rejects selections not in the configured options: %s",
+    (selectedValue: string) => {
+      expect(() => {
+        return filter({ selectedValue });
+      }).toThrow(/offered by this dashboard/);
+    },
+  );
+
+  test("an invalid default does not silently fall back to all monitors", () => {
+    expect(() => {
+      return filter({ defaultValue: NETWORK });
+    }).toThrow(/offered by this dashboard/);
+  });
+
+  test("validates every multi-selection instead of dropping invalid values", () => {
+    expect(() => {
+      return filter({
+        isMultiSelect: true,
+        selectedValues: [UNIT_660, NETWORK],
+      });
+    }).toThrow(/offered by this dashboard/);
+  });
+
+  test("bounds multi-selection size", () => {
+    expect(() => {
+      return filter({
+        isMultiSelect: true,
+        selectedValues: Array(101).fill(UNIT_660) as Array<string>,
+      });
+    }).toThrow(/100 labels/);
+  });
+
+  test.each([
+    undefined,
+    [],
+    [{ label: "0660", value: "0660" }],
+    [{ label: "", value: UNIT_660 }],
+    [{ label: " ", value: UNIT_660 }],
+    [{ label: "x".repeat(1025), value: UNIT_660 }],
+    [
+      { label: "0660", value: UNIT_660 },
+      { label: "Duplicate", value: UNIT_660 },
+    ],
+    Array(1001).fill({ label: "0660", value: UNIT_660 }),
+  ])(
+    "rejects malformed label choices %#",
+    (labelOptions: DashboardVariable["labelOptions"]) => {
+      expect(() => {
+        return filter({ labelOptions });
+      }).toThrow();
+    },
+  );
+
+  test("filter operators survive the API serialization round trip", () => {
+    const original: IncludesAnyOfGroups = filter({ selectedValue: UNIT_660 }, [
+      NETWORK,
+    ]) as IncludesAnyOfGroups;
+    expect(
+      JSONFunctions.deserializeValue(JSONFunctions.serializeValue(original)),
+    ).toEqual(original);
+  });
+});
+
+describe("dashboard title display interpolation", () => {
+  test.each([
+    [{ selectedValue: UNIT_660 }, "0660 NETWORK"],
+    [{ defaultValue: UNIT_661 }, "0661 NETWORK"],
+    [{ selectedValue: "", defaultValue: UNIT_660 }, "All NETWORK"],
+    [
+      { isMultiSelect: true, selectedValues: [UNIT_660, UNIT_661] },
+      "0660, 0661 NETWORK",
+    ],
+    [
+      { isMultiSelect: true, selectedValues: [], defaultValue: UNIT_660 },
+      "All NETWORK",
+    ],
+    [{ selectedValue: NETWORK }, "Unavailable label NETWORK"],
+  ])(
+    "renders a label selection using display names %#",
+    (overrides: Partial<DashboardVariable>, expected: string) => {
+      expect(
+        DashboardLabelVariable.interpolateTitle("{{UNIT}} NETWORK", [
+          variable(overrides),
+        ]),
+      ).toBe(expected);
+    },
+  );
+
+  test("preserves unknown references and ordinary titles", () => {
+    expect(
+      DashboardLabelVariable.interpolateTitle("{{missing}} NETWORK", [
+        variable(),
+      ]),
+    ).toBe("{{missing}} NETWORK");
+    expect(DashboardLabelVariable.interpolateTitle("Monitors", [])).toBe(
+      "Monitors",
+    );
+    expect(
+      DashboardLabelVariable.interpolateTitle(undefined, []),
+    ).toBeUndefined();
+  });
+
+  test("supports multiple references and text values without interpreting markup", () => {
+    const text: DashboardVariable = {
+      id: "env",
+      name: "ENV",
+      type: DashboardVariableType.TextInput,
+      selectedValue: "<b>prod</b>",
+    };
+    expect(
+      DashboardLabelVariable.interpolateTitle("{{UNIT}} / {{ENV}} / {{UNIT}}", [
+        variable({ selectedValue: UNIT_660 }),
+        text,
+      ]),
+    ).toBe("0660 / <b>prod</b> / 0660");
+  });
+});

--- a/Common/Tests/Utils/Dashboard/VariableUrlState.test.ts
+++ b/Common/Tests/Utils/Dashboard/VariableUrlState.test.ts
@@ -100,12 +100,64 @@ describe("DashboardVariableUrlState", () => {
     });
 
     test("applies multi-selected values from the url", () => {
-      const variable: DashboardVariable = makeVariable({ name: "region" });
+      const variable: DashboardVariable = makeVariable({
+        name: "region",
+        isMultiSelect: true,
+      });
       const result: Array<DashboardVariable> =
         DashboardVariableUrlState.applyUrlToVariables([variable], {
           region: { selectedValues: ["a", "b"] },
         });
       expect(result[0]?.selectedValues).toEqual(["a", "b"]);
+    });
+
+    test("restores one choice into a multi-select and clears a stale scalar", () => {
+      const variable: DashboardVariable = makeVariable({
+        name: "UNIT",
+        type: DashboardVariableType.ProjectLabel,
+        isMultiSelect: true,
+        selectedValue: "old",
+        selectedValues: ["old"],
+      });
+      const result: Array<DashboardVariable> =
+        DashboardVariableUrlState.applyUrlToVariables([variable], {
+          UNIT: { selectedValue: "label-0660" },
+        });
+      expect(result[0]?.selectedValues).toEqual(["label-0660"]);
+      expect(result[0]?.selectedValue).toBeUndefined();
+      expect(variable.selectedValues).toEqual(["old"]);
+    });
+
+    test("normalizes an explicit All to an empty multi-select", () => {
+      const result: Array<DashboardVariable> =
+        DashboardVariableUrlState.applyUrlToVariables(
+          [
+            makeVariable({
+              name: "UNIT",
+              isMultiSelect: true,
+              selectedValues: ["old"],
+            }),
+          ],
+          { UNIT: { selectedValue: "" } },
+        );
+      expect(result[0]?.selectedValues).toEqual([]);
+      expect(result[0]?.selectedValue).toBeUndefined();
+    });
+
+    test("normalizes a comma-containing scalar using the single-select definition", () => {
+      const result: Array<DashboardVariable> =
+        DashboardVariableUrlState.applyUrlToVariables(
+          [
+            makeVariable({
+              name: "text",
+              type: DashboardVariableType.TextInput,
+              selectedValues: ["stale"],
+            }),
+          ],
+          DashboardVariableUrlState.parseFromSearch("?var-text=a,b"),
+        );
+      expect(result[0]?.selectedValue).toBe("a,b");
+      expect(result[0]?.selectedValues).toBeUndefined();
     });
 
     test("does not mutate the original variable object", () => {
@@ -135,7 +187,7 @@ describe("DashboardVariableUrlState", () => {
     test("a shared url reproduces the selection on the variables", () => {
       const variables: Array<DashboardVariable> = [
         makeVariable({ name: "cluster" }),
-        makeVariable({ name: "region" }),
+        makeVariable({ name: "region", isMultiSelect: true }),
       ];
 
       const fromUrl: Record<string, VariableUrlSnapshot> =
@@ -149,14 +201,7 @@ describe("DashboardVariableUrlState", () => {
       expect(applied[1]?.selectedValues).toEqual(["us", "eu"]);
     });
 
-    /*
-     * "All" is the absence of a var- param — writeToBrowserUrl emits
-     * nothing for an empty selection, so a reload cannot tell "cleared"
-     * from "never touched" and must treat both as All. That only holds
-     * because resolveValue ignores defaultValue for a multi-select; if it
-     * fell back, a viewer who cleared the popover would silently get the
-     * author's Default back on every refresh and on every shared link.
-     */
+    // Explicit All must override any selection persisted in the saved config.
     test("a cleared multi-select survives a url round trip as All", () => {
       window.history.replaceState({}, "", "/dashboard");
       DashboardVariableUrlState.writeToBrowserUrl([
@@ -168,7 +213,7 @@ describe("DashboardVariableUrlState", () => {
         }),
       ]);
 
-      expect(window.location.search).toBe("");
+      expect(window.location.search).toBe("?var-region=");
 
       const applied: Array<DashboardVariable> =
         DashboardVariableUrlState.applyUrlToVariables(
@@ -177,16 +222,58 @@ describe("DashboardVariableUrlState", () => {
               name: "region",
               isMultiSelect: true,
               defaultValue: "us",
+              selectedValues: ["eu"],
             }),
           ],
           DashboardVariableUrlState.parseFromSearch(window.location.search),
         );
 
-      expect(applied[0]?.selectedValues).toBeUndefined();
+      expect(applied[0]?.selectedValues).toEqual([]);
       expect(
         DashboardVariableInterpolation.resolveValue(
           applied[0] as DashboardVariable,
         ),
+      ).toBeUndefined();
+    });
+
+    test("a single project label selection survives a multi-select URL round trip", () => {
+      window.history.replaceState({}, "", "/dashboard");
+      const variable: DashboardVariable = makeVariable({
+        name: "UNIT",
+        type: DashboardVariableType.ProjectLabel,
+        isMultiSelect: true,
+        selectedValues: ["0660"],
+      });
+      DashboardVariableUrlState.writeToBrowserUrl([variable]);
+      expect(window.location.search).toBe("?var-UNIT=0660");
+      const [restored]: Array<DashboardVariable> =
+        DashboardVariableUrlState.applyUrlToVariables(
+          [{ ...variable, selectedValues: undefined }],
+          DashboardVariableUrlState.parseFromSearch(window.location.search),
+        );
+      expect(DashboardVariableInterpolation.resolveValue(restored!)).toEqual({
+        multi: ["0660"],
+      });
+    });
+
+    test("explicit All survives a single-select URL round trip despite a stored default", () => {
+      window.history.replaceState({}, "", "/dashboard");
+      const variable: DashboardVariable = makeVariable({
+        name: "UNIT",
+        type: DashboardVariableType.ProjectLabel,
+        defaultValue: "0660",
+        selectedValue: "",
+      });
+      DashboardVariableUrlState.writeToBrowserUrl([variable]);
+      expect(window.location.search).toBe("?var-UNIT=");
+      const [restored]: Array<DashboardVariable> =
+        DashboardVariableUrlState.applyUrlToVariables(
+          [{ ...variable, selectedValue: undefined }],
+          DashboardVariableUrlState.parseFromSearch(window.location.search),
+        );
+      expect(restored?.selectedValue).toBe("");
+      expect(
+        DashboardVariableInterpolation.resolveValue(restored!),
       ).toBeUndefined();
     });
   });
@@ -209,7 +296,11 @@ describe("DashboardVariableUrlState", () => {
 
     test("writes multi-selected values joined by commas", () => {
       DashboardVariableUrlState.writeToBrowserUrl([
-        makeVariable({ name: "region", selectedValues: ["us", "eu"] }),
+        makeVariable({
+          name: "region",
+          isMultiSelect: true,
+          selectedValues: ["us", "eu"],
+        }),
       ]);
       expect(
         DashboardVariableUrlState.parseFromSearch(window.location.search)[
@@ -239,6 +330,41 @@ describe("DashboardVariableUrlState", () => {
       expect(window.location.search).toBe("");
     });
 
+    test("keeps explicit All distinct from an untouched default", () => {
+      DashboardVariableUrlState.writeToBrowserUrl([
+        makeVariable({
+          name: "cleared",
+          selectedValue: "",
+          defaultValue: "prod",
+        }),
+        makeVariable({ name: "untouched", defaultValue: "prod" }),
+        makeVariable({
+          name: "clearedMulti",
+          isMultiSelect: true,
+          selectedValues: [],
+        }),
+        makeVariable({ name: "untouchedMulti", isMultiSelect: true }),
+      ]);
+      expect(window.location.search).toBe("?var-cleared=&var-clearedMulti=");
+    });
+
+    test("writes only the selection field used by the saved selection mode", () => {
+      DashboardVariableUrlState.writeToBrowserUrl([
+        makeVariable({
+          name: "single",
+          selectedValue: "prod",
+          selectedValues: ["stale"],
+        }),
+        makeVariable({
+          name: "multi",
+          isMultiSelect: true,
+          selectedValue: "stale",
+          selectedValues: [],
+        }),
+      ]);
+      expect(window.location.search).toBe("?var-single=prod&var-multi=");
+    });
+
     test("does not push a new history entry (uses replaceState)", () => {
       const lengthBefore: number = window.history.length;
       DashboardVariableUrlState.writeToBrowserUrl([
@@ -250,7 +376,11 @@ describe("DashboardVariableUrlState", () => {
     test("write -> parse round trip preserves the selection", () => {
       DashboardVariableUrlState.writeToBrowserUrl([
         makeVariable({ name: "cluster", selectedValue: "prod" }),
-        makeVariable({ name: "region", selectedValues: ["us", "eu"] }),
+        makeVariable({
+          name: "region",
+          isMultiSelect: true,
+          selectedValues: ["us", "eu"],
+        }),
       ]);
       const parsed: Record<string, VariableUrlSnapshot> =
         DashboardVariableUrlState.parseFromSearch(window.location.search);

--- a/Common/Types/BaseDatabase/IncludesAnyOfGroups.ts
+++ b/Common/Types/BaseDatabase/IncludesAnyOfGroups.ts
@@ -1,0 +1,77 @@
+import BadDataException from "../Exception/BadDataException";
+import { JSONObject, ObjectType } from "../JSON";
+import QueryOperator from "./QueryOperator";
+
+/**
+ * Matches at least one related entity in each group. Groups are combined with
+ * AND, while ids within a group are combined with OR. An empty group matches
+ * nothing; callers should omit the operator when there are no conditions.
+ */
+export default class IncludesAnyOfGroups extends QueryOperator<
+  Array<Array<string>>
+> {
+  private readonly _groups: Array<Array<string>>;
+
+  public constructor(groups: Array<Array<string>>) {
+    super();
+
+    if (!Array.isArray(groups) || groups.length === 0 || groups.length > 32) {
+      throw new BadDataException(
+        "IncludesAnyOfGroups requires between 1 and 32 groups.",
+      );
+    }
+
+    let totalValues: number = 0;
+    for (const group of groups) {
+      if (!Array.isArray(group) || group.length > 1000) {
+        throw new BadDataException(
+          "IncludesAnyOfGroups requires arrays of at most 1000 ids.",
+        );
+      }
+
+      totalValues += group.length;
+      for (const value of group) {
+        if (
+          typeof value !== "string" ||
+          value.length === 0 ||
+          value.length > 256
+        ) {
+          throw new BadDataException(
+            "IncludesAnyOfGroups ids must be nonempty strings of at most 256 characters.",
+          );
+        }
+      }
+    }
+
+    if (totalValues > 10000) {
+      throw new BadDataException(
+        "IncludesAnyOfGroups supports at most 10000 ids in total.",
+      );
+    }
+
+    this._groups = groups.map((group: Array<string>) => {
+      return [...new Set(group)];
+    });
+  }
+
+  public get groups(): Array<Array<string>> {
+    return this._groups.map((group: Array<string>) => {
+      return [...group];
+    });
+  }
+
+  public override toJSON(): JSONObject {
+    return {
+      _type: ObjectType.IncludesAnyOfGroups,
+      value: this.groups,
+    };
+  }
+
+  public static override fromJSON(json: JSONObject): IncludesAnyOfGroups {
+    if (json["_type"] !== ObjectType.IncludesAnyOfGroups) {
+      throw new BadDataException("Invalid IncludesAnyOfGroups JSON type.");
+    }
+
+    return new IncludesAnyOfGroups(json["value"] as Array<Array<string>>);
+  }
+}

--- a/Common/Types/Dashboard/DashboardComponents/ComponentArgument.ts
+++ b/Common/Types/Dashboard/DashboardComponents/ComponentArgument.ts
@@ -18,6 +18,7 @@ export enum ComponentInputType {
   MultiSelectDropdown = "MultiSelectDropdown",
   EntityDropdown = "EntityDropdown",
   EntityMultiSelectDropdown = "EntityMultiSelectDropdown",
+  ProjectLabelVariable = "ProjectLabelVariable",
   // Monaco code editors, one per language.
   Html = "Html",
   Css = "Css",

--- a/Common/Types/Dashboard/DashboardComponents/DashboardMonitorListComponent.ts
+++ b/Common/Types/Dashboard/DashboardComponents/DashboardMonitorListComponent.ts
@@ -13,5 +13,6 @@ export default interface DashboardMonitorListComponent extends BaseComponent {
     monitorStatusIds?: Array<string> | undefined;
     monitorTypes?: Array<string> | undefined;
     labelIds?: Array<string> | undefined;
+    labelVariableId?: string | undefined;
   };
 }

--- a/Common/Types/Dashboard/DashboardVariable.ts
+++ b/Common/Types/Dashboard/DashboardVariable.ts
@@ -3,6 +3,12 @@ export enum DashboardVariableType {
   Query = "Query",
   TextInput = "Text Input",
   TelemetryAttribute = "Telemetry Attribute",
+  ProjectLabel = "Project Labels",
+}
+
+export interface DashboardVariableOption {
+  label: string;
+  value: string;
 }
 
 export default interface DashboardVariable {
@@ -12,6 +18,8 @@ export default interface DashboardVariable {
   type: DashboardVariableType;
   // For CustomList: comma-separated values
   customListValues?: string | undefined;
+  // Author-selected project label IDs and their published display names.
+  labelOptions?: Array<DashboardVariableOption> | undefined;
   // For Query: a ClickHouse query to populate options
   query?: string | undefined;
   /*

--- a/Common/Types/JSON.ts
+++ b/Common/Types/JSON.ts
@@ -8,6 +8,7 @@ import GreaterThanOrEqual from "./BaseDatabase/GreaterThanOrEqual";
 import InBetween from "./BaseDatabase/InBetween";
 import Includes from "./BaseDatabase/Includes";
 import IncludesAll from "./BaseDatabase/IncludesAll";
+import IncludesAnyOfGroups from "./BaseDatabase/IncludesAnyOfGroups";
 import IncludesNone from "./BaseDatabase/IncludesNone";
 import StartsWith from "./BaseDatabase/StartsWith";
 import EndsWith from "./BaseDatabase/EndsWith";
@@ -81,6 +82,7 @@ export enum ObjectType {
   IsNull = "IsNull",
   Includes = "Includes",
   IncludesAll = "IncludesAll",
+  IncludesAnyOfGroups = "IncludesAnyOfGroups",
   IncludesNone = "IncludesNone",
   StartsWith = "StartsWith",
   EndsWith = "EndsWith",
@@ -176,6 +178,8 @@ export type JSONValue =
   | Array<Includes>
   | IncludesAll
   | Array<IncludesAll>
+  | IncludesAnyOfGroups
+  | Array<IncludesAnyOfGroups>
   | IncludesNone
   | Array<IncludesNone>
   | StartsWith<string>

--- a/Common/Types/SerializableObjectDictionary.ts
+++ b/Common/Types/SerializableObjectDictionary.ts
@@ -8,6 +8,7 @@ import GreaterThanOrEqual from "./BaseDatabase/GreaterThanOrEqual";
 import InBetween from "./BaseDatabase/InBetween";
 import Includes from "./BaseDatabase/Includes";
 import IncludesAll from "./BaseDatabase/IncludesAll";
+import IncludesAnyOfGroups from "./BaseDatabase/IncludesAnyOfGroups";
 import IncludesNone from "./BaseDatabase/IncludesNone";
 import StartsWith from "./BaseDatabase/StartsWith";
 import EndsWith from "./BaseDatabase/EndsWith";
@@ -154,6 +155,9 @@ const SerializableObjectDictionary: Dictionary<any> = {
   },
   get [ObjectType.IncludesAll](): any {
     return IncludesAll;
+  },
+  get [ObjectType.IncludesAnyOfGroups](): any {
+    return IncludesAnyOfGroups;
   },
   get [ObjectType.IncludesNone](): any {
     return IncludesNone;

--- a/Common/UI/Components/Dashboard/DashboardVariableControl.tsx
+++ b/Common/UI/Components/Dashboard/DashboardVariableControl.tsx
@@ -1,0 +1,285 @@
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import DashboardVariable, {
+  DashboardVariableType,
+  DashboardVariableOption,
+} from "../../../Types/Dashboard/DashboardVariable";
+
+export interface VariableValueChange {
+  selectedValue?: string | undefined;
+  selectedValues?: Array<string> | undefined;
+}
+
+export interface ComponentProps {
+  variable: DashboardVariable;
+  dynamicOptions?: Array<string> | undefined;
+  isLoadingOptions?: boolean | undefined;
+  onVariableValueChange: (
+    variableId: string,
+    change: VariableValueChange,
+  ) => void;
+}
+
+const MultiSelectPopover: FunctionComponent<{
+  options: Array<DashboardVariableOption>;
+  selected: Array<string>;
+  label: string;
+  isLoading: boolean;
+  maxSelections?: number | undefined;
+  unavailableLabel?: string | undefined;
+  onChange: (next: Array<string>) => void;
+}> = ({
+  options,
+  selected,
+  label,
+  isLoading,
+  maxSelections,
+  unavailableLabel,
+  onChange,
+}: {
+  options: Array<DashboardVariableOption>;
+  selected: Array<string>;
+  label: string;
+  isLoading: boolean;
+  maxSelections?: number | undefined;
+  unavailableLabel?: string | undefined;
+  onChange: (next: Array<string>) => void;
+}): ReactElement => {
+  const [open, setOpen] = useState<boolean>(false);
+  const wrapRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    const onDocClick: (e: MouseEvent) => void = (e: MouseEvent): void => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+    };
+  }, [open]);
+
+  const buttonText: string =
+    selected.length === 0
+      ? isLoading
+        ? "Loading…"
+        : "All"
+      : selected.length === 1
+        ? options.find((option: DashboardVariableOption) => {
+            return option.value === selected[0];
+          })?.label ||
+          unavailableLabel ||
+          (selected[0] as string)
+        : `${selected.length} selected`;
+
+  const toggle: (value: string) => void = (value: string): void => {
+    if (selected.includes(value)) {
+      onChange(
+        selected.filter((v: string) => {
+          return v !== value;
+        }),
+      );
+    } else {
+      onChange([...selected, value]);
+    }
+  };
+
+  return (
+    <div className="relative" ref={wrapRef}>
+      <button
+        type="button"
+        className="text-xs border border-gray-200 rounded-md px-2.5 py-1.5 bg-white text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-300 transition-colors flex items-center gap-1"
+        disabled={isLoading}
+        onClick={() => {
+          setOpen(!open);
+        }}
+        title={label}
+        aria-label={`${label}: ${buttonText}`}
+        aria-expanded={open}
+      >
+        <span className="truncate max-w-[10rem]">{buttonText}</span>
+        <span className="text-gray-400">▾</span>
+      </button>
+      {open && (
+        <div className="absolute z-30 mt-1 right-0 w-56 max-h-72 overflow-auto rounded-md border border-gray-200 bg-white shadow-lg py-1">
+          <div className="flex items-center justify-between px-3 py-1.5 border-b border-gray-100 text-[11px] text-gray-500">
+            <span>{selected.length} selected</span>
+            <button
+              type="button"
+              className="text-blue-600 hover:underline disabled:text-gray-300"
+              disabled={selected.length === 0}
+              onClick={() => {
+                onChange([]);
+              }}
+            >
+              Clear
+            </button>
+          </div>
+          {maxSelections !== undefined && selected.length >= maxSelections && (
+            <p className="px-3 py-1 text-xs text-gray-500">
+              Choose up to {maxSelections} labels.
+            </p>
+          )}
+          {options.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-gray-400">
+              {isLoading ? "Loading options…" : "No options available"}
+            </div>
+          ) : (
+            options.map((option: DashboardVariableOption) => {
+              const checked: boolean = selected.includes(option.value);
+              return (
+                <label
+                  key={option.value}
+                  className="flex items-center gap-2 px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50 cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    className="h-3.5 w-3.5"
+                    checked={checked}
+                    disabled={
+                      !checked &&
+                      maxSelections !== undefined &&
+                      selected.length >= maxSelections
+                    }
+                    onChange={() => {
+                      toggle(option.value);
+                    }}
+                  />
+                  <span className="truncate">{option.label}</span>
+                </label>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const DashboardVariableControl: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const { variable } = props;
+  const isTelemetryAttribute: boolean =
+    variable.type === DashboardVariableType.TelemetryAttribute;
+  const isCustomList: boolean =
+    variable.type === DashboardVariableType.CustomList ||
+    Boolean(variable.customListValues);
+
+  const customListOptions: Array<string> = variable.customListValues
+    ? variable.customListValues.split(",").map((v: string) => {
+        return v.trim();
+      })
+    : [];
+
+  const isProjectLabel: boolean =
+    variable.type === DashboardVariableType.ProjectLabel;
+  const options: Array<DashboardVariableOption> = isProjectLabel
+    ? variable.labelOptions || []
+    : (isTelemetryAttribute
+        ? props.dynamicOptions || []
+        : customListOptions
+      ).map((value: string) => {
+        return { label: value, value };
+      });
+  const selectedValue: string =
+    variable.selectedValue ?? variable.defaultValue ?? "";
+  const isUnavailableSelection: boolean = Boolean(
+    isProjectLabel &&
+      selectedValue &&
+      !options.some((option: DashboardVariableOption) => {
+        return option.value === selectedValue;
+      }),
+  );
+
+  const useSelect: boolean =
+    isTelemetryAttribute || isCustomList || isProjectLabel;
+  const label: string = variable.label || variable.name;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <label className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+        {label}
+      </label>
+      {useSelect && variable.isMultiSelect ? (
+        /*
+         * `selectedValues` only — never defaultValue. The popover renders
+         * "All" for an empty list, and DashboardVariableInterpolation
+         * resolves an empty list to no predicate, so the two agree. Seeding
+         * this from defaultValue would put a filter behind a control that
+         * reads "All".
+         */
+        <MultiSelectPopover
+          options={options}
+          selected={variable.selectedValues || []}
+          label={label}
+          isLoading={Boolean(props.isLoadingOptions)}
+          maxSelections={isProjectLabel ? 100 : undefined}
+          unavailableLabel={isProjectLabel ? "Unavailable label" : undefined}
+          onChange={(next: Array<string>) => {
+            props.onVariableValueChange(variable.id, { selectedValues: next });
+          }}
+        />
+      ) : useSelect ? (
+        <select
+          aria-label={label}
+          className="text-xs border border-gray-200 rounded-md px-2.5 py-1.5 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-300 transition-colors"
+          /*
+           * `??`, not `||`: picking "All" stores selectedValue as "", which is
+           * a real selection and must not collapse back to defaultValue. Only
+           * an unset (undefined) selection falls through to the default — the
+           * same rule the query side applies in
+           * Common/Utils/Dashboard/VariableInterpolation.ts, so what the
+           * toolbar shows and what the widgets are filtered by stay in step.
+           */
+          value={variable.selectedValue ?? variable.defaultValue ?? ""}
+          disabled={props.isLoadingOptions}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+            props.onVariableValueChange(variable.id, {
+              selectedValue: e.target.value,
+            });
+          }}
+        >
+          <option value="">
+            {props.isLoadingOptions ? "Loading…" : "All"}
+          </option>
+          {isUnavailableSelection && (
+            <option value={selectedValue}>Unavailable label</option>
+          )}
+          {options.map((option: DashboardVariableOption) => {
+            return (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            );
+          })}
+        </select>
+      ) : (
+        <input
+          type="text"
+          aria-label={label}
+          className="text-xs border border-gray-200 rounded-md px-2.5 py-1.5 bg-white text-gray-700 w-28 focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-300 transition-colors"
+          // `??` so clearing the box stays cleared. See the select above.
+          value={variable.selectedValue ?? variable.defaultValue ?? ""}
+          placeholder={variable.name}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            props.onVariableValueChange(variable.id, {
+              selectedValue: e.target.value,
+            });
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default DashboardVariableControl;

--- a/Common/UI/esbuild-config.js
+++ b/Common/UI/esbuild-config.js
@@ -304,6 +304,8 @@ function createConfig(options) {
   const isDev = process.env.NODE_ENV !== "production";
   const isAnalyze = process.env.analyze === "true";
   const reactRoot = resolvePackageRoot("react");
+  const reactRouterRoot = resolvePackageRoot("react-router");
+  const reactRouterDomRoot = resolvePackageRoot("react-router-dom");
   const reactI18nextRoot = resolvePackageRoot("react-i18next");
   const i18nextRoot = resolvePackageRoot("i18next");
 
@@ -356,6 +358,10 @@ function createConfig(options) {
       react: reactRoot,
       "react/jsx-runtime": path.join(reactRoot, "jsx-runtime.js"),
       "react/jsx-dev-runtime": path.join(reactRoot, "jsx-dev-runtime.js"),
+      // Public dashboards reuse widgets from the private dashboard package.
+      // Their links must share the router context installed by the entry app.
+      "react-router": reactRouterRoot,
+      "react-router-dom": reactRouterDomRoot,
       // Force a single instance of i18next/react-i18next so that translations
       // initialized in the service entry are visible to Common UI components.
       // Without this, Common's own node_modules copy gets a separate, never-

--- a/Common/Utils/Dashboard/Components/DashboardMonitorListComponent.ts
+++ b/Common/Utils/Dashboard/Components/DashboardMonitorListComponent.ts
@@ -74,7 +74,8 @@ export default class DashboardMonitorListComponentUtil extends DashboardBaseComp
 
     componentArguments.push({
       name: "Title",
-      description: "Header shown above the monitor list",
+      description:
+        "Header shown above the monitor list. Use {{UNIT}} to show a dashboard variable’s selected label; configure Label Variable separately to filter monitors.",
       required: false,
       type: ComponentInputType.Text,
       id: "title",
@@ -140,6 +141,16 @@ export default class DashboardMonitorListComponentUtil extends DashboardBaseComp
       placeholder: "All labels",
       section: FiltersSection,
       entityFilterModelType: EntityFilterModelType.Label,
+    });
+
+    componentArguments.push({
+      name: "Label Variable",
+      description:
+        "Filter monitors using a Project Labels dashboard variable. This is combined with the fixed filters above. All removes only the variable filter.",
+      required: false,
+      type: ComponentInputType.ProjectLabelVariable,
+      id: "labelVariableId",
+      section: FiltersSection,
     });
 
     return componentArguments;

--- a/Common/Utils/Dashboard/LabelVariable.ts
+++ b/Common/Utils/Dashboard/LabelVariable.ts
@@ -1,0 +1,152 @@
+import Includes from "../../Types/BaseDatabase/Includes";
+import IncludesAnyOfGroups from "../../Types/BaseDatabase/IncludesAnyOfGroups";
+import DashboardVariable, {
+  DashboardVariableOption,
+  DashboardVariableType,
+} from "../../Types/Dashboard/DashboardVariable";
+import BadDataException from "../../Types/Exception/BadDataException";
+import ObjectID from "../../Types/ObjectID";
+import DashboardVariableInterpolation, {
+  ResolvedVariableValue,
+} from "./VariableInterpolation";
+
+export interface DashboardLabelFilterData {
+  labelIds?: Array<string> | undefined;
+  labelVariableId?: string | undefined;
+  variables?: Array<DashboardVariable> | undefined;
+}
+
+export default class DashboardLabelVariable {
+  public static getOptions(
+    variable: DashboardVariable,
+  ): Array<DashboardVariableOption> {
+    const options: Array<DashboardVariableOption> | undefined =
+      variable.labelOptions;
+    if (
+      !Array.isArray(options) ||
+      options.length === 0 ||
+      options.length > 1000
+    ) {
+      throw new BadDataException(
+        "A project label variable must offer between 1 and 1000 labels.",
+      );
+    }
+
+    const seen: Set<string> = new Set<string>();
+    for (const option of options) {
+      if (
+        !option ||
+        typeof option.value !== "string" ||
+        !ObjectID.isValidUUID(option.value) ||
+        typeof option.label !== "string" ||
+        option.label.trim().length === 0 ||
+        option.label.length > 1024 ||
+        seen.has(option.value)
+      ) {
+        throw new BadDataException(
+          "Project label variable choices must have unique label IDs and nonempty display names.",
+        );
+      }
+      seen.add(option.value);
+    }
+    return options;
+  }
+
+  public static getFilter(
+    data: DashboardLabelFilterData,
+  ): Includes | IncludesAnyOfGroups | undefined {
+    const fixed: Array<string> = [...new Set(data.labelIds || [])];
+    if (!data.labelVariableId) {
+      return fixed.length > 0 ? new Includes(fixed) : undefined;
+    }
+
+    const matching: Array<DashboardVariable> = (data.variables || []).filter(
+      (variable: DashboardVariable) => {
+        return variable.id === data.labelVariableId;
+      },
+    );
+    const variable: DashboardVariable | undefined = matching[0];
+    if (
+      matching.length !== 1 ||
+      !variable ||
+      variable.type !== DashboardVariableType.ProjectLabel
+    ) {
+      throw new BadDataException(
+        "The monitor widget's label variable is missing or is not a project label variable. Edit the widget to select a label variable.",
+      );
+    }
+
+    const allowed: Set<string> = new Set(
+      DashboardLabelVariable.getOptions(variable).map(
+        (option: DashboardVariableOption) => {
+          return option.value;
+        },
+      ),
+    );
+    const resolved: ResolvedVariableValue | undefined =
+      DashboardVariableInterpolation.resolveValue(variable);
+    const selected: Array<string> =
+      resolved?.multi ||
+      (resolved?.scalar !== undefined ? [resolved.scalar] : []);
+    if (
+      selected.length > 100 ||
+      selected.some((value: string) => {
+        return !allowed.has(value);
+      })
+    ) {
+      throw new BadDataException(
+        "Choose up to 100 labels offered by this dashboard variable, or select All.",
+      );
+    }
+
+    if (selected.length === 0) {
+      return fixed.length > 0 ? new Includes(fixed) : undefined;
+    }
+    const dynamic: Array<string> = [...new Set(selected)];
+    return fixed.length > 0
+      ? new IncludesAnyOfGroups([fixed, dynamic])
+      : new Includes(dynamic);
+  }
+
+  public static interpolateTitle(
+    title: string | undefined,
+    variables: Array<DashboardVariable> | undefined,
+  ): string | undefined {
+    if (!title || !variables?.length) {
+      return title;
+    }
+    return title.replace(
+      /\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}/g,
+      (placeholder: string, name: string): string => {
+        const variable: DashboardVariable | undefined = variables.find(
+          (item: DashboardVariable) => {
+            return item.name === name;
+          },
+        );
+        if (!variable) {
+          return placeholder;
+        }
+        const resolved: ResolvedVariableValue | undefined =
+          DashboardVariableInterpolation.resolveValue(variable);
+        if (!resolved) {
+          return "All";
+        }
+        const values: Array<string> = resolved.multi || [
+          resolved.scalar as string,
+        ];
+        return values
+          .map((value: string): string => {
+            if (variable.type !== DashboardVariableType.ProjectLabel) {
+              return value;
+            }
+            return (
+              variable.labelOptions?.find((option: DashboardVariableOption) => {
+                return option.value === value;
+              })?.label || "Unavailable label"
+            );
+          })
+          .join(", ");
+      },
+    );
+  }
+}

--- a/Common/Utils/Dashboard/VariableUrlState.ts
+++ b/Common/Utils/Dashboard/VariableUrlState.ts
@@ -65,10 +65,25 @@ export default class DashboardVariableUrlState {
       if (!fromName) {
         return variable;
       }
+
+      /*
+       * The URL's comma syntax cannot distinguish one multi-select choice
+       * from a scalar. Resolve that ambiguity using the saved definition.
+       */
+      if (variable.isMultiSelect) {
+        return {
+          ...variable,
+          selectedValue: undefined,
+          selectedValues:
+            fromName.selectedValues ||
+            (fromName.selectedValue ? [fromName.selectedValue] : []),
+        };
+      }
       return {
         ...variable,
-        selectedValue: fromName.selectedValue,
-        selectedValues: fromName.selectedValues,
+        selectedValue:
+          fromName.selectedValue ?? fromName.selectedValues?.join(","),
+        selectedValues: undefined,
       };
     });
   }
@@ -110,11 +125,18 @@ export default class DashboardVariableUrlState {
         continue;
       }
       const paramKey: string = `${VAR_PREFIX}${name}`;
-      if (variable.selectedValues && variable.selectedValues.length > 0) {
-        params.set(paramKey, variable.selectedValues.join(","));
+      if (variable.isMultiSelect) {
+        if (Array.isArray(variable.selectedValues)) {
+          params.set(paramKey, variable.selectedValues.join(","));
+        }
         continue;
       }
-      if (variable.selectedValue && variable.selectedValue.length > 0) {
+
+      /*
+       * Keep an explicit All as `var-name=`. Omitting it would restore the
+       * saved selection or default when this URL is reopened.
+       */
+      if (typeof variable.selectedValue === "string") {
         params.set(paramKey, variable.selectedValue);
       }
     }


### PR DESCRIPTION
Monitor List widgets previously ignored dashboard variable selections, and titles such as `{{UNIT}} NETWORK` stayed literal. This adds a **Project Labels** variable source and an explicit **Label Variable** setting on Monitor List widgets, so a single dashboard can switch between units using existing project labels.

- Authors choose the labels offered by the variable. Stored label IDs drive filtering; saved display names appear in the selector and interpolated title.
- Selected units match any chosen unit and combine with the widget's fixed label filters. **All** removes only the variable condition; status, type, and fixed label filters remain active.
- Private and public dashboards share single-select, multi-select, default, URL restoration, and title behavior. Rapid changes keep the latest response, and missing bindings or invalid selections show an error.
- Public resource queries use the published widget and variable definitions. The grouped label query preserves project and record filters, including label-based read restrictions.
- Shared widgets and their host app use one React Router instance, fixing the public Monitor List rendering failure found during browser verification.

To configure the reported example, create `UNIT` with source **Project Labels**, choose `0660` and `0661`, then bind `UNIT` under the Monitor List widget's **Filters → Label Variable**. Set its title to `{{UNIT}} NETWORK`. Existing custom-list variables require this explicit configuration. No database migration is needed.

### Validation

- **470 tests passed across 23 focused suites**, covering authoring, selectors, widget refreshes, stale requests, URL/default persistence, title substitution, serialization, public policy/API behavior, read-filter composition, and real shared-link bundles in development and production.
- This includes **12 PostgreSQL integration tests** using the real Monitor/Label relation in an isolated temporary schema: fixed-label AND selected-unit matching, multi-select OR, deleted labels, paging, counts, and project/record filters. These opt-in tests ran with `RUN_POSTGRES_DASHBOARD_LABEL_TESTS=true` and the local development database configuration.
- TypeScript compile checks for Common, App, Dashboard, and PublicDashboard, plus a separate typecheck of the changed tests.
- Root `npm run fix` passed with generated `output/**` artifacts and the pre-existing, unrelated `StatusPageOidcOrigin.test.tsx` lint failure excluded. The original StatusPage files are unchanged by this PR.
- Live private and anonymous public checks: All shows five network monitors; 0660 and 0661 each show two matching monitors with the correct title. Verified binding changes, URL restoration, and definition/default persistence using synthetic local data.

CI currently has two failures inherited from the base revision:

- [App Test](https://github.com/OneUptime/oneuptime/actions/runs/34109435497/job/101701989936): four monitor-template assertion failures in `ProjectScopedApiTenantHeader.test.ts`, `MonitorTemplateSyncResultUtil.test.ts`, and `MonitorCreateLabels.test.ts`. An isolated run at base `097b5d57360f` reproduced all four (39 passed across these three suites). Their expectations predate the custom-field defaults added in #3548; the affected tests and source files are unchanged by this PR.
- [JS lint](https://github.com/OneUptime/oneuptime/actions/runs/34109435527/job/101701992089): `react/jsx-pascal-case` for `SSO` at `Common/Tests/App/StatusPage/StatusPageOidcOrigin.test.tsx:199`. This file is byte-identical on the base revision and PR head.

Other CI checks are still running.

Closes #3525.

### Screenshots

Captured from the local Docker development app using synthetic monitor and label data.

Private dashboard — All retains the fixed network filter and shows five monitors.

![Private dashboard — All retains the fixed network filter and shows five monitors.](https://github.com/user-attachments/assets/63c67f0e-3fe2-40b4-8b50-11becd24af13)

Private dashboard — selecting 0660 shows two matching monitors and updates the title.

![Private dashboard — selecting 0660 shows two matching monitors and updates the title.](https://github.com/user-attachments/assets/918ad540-be99-4bbd-bf36-a26a5a8b8b0f)

Anonymous public dashboard — selecting 0661 shows its two monitors and the matching title.

![Anonymous public dashboard — selecting 0661 shows its two monitors and the matching title.](https://github.com/user-attachments/assets/9d0318e8-8f9a-4f7e-a449-e417f985c996)

<details>
<summary>Variable authoring and widget binding</summary>

Choose the project labels offered by UNIT.

![Project label variable configuration](https://github.com/user-attachments/assets/d0ffeb67-0a08-4e0f-a3c1-f358566c4ab4)

Bind UNIT to the Monitor List while retaining its fixed network label filter.

![Monitor List label variable binding](https://github.com/user-attachments/assets/c8eb6698-3ca8-416a-a4c3-db407ebf0057)

</details>
