### PR TITLE
fix: align monitor evaluation logs with alert emails, and repair the on-call page-out emails

### DIFF
--- a/App/FeatureSet/Notification/Templates/AcknowledgeAlert.hbs
+++ b/App/FeatureSet/Notification/Templates/AcknowledgeAlert.hbs
@@ -4,17 +4,17 @@
 {{> Logo this}}
 {{> EmailTitle title=(concat "Alert " alertNumber ": " alertTitle) }}
 
-{{> InfoBlock info=(concat "A new alert has been created in the project - " projectName)}}
+{{> InfoBlock plainInfo=(concat "A new alert has been created in the project - " projectName)}}
 
 {{> InfoBlock info="Here are the details: "}}
 
 {{> DetailBoxStart this }}
-{{> DetailBoxField title="Alert Title:" text=alertTitle }}
-{{> DetailBoxField title="Current State: " text=currentState  }}
-{{> DetailBoxField title="Resources Affected: " text=resourcesAffected  }}
-{{> DetailBoxField title="Severity: " text=alertSeverity  }}
-{{> DetailBoxField title="Root Cause: " text=rootCause  }}
-{{> DetailBoxField title="Description: " text=alertDescription  }}
+{{> DetailBoxField title="Alert Title:" plainText=alertTitle }}
+{{> DetailBoxField title="Current State: " plainText=currentState  }}
+{{> DetailBoxField title="Resources Affected: " plainText=resourcesAffected  }}
+{{> DetailBoxField title="Severity: " plainText=alertSeverity  }}
+{{> DetailBoxField title="Root Cause: " blockText=rootCause  }}
+{{> DetailBoxField title="Description: " blockText=alertDescription  }}
 {{> DetailBoxEnd this }}
 
 

--- a/App/FeatureSet/Notification/Templates/AcknowledgeAlertEpisode.hbs
+++ b/App/FeatureSet/Notification/Templates/AcknowledgeAlertEpisode.hbs
@@ -4,17 +4,17 @@
 {{> Logo this}}
 {{> EmailTitle title=(concat "Alert Episode " episodeNumber ": " alertEpisodeTitle) }}
 
-{{> InfoBlock info=(concat "A new alert episode has been created in the project - " projectName)}}
+{{> InfoBlock plainInfo=(concat "A new alert episode has been created in the project - " projectName)}}
 
 {{> InfoBlock info="Here are the details: "}}
 
 {{> DetailBoxStart this }}
-{{> DetailBoxField title="Alert Episode Title:" text=alertEpisodeTitle }}
-{{> DetailBoxField title="Current State: " text=currentState  }}
-{{> DetailBoxField title="Resources Affected: " text=resourcesAffected  }}
-{{> DetailBoxField title="Severity: " text=alertEpisodeSeverity  }}
-{{> DetailBoxField title="Root Cause: " text=rootCause  }}
-{{> DetailBoxField title="Description: " text=alertEpisodeDescription  }}
+{{> DetailBoxField title="Alert Episode Title:" plainText=alertEpisodeTitle }}
+{{> DetailBoxField title="Current State: " plainText=currentState  }}
+{{> DetailBoxField title="Resources Affected: " plainText=resourcesAffected  }}
+{{> DetailBoxField title="Severity: " plainText=alertEpisodeSeverity  }}
+{{> DetailBoxField title="Root Cause: " blockText=rootCause  }}
+{{> DetailBoxField title="Description: " blockText=alertEpisodeDescription  }}
 {{> DetailBoxEnd this }}
 
 {{#if alertsList}}

--- a/App/FeatureSet/Notification/Templates/AcknowledgeIncident.hbs
+++ b/App/FeatureSet/Notification/Templates/AcknowledgeIncident.hbs
@@ -4,17 +4,17 @@
 {{> Logo this}}
 {{> EmailTitle title=(concat "Incident " incidentNumber ": " incidentTitle) }}
 
-{{> InfoBlock info=(concat "A new incident has been created in the project - " projectName)}}
+{{> InfoBlock plainInfo=(concat "A new incident has been created in the project - " projectName)}}
 
 {{> InfoBlock info="Here are the details: "}}
 
 {{> DetailBoxStart this }}
-{{> DetailBoxField title="Incident Title:" text=incidentTitle }}
-{{> DetailBoxField title="Current State: " text=currentState  }}
-{{> DetailBoxField title="Resources Affected: " text=resourcesAffected  }}
-{{> DetailBoxField title="Severity: " text=incidentSeverity  }}
-{{> DetailBoxField title="Root Cause: " text=rootCause  }}
-{{> DetailBoxField title="Description: " text=incidentDescription  }}
+{{> DetailBoxField title="Incident Title:" plainText=incidentTitle }}
+{{> DetailBoxField title="Current State: " plainText=currentState  }}
+{{> DetailBoxField title="Resources Affected: " plainText=resourcesAffected  }}
+{{> DetailBoxField title="Severity: " plainText=incidentSeverity  }}
+{{> DetailBoxField title="Root Cause: " blockText=rootCause  }}
+{{> DetailBoxField title="Description: " blockText=incidentDescription  }}
 {{> DetailBoxEnd this }}
 
 

--- a/App/FeatureSet/Notification/Templates/AcknowledgeIncidentEpisode.hbs
+++ b/App/FeatureSet/Notification/Templates/AcknowledgeIncidentEpisode.hbs
@@ -4,17 +4,17 @@
 {{> Logo this}}
 {{> EmailTitle title=(concat "Incident Episode " episodeNumber ": " incidentEpisodeTitle) }}
 
-{{> InfoBlock info=(concat "A new incident episode has been created in the project - " projectName)}}
+{{> InfoBlock plainInfo=(concat "A new incident episode has been created in the project - " projectName)}}
 
 {{> InfoBlock info="Here are the details: "}}
 
 {{> DetailBoxStart this }}
-{{> DetailBoxField title="Incident Episode Title:" text=incidentEpisodeTitle }}
-{{> DetailBoxField title="Current State: " text=currentState  }}
-{{> DetailBoxField title="Resources Affected: " text=resourcesAffected  }}
-{{> DetailBoxField title="Severity: " text=incidentEpisodeSeverity  }}
-{{> DetailBoxField title="Root Cause: " text=rootCause  }}
-{{> DetailBoxField title="Description: " text=incidentEpisodeDescription  }}
+{{> DetailBoxField title="Incident Episode Title:" plainText=incidentEpisodeTitle }}
+{{> DetailBoxField title="Current State: " plainText=currentState  }}
+{{> DetailBoxField title="Resources Affected: " plainText=resourcesAffected  }}
+{{> DetailBoxField title="Severity: " plainText=incidentEpisodeSeverity  }}
+{{> DetailBoxField title="Root Cause: " blockText=rootCause  }}
+{{> DetailBoxField title="Description: " blockText=incidentEpisodeDescription  }}
 {{> DetailBoxEnd this }}
 
 {{#if incidentsList}}

--- a/App/FeatureSet/Notification/Templates/AlertOwnerAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/AlertOwnerAdded.hbs
@@ -13,7 +13,7 @@
 {{> DetailBoxField title="Current State: " text=currentState  }}
 {{> DetailBoxField title="Resources Affected: " text=resourcesAffected  }}
 {{> DetailBoxField title="Severity: " text=alertSeverity  }}
-{{> DetailBoxField title="Description: " text=alertDescription  }}
+{{> DetailBoxField title="Description: " blockText=alertDescription  }}
 {{> DetailBoxEnd this }}
 
 

--- a/App/FeatureSet/Notification/Templates/AlertOwnerResourceCreated.hbs
+++ b/App/FeatureSet/Notification/Templates/AlertOwnerResourceCreated.hbs
@@ -39,7 +39,7 @@
 --}}
 {{> DetailBoxStart this }}
 {{> DetailBoxField title="Affected Resource: " plainText=resourcesAffected }}
-{{> DetailBoxField title="Root Cause: " text=rootCause }}
+{{> DetailBoxField title="Root Cause: " blockText=rootCause }}
 {{> DetailBoxField title="Severity: " plainText=alertSeverity }}
 {{> DetailBoxField title="Current State: " plainText=currentState }}
 {{> DetailBoxField title="Declared At: " text=declaredAt }}
@@ -49,9 +49,9 @@
 {{> DetailBoxField title="Project: " plainText=projectName }}
 {{> DetailBoxField title="Declared By: " plainText=declaredBy }}
 {{#ifNotCond remediationNotes ""}}
-{{> DetailBoxField title="Remediation Notes: " text=remediationNotes }}
+{{> DetailBoxField title="Remediation Notes: " blockText=remediationNotes }}
 {{/ifNotCond}}
-{{> DetailBoxField title="Description: " text=alertDescription }}
+{{> DetailBoxField title="Description: " blockText=alertDescription }}
 {{> DetailBoxEnd this }}
 
 

--- a/App/FeatureSet/Notification/Templates/AlertOwnerStateChanged.hbs
+++ b/App/FeatureSet/Notification/Templates/AlertOwnerStateChanged.hbs
@@ -32,7 +32,7 @@
   !==, so an ABSENT var would pass it and render an empty bordered row.
 --}}
 {{#if stateChangeRootCause}}
-{{> DetailBoxField title="Root Cause:" text=stateChangeRootCause }}
+{{> DetailBoxField title="Root Cause:" blockText=stateChangeRootCause }}
 {{/if}}
 {{#ifNotCond previousStateDurationText ""}}
 {{> DetailBoxField title="Duration in Previous State:" plainText=previousStateDurationText }}
@@ -40,7 +40,7 @@
 {{> DetailBoxField title="State changed at:" text=stateChangedAt }}
 {{> DetailBoxField title="Severity:" plainText=alertSeverity }}
 {{> DetailBoxField title="Alert Title:" plainText=alertTitle }}
-{{> DetailBoxField title="Description:" text=alertDescription }}
+{{> DetailBoxField title="Description:" blockText=alertDescription }}
 {{> DetailBoxEnd this }}
 
 

--- a/App/FeatureSet/Notification/Templates/AlertOwnerUnresolvedReminder.hbs
+++ b/App/FeatureSet/Notification/Templates/AlertOwnerUnresolvedReminder.hbs
@@ -15,7 +15,7 @@
 {{> DetailBoxField title="Created At:" text=createdAt }}
 {{> DetailBoxField title="Resources Affected:" text=resourcesAffected }}
 {{> DetailBoxField title="Severity:" text=alertSeverity }}
-{{> DetailBoxField title="Description:" text=alertDescription }}
+{{> DetailBoxField title="Description:" blockText=alertDescription }}
 {{> DetailBoxEnd this }}
 
 

--- a/App/FeatureSet/Notification/Templates/IncidentMemberAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/IncidentMemberAdded.hbs
@@ -14,7 +14,7 @@
 {{> DetailBoxField title="Current State: " text=currentState  }}
 {{> DetailBoxField title="Resources Affected: " text=resourcesAffected  }}
 {{> DetailBoxField title="Severity: " text=incidentSeverity  }}
-{{> DetailBoxField title="Description: " text=incidentDescription  }}
+{{> DetailBoxField title="Description: " blockText=incidentDescription  }}
 {{> DetailBoxEnd this }}
 
 

--- a/App/FeatureSet/Notification/Templates/IncidentOwnerAdded.hbs
+++ b/App/FeatureSet/Notification/Templates/IncidentOwnerAdded.hbs
@@ -13,7 +13,7 @@
 {{> DetailBoxField title="Current State: " text=currentState  }}
 {{> DetailBoxField title="Resources Affected: " text=resourcesAffected  }}
 {{> DetailBoxField title="Severity: " text=incidentSeverity  }}
-{{> DetailBoxField title="Description: " text=incidentDescription  }}
+{{> DetailBoxField title="Description: " blockText=incidentDescription  }}
 {{> DetailBoxEnd this }}
 
 

--- a/App/FeatureSet/Notification/Templates/IncidentOwnerResourceCreated.hbs
+++ b/App/FeatureSet/Notification/Templates/IncidentOwnerResourceCreated.hbs
@@ -15,10 +15,10 @@
 {{> DetailBoxField title="Incident Declared By: " text=declaredBy  }}
 {{> DetailBoxField title="Incident Declared At: " text=declaredAt  }}
 {{> DetailBoxField title="Severity: " text=incidentSeverity  }}
-{{> DetailBoxField title="Root Cause: " text=rootCause  }}
-{{> DetailBoxField title="Description: " text=incidentDescription  }}
+{{> DetailBoxField title="Root Cause: " blockText=rootCause  }}
+{{> DetailBoxField title="Description: " blockText=incidentDescription  }}
 {{#ifNotCond remediationNotes ""}}
-{{> DetailBoxField title="Remediation Notes: " text=remediationNotes  }}
+{{> DetailBoxField title="Remediation Notes: " blockText=remediationNotes  }}
 {{/ifNotCond}}
 {{> DetailBoxEnd this }}
 

--- a/App/FeatureSet/Notification/Templates/IncidentOwnerStateChanged.hbs
+++ b/App/FeatureSet/Notification/Templates/IncidentOwnerStateChanged.hbs
@@ -17,7 +17,7 @@
 {{> DetailBoxField title="State changed at:" text=stateChangedAt }}
 {{> DetailBoxField title="Resources Affected:" text=resourcesAffected }}
 {{> DetailBoxField title="Severity:" text=incidentSeverity }}
-{{> DetailBoxField title="Description:" text=incidentDescription }}
+{{> DetailBoxField title="Description:" blockText=incidentDescription }}
 {{> DetailBoxEnd this }}
 
 

--- a/App/FeatureSet/Notification/Templates/IncidentOwnerUnresolvedReminder.hbs
+++ b/App/FeatureSet/Notification/Templates/IncidentOwnerUnresolvedReminder.hbs
@@ -15,7 +15,7 @@
 {{> DetailBoxField title="Declared At:" text=declaredAt }}
 {{> DetailBoxField title="Resources Affected:" text=resourcesAffected }}
 {{> DetailBoxField title="Severity:" text=incidentSeverity }}
-{{> DetailBoxField title="Description:" text=incidentDescription }}
+{{> DetailBoxField title="Description:" blockText=incidentDescription }}
 {{> DetailBoxEnd this }}
 
 

--- a/App/FeatureSet/Notification/Templates/MonitorOwnerStatusChanged.hbs
+++ b/App/FeatureSet/Notification/Templates/MonitorOwnerStatusChanged.hbs
@@ -22,7 +22,7 @@
 {{/ifCond}}
 {{/ifNotCond}}
 {{#ifNotCond rootCause ""}}
-{{> DetailBoxField title="Root Cause:" text=rootCause }}
+{{> DetailBoxField title="Root Cause:" blockText=rootCause }}
 {{/ifNotCond}}
 {{> DetailBoxField title="Status changed at:" text=statusChangedAt }}
 {{> DetailBoxField title="Description:" text=monitorDescription }}

--- a/App/FeatureSet/Notification/Templates/Partials/DetailBoxField.hbs
+++ b/App/FeatureSet/Notification/Templates/Partials/DetailBoxField.hbs
@@ -35,7 +35,28 @@
     byte-identical, and the HTML/plain split is not expressible per variable
     name (incidentDescription is Markdown-HTML in one sender and raw in
     another).
+
+    `blockText` is the third slot, and carries the SAME escaping contract as
+    `text` — raw HTML, Markdown.convertToHTML output only. It exists because
+    `text` renders inside a <p>, and Markdown.convertToHTML emits BLOCK
+    elements: the breaching-samples <table> in an alert root cause, and the
+    <ul> in any description written as a list. A <table> inside a <p> is
+    invalid nesting, and every mail client resolves it by auto-closing the
+    paragraph early — so the table escaped the styled .st-DetailCard-value
+    box and landed unstyled against the card edge. This branch is a <div>
+    carrying identical typography, so block content nests legally and still
+    looks like every other field.
+
+    Use `blockText` for anything that came out of Markdown.convertToHTML;
+    `text` remains correct for inline HTML such as
+    OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones.
   --}}
+  {{#if blockText}}
+    <div
+      class="st-DetailCard-value"
+      style="Margin:0;font-size:15px;font-family:'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;line-height:24px;color:#1e293b;font-weight:500;"
+    >{{{blockText}}}</div>
+  {{/if}}
   {{#if text}}
     <p
       class="st-DetailCard-value"

--- a/App/FeatureSet/Notification/Templates/Partials/InfoBlock.hbs
+++ b/App/FeatureSet/Notification/Templates/Partials/InfoBlock.hbs
@@ -20,7 +20,18 @@
         class="st-Font st-Font--body"
         style="border: 0; margin: 0; padding: 0; color: #374151 !important; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Ubuntu, sans-serif; font-size: 15px; line-height: 26px;"
       >
-        {{{info}}}
+        {{!--
+          `info` is RAW HTML — same contract as DetailBoxField's `text`.
+          Most call sites pass a literal string from the template itself,
+          which is safe, but a few interpolate a DB value through the
+          `concat` helper, and `concat` only String()s and joins: it does
+          not escape. A project name containing markup therefore reached
+          the reader as live HTML inside an email they trust.
+
+          `plainInfo` is the escaped slot for exactly those call sites.
+          Use it whenever any part of the string comes from the database.
+        --}}
+        {{#if plainInfo}}{{plainInfo}}{{/if}}{{{info}}}
       </td>
       <td
         class="st-Spacer st-Spacer--gutter"

--- a/App/FeatureSet/Notification/Templates/SubscriberIncidentCreated.hbs
+++ b/App/FeatureSet/Notification/Templates/SubscriberIncidentCreated.hbs
@@ -11,7 +11,7 @@
 {{> DetailBoxField title="Severity" text=incidentSeverity  }}
 {{> DetailBoxField title="Affected Resources" text=resourcesAffected  }}
 {{#if incidentDescription}}
-{{> DetailBoxField title="Description" text=incidentDescription  }}
+{{> DetailBoxField title="Description" blockText=incidentDescription  }}
 {{/if}}
 {{> DetailBoxEnd this }}
 

--- a/App/Tests/Notification/AcknowledgeEmailTemplates.test.ts
+++ b/App/Tests/Notification/AcknowledgeEmailTemplates.test.ts
@@ -1,0 +1,269 @@
+import Handlebars from "handlebars";
+import fs from "fs";
+import Path from "path";
+import { beforeAll, describe, expect, test } from "@jest/globals";
+
+/*
+ * Registers the product's real `concat` / `ifCond` helpers as an import
+ * side effect, so this suite renders with the helpers the product ships.
+ */
+import "../../FeatureSet/Notification/Utils/Handlebars";
+
+/*
+ * THE FOUR PAGE-OUT EMAILS.
+ *
+ * These are what an on-call responder is woken up by, and they were the
+ * last email family still passing every detail row through DetailBoxField's
+ * RAW `text` slot. Two consequences, both visible in a real inbox:
+ *
+ *  1. `rootCause` is a Markdown column — MonitorCriteriaEvaluator writes
+ *     "**Filter Conditions Met**: ..." into it, and for a metric monitor a
+ *     "| Timestamp | Metric | Alias | Value |" table underneath. Passed
+ *     raw, the responder read literal asterisks and literal pipe rows.
+ *  2. Titles, state names, severities and resource names are free text a
+ *     project member typed. In a raw slot they are live HTML in an email
+ *     the recipient trusts — the precise hole DetailBoxField's `plainText`
+ *     branch was added to close, and which these four never adopted.
+ *
+ * A third defect had no visible symptom at all: AcknowledgeAlert.hbs asks
+ * for a Root Cause row and its generator never set the variable, so
+ * `{{#if}}` silently dropped it. The person being paged for the alert was
+ * the only one who could not see why it fired.
+ */
+
+const NOTIFICATION_DIR: string = Path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Notification",
+);
+
+const TEMPLATES_DIR: string = Path.resolve(NOTIFICATION_DIR, "Templates");
+
+/** A metric-monitor root cause, as the evaluator actually writes it. */
+const ROOT_CAUSE_HTML: string = [
+  "<p><strong>Filter Conditions Met</strong>: Metric Value is 1.07 GB",
+  " which is greater than 1 GB.</p>",
+  '<table cellpadding="0" cellspacing="0" border="0" width="100%"',
+  ' style="border-collapse:collapse;"><thead><tr>',
+  '<th style="padding:8px 10px;">Timestamp</th>',
+  '<th style="padding:8px 10px;">Value</th>',
+  "</tr></thead><tbody><tr>",
+  '<td style="padding:8px 10px;">2026-08-14T10:30:00.000Z</td>',
+  '<td style="padding:8px 10px;">1.07 GB</td>',
+  "</tr></tbody></table>",
+].join("");
+
+const HOSTILE: string = '<img src=x onerror="alert(1)">';
+
+function templateSource(name: string): string {
+  return fs.readFileSync(Path.resolve(TEMPLATES_DIR, name), {
+    encoding: "utf8",
+  });
+}
+
+function render(name: string, vars: Record<string, unknown>): string {
+  return Handlebars.compile(templateSource(name))(vars);
+}
+
+beforeAll(() => {
+  const partialsDir: string = Path.resolve(TEMPLATES_DIR, "Partials");
+
+  for (const filename of fs.readdirSync(partialsDir)) {
+    const matches: RegExpMatchArray | null = filename.match(/^(.*)\.hbs$/u);
+
+    if (!matches) {
+      continue;
+    }
+
+    Handlebars.registerPartial(
+      matches[1]!,
+      fs.readFileSync(Path.resolve(partialsDir, filename), {
+        encoding: "utf8",
+      }),
+    );
+  }
+});
+
+interface AcknowledgeTemplate {
+  file: string;
+  titleVar: string;
+  severityVar: string;
+  descriptionVar: string;
+}
+
+const TEMPLATES: Array<AcknowledgeTemplate> = [
+  {
+    file: "AcknowledgeAlert.hbs",
+    titleVar: "alertTitle",
+    severityVar: "alertSeverity",
+    descriptionVar: "alertDescription",
+  },
+  {
+    file: "AcknowledgeIncident.hbs",
+    titleVar: "incidentTitle",
+    severityVar: "incidentSeverity",
+    descriptionVar: "incidentDescription",
+  },
+  {
+    file: "AcknowledgeAlertEpisode.hbs",
+    titleVar: "alertEpisodeTitle",
+    severityVar: "alertEpisodeSeverity",
+    descriptionVar: "alertEpisodeDescription",
+  },
+  {
+    file: "AcknowledgeIncidentEpisode.hbs",
+    titleVar: "incidentEpisodeTitle",
+    severityVar: "incidentEpisodeSeverity",
+    descriptionVar: "incidentEpisodeDescription",
+  },
+];
+
+function varsFor(
+  template: AcknowledgeTemplate,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    [template.titleVar]: "Pod CPU saturating limit",
+    [template.severityVar]: "Critical",
+    [template.descriptionVar]: "<p>A pod is over its CPU limit.</p>",
+    currentState: "Created",
+    resourcesAffected: "web-7d9f",
+    projectName: "acme-prod",
+    rootCause: ROOT_CAUSE_HTML,
+    alertNumber: "ALT-113",
+    incidentNumber: "INC-9",
+    episodeNumber: "EP-4",
+    alertsCount: "2",
+    incidentsCount: "2",
+    alertsList: "",
+    incidentsList: "",
+    ...overrides,
+  };
+}
+
+describe("the acknowledge emails render the root cause as HTML", () => {
+  for (const template of TEMPLATES) {
+    test(`${template.file} renders root-cause markup, not literal markdown`, () => {
+      const html: string = render(template.file, varsFor(template));
+
+      expect(html).toContain("<strong>Filter Conditions Met</strong>");
+      expect(html).toContain("<table");
+      expect(html).toContain("1.07 GB");
+
+      // What the responder used to read instead.
+      expect(html).not.toContain("**Filter Conditions Met**");
+      expect(html).not.toContain("| Timestamp | Metric | Alias | Value |");
+    });
+
+    /*
+     * The <table> arrives inside a DetailBoxField. On the `text` slot that
+     * meant <p><table>…</table></p>, which every mail client repairs by
+     * closing the paragraph early — dropping the table out of the styled
+     * value box. `blockText` renders a <div>, where it nests legally.
+     */
+    test(`${template.file} puts block content in a div, never a p`, () => {
+      const html: string = render(template.file, varsFor(template));
+
+      expect(html).toMatch(/<div[^>]*class="st-DetailCard-value"[^>]*>\s*<p>/u);
+      expect(html).not.toMatch(
+        /<p[^>]*class="st-DetailCard-value"[^>]*>\s*<p>/u,
+      );
+      expect(html).not.toMatch(
+        /<p[^>]*class="st-DetailCard-value"[^>]*>\s*<table/u,
+      );
+    });
+  }
+});
+
+describe("the acknowledge emails escape everything that is not markup", () => {
+  for (const template of TEMPLATES) {
+    test(`${template.file} escapes a hostile title, state, severity and resource`, () => {
+      const html: string = render(
+        template.file,
+        varsFor(template, {
+          [template.titleVar]: HOSTILE,
+          [template.severityVar]: HOSTILE,
+          currentState: HOSTILE,
+          resourcesAffected: HOSTILE,
+        }),
+      );
+
+      expect(html).not.toContain(HOSTILE);
+      expect(html).not.toContain('onerror="alert(1)"');
+      /*
+       * Handlebars escapes "=" to "&#x3D;" as well as the angle brackets,
+       * so the tag arrives as inert text the reader can see.
+       */
+      expect(html).toContain("&lt;img");
+      expect(html).toContain("onerror&#x3D;");
+    });
+
+    /*
+     * `concat` joins without escaping, and its output went into InfoBlock's
+     * raw {{{info}}}. A project name is free text a member typed.
+     */
+    test(`${template.file} escapes a hostile project name in the intro line`, () => {
+      const html: string = render(
+        template.file,
+        varsFor(template, { projectName: HOSTILE }),
+      );
+
+      expect(html).not.toContain(HOSTILE);
+      expect(html).toContain("&lt;img");
+    });
+
+    /*
+     * The control: the description and root cause are Markdown.convertToHTML
+     * output, which has already escaped what the user typed. If this branch
+     * ever started escaping, every email would show its own tags.
+     */
+    test(`${template.file} still renders converted markdown unescaped`, () => {
+      const html: string = render(template.file, varsFor(template));
+
+      expect(html).toContain("<p>A pod is over its CPU limit.</p>");
+      expect(html).not.toContain("&lt;strong&gt;Filter Conditions Met");
+    });
+  }
+});
+
+describe("the acknowledge emails show every row their template asks for", () => {
+  for (const template of TEMPLATES) {
+    /*
+     * DetailBoxField renders the LABEL from `title` but guards the VALUE
+     * with `{{#if}}`. A variable the generator forgets to set therefore
+     * produces a labelled row with nothing under it — no error, no blank
+     * where a reader would notice one. That is how AcknowledgeAlert.hbs
+     * shipped a "ROOT CAUSE:" heading over empty space for as long as its
+     * generator never set the variable.
+     *
+     * This test pins the failure mode so the service-level fix that now
+     * supplies the variable has something to be measured against.
+     */
+    test(`${template.file} renders an empty value box when a variable is missing`, () => {
+      const withRow: string = render(template.file, varsFor(template));
+      const withoutRow: string = render(
+        template.file,
+        varsFor(template, { rootCause: undefined }),
+      );
+
+      expect(withRow).toContain("<strong>Filter Conditions Met</strong>");
+      expect(withoutRow).not.toContain(
+        "<strong>Filter Conditions Met</strong>",
+      );
+
+      // The label survives either way — which is exactly why it went unnoticed.
+      expect(withoutRow).toContain("Root Cause:");
+    });
+
+    test(`${template.file} asks for a Resources Affected row`, () => {
+      const source: string = templateSource(template.file);
+
+      expect(source).toContain("plainText=resourcesAffected");
+
+      const html: string = render(template.file, varsFor(template));
+      expect(html).toContain("web-7d9f");
+    });
+  }
+});

--- a/App/Tests/Notification/AlertOwnerEmailTemplates.test.ts
+++ b/App/Tests/Notification/AlertOwnerEmailTemplates.test.ts
@@ -295,6 +295,23 @@ describe("DetailBoxField escaping", () => {
   });
 
   /*
+   * `blockText` is the third slot and carries the SAME raw-HTML contract as
+   * `text` — it exists for the <p>-nesting problem, not for escaping, and
+   * must never be mistaken for the escaped branch.
+   */
+  test("the partial's blockText branch is raw HTML in a block container", () => {
+    const source: string = fs.readFileSync(
+      Path.resolve(TEMPLATES_DIR, "Partials", "DetailBoxField.hbs"),
+      { encoding: "utf8" },
+    );
+
+    expect(source).toContain("{{{blockText}}}");
+    expect(source).not.toContain("{{blockText}}}}");
+    // A block container, so a <table> or <ul> can nest legally inside it.
+    expect(source).toMatch(/<div[^>]*>\{\{\{blockText\}\}\}<\/div>/u);
+  });
+
+  /*
    * Every value the alert templates pass that is NOT Markdown output or a
    * pre-rendered date must be on plainText=. Reading the two templates
    * catches a new row added on the wrong parameter, which no rendering
@@ -322,12 +339,93 @@ describe("DetailBoxField escaping", () => {
       expect(changed).toContain(`plainText=${variable}`);
     }
 
-    // ...and their HTML-bearing ones stay on text=.
-    expect(created).toContain("text=rootCause");
+    /*
+     * ...and their HTML-bearing ones stay on a raw slot. Markdown output
+     * moved to `blockText` (it emits <table>/<ul>, which cannot nest in the
+     * <p> that `text` renders); a pre-rendered date stays on `text`,
+     * because it is inline <br/> markup and a <p> is the right box for it.
+     */
+    expect(created).toContain("blockText=rootCause");
+    expect(created).toContain("blockText=alertDescription");
     expect(created).toContain("text=declaredAt");
-    expect(created).toContain("text=alertDescription");
-    expect(changed).toContain("text=stateChangeRootCause");
+    expect(changed).toContain("blockText=stateChangeRootCause");
     expect(changed).toContain("text=stateChangedAt");
+  });
+
+  /*
+   * The four on-call page-out emails were the last family still passing
+   * every row — titles, state names, severity, resources — through the raw
+   * `text` slot, which is the hole the `plainText` branch was added to
+   * close. They are also the emails a responder reads at 3am, so they are
+   * the worst place to leave attacker-authored markup live.
+   */
+  test("the acknowledge templates pass their plain strings on plainText=", () => {
+    const acknowledgeTemplates: Record<string, Array<string>> = {
+      "AcknowledgeAlert.hbs": [
+        "alertTitle",
+        "currentState",
+        "resourcesAffected",
+        "alertSeverity",
+      ],
+      "AcknowledgeIncident.hbs": [
+        "incidentTitle",
+        "currentState",
+        "resourcesAffected",
+        "incidentSeverity",
+      ],
+      "AcknowledgeAlertEpisode.hbs": [
+        "alertEpisodeTitle",
+        "currentState",
+        "resourcesAffected",
+        "alertEpisodeSeverity",
+      ],
+      "AcknowledgeIncidentEpisode.hbs": [
+        "incidentEpisodeTitle",
+        "currentState",
+        "resourcesAffected",
+        "incidentEpisodeSeverity",
+      ],
+    };
+
+    for (const [templateName, variables] of Object.entries(
+      acknowledgeTemplates,
+    )) {
+      const source: string = templateSource(templateName);
+
+      for (const variable of variables) {
+        expect(source).toContain(`plainText=${variable}`);
+        expect(source).not.toContain(`text=${variable} `);
+      }
+
+      // The one genuinely-HTML row per template rides the block slot.
+      expect(source).toContain("blockText=rootCause");
+    }
+  });
+
+  /*
+   * `concat` only String()s and joins — it does not escape — so a project
+   * name reaching InfoBlock's raw {{{info}}} through it was live HTML.
+   */
+  test("the acknowledge templates put their concatenated project name on plainInfo=", () => {
+    for (const templateName of [
+      "AcknowledgeAlert.hbs",
+      "AcknowledgeIncident.hbs",
+      "AcknowledgeAlertEpisode.hbs",
+      "AcknowledgeIncidentEpisode.hbs",
+    ]) {
+      const source: string = templateSource(templateName);
+
+      expect(source).toContain("InfoBlock plainInfo=(concat");
+      expect(source).not.toContain("InfoBlock info=(concat");
+    }
+
+    const infoBlock: string = fs.readFileSync(
+      Path.resolve(TEMPLATES_DIR, "Partials", "InfoBlock.hbs"),
+      { encoding: "utf8" },
+    );
+
+    expect(infoBlock).toContain("{{plainInfo}}");
+    expect(infoBlock).not.toContain("{{{plainInfo}}}");
   });
 });
 

--- a/Common/Server/Services/UserNotificationRuleService.ts
+++ b/Common/Server/Services/UserNotificationRuleService.ts
@@ -982,6 +982,16 @@ export class Service extends DatabaseService<Model> {
           rootCause: true,
           incidentNumber: true,
           incidentNumberWithPrefix: true,
+          /*
+           * AcknowledgeIncident.hbs asks for a Resources Affected row and
+           * the generator had nothing to build it from, so the row was
+           * silently dropped — the same `{{#if}}` swallow that hid the
+           * alert's Root Cause.
+           */
+          monitors: {
+            _id: true,
+            name: true,
+          },
         },
       });
     }
@@ -1012,6 +1022,20 @@ export class Service extends DatabaseService<Model> {
           },
           alertNumber: true,
           alertNumberWithPrefix: true,
+          /*
+           * AcknowledgeAlert.hbs has always asked for a Root Cause row, but
+           * this select never loaded the column and the template's
+           * `{{#if text}}` guard silently dropped the row — so the one
+           * person being woken up for the alert was the only one who could
+           * not see why it fired. The other three on-call templates already
+           * select it.
+           */
+          rootCause: true,
+          // Same story for the template's Resources Affected row.
+          monitor: {
+            _id: true,
+            name: true,
+          },
         },
       });
     }
@@ -4589,6 +4613,11 @@ export class Service extends DatabaseService<Model> {
         MarkdownContentType.Email,
       ),
       alertSeverity: alert.alertSeverity!.name!,
+      resourcesAffected: alert.monitor?.name || "No resources identified",
+      rootCause: await Markdown.convertToHTML(
+        alert.rootCause || "No root cause identified for this alert",
+        MarkdownContentType.Email,
+      ),
       alertViewLink: (
         await AlertService.getAlertLinkInDashboard(alert.projectId!, alert.id!)
       ).toString(),
@@ -4634,8 +4663,19 @@ export class Service extends DatabaseService<Model> {
         MarkdownContentType.Email,
       ),
       incidentSeverity: incident.incidentSeverity!.name!,
-      rootCause:
+      resourcesAffected:
+        (incident.monitors || [])
+          .map((monitor: Monitor): string => {
+            return monitor.name || "";
+          })
+          .filter((name: string): boolean => {
+            return name.length > 0;
+          })
+          .join(", ") || "No resources identified",
+      rootCause: await Markdown.convertToHTML(
         incident.rootCause || "No root cause identified for this incident",
+        MarkdownContentType.Email,
+      ),
       incidentViewLink: (
         await IncidentService.getIncidentLinkInDashboard(
           incident.projectId!,
@@ -4738,7 +4778,9 @@ export class Service extends DatabaseService<Model> {
     if (alerts.length > 0) {
       const alertRows: string[] = [];
       for (const alert of alerts) {
-        const alertTitle: string = alert.title || "Untitled Alert";
+        const alertTitle: string = Markdown.escapeHtml(
+          alert.title || "Untitled Alert",
+        );
         const alertNumber: string =
           alert.alertNumberWithPrefix ||
           (alert.alertNumber ? `#${alert.alertNumber}` : "");
@@ -4748,7 +4790,9 @@ export class Service extends DatabaseService<Model> {
             alert.id!,
           )
         ).toString();
-        const monitorName: string = alert.monitor?.name || "";
+        const monitorName: string = Markdown.escapeHtml(
+          alert.monitor?.name || "",
+        );
 
         alertRows.push(`
             <tr>
@@ -4795,9 +4839,11 @@ export class Service extends DatabaseService<Model> {
       ),
       alertEpisodeSeverity: alertEpisode.alertSeverity!.name!,
       resourcesAffected: resourcesAffected,
-      rootCause:
+      rootCause: await Markdown.convertToHTML(
         alertEpisode.rootCause ||
-        "No root cause identified for this alert episode",
+          "No root cause identified for this alert episode",
+        MarkdownContentType.Email,
+      ),
       alertsList: alertsListHtml,
       alertsCount: alerts.length.toString(),
       alertEpisodeViewLink: (
@@ -4908,7 +4954,9 @@ export class Service extends DatabaseService<Model> {
     if (incidents.length > 0) {
       const incidentRows: string[] = [];
       for (const incident of incidents) {
-        const incidentTitle: string = incident.title || "Untitled Incident";
+        const incidentTitle: string = Markdown.escapeHtml(
+          incident.title || "Untitled Incident",
+        );
         const incidentNumber: string =
           incident.incidentNumberWithPrefix ||
           (incident.incidentNumber ? `#${incident.incidentNumber}` : "");
@@ -4918,7 +4966,7 @@ export class Service extends DatabaseService<Model> {
             incident.id!,
           )
         ).toString();
-        const monitorName: string =
+        const monitorName: string = Markdown.escapeHtml(
           (incident.monitors || [])
             .map((monitor: Monitor): string => {
               return monitor.name || "";
@@ -4926,7 +4974,8 @@ export class Service extends DatabaseService<Model> {
             .filter((name: string): boolean => {
               return name.length > 0;
             })
-            .join(", ") || "";
+            .join(", ") || "",
+        );
 
         incidentRows.push(`
             <tr>
@@ -4975,9 +5024,11 @@ export class Service extends DatabaseService<Model> {
       ),
       incidentEpisodeSeverity: incidentEpisode.incidentSeverity!.name!,
       resourcesAffected: resourcesAffected,
-      rootCause:
+      rootCause: await Markdown.convertToHTML(
         incidentEpisode.rootCause ||
-        "No root cause identified for this incident episode",
+          "No root cause identified for this incident episode",
+        MarkdownContentType.Email,
+      ),
       incidentsList: incidentsListHtml,
       incidentsCount: incidents.length.toString(),
       incidentEpisodeViewLink: (

--- a/Common/Server/Types/Markdown.ts
+++ b/Common/Server/Types/Markdown.ts
@@ -119,7 +119,15 @@ export default class Markdown {
     return htmlBody;
   }
 
-  private static escapeHtml(text: string): string {
+  /**
+   * Escape the five characters that can break out of HTML text or an
+   * attribute value.
+   *
+   * Public because it is not only marked's business: code that hand-builds
+   * an email fragment by string interpolation needs the same escaping, and
+   * a second implementation is a second thing to get wrong.
+   */
+  public static escapeHtml(text: string): string {
     return text
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
@@ -128,12 +136,96 @@ export default class Markdown {
       .replace(/'/g, "&#39;");
   }
 
+  /*
+   * The email renderer.
+   *
+   * Everything here is an INLINE style, and that is not a preference.
+   * MailService compiles the Handlebars template and sends it — there is no
+   * CSS inlining step anywhere in the pipeline — and Gmail strips <style>
+   * blocks from the document head, so a class name emitted here reaches the
+   * reader as nothing at all. That is why the Docs/Blog renderers' Tailwind
+   * classes cannot be copied even though the override shape can.
+   *
+   * Until this existed the renderer was a bare `new Renderer()`. Alert and
+   * incident root causes carry a GitHub-flavoured table of breaching
+   * samples, and marked emitted it as a naked <table> with no borders, no
+   * padding and no alignment: every row ran into the next, which is
+   * precisely the part of the email an on-call engineer reads first.
+   *
+   * Outlook renders through Word, which ignores border-radius, box-shadow
+   * and — importantly — overflow, so the scrolling wrapper the Docs and
+   * Blog renderers use does not transfer. The table has to FIT instead:
+   * the DetailBox card is 472px wide with 28px of padding either side,
+   * leaving roughly 416px for a root-cause table that routinely runs to
+   * four or more columns. Hence `width:100%` with `table-layout:auto` and
+   * `word-break:break-word` on the cells — a long metric name wraps inside
+   * its column rather than pushing the table past the body width.
+   */
   private static getEmailRenderer(): Renderer {
     if (this.emailRenderer !== null) {
       return this.emailRenderer;
     }
 
     const renderer: Renderer = new Renderer();
+
+    const cellFont: string =
+      "font-family:'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;font-size:13px;line-height:20px;";
+
+    renderer.table = function (header: string, body: string): string {
+      return (
+        `<table cellpadding="0" cellspacing="0" border="0" width="100%" ` +
+        `style="border-collapse:collapse;width:100%;table-layout:auto;` +
+        `margin:12px 0;border:1px solid #e2e8f0;">` +
+        `<thead>${header}</thead><tbody>${body}</tbody></table>`
+      );
+    };
+
+    renderer.tablerow = function (content: string): string {
+      return `<tr>${content}</tr>`;
+    };
+
+    renderer.tablecell = function (
+      content: string,
+      flags: { header?: boolean; align?: string | null },
+    ): string {
+      const tag: string = flags.header ? "th" : "td";
+      const align: string = flags.align ? `text-align:${flags.align};` : "";
+
+      /*
+       * A header cell gets the tinted band and the heavier bottom rule; a
+       * body cell gets a hairline so consecutive rows stay separable. Both
+       * keep the same padding so the columns line up.
+       */
+      const tone: string = flags.header
+        ? "background-color:#f8fafc;color:#475569;font-weight:600;border-bottom:1px solid #cbd5e1;"
+        : "color:#1e293b;font-weight:400;border-bottom:1px solid #f1f5f9;";
+
+      return (
+        `<${tag} style="padding:8px 10px;${cellFont}${tone}` +
+        `word-break:break-word;${align || "text-align:left;"}">` +
+        `${content}</${tag}>`
+      );
+    };
+
+    /*
+     * The root cause backticks metric names, aliases and timestamps. Left
+     * bare they were indistinguishable from the prose around them.
+     *
+     * `code` arrives ALREADY escaped — marked escapes codespan text before
+     * it reaches the renderer — so escaping again here would turn a typed
+     * "<img>" into the literal "&lt;img&gt;" on screen rather than the
+     * "<img>" the author wrote. (The Docs and BlogValidation renderers do
+     * escape a second time; that is a separate defect in those surfaces,
+     * not a pattern to copy.)
+     */
+    renderer.codespan = function (code: string): string {
+      return (
+        `<code style="background-color:#f1f5f9;color:#0f172a;` +
+        `padding:1px 5px;border-radius:4px;` +
+        `font-family:'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;` +
+        `font-size:12px;">${code}</code>`
+      );
+    };
 
     this.emailRenderer = renderer;
 

--- a/Common/Server/Utils/Monitor/MonitorCriteriaExpectationBuilder.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaExpectationBuilder.ts
@@ -2,10 +2,21 @@ import {
   CriteriaFilter,
   FilterType,
 } from "../../../Types/Monitor/CriteriaFilter";
+import MetricValueFormatter from "../../../Utils/Monitor/MetricValueFormatter";
+
+/**
+ * How a criteria's values are displayed: the unit, and the metric name
+ * the formatter's fraction / epoch rules are keyed on.
+ */
+export interface CriteriaDisplayOptions {
+  unit?: string | undefined;
+  metricName?: string | undefined;
+}
 
 export default class MonitorCriteriaExpectationBuilder {
   public static getCriteriaFilterDescription(
     criteriaFilter: CriteriaFilter,
+    options?: CriteriaDisplayOptions,
   ): string {
     const parts: Array<string> = [criteriaFilter.checkOn];
 
@@ -14,15 +25,51 @@ export default class MonitorCriteriaExpectationBuilder {
     }
 
     if (criteriaFilter.value !== undefined && criteriaFilter.value !== null) {
-      parts.push(String(criteriaFilter.value));
+      const formatted: string | number =
+        MonitorCriteriaExpectationBuilder.formatThreshold(
+          criteriaFilter.value,
+          options,
+        ) ?? criteriaFilter.value;
+
+      parts.push(String(formatted));
     }
 
     return parts.join(" ").trim();
   }
 
+  /*
+   * The threshold, rendered exactly as an observed value would be — or
+   * returned untouched when it cannot be.
+   *
+   * Untouched covers three cases, and each matters: no unit was resolved
+   * (every non-metric checkOn, whose unit lives in its CheckOn label), the
+   * threshold is a string (the Contains / StartsWith family, which must
+   * quote what the user typed), or it is not a finite number.
+   */
+  private static formatThreshold(
+    value: string | number | undefined,
+    options?: CriteriaDisplayOptions,
+  ): string | number | undefined {
+    if (!options?.unit) {
+      return value;
+    }
+
+    const numeric: number = Number(value);
+
+    if (typeof value === "boolean" || !Number.isFinite(numeric)) {
+      return value;
+    }
+
+    return MetricValueFormatter.format({
+      value: numeric,
+      unit: options.unit,
+      metricName: options.metricName,
+    });
+  }
+
   public static describeCriteriaExpectation(
     criteriaFilter: CriteriaFilter,
-    options?: { unit?: string | undefined },
+    options?: CriteriaDisplayOptions,
   ): string | null {
     if (!criteriaFilter.filterType) {
       return null;
@@ -30,7 +77,29 @@ export default class MonitorCriteriaExpectationBuilder {
 
     let expectation: string;
 
+    /*
+     * Render the threshold the way the observed value is rendered, so the
+     * two halves of one sentence cannot describe one quantity differently.
+     * Reformatting only the observation produced "recorded latest 1.07 GB
+     * (expected to be greater than 1000000000 By)".
+     *
+     * A NON-numeric threshold falls back to the previous text verbatim —
+     * `criteriaFilter.value` is `string | number | undefined`, and the
+     * string filter types below must keep quoting exactly what the user
+     * typed. So must a threshold with no unit: `formatThreshold` is only
+     * installed when a unit was resolved, which happens for the two metric
+     * checkOns and nothing else.
+     */
     const value: string | number | undefined = criteriaFilter.value;
+
+    /*
+     * The threshold as the six value-comparison cases below should print
+     * it, unit included. Only those six get it: the string comparisons
+     * quote what the user typed, and the heartbeat windows carry their own
+     * "minutes" — formatting their value produced "within 5 sec minutes".
+     */
+    const comparedValue: string | number | undefined =
+      MonitorCriteriaExpectationBuilder.formatThreshold(value, options);
 
     /*
      * Suffix numeric-threshold comparisons with the metric's display unit
@@ -38,27 +107,31 @@ export default class MonitorCriteriaExpectationBuilder {
      * as the observed value. Only the value-comparison filter types below
      * carry a numeric threshold — the others (empty, boolean, heartbeat
      * windows, …) supply their own wording and get no suffix.
+     *
+     * When the value was formatted above it already carries its unit, so
+     * this suffix collapses to empty and the unit is not printed twice.
      */
-    const unitSuffix: string = options?.unit ? ` ${options.unit}` : "";
+    const unitSuffix: string =
+      options?.unit && comparedValue === value ? ` ${options.unit}` : "";
 
     switch (criteriaFilter.filterType) {
       case FilterType.GreaterThan:
-        expectation = `to be greater than ${value}${unitSuffix}`;
+        expectation = `to be greater than ${comparedValue}${unitSuffix}`;
         break;
       case FilterType.GreaterThanOrEqualTo:
-        expectation = `to be greater than or equal to ${value}${unitSuffix}`;
+        expectation = `to be greater than or equal to ${comparedValue}${unitSuffix}`;
         break;
       case FilterType.LessThan:
-        expectation = `to be less than ${value}${unitSuffix}`;
+        expectation = `to be less than ${comparedValue}${unitSuffix}`;
         break;
       case FilterType.LessThanOrEqualTo:
-        expectation = `to be less than or equal to ${value}${unitSuffix}`;
+        expectation = `to be less than or equal to ${comparedValue}${unitSuffix}`;
         break;
       case FilterType.EqualTo:
-        expectation = `to equal ${value}${unitSuffix}`;
+        expectation = `to equal ${comparedValue}${unitSuffix}`;
         break;
       case FilterType.NotEqualTo:
-        expectation = `to not equal ${value}${unitSuffix}`;
+        expectation = `to not equal ${comparedValue}${unitSuffix}`;
         break;
       case FilterType.Contains:
         expectation = `to contain ${value}`;

--- a/Common/Server/Utils/Monitor/MonitorCriteriaMessageBuilder.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaMessageBuilder.ts
@@ -59,17 +59,19 @@ export default class MonitorCriteriaMessageBuilder {
      * the observed value — "recorded latest 0.06 sec (expected to be greater
      * than 5 sec)" rather than the unitless "0.06 (expected ... 5)".
      */
-    const metricDisplayUnit: string | undefined =
-      MonitorCriteriaObservationBuilder.getMetricValueDisplayUnit({
-        criteriaFilter: input.criteriaFilter,
-        dataToProcess: input.dataToProcess,
-        monitorStep: input.monitorStep,
-      });
+    const metricDisplay: {
+      unit: string | undefined;
+      metricName: string | undefined;
+    } = MonitorCriteriaObservationBuilder.getMetricValueDisplayContext({
+      criteriaFilter: input.criteriaFilter,
+      dataToProcess: input.dataToProcess,
+      monitorStep: input.monitorStep,
+    });
 
     const expectation: string | null =
       MonitorCriteriaExpectationBuilder.describeCriteriaExpectation(
         input.criteriaFilter,
-        { unit: metricDisplayUnit },
+        metricDisplay,
       );
 
     const observation: string | null =
@@ -89,9 +91,16 @@ export default class MonitorCriteriaMessageBuilder {
     }
 
     if (expectation) {
+      /*
+       * Both halves of this sentence quote the same threshold, so both
+       * must render it the same way — otherwise it reads "Metric Value
+       * greater than 1000000000 did not satisfy the configured condition
+       * (expected to be greater than 1 GB)".
+       */
       const description: string =
         MonitorCriteriaExpectationBuilder.getCriteriaFilterDescription(
           input.criteriaFilter,
+          metricDisplay,
         );
 
       return `${description} did not satisfy the configured condition (${expectation}).`;

--- a/Common/Server/Utils/Monitor/MonitorCriteriaMessageFormatter.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaMessageFormatter.ts
@@ -136,9 +136,24 @@ export default class MonitorCriteriaMessageFormatter {
     return null;
   }
 
+  /**
+   * "latest 1.07 GB (min 900 KB, max 1.07 GB) across 3 data points".
+   *
+   * `format`, when supplied, renders ONE value — unit included — and is
+   * applied to latest, min and max independently. That independence is the
+   * point: auto-scaling can land min and max on different rungs of the
+   * ladder, which a single trailing unit suffix cannot express. It is the
+   * same reason CompareCriteria puts the unit on each number rather than on
+   * the sentence, and using the same callback in both places is what stops
+   * the evaluation log and the alert email describing one sample two ways.
+   *
+   * Without it the `unit` string is appended as before, so the caller that
+   * passes no unit at all (execution time) stays byte-identical.
+   */
   public static summarizeNumericSeries(
     values: Array<number>,
     unit?: string | undefined,
+    format?: ((value: number) => string) | undefined,
   ): string | null {
     if (!values.length) {
       return null;
@@ -156,29 +171,26 @@ export default class MonitorCriteriaMessageFormatter {
      */
     const unitSuffix: string = unit ? ` ${unit}` : "";
 
-    const latestFormatted: string | null =
-      MonitorCriteriaMessageFormatter.formatNumber(latest, {
-        maximumFractionDigits: 2,
-      });
+    const renderValue: (value: number) => string = (value: number): string => {
+      if (format) {
+        return format(value);
+      }
 
-    let summary: string = `latest ${latestFormatted ?? latest}${unitSuffix}`;
+      const formatted: string | null =
+        MonitorCriteriaMessageFormatter.formatNumber(value, {
+          maximumFractionDigits: 2,
+        });
+
+      return `${formatted ?? value}${unitSuffix}`;
+    };
+
+    let summary: string = `latest ${renderValue(latest)}`;
 
     if (values.length > 1) {
       const min: number = Math.min(...values);
       const max: number = Math.max(...values);
 
-      const minFormatted: string | null =
-        MonitorCriteriaMessageFormatter.formatNumber(min, {
-          maximumFractionDigits: 2,
-        });
-      const maxFormatted: string | null =
-        MonitorCriteriaMessageFormatter.formatNumber(max, {
-          maximumFractionDigits: 2,
-        });
-
-      summary += ` (min ${minFormatted ?? min}${unitSuffix}, max ${
-        maxFormatted ?? max
-      }${unitSuffix})`;
+      summary += ` (min ${renderValue(min)}, max ${renderValue(max)})`;
     }
 
     summary += ` across ${values.length} data point${

--- a/Common/Server/Utils/Monitor/MonitorCriteriaObservationBuilder.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaObservationBuilder.ts
@@ -41,6 +41,7 @@ import MetricQueryConfigData from "../../../Types/Metrics/MetricQueryConfigData"
 import MetricFormulaConfigData from "../../../Types/Metrics/MetricFormulaConfigData";
 import MetricsViewConfig from "../../../Types/Metrics/MetricsViewConfig";
 import MetricUnitUtil from "../../../Utils/MetricUnitUtil";
+import MetricValueFormatter from "../../../Utils/Monitor/MetricValueFormatter";
 
 export default class MonitorCriteriaObservationBuilder {
   public static describeFilterObservation(input: {
@@ -1220,18 +1221,33 @@ export default class MonitorCriteriaObservationBuilder {
      * that unit alongside the numbers so the message reads "latest 0.06 sec"
      * instead of the unitless "latest 0.06".
      */
-    const displayUnit: string | undefined =
-      MonitorCriteriaObservationBuilder.resolveMetricUnits({
-        criteriaFilter: input.criteriaFilter,
-        dataToProcess: input.dataToProcess,
-        monitorStep: input.monitorStep,
-        alias: metricValues.alias,
-      }).displayUnit;
+    const resolvedUnits: {
+      displayUnit: string | undefined;
+      metricName: string | undefined;
+    } = MonitorCriteriaObservationBuilder.resolveMetricUnits({
+      criteriaFilter: input.criteriaFilter,
+      dataToProcess: input.dataToProcess,
+      monitorStep: input.monitorStep,
+      alias: metricValues.alias,
+    });
 
+    /*
+     * The same renderer the fired-alert email uses. Before this, a breach
+     * that CompareCriteria wrote into the email as "1.07 GB" appeared in
+     * the monitor's own evaluation log as "1073741824.00 By" — one sample,
+     * two descriptions, on two screens a reader compares.
+     */
     const summary: string | null =
       MonitorCriteriaMessageFormatter.summarizeNumericSeries(
         displayValues,
-        displayUnit,
+        resolvedUnits.displayUnit,
+        (value: number): string => {
+          return MetricValueFormatter.format({
+            value: value,
+            unit: resolvedUnits.displayUnit,
+            metricName: resolvedUnits.metricName,
+          });
+        },
       );
 
     if (!summary) {
@@ -1304,6 +1320,18 @@ export default class MonitorCriteriaObservationBuilder {
     sampleUnit: string | undefined;
     thresholdUnit: string | undefined;
     displayUnit: string | undefined;
+    /**
+     * The metric NAME, for the two decisions MetricValueFormatter cannot
+     * make from a unit alone: whether a "1"-unit value is a fraction to
+     * render as a percent, and whether a "seconds"-unit value is really an
+     * epoch that must skip the duration ladder.
+     *
+     * Undefined for a formula. A formula's "name" is its expression, and an
+     * expression ending in `_ratio` would trip the fraction heuristic into
+     * reporting every value at 100x — the same guard
+     * MonitorCriteriaEvaluator.metricNameForUnitHeuristics applies.
+     */
+    metricName: string | undefined;
   } {
     const thresholdUnit: string | undefined =
       input.criteriaFilter.metricMonitorOptions?.thresholdUnit || undefined;
@@ -1317,6 +1345,7 @@ export default class MonitorCriteriaObservationBuilder {
         sampleUnit: undefined,
         thresholdUnit,
         displayUnit: thresholdUnit,
+        metricName: undefined,
       };
     }
 
@@ -1355,35 +1384,42 @@ export default class MonitorCriteriaObservationBuilder {
       nativeUnitFromMap ||
       undefined;
 
+    const displayUnit: string | undefined = thresholdUnit || sampleUnit;
+
     return {
       sampleUnit,
       thresholdUnit,
       displayUnit: MonitorCriteriaObservationBuilder.normalizeDisplayUnit(
-        thresholdUnit || sampleUnit,
+        displayUnit,
+        rawMetricName,
       ),
+      metricName: rawMetricName,
     };
   }
 
   /*
-   * Suppress units that would read as noise next to a raw number. OTel's
-   * dimensionless "1" marks ratio metrics whose samples are fractions in
-   * [0, 1]; rendering "0.06 1" is both ugly and misleading (it is not 1% —
-   * it is 6%). Returning undefined leaves the number unlabelled, matching
-   * the pre-unit behavior for that specific case. Any real unit passes
-   * through unchanged.
+   * Suppress units that name no dimension, so they never reach a reader
+   * next to a number.
+   *
+   * This used to be a hand-rolled rule that dropped only the literal "1",
+   * and it drifted from the one CompareCriteria applies to the very same
+   * sample: a ratio metric's evaluation log read a bare "latest 0.06"
+   * while the alert email for the identical value said "6.00%". It also
+   * let UCUM's "{restarts}" and the platform catalogs' "count" / "ratio"
+   * through, none of which mean anything to a reader.
+   *
+   * MetricValueFormatter owns that rule now. Note it is name-AWARE where
+   * the old one was not: "1" on a `.utilization` metric is a real
+   * dimension (a fraction to be shown as a percent), so it survives here
+   * and the formatter turns it into "%".
    */
   private static normalizeDisplayUnit(
     unit: string | undefined,
+    metricName?: string | undefined,
   ): string | undefined {
-    if (!unit || !unit.trim()) {
-      return undefined;
-    }
-
-    if (unit.trim() === "1") {
-      return undefined;
-    }
-
-    return unit;
+    return MetricValueFormatter.hasDisplayableUnit(unit, metricName)
+      ? unit
+      : undefined;
   }
 
   /*
@@ -1399,6 +1435,24 @@ export default class MonitorCriteriaObservationBuilder {
     dataToProcess: DataToProcess;
     monitorStep: MonitorStep;
   }): string | undefined {
+    return MonitorCriteriaObservationBuilder.getMetricValueDisplayContext(input)
+      .unit;
+  }
+
+  /**
+   * The unit AND the metric name a criteria's values are displayed in.
+   *
+   * The expectation clause needs both, not just the unit: it renders the
+   * threshold through the same MetricValueFormatter as the observation, and
+   * the formatter's fraction and epoch-timestamp rules are keyed on the
+   * name. Without it, "recorded latest 6.00%" would be followed by
+   * "(expected to be greater than 0.9)".
+   */
+  public static getMetricValueDisplayContext(input: {
+    criteriaFilter: CriteriaFilter;
+    dataToProcess: DataToProcess;
+    monitorStep: MonitorStep;
+  }): { unit: string | undefined; metricName: string | undefined } {
     /*
      * Database Health thresholds are typed in the metric's own unit, which
      * only the catalog knows - without this the expectation clause reads
@@ -1412,13 +1466,17 @@ export default class MonitorCriteriaObservationBuilder {
         ? getDatabaseMetricByMetricType(metricType)
         : null;
 
-      return MonitorCriteriaObservationBuilder.normalizeDisplayUnit(
-        definition?.unit,
-      );
+      return {
+        unit: MonitorCriteriaObservationBuilder.normalizeDisplayUnit(
+          definition?.unit,
+        ),
+        // Catalog units are explicit; no name-based heuristic is wanted.
+        metricName: undefined,
+      };
     }
 
     if (input.criteriaFilter.checkOn !== CheckOn.MetricValue) {
-      return undefined;
+      return { unit: undefined, metricName: undefined };
     }
 
     const metricValues: {
@@ -1430,12 +1488,17 @@ export default class MonitorCriteriaObservationBuilder {
       monitorStep: input.monitorStep,
     });
 
-    return MonitorCriteriaObservationBuilder.resolveMetricUnits({
+    const resolved: {
+      displayUnit: string | undefined;
+      metricName: string | undefined;
+    } = MonitorCriteriaObservationBuilder.resolveMetricUnits({
       criteriaFilter: input.criteriaFilter,
       dataToProcess: input.dataToProcess,
       monitorStep: input.monitorStep,
       alias: metricValues?.alias ?? null,
-    }).displayUnit;
+    });
+
+    return { unit: resolved.displayUnit, metricName: resolved.metricName };
   }
 
   private static getSnmpResponse(input: {
@@ -1743,28 +1806,24 @@ export default class MonitorCriteriaObservationBuilder {
     }
   }
 
+  /*
+   * A Database Health metric carries an explicit catalog unit, and
+   * DatabaseMonitorCriteria already hands that same unit to CompareCriteria
+   * for the fired-alert email. Rendering it here through anything else made
+   * one byte count read three ways in one product: the email said
+   * "1.07 GB" (decimal, via MetricValueFormatter), this observation said
+   * "1.00 GB" (formatBytes divides by 1024 but labels the rungs SI), and
+   * the expectation clause beside it said "1000000000 bytes".
+   *
+   * formatBytes stays for the server-monitor memory and disk observations,
+   * where the values come from BasicMetrics with no unit metadata at all
+   * and 1024 is the right convention for RAM and volumes.
+   */
   private static formatDatabaseMetricValue(
     value: number,
     unit: string,
   ): string {
-    if (unit === "%") {
-      return (
-        MonitorCriteriaMessageFormatter.formatPercentage(value) ?? String(value)
-      );
-    }
-
-    if (unit === "bytes") {
-      return (
-        MonitorCriteriaMessageFormatter.formatBytes(value) ?? String(value)
-      );
-    }
-
-    const formatted: string =
-      MonitorCriteriaMessageFormatter.formatNumber(value, {
-        maximumFractionDigits: 2,
-      }) ?? String(value);
-
-    return unit ? `${formatted} ${unit}` : formatted;
+    return MetricValueFormatter.format({ value: value, unit: unit });
   }
 
   private static describeDatabaseCollectionErrorObservation(input: {

--- a/Common/Tests/Server/Types/Markdown.test.ts
+++ b/Common/Tests/Server/Types/Markdown.test.ts
@@ -1,4 +1,4 @@
-import Markdown from "../../../Server/Types/Markdown";
+import Markdown, { MarkdownContentType } from "../../../Server/Types/Markdown";
 
 /*
  * slugify turns a heading into the `id` the docs renderer emits, and therefore
@@ -102,5 +102,198 @@ describe("Markdown.slugify", () => {
     test("emoji are dropped rather than becoming part of the id", () => {
       expect(Markdown.slugify("🚀 Getting Started")).toBe("getting-started");
     });
+  });
+});
+
+/*
+ * THE EMAIL RENDERER.
+ *
+ * Until this suite existed there was no coverage of convertToHTML at all,
+ * for any content type — and the email renderer was a bare `new Renderer()`,
+ * so marked's stock output went straight into the message. That mattered
+ * most for the alert and incident root cause, which carries a
+ * GitHub-flavoured table of breaching samples: it arrived as a naked
+ * <table> with no borders and no padding, every row running into the next.
+ *
+ * Two properties are load-bearing and easy to break:
+ *
+ *  - the styling must be INLINE. MailService compiles the Handlebars
+ *    template and hands the string to nodemailer with no CSS-inlining step
+ *    anywhere in the pipeline, and Gmail strips <style> from the head, so a
+ *    class name reaches the reader as nothing at all.
+ *  - raw HTML a user typed must still be escaped. convertToHTML overrides
+ *    `renderer.html` for exactly that, on a renderer every email shares.
+ */
+describe("Markdown.convertToHTML - email renderer", () => {
+  const TABLE_MARKDOWN: string = [
+    "| Timestamp | Value |",
+    "| --- | --- |",
+    "| `2026-08-14T10:30:00.000Z` | 1.07 GB |",
+  ].join("\n");
+
+  test("renders a GFM table with inline styles, not class names", async () => {
+    const html: string = await Markdown.convertToHTML(
+      TABLE_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+
+    expect(html).toContain("<table");
+    expect(html).toContain("<th");
+    expect(html).toContain("<td");
+    expect(html).toContain("border-collapse:collapse");
+    expect(html).toContain("padding:8px 10px");
+
+    /*
+     * A class would be dead weight: nothing inlines CSS before send and
+     * Gmail drops the <style> block Style.hbs emits.
+     */
+    expect(html).not.toContain('class="');
+  });
+
+  test("the table carries the legacy attributes Outlook honours over CSS", async () => {
+    const html: string = await Markdown.convertToHTML(
+      TABLE_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+
+    expect(html).toContain('cellpadding="0"');
+    expect(html).toContain('cellspacing="0"');
+    expect(html).toContain('border="0"');
+    expect(html).toContain('width="100%"');
+  });
+
+  /*
+   * The DetailBox card leaves roughly 416px of usable width and a
+   * root-cause table routinely runs to four or more columns, so a long
+   * metric name has to wrap inside its column rather than push the table
+   * past the body width. Email clients ignore overflow, so there is no
+   * scrollbar to fall back on.
+   */
+  test("cells wrap long words rather than overflowing the card", async () => {
+    const html: string = await Markdown.convertToHTML(
+      TABLE_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+
+    expect(html).toContain("word-break:break-word");
+    expect(html).not.toContain("overflow-x");
+  });
+
+  test("header cells are distinguishable from body cells", async () => {
+    const html: string = await Markdown.convertToHTML(
+      TABLE_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+
+    const header: string = html.slice(
+      html.indexOf("<thead>"),
+      html.indexOf("</thead>"),
+    );
+    const body: string = html.slice(html.indexOf("<tbody>"));
+
+    expect(header).toContain("font-weight:600");
+    expect(header).toContain("background-color:#f8fafc");
+    expect(body).not.toContain("background-color:#f8fafc");
+  });
+
+  test("column alignment from the markdown survives", async () => {
+    const html: string = await Markdown.convertToHTML(
+      ["| A | B |", "| ---: | :--- |", "| 1 | 2 |"].join("\n"),
+      MarkdownContentType.Email,
+    );
+
+    expect(html).toContain("text-align:right");
+    expect(html).toContain("text-align:left");
+  });
+
+  // The root cause backticks every metric name, alias and timestamp.
+  test("inline code is styled and its content preserved", async () => {
+    const html: string = await Markdown.convertToHTML(
+      "Metric `k8s.pod.memory.usage` breached",
+      MarkdownContentType.Email,
+    );
+
+    expect(html).toContain("<code");
+    expect(html).toContain("background-color:#f1f5f9");
+    expect(html).toContain("k8s.pod.memory.usage");
+  });
+
+  test("code content is escaped rather than left live", async () => {
+    const html: string = await Markdown.convertToHTML(
+      "Metric `<img src=x onerror=alert(1)>` breached",
+      MarkdownContentType.Email,
+    );
+
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;img");
+  });
+
+  /*
+   * The reason the DetailBoxField contract permits this output on a raw
+   * slot at all: convertToHTML escapes the raw-HTML tokens a user typed
+   * while letting the renderer's own tags through.
+   */
+  test("raw HTML typed into the markdown source is escaped", async () => {
+    const html: string = await Markdown.convertToHTML(
+      'Hello <img src=x onerror="alert(1)"> world',
+      MarkdownContentType.Email,
+    );
+
+    expect(html).not.toContain('onerror="alert(1)"');
+    expect(html).toContain("&lt;img");
+  });
+
+  test("bold and links still render, so the rest of the email is unchanged", async () => {
+    const html: string = await Markdown.convertToHTML(
+      "**Filter Conditions Met**: see [the dashboard](https://example.com)",
+      MarkdownContentType.Email,
+    );
+
+    expect(html).toContain("<strong>Filter Conditions Met</strong>");
+    expect(html).toContain('href="https://example.com"');
+  });
+
+  /*
+   * The renderer is memoised in a static field and convertToHTML reassigns
+   * `renderer.html` on it for every call, so any per-call state would leak
+   * between emails. Rendering twice must be identical.
+   */
+  test("repeated renders are identical", async () => {
+    const first: string = await Markdown.convertToHTML(
+      TABLE_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+    const second: string = await Markdown.convertToHTML(
+      TABLE_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+
+    expect(second).toBe(first);
+  });
+
+  test("an empty root cause does not throw", async () => {
+    await expect(
+      Markdown.convertToHTML("", MarkdownContentType.Email),
+    ).resolves.toBe("");
+  });
+});
+
+describe("Markdown.escapeHtml", () => {
+  /*
+   * Public so that code hand-building an email fragment by string
+   * interpolation escapes the same way marked's own path does.
+   */
+  test("escapes the five characters that break out of HTML", () => {
+    expect(Markdown.escapeHtml(`<a href="x" title='y'>&</a>`)).toBe(
+      "&lt;a href=&quot;x&quot; title=&#39;y&#39;&gt;&amp;&lt;/a&gt;",
+    );
+  });
+
+  test("escapes the ampersand first, so entities are not double-encoded wrongly", () => {
+    expect(Markdown.escapeHtml("&lt;")).toBe("&amp;lt;");
+  });
+
+  test("leaves ordinary text alone", () => {
+    expect(Markdown.escapeHtml("web-7d9f / prod")).toBe("web-7d9f / prod");
   });
 });

--- a/Common/Tests/Server/Utils/Monitor/Criteria/DatabaseMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/DatabaseMonitorCriteria.test.ts
@@ -178,6 +178,35 @@ describe("DatabaseMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
       expect(result).toContain("95");
     });
 
+    /*
+     * A Database Health metric carries an explicit catalog unit, and
+     * DatabaseMonitorCriteria hands that unit to CompareCriteria for the
+     * alert email. The observation beside it used to render bytes with a
+     * 1024 divisor while labelling the rungs SI, so one byte count read
+     * three ways across the product: "1.07 GB" in the email, "1.00 GB" in
+     * the evaluation log, and "1000000000 bytes" in the expectation
+     * clause. All three now agree.
+     */
+    test("a bytes metric is rescaled decimally, matching the alert email", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          metrics: {
+            [MonitorMetricType.DatabaseSizeBytes]: 1073741824,
+          },
+        }),
+        metricFilter(
+          MonitorMetricType.DatabaseSizeBytes,
+          FilterType.GreaterThan,
+          "1000000000",
+        ),
+      );
+
+      expect(result).toContain("1.07 GB");
+      // The 1024-based rendering this used to produce.
+      expect(result).not.toContain("1.00 GB");
+      expect(result).not.toContain("1073741824");
+    });
+
     test("percent metric 40 > 90 -> not met", async () => {
       const result: string | null = await evaluate(
         buildDataToProcess({

--- a/Common/Tests/Server/Utils/Monitor/MonitorCriteriaEmailEvalLogAgreement.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorCriteriaEmailEvalLogAgreement.test.ts
@@ -1,0 +1,280 @@
+import MonitorCriteriaMessageBuilder from "../../../../Server/Utils/Monitor/MonitorCriteriaMessageBuilder";
+import CompareCriteria from "../../../../Server/Utils/Monitor/Criteria/CompareCriteria";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import {
+  CheckOn,
+  CriteriaFilter,
+  EvaluateOverTimeType,
+  FilterType,
+} from "../../../../Types/Monitor/CriteriaFilter";
+import AggregateModel from "../../../../Types/BaseDatabase/AggregatedModel";
+import AggregatedResult from "../../../../Types/BaseDatabase/AggregatedResult";
+import MetricAliasData from "../../../../Types/Metrics/MetricAliasData";
+import MetricQueryConfigData from "../../../../Types/Metrics/MetricQueryConfigData";
+import MetricQueryData from "../../../../Types/Metrics/MetricQueryData";
+import MetricsViewConfig from "../../../../Types/Metrics/MetricsViewConfig";
+import MetricMonitorResponse from "../../../../Types/Monitor/MetricMonitor/MetricMonitorResponse";
+import MonitorStep from "../../../../Types/Monitor/MonitorStep";
+import RollingTime from "../../../../Types/RollingTime/RollingTime";
+import ObjectID from "../../../../Types/ObjectID";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * ONE SAMPLE, ONE DESCRIPTION.
+ *
+ * A metric breach is written twice, by two different code paths, and a
+ * user compares them side by side:
+ *
+ *   - the ALERT EMAIL's "Filter Conditions Met" line, produced by
+ *     CompareCriteria when the filter MATCHED, and
+ *   - the monitor's EVALUATION LOG line, produced by the observation and
+ *     expectation builders when the filter did NOT match.
+ *
+ * Only the first was migrated to MetricValueFormatter, so the same
+ * 1073741824-byte sample read "1.07 GB" in the inbox and
+ * "1073741824.00 By" on the monitor page — and a ratio metric read "6.00%"
+ * in one and "0.06" in the other.
+ *
+ * These tests assert the two paths render the same quantity the same way.
+ * They are deliberately about AGREEMENT rather than about either exact
+ * wording: the sentences around the number differ by design, the number
+ * and its unit must not.
+ */
+
+function buildInputs(input: {
+  metricNativeUnit: string;
+  metricName: string;
+  sampleValues: Array<number>;
+  criteriaFilter: CriteriaFilter;
+}): {
+  monitor: Monitor;
+  criteriaFilter: CriteriaFilter;
+  monitorStep: MonitorStep;
+  dataToProcess: MetricMonitorResponse;
+} {
+  const aliasData: MetricAliasData = {
+    metricVariable: "a",
+    title: input.metricName,
+    description: undefined,
+    legend: undefined,
+    legendUnit: input.metricNativeUnit,
+  };
+
+  const queryConfig: MetricQueryConfigData = {
+    metricAliasData: aliasData,
+    metricQueryData: {
+      filterData: {
+        metricName: input.metricName,
+      },
+    } as unknown as MetricQueryData,
+  };
+
+  const metricViewConfig: MetricsViewConfig = {
+    queryConfigs: [queryConfig],
+    formulaConfigs: [],
+  };
+
+  const monitorStep: MonitorStep = new MonitorStep();
+  monitorStep.data = {
+    id: ObjectID.generate().toString(),
+    monitorCriteria: { data: undefined } as never,
+  } as unknown as MonitorStep["data"];
+  monitorStep.data!.metricMonitor = {
+    metricViewConfig,
+    rollingTime: RollingTime.Past1Minute,
+  };
+
+  const aggregated: AggregatedResult = {
+    data: input.sampleValues.map((v: number) => {
+      return {
+        timestamp: new Date(),
+        value: v,
+      } as AggregateModel;
+    }),
+  };
+
+  return {
+    monitor: new Monitor(),
+    criteriaFilter: input.criteriaFilter,
+    monitorStep,
+    dataToProcess: {
+      projectId: ObjectID.generate(),
+      metricResult: [aggregated],
+      metricViewConfig,
+      monitorId: ObjectID.generate(),
+    },
+  };
+}
+
+interface AgreementCase {
+  name: string;
+  metricName: string;
+  nativeUnit: string;
+  sample: number;
+  threshold: string;
+  /** The rendering both paths must produce for `sample`. */
+  expectedValue: string;
+  /** The rendering both paths must produce for `threshold`. */
+  expectedThreshold: string;
+}
+
+const CASES: Array<AgreementCase> = [
+  {
+    name: "bytes rescale to gigabytes",
+    metricName: "k8s.pod.memory.usage",
+    nativeUnit: "By",
+    sample: 1073741824,
+    threshold: "1000000000",
+    expectedValue: "1.07 GB",
+    expectedThreshold: "1 GB",
+  },
+  {
+    name: "milliseconds rescale to seconds",
+    metricName: "http.server.request.duration",
+    nativeUnit: "ms",
+    sample: 1500,
+    threshold: "1000",
+    expectedValue: "1.5 sec",
+    expectedThreshold: "1 sec",
+  },
+  {
+    name: "a fraction metric reads as a percentage",
+    metricName: "system.cpu.utilization",
+    nativeUnit: "1",
+    sample: 0.0585,
+    threshold: "0.05",
+    expectedValue: "5.85%",
+    expectedThreshold: "5.00%",
+  },
+  {
+    name: "a non-fraction metric carrying '1' stays bare",
+    metricName: "browser.cumulative_layout_shift",
+    nativeUnit: "1",
+    sample: 0.31,
+    threshold: "0.25",
+    expectedValue: "0.31",
+    expectedThreshold: "0.25",
+  },
+  {
+    name: "a metric with no unit keeps its exact digits",
+    metricName: "http.server.request.count",
+    nativeUnit: "",
+    sample: 5000,
+    threshold: "4900",
+    expectedValue: "5000",
+    expectedThreshold: "4900",
+  },
+];
+
+describe("the alert email and the evaluation log describe one sample identically", () => {
+  for (const testCase of CASES) {
+    test(testCase.name, () => {
+      const criteriaFilter: CriteriaFilter = {
+        checkOn: CheckOn.MetricValue,
+        filterType: FilterType.GreaterThan,
+        value: testCase.threshold,
+        metricMonitorOptions: {
+          metricAlias: "a",
+          metricAggregationType: EvaluateOverTimeType.AnyValue,
+        },
+      };
+
+      const inputs: ReturnType<typeof buildInputs> = buildInputs({
+        metricNativeUnit: testCase.nativeUnit,
+        metricName: testCase.metricName,
+        sampleValues: [testCase.sample],
+        criteriaFilter,
+      });
+
+      /*
+       * What the alert email says — CompareCriteria's sentence, which is
+       * returned verbatim as the root cause when the filter matched.
+       */
+      const emailLine: string = CompareCriteria.getCompareMessage({
+        values: testCase.sample,
+        threshold: Number(testCase.threshold),
+        criteriaFilter: criteriaFilter,
+        metricDisplayName: testCase.metricName,
+        metricName: testCase.metricName,
+        unit: testCase.nativeUnit || undefined,
+      });
+
+      // What the monitor's evaluation log says for the same sample.
+      const evalLogLine: string =
+        MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage({
+          ...inputs,
+          didMeetCriteria: false,
+          matchMessage: null,
+        });
+
+      expect(emailLine).toContain(testCase.expectedValue);
+      expect(evalLogLine).toContain(testCase.expectedValue);
+
+      expect(emailLine).toContain(testCase.expectedThreshold);
+      expect(evalLogLine).toContain(testCase.expectedThreshold);
+    });
+  }
+
+  /*
+   * The specific strings the drift used to produce. Asserting their
+   * absence is what makes this suite fail loudly if either path is
+   * reverted to its own formatter.
+   */
+  test("neither path emits the pre-migration renderings", () => {
+    const criteriaFilter: CriteriaFilter = {
+      checkOn: CheckOn.MetricValue,
+      filterType: FilterType.GreaterThan,
+      value: "1000000000",
+      metricMonitorOptions: {
+        metricAlias: "a",
+        metricAggregationType: EvaluateOverTimeType.AnyValue,
+      },
+    };
+
+    const inputs: ReturnType<typeof buildInputs> = buildInputs({
+      metricNativeUnit: "By",
+      metricName: "k8s.pod.memory.usage",
+      sampleValues: [1073741824],
+      criteriaFilter,
+    });
+
+    const evalLogLine: string =
+      MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage({
+        ...inputs,
+        didMeetCriteria: false,
+        matchMessage: null,
+      });
+
+    expect(evalLogLine).not.toContain("1073741824");
+    expect(evalLogLine).not.toContain(" By");
+  });
+
+  /*
+   * A matched filter short-circuits: the message builder returns
+   * CompareCriteria's sentence untouched. Pinning this keeps the two
+   * paths from being confused for one another — the agreement above is a
+   * property of two DIFFERENT renderers, not of one shared call.
+   */
+  test("a matched filter returns the email sentence verbatim", () => {
+    const criteriaFilter: CriteriaFilter = {
+      checkOn: CheckOn.MetricValue,
+      filterType: FilterType.GreaterThan,
+      value: "1000000000",
+    };
+
+    const inputs: ReturnType<typeof buildInputs> = buildInputs({
+      metricNativeUnit: "By",
+      metricName: "k8s.pod.memory.usage",
+      sampleValues: [1073741824],
+      criteriaFilter,
+    });
+
+    expect(
+      MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage({
+        ...inputs,
+        didMeetCriteria: true,
+        matchMessage: "Metric Value is 1.07 GB which is greater than 1 GB.",
+      }),
+    ).toBe("Metric Value is 1.07 GB which is greater than 1 GB.");
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorCriteriaExpectationBuilderUnits.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorCriteriaExpectationBuilderUnits.test.ts
@@ -517,7 +517,18 @@ describe("MonitorCriteriaExpectationBuilder.describeCriteriaExpectation", () => 
    * template string, so a negative sign and any decimals survive verbatim
    * (no toFixed / number formatting), and the unit suffix still follows.
    */
-  describe("negative thresholds with a unit are interpolated raw", () => {
+  /*
+   * A threshold carrying a unit is rendered by the same formatter as the
+   * observed value beside it, so both halves of one sentence describe the
+   * quantity the same way. That means it can be RESCALED — "-0.5 sec" is
+   * written "-500 ms", the same number at the scale a reader reads it at,
+   * and the observation in that sentence uses milliseconds too.
+   *
+   * What must never happen is decimal PADDING: a threshold the user typed
+   * as "-5" must not come back as "-5.00", which is what the old raw
+   * interpolation was protecting against and what these still assert.
+   */
+  describe("negative thresholds with a unit are formatted, never padded", () => {
     test("GreaterThan '-5' with { unit: 'sec' } => 'to be greater than -5 sec'", () => {
       const filter: CriteriaFilter = makeFilter({
         filterType: FilterType.GreaterThan,
@@ -530,11 +541,11 @@ describe("MonitorCriteriaExpectationBuilder.describeCriteriaExpectation", () => 
         });
 
       expect(result).toBe("to be greater than -5 sec");
-      // Raw interpolation — never number-formatted.
+      // Integers keep their digits — never padded to "-5.00".
       expect(result).not.toContain("-5.00");
     });
 
-    test("LessThan '-0.5' with { unit: 'sec' } => 'to be less than -0.5 sec'", () => {
+    test("LessThan '-0.5' with { unit: 'sec' } rescales to milliseconds", () => {
       const filter: CriteriaFilter = makeFilter({
         filterType: FilterType.LessThan,
         value: "-0.5",
@@ -545,9 +556,23 @@ describe("MonitorCriteriaExpectationBuilder.describeCriteriaExpectation", () => 
           unit: "sec",
         });
 
-      expect(result).toBe("to be less than -0.5 sec");
-      // Raw interpolation — the decimal is kept as-is, not padded to "-0.50".
+      expect(result).toBe("to be less than -500 ms");
       expect(result).not.toContain("-0.50");
+    });
+
+    /*
+     * The boundary the formatter is gated on: with no unit resolved — every
+     * non-metric checkOn — the threshold is interpolated exactly as before.
+     */
+    test("a threshold with no unit is still interpolated raw", () => {
+      const filter: CriteriaFilter = makeFilter({
+        filterType: FilterType.LessThan,
+        value: "-0.5",
+      });
+
+      expect(
+        MonitorCriteriaExpectationBuilder.describeCriteriaExpectation(filter),
+      ).toBe("to be less than -0.5");
     });
   });
 });

--- a/Common/Tests/Server/Utils/Monitor/MonitorCriteriaMessageBuilderUnits.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorCriteriaMessageBuilderUnits.test.ts
@@ -116,9 +116,9 @@ describe("MonitorCriteriaMessageBuilder — metric unit labelling", () => {
       });
 
     // Observed value carries the unit.
-    expect(message).toContain("latest 0.06 sec");
-    expect(message).toContain("min 0.06 sec");
-    expect(message).toContain("max 0.06 sec");
+    expect(message).toContain("latest 60 ms");
+    expect(message).toContain("min 60 ms");
+    expect(message).toContain("max 60 ms");
     // Threshold in the expectation clause carries the same unit.
     expect(message).toContain("greater than 5 sec");
   });
@@ -150,11 +150,20 @@ describe("MonitorCriteriaMessageBuilder — metric unit labelling", () => {
         matchMessage: null,
       });
 
-    expect(message).toContain("latest 0.50 sec");
+    expect(message).toContain("latest 500 ms");
     expect(message).toContain("greater than 2 sec");
   });
 
-  test("omits the unit for dimensionless ratio metrics (native unit '1')", () => {
+  /*
+   * A ratio metric carries OTel's dimensionless "1" over samples that are
+   * fractions in [0, 1]. Printing "0.06 1" is meaningless and printing a
+   * bare "0.06" reads as 0.06% when the value is 6%.
+   *
+   * The fired-alert email has rendered this as "6.00%" since CompareCriteria
+   * adopted MetricValueFormatter; this line — the monitor's own evaluation
+   * log for the SAME sample — used to say "0.06". Both now agree.
+   */
+  test("renders a dimensionless ratio metric as the percentage it means", () => {
     const criteriaFilter: CriteriaFilter = {
       checkOn: CheckOn.MetricValue,
       filterType: FilterType.GreaterThan,
@@ -179,11 +188,49 @@ describe("MonitorCriteriaMessageBuilder — metric unit labelling", () => {
         matchMessage: null,
       });
 
-    expect(message).toContain("latest 0.06");
-    // No stray "0.06 1" and no unit on the threshold.
+    expect(message).toContain("latest 6.00%");
+    // Never the dimensionless marker, and never the unscaled fraction.
     expect(message).not.toContain("0.06 1");
-    expect(message).toContain("greater than 0.9");
+    expect(message).not.toContain("latest 0.06");
+    // The threshold is scaled the same way, so the two halves agree.
+    expect(message).toContain("greater than 90.00%");
     expect(message).not.toContain("greater than 0.9 1");
+  });
+
+  /*
+   * The control for the rule above: "1" is only a percentage when the
+   * metric NAME says the value is a fraction. A counter carrying "1" —
+   * cumulative layout shift is the canonical one — keeps its bare number.
+   */
+  test("a non-fraction metric carrying '1' keeps its bare number", () => {
+    const criteriaFilter: CriteriaFilter = {
+      checkOn: CheckOn.MetricValue,
+      filterType: FilterType.GreaterThan,
+      value: "0.25",
+      metricMonitorOptions: {
+        metricAlias: "a",
+        metricAggregationType: EvaluateOverTimeType.Average,
+      },
+    };
+
+    const inputs: ReturnType<typeof buildInputs> = buildInputs({
+      metricNativeUnit: "1",
+      metricName: "browser.cumulative_layout_shift",
+      sampleValues: [0.31],
+      criteriaFilter,
+    });
+
+    const message: string =
+      MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage({
+        ...inputs,
+        didMeetCriteria: false,
+        matchMessage: null,
+      });
+
+    expect(message).toContain("latest 0.31");
+    expect(message).not.toContain("0.31 1");
+    expect(message).not.toContain("31.00%");
+    expect(message).toContain("greater than 0.25");
   });
 });
 
@@ -221,7 +268,7 @@ describe("MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage — Evaluatio
       });
 
     expect(message).toBe(
-      "Metric Value (a) recorded latest 0.06 sec (min 0.06 sec, max 0.06 sec) across 3 data points. (expected to be greater than 5 sec using average).",
+      "Metric Value (a) recorded latest 60 ms (min 60 ms, max 60 ms) across 3 data points. (expected to be greater than 5 sec using average).",
     );
   });
 
@@ -251,10 +298,10 @@ describe("MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage — Evaluatio
       });
 
     expect(message).toBe(
-      "Metric Value (a) recorded latest 10.00 sec (min 8.00 sec, max 12.00 sec) across 3 data points. (expected to be less than 5 sec using average).",
+      "Metric Value (a) recorded latest 10 sec (min 8 sec, max 12 sec) across 3 data points. (expected to be less than 5 sec using average).",
     );
     // The unit rides both the observed value and the "less than N unit" clause.
-    expect(message).toContain("latest 10.00 sec");
+    expect(message).toContain("latest 10 sec");
     expect(message).toContain("less than 5 sec");
   });
 
@@ -286,7 +333,7 @@ describe("MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage — Evaluatio
       });
 
     expect(message).toBe(
-      "Metric Value (a) recorded latest 3.50 sec (min 1.50 sec, max 3.50 sec) across 3 data points. (expected to be greater than 2 sec using maximum value).",
+      "Metric Value (a) recorded latest 3.5 sec (min 1.5 sec, max 3.5 sec) across 3 data points. (expected to be greater than 2 sec using maximum value).",
     );
     // The raw ms magnitudes never leak into the rendered line.
     expect(message).not.toContain("1500");
@@ -329,14 +376,14 @@ describe("MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage — Evaluatio
      * observed value and the threshold, even though "1.00" appears in the text.
      */
     expect(message).toBe(
-      "Metric Value (a) recorded latest 1.00 (min 0.95, max 1.00) across 3 data points. (expected to be greater than 0.9 using average).",
+      "Metric Value (a) recorded latest 100.00% (min 95.00%, max 100.00%) across 3 data points. (expected to be greater than 90.00% using average).",
     );
     /*
      * Neither the value nor the threshold carries a unit: each number is
      * immediately followed by punctuation/wording, never a " 1" unit suffix.
      */
-    expect(message).toContain("latest 1.00 (min 0.95, max 1.00)");
-    expect(message).toContain("greater than 0.9 using average");
+    expect(message).toContain("latest 100.00% (min 95.00%, max 100.00%)");
+    expect(message).toContain("greater than 90.00% using average");
   });
 
   /*
@@ -375,11 +422,11 @@ describe("MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage — Evaluatio
       });
 
     expect(message).toBe(
-      "Metric Value (a) recorded latest 6.00 % across 1 data point. (expected to be greater than 90 % using average).",
+      "Metric Value (a) recorded latest 6.00% across 1 data point. (expected to be greater than 90.00% using average).",
     );
     // Both the converted observed value and the threshold carry the "%" unit.
-    expect(message).toContain("latest 6.00 %");
-    expect(message).toContain("greater than 90 %");
+    expect(message).toContain("latest 6.00%");
+    expect(message).toContain("greater than 90.00%");
     // The raw fraction magnitude never leaks into the rendered line.
     expect(message).not.toContain("0.06");
     // Singular grammar for the lone sample — no "(min .., max ..)" clause.
@@ -488,7 +535,7 @@ describe("MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage — Evaluatio
       });
 
     expect(message).toBe(
-      "Metric Value (a) recorded latest 7.00 sec across 1 data point. (expected to be greater than 5 sec using average).",
+      "Metric Value (a) recorded latest 7 sec across 1 data point. (expected to be greater than 5 sec using average).",
     );
     // Singular grammar, and no "(min .., max ..)" clause for a lone sample.
     expect(message).toContain("across 1 data point.");
@@ -522,7 +569,7 @@ describe("MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage — Evaluatio
       });
 
     expect(message).toBe(
-      "Metric Value (a) recorded latest 100.00 ms (min 100.00 ms, max 100.00 ms) across 3 data points. (expected to equal 100 ms using average).",
+      "Metric Value (a) recorded latest 100 ms (min 100 ms, max 100 ms) across 3 data points. (expected to equal 100 ms using average).",
     );
   });
 
@@ -552,7 +599,7 @@ describe("MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage — Evaluatio
       });
 
     expect(message).toBe(
-      "Metric Value (a) recorded latest 70.00 ms (min 55.00 ms, max 70.00 ms) across 3 data points. (expected to be greater than or equal to 50 ms using maximum value).",
+      "Metric Value (a) recorded latest 70 ms (min 55 ms, max 70 ms) across 3 data points. (expected to be greater than or equal to 50 ms using maximum value).",
     );
   });
 

--- a/Common/Tests/Server/Utils/Monitor/MonitorCriteriaObservationBuilderUnits.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorCriteriaObservationBuilderUnits.test.ts
@@ -318,7 +318,7 @@ describe("MonitorCriteriaObservationBuilder.describeFilterObservation — metric
       MonitorCriteriaObservationBuilder.describeFilterObservation(inputs);
 
     expect(observation).toBe(
-      "Metric Value (a) recorded latest 0.06 sec (min 0.06 sec, max 0.06 sec) across 3 data points.",
+      "Metric Value (a) recorded latest 60 ms (min 60 ms, max 60 ms) across 3 data points.",
     );
   });
 
@@ -339,7 +339,7 @@ describe("MonitorCriteriaObservationBuilder.describeFilterObservation — metric
       MonitorCriteriaObservationBuilder.describeFilterObservation(inputs);
 
     expect(observation).toBe(
-      "Metric Value (a) recorded latest 60.00 ms (min 40.00 ms, max 60.00 ms) across 2 data points.",
+      "Metric Value (a) recorded latest 60 ms (min 40 ms, max 60 ms) across 2 data points.",
     );
   });
 
@@ -364,9 +364,9 @@ describe("MonitorCriteriaObservationBuilder.describeFilterObservation — metric
       MonitorCriteriaObservationBuilder.describeFilterObservation(inputs);
 
     expect(observation).toBe(
-      "Metric Value (a) recorded latest 2.50 sec across 1 data point.",
+      "Metric Value (a) recorded latest 2.5 sec across 1 data point.",
     );
-    expect(observation).toContain("2.50 sec");
+    expect(observation).toContain("2.5 sec");
   });
 
   /*
@@ -389,9 +389,9 @@ describe("MonitorCriteriaObservationBuilder.describeFilterObservation — metric
       MonitorCriteriaObservationBuilder.describeFilterObservation(inputs);
 
     expect(observation).toBe(
-      "Metric Value (a) recorded latest 2.50 GB across 1 data point.",
+      "Metric Value (a) recorded latest 2.5 GB across 1 data point.",
     );
-    expect(observation).toContain("2.50 GB");
+    expect(observation).toContain("2.5 GB");
   });
 
   /*
@@ -413,13 +413,30 @@ describe("MonitorCriteriaObservationBuilder.describeFilterObservation — metric
     const observation: string | null =
       MonitorCriteriaObservationBuilder.describeFilterObservation(inputs);
 
+    /*
+     * The user mislabelled a millisecond metric as megabytes. The
+     * conversion still no-ops — ms and MB are different families — so the
+     * SAMPLE is untouched at 5000, and the renderer then takes the label
+     * at its word and reads 5000 MB out as "5 GB". Every string this
+     * sentence can produce is wrong, because the configuration is; what
+     * this test pins is that the mislabelling is passed through rather
+     * than silently repaired.
+     */
     expect(observation).toBe(
-      "Metric Value (a) recorded latest 5000.00 MB across 1 data point.",
+      "Metric Value (a) recorded latest 5 GB across 1 data point.",
     );
-    // Unconverted value passed through.
-    expect(observation).toContain("5000.00");
-    // But labelled with the (incompatible) threshold unit.
-    expect(observation).toContain("MB");
+    expect(observation).toContain("5 GB");
+    /*
+     * Still reported in the threshold unit's FAMILY — the label the user
+     * chose won, which is the behaviour this test guards. It reads "GB"
+     * rather than "MB" only because the ladder rescales within that family;
+     * the alternative would be to drop the user's unit when it looks
+     * incompatible, which would hide the misconfiguration entirely.
+     */
+    expect(observation).not.toContain("ms");
+    expect(
+      MonitorCriteriaObservationBuilder.getMetricValueDisplayUnit(inputs),
+    ).toBe("MB");
   });
 
   /*
@@ -486,7 +503,7 @@ describe("MonitorCriteriaObservationBuilder.describeFilterObservation — metric
       MonitorCriteriaObservationBuilder.describeFilterObservation(inputs);
 
     expect(observation).toBe(
-      "Metric Value (a) recorded latest 60.00 ms (min 40.00 ms, max 60.00 ms) across 2 data points.",
+      "Metric Value (a) recorded latest 60 ms (min 40 ms, max 60 ms) across 2 data points.",
     );
   });
 
@@ -532,7 +549,7 @@ describe("MonitorCriteriaObservationBuilder.describeFilterObservation — metric
       MonitorCriteriaObservationBuilder.describeFilterObservation(inputs);
 
     expect(observation).toBe(
-      "Metric Value (b) recorded latest 3.00 sec (min 1.00 sec, max 3.00 sec) across 3 data points.",
+      "Metric Value (b) recorded latest 3 sec (min 1 sec, max 3 sec) across 3 data points.",
     );
     // The a-series (ms, 40/60) must not leak in.
     expect(observation).not.toContain("(a)");
@@ -562,7 +579,7 @@ describe("MonitorCriteriaObservationBuilder.describeFilterObservation — metric
       MonitorCriteriaObservationBuilder.describeFilterObservation(inputs);
 
     expect(observation).toBe(
-      "Metric Value (a) recorded latest 6.00 % across 1 data point.",
+      "Metric Value (a) recorded latest 6.00% across 1 data point.",
     );
 
     const unit: string | undefined =
@@ -630,7 +647,7 @@ describe("MonitorCriteriaObservationBuilder.describeFilterObservation — metric
       MonitorCriteriaObservationBuilder.describeFilterObservation(inputs);
 
     expect(observation).toBe(
-      "Metric Value (c) recorded latest 2.50 sec (min 1.50 sec, max 2.50 sec) across 2 data points.",
+      "Metric Value (c) recorded latest 2.5 sec (min 1.5 sec, max 2.5 sec) across 2 data points.",
     );
     // The formula alias, not the base query, is summarized.
     expect(observation).toContain("(c)");
@@ -659,9 +676,9 @@ describe("MonitorCriteriaObservationBuilder.describeFilterObservation — metric
       MonitorCriteriaObservationBuilder.describeFilterObservation(inputs);
 
     expect(observation).toBe(
-      "Metric Value (a) recorded latest 1.50 gbit across 1 data point.",
+      "Metric Value (a) recorded latest 1.5 Gbit across 1 data point.",
     );
-    expect(observation).toContain("1.50 gbit");
+    expect(observation).toContain("1.5 Gbit");
   });
 
   /*
@@ -686,10 +703,10 @@ describe("MonitorCriteriaObservationBuilder.describeFilterObservation — metric
       MonitorCriteriaObservationBuilder.describeFilterObservation(inputs);
 
     expect(observation).toBe(
-      "Metric Value (a) recorded latest 5.00 sec across 1 data point.",
+      "Metric Value (a) recorded latest 5 sec across 1 data point.",
     );
     // Unconverted value, but labelled with the threshold unit.
-    expect(observation).toContain("5.00 sec");
+    expect(observation).toContain("5 sec");
   });
 });
 


### PR DESCRIPTION
Three follow-ups to #3624, which made metric values human-readable in alert and incident emails but left three neighbouring defects in place.

## 1. The evaluation log disagreed with the email

The Evaluation Logs line has **two producers**, and only one was migrated. When a filter **matches**, `CompareCriteria`'s sentence is returned verbatim — that path says `1.07 GB`. When it does **not** match, the observation and expectation builders produce the line instead, and they had never heard of `MetricValueFormatter` — that path said `latest 1073741824.00 By`.

One sample, two descriptions, on two screens a user compares side by side.

Both now use the same formatter — **and so does the threshold beside the value**. Reformatting only the observation would have produced *"recorded latest 1.07 GB (expected to be greater than 1000000000 By)"*, so the expectation clause, which interpolated the threshold completely raw, was migrated with it.

Three narrower drifts went along:

| | Before | After |
| --- | --- | --- |
| Ratio metric (unit `1`) | `latest 0.06` here, `6.00%` in the email | `6.00%` in both |
| Database bytes | `1.00 GB` (1024, labelled SI) vs `1.07 GB` in the email vs `1000000000 bytes` in the expectation | `1.07 GB` everywhere |
| A window spanning two rungs | one trailing unit for latest/min/max | each number carries its own |

`normalizeDisplayUnit` suppressed only the literal `"1"`; it now defers to `MetricValueFormatter`, which also drops UCUM's `{restarts}` and the platform catalogs' informal `count` / `ratio`.

**`formatBytes` deliberately stays 1024-based** for the server-monitor memory and disk observations. Those values come from `BasicMetrics` with no unit metadata at all, and binary is the right convention for RAM and volumes — only the *database* caller, which has an explicit catalog unit and an email that already disagreed with it, moved.

## 2. The on-call page-out emails

`rootCause` is a Markdown column. Three of the four `Acknowledge*` generators passed it **raw** into a triple-stache, so the person being woken up read literal `**Filter Conditions Met**:` and literal `| Timestamp | Metric |` pipe rows.

The fourth never set the variable at all — and never selected the column — so `AcknowledgeAlert.hbs` rendered a `ROOT CAUSE:` heading over empty space. `DetailBoxField` renders the *label* unconditionally and guards only the *value*, which is why nobody noticed. Its `Resources Affected` row was missing the same way, as was the incident's.

Those four were also the last email family passing **every** row — titles, state names, severities, resource names — through the raw `text` slot, which is exactly the hole `plainText` was added to close. They now use it. Alongside:

- `concat` does not escape, and its output went into `InfoBlock`'s raw `{{{info}}}`, so a **project name** was live HTML — a new escaped `plainInfo` slot fixes it;
- the two episode generators hand-build `<a>` lists by interpolating alert/incident titles and monitor names — now escaped through a newly-public `Markdown.escapeHtml`.

## 3. The email table

`getEmailRenderer()` was a bare `new Renderer()`, so the breaching-samples table arrived with no borders and no padding, every row running into the next — the part of the email an on-call engineer reads first.

It now emits **inline styles**. That is not a preference: `MailService` compiles the template and hands the string to nodemailer with no CSS-inlining step anywhere, and Gmail strips `<style>` from the head, so a class name reaches the reader as nothing at all. Plus the legacy `cellpadding` / `cellspacing` / `width` attributes Outlook's Word engine honours over CSS.

No overflow wrapper — email clients ignore it, so the cells `word-break` instead, which is what the ~416px of usable card width actually requires.

`DetailBoxField` gains a **`blockText`** slot. `text` renders inside a `<p>`, and `Markdown.convertToHTML` emits block elements: a `<table>` in a `<p>` is invalid nesting that every client repairs by closing the paragraph early, dropping the table out of the styled value box. The 24 slots carrying converted markdown moved over; the other ~310 `text=` call sites are untouched and byte-identical, which the existing source-level ratchet still guards.

## A bug the tests caught

My first `codespan` override called `escapeHtml` on content marked had **already** escaped, turning a typed `<img>` into a literal `&lt;img&gt;` on screen. (The Docs and BlogValidation renderers still double-escape — a separate defect in those surfaces, noted but not touched here.)

## Testing

**2454 tests pass in Common** (102 suites) and **305 in App** (14 suites). New coverage:

- an **agreement suite** asserting the email path and the evaluation-log path render one sample identically across bytes, durations, fraction metrics, non-fraction `"1"` metrics and unitless counters — the property whose absence let them drift;
- a **rendering suite for the four Acknowledge templates**: markdown becomes markup, hostile titles/states/severities/resources/project names are escaped, converted markdown still renders unescaped, block content lands in a `<div>`;
- the **first coverage of `Markdown.convertToHTML` for any content type** — that file previously tested only `slugify`.

23 existing assertions moved deliberately, each with a comment saying what changed and why. Two were real bugs my change introduced and the suites caught: a unit suffix leaking into the heartbeat wording (`"within 5 sec minutes"`), and the double-escape above.

## Not in this PR

`text=resourcesAffected` is still on the raw slot in **24 other templates**. That value is built from telemetry attributes, so it is the same class of hole — but it is a separate audit across a different email family, not a follow-up to this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yEwmjVLY8YNvgEnNSnLx2
