### PR TITLE
fix(inventory): remove filtered view banner

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Inventory/InventoryScope.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Inventory/InventoryScope.ts
@@ -1,8 +1,6 @@
 import EntitySource from "Common/Types/Telemetry/EntitySource";
 import EntityType from "Common/Types/Telemetry/EntityType";
 import LessThan from "Common/Types/BaseDatabase/LessThan";
-import { getInventoryTypePluralLabel } from "./InventoryTypeCatalog";
-import { getInventorySourceLabel } from "./InventorySource";
 import { INVENTORY_STALE_AFTER_MINUTES } from "./InventoryLiveness";
 
 /*
@@ -16,8 +14,7 @@ import { INVENTORY_STALE_AFTER_MINUTES } from "./InventoryLiveness";
  * page turns them straight into the base query it lists with.
  *
  * That makes the scope part of the model query rather than a user-removable
- * filter chip, which is the behaviour we want: the page says what it is
- * scoped to and offers one control to clear it. It also means the params are
+ * filter chip. The side menu's All Items link clears the scope. The params are
  * attacker-reachable — anyone can hand-edit the URL — so `parseInventoryScope`
  * validates against the real vocabularies and drops anything it does not
  * recognise, instead of forwarding an arbitrary string into a query.
@@ -156,41 +153,4 @@ export const buildInventoryScopeQuery: BuildInventoryScopeQueryFunction = (
   }
 
   return query;
-};
-
-export type DescribeInventoryScopeFunction = (
-  scope: InventoryScope,
-) => string | null;
-
-/**
- * The sentence the Items page shows above the table when it is scoped, e.g.
- * "Showing Kubernetes Pods discovered from telemetry". `null` for the empty
- * scope, where there is nothing to explain.
- */
-export const describeInventoryScope: DescribeInventoryScopeFunction = (
-  scope: InventoryScope,
-): string | null => {
-  if (isInventoryScopeEmpty(scope)) {
-    return null;
-  }
-
-  const noun: string = scope.entityType
-    ? getInventoryTypePluralLabel(scope.entityType)
-    : "items";
-
-  const qualifiers: Array<string> = [];
-
-  if (scope.source) {
-    qualifiers.push(`from source "${getInventorySourceLabel(scope.source)}"`);
-  }
-
-  if (scope.staleOnly) {
-    qualifiers.push("not seen in over a day");
-  }
-
-  if (qualifiers.length === 0) {
-    return `Showing ${noun} only.`;
-  }
-
-  return `Showing ${noun} ${qualifiers.join(", ")}.`;
 };

--- a/App/FeatureSet/Dashboard/src/Pages/Inventory/Items.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Inventory/Items.tsx
@@ -4,39 +4,22 @@ import {
   InventoryScope,
   InventoryScopeQuery,
   buildInventoryScopeQuery,
-  describeInventoryScope,
   isInventoryScopeEmpty,
   parseInventoryScope,
 } from "../../Components/Inventory/InventoryScope";
-import Alert, { AlertType } from "Common/UI/Components/Alerts/Alert";
 import Query from "Common/Types/BaseDatabase/Query";
-import Route from "Common/Types/API/Route";
 import InventoryItem from "Common/Models/DatabaseModels/InventoryItem";
-import Navigation from "Common/UI/Utils/Navigation";
-import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
-import PageMap from "../../Utils/PageMap";
-import React, {
-  Fragment,
-  FunctionComponent,
-  ReactElement,
-  useMemo,
-} from "react";
+import React, { FunctionComponent, ReactElement, useMemo } from "react";
 import { useLocation, Location } from "react-router-dom";
 
 /*
  * The full inventory list, optionally scoped by the `?type` / `?source` /
  * `?stale` params the Overview's drill-downs and the side menu link with.
  *
- * The scope is part of the table's base query rather than a filter chip, so
- * this page always shows what it says it shows. That makes the banner the
- * only way out of it, which is why the banner appears whenever a scope is
- * set — a narrowed list with nothing explaining the narrowing is the most
- * confusing state a list page can be in.
- *
  * The params are read off `useLocation().search` rather than through
  * Navigation's global: a query-string-only change does not remount this
  * component, so a value captured at first render would leave the table showing
- * the previous scope under the new banner.
+ * the previous scope after navigation.
  */
 
 const InventoryItems: FunctionComponent<
@@ -73,38 +56,18 @@ const InventoryItems: FunctionComponent<
     return built as Query<InventoryItem>;
   }, [scope]);
 
-  const scopeDescription: string | null = describeInventoryScope(scope);
-
   return (
-    <Fragment>
-      {scopeDescription ? (
-        <Alert
-          dataTestId="inventory-scope-banner"
-          type={AlertType.INFO}
-          strongTitle="Filtered view"
-          title={`${scopeDescription} Dismiss this to see everything.`}
-          onClose={() => {
-            Navigation.navigate(
-              RouteUtil.populateRouteParams(
-                RouteMap[PageMap.INVENTORY_ITEMS] as Route,
-              ),
-            );
-          }}
-        />
-      ) : null}
-
-      <InventoryTable
-        /*
-         * Keyed by the scope so a change of scope remounts the table. Without
-         * it the table keeps the previous scope's page number and sort, and
-         * page 4 of a 300-row list is rarely a valid page of a 6-row one.
-         */
-        key={`inventory-items-${search}`}
-        query={scopeQuery}
-        cardTitle="All Items"
-        cardDescription="Every service, host, pod, container, device and hand-registered dependency OneUptime knows about in this project."
-      />
-    </Fragment>
+    <InventoryTable
+      /*
+       * Keyed by the scope so a change of scope remounts the table. Without
+       * it the table keeps the previous scope's page number and sort, and
+       * page 4 of a 300-row list is rarely a valid page of a 6-row one.
+       */
+      key={`inventory-items-${search}`}
+      query={scopeQuery}
+      cardTitle="All Items"
+      cardDescription="Every service, host, pod, container, device and hand-registered dependency OneUptime knows about in this project."
+    />
   );
 };
 

--- a/App/Tests/Dashboard/InventoryScope.test.ts
+++ b/App/Tests/Dashboard/InventoryScope.test.ts
@@ -10,7 +10,6 @@ import {
   InventoryScopeQuery,
   buildInventoryScopeQuery,
   buildInventoryScopeQueryString,
-  describeInventoryScope,
   isInventoryScopeEmpty,
   parseInventoryScope,
 } from "../../FeatureSet/Dashboard/src/Components/Inventory/InventoryScope";
@@ -21,13 +20,13 @@ import { INVENTORY_STALE_AFTER_MINUTES } from "../../FeatureSet/Dashboard/src/Co
  * page. It travels through the URL, which means:
  *
  *   - it has to round-trip exactly (a link that loses its `stale=true` opens
- *     an unfiltered list under a banner claiming otherwise), and
+ *     an unfiltered list instead of the selected drill-down), and
  *   - it is attacker-reachable, so parsing must validate against the real
  *     vocabularies rather than forwarding whatever the URL said into a model
  *     query.
  *
- * Both are checked here, plus the derived query fragment, since a scope whose
- * query does not match its description is the failure nobody notices.
+ * Both are checked here, plus the derived query fragment, so drill-downs
+ * always load the selected inventory items.
  */
 
 const NOW: Date = new Date("2026-08-13T12:00:00.000Z");
@@ -67,10 +66,6 @@ describe("the empty scope", () => {
 
   test("builds a clean URL rather than a bare question mark", () => {
     expect(buildInventoryScopeQueryString({})).toBe("");
-  });
-
-  test("has nothing to explain", () => {
-    expect(describeInventoryScope({})).toBeNull();
   });
 
   test("adds nothing to the model query", () => {
@@ -254,56 +249,5 @@ describe("the model query fragment", () => {
     );
 
     expect(query.lastSeenAt!.value.getTime()).toBeLessThan(earlier.getTime());
-  });
-});
-
-describe("describing a scope for the banner", () => {
-  test("names the type in plural, human form", () => {
-    expect(
-      describeInventoryScope({ entityType: EntityType.KubernetesPod }),
-    ).toBe("Showing Kubernetes Pods only.");
-  });
-
-  test("names the source", () => {
-    const description: string = describeInventoryScope({
-      source: EntitySource.Manual,
-    })!;
-
-    expect(description).toContain("Added by you");
-  });
-
-  test("mentions staleness", () => {
-    expect(describeInventoryScope({ staleOnly: true })).toContain(
-      "not seen in over a day",
-    );
-  });
-
-  test("every non-empty scope produces a description", () => {
-    /*
-     * A scoped list with no banner is a list silently hiding rows, and the
-     * banner is also the only control that clears the scope.
-     */
-    for (const entityType of Object.values(EntityType)) {
-      expect(describeInventoryScope({ entityType })).not.toBeNull();
-    }
-
-    for (const source of Object.values(EntitySource)) {
-      expect(describeInventoryScope({ source })).not.toBeNull();
-      expect(
-        describeInventoryScope({ source, staleOnly: true }),
-      ).not.toBeNull();
-    }
-  });
-
-  test("a combined scope mentions every part of itself", () => {
-    const description: string = describeInventoryScope({
-      entityType: EntityType.Service,
-      source: EntitySource.Discovered,
-      staleOnly: true,
-    })!;
-
-    expect(description).toContain("Services");
-    expect(description).toContain("Discovered");
-    expect(description).toContain("not seen in over a day");
   });
 });

--- a/App/Tests/Dashboard/InventoryTableInvariants.test.ts
+++ b/App/Tests/Dashboard/InventoryTableInvariants.test.ts
@@ -364,7 +364,7 @@ describe("the pages that mount the table", () => {
     /*
      * A query-string-only change does not remount the page, so a scope
      * captured at first render leaves the table showing the previous scope
-     * under the new banner.
+     * after navigation.
      */
     const items: string = readPage("Items.tsx");
 
@@ -372,18 +372,21 @@ describe("the pages that mount the table", () => {
     expect(items).toContain("parseInventoryScope");
   });
 
-  test("the Items page always explains a scope it is under", () => {
+  test("the Items page renders without the filtered-view banner", () => {
     const items: string = readPage("Items.tsx");
 
-    expect(items).toContain("describeInventoryScope");
-    expect(items).toContain('dataTestId="inventory-scope-banner"');
+    expect(items).toContain("<InventoryTable");
+    expect(items).not.toContain('dataTestId="inventory-scope-banner"');
+    expect(items).not.toContain('strongTitle="Filtered view"');
+    expect(items).not.toContain("Dismiss this to see everything.");
   });
 
-  test("the banner clears the scope", () => {
+  test("the Items page keeps its scope query and remounts on navigation", () => {
     const items: string = readPage("Items.tsx");
 
-    expect(items).toContain("onClose=");
-    expect(items).toContain("RouteMap[PageMap.INVENTORY_ITEMS] as Route");
+    expect(items).toContain("buildInventoryScopeQuery");
+    expect(items).toContain("query={scopeQuery}");
+    expect(items).toContain("key={`inventory-items-${search}`}");
   });
 
   test("the Overview folds one snapshot into both the tiles and the breakdown", () => {

--- a/Common/Tests/App/Dashboard/InventoryItems.test.tsx
+++ b/Common/Tests/App/Dashboard/InventoryItems.test.tsx
@@ -1,0 +1,150 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React, { ReactElement } from "react";
+import { Link, MemoryRouter } from "react-router-dom";
+import InventoryItems from "../../../../App/FeatureSet/Dashboard/src/Pages/Inventory/Items";
+import { InventoryScopeQuery } from "../../../../App/FeatureSet/Dashboard/src/Components/Inventory/InventoryScope";
+import Route from "../../../Types/API/Route";
+import LessThan from "../../../Types/BaseDatabase/LessThan";
+import EntitySource from "../../../Types/Telemetry/EntitySource";
+import EntityType from "../../../Types/Telemetry/EntityType";
+
+interface InventoryTableProps {
+  query?: InventoryScopeQuery | undefined;
+  cardTitle: string;
+}
+
+let capturedTable: InventoryTableProps | null = null;
+
+// Exercise the real page, router and query builder without fetching table rows.
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Inventory/InventoryTable",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: InventoryTableProps): ReactElement => {
+        capturedTable = props;
+
+        return <h1 data-testid="inventory-table">{props.cardTitle}</h1>;
+      },
+    };
+  },
+);
+
+const ITEMS_PATH: string = "/dashboard/project/inventory/items";
+const NOW: Date = new Date("2026-09-07T12:00:00.000Z");
+const STALE_CUTOFF: Date = new Date("2026-09-06T12:00:00.000Z");
+
+function renderPage(search: string): void {
+  render(
+    <MemoryRouter initialEntries={[`${ITEMS_PATH}${search}`]}>
+      <Link to={`${ITEMS_PATH}?type=k8s.pod`}>Pods</Link>
+      <Link to={`${ITEMS_PATH}?source=manual`}>Added by You</Link>
+      <Link to={ITEMS_PATH}>All Items</Link>
+      <InventoryItems
+        pageRoute={new Route(ITEMS_PATH)}
+        currentProject={null}
+        hasPaymentMethod={false}
+      />
+    </MemoryRouter>,
+  );
+}
+
+function expectNoScopeBanner(): void {
+  expect(
+    screen.queryByTestId("inventory-scope-banner"),
+  ).not.toBeInTheDocument();
+  expect(screen.queryByText("Filtered view")).not.toBeInTheDocument();
+  expect(
+    screen.queryByText(/Dismiss this to see everything/),
+  ).not.toBeInTheDocument();
+}
+
+describe("Inventory Items without the scope banner", () => {
+  beforeEach(() => {
+    capturedTable = null;
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.useRealTimers();
+  });
+
+  const SCOPES: Array<[string, string, InventoryScopeQuery | undefined]> = [
+    ["all items", "", undefined],
+    ["a type", "?type=k8s.pod", { entityType: EntityType.KubernetesPod }],
+    ["a source", "?source=manual", { source: EntitySource.Manual }],
+    [
+      "Gone Quiet",
+      "?source=discovered&stale=true",
+      {
+        source: EntitySource.Discovered,
+        lastSeenAt: new LessThan<Date>(STALE_CUTOFF),
+      },
+    ],
+    [
+      "a combined type, source and stale scope",
+      "?type=host&source=discovered&stale=true",
+      {
+        entityType: EntityType.Host,
+        source: EntitySource.Discovered,
+        lastSeenAt: new LessThan<Date>(STALE_CUTOFF),
+      },
+    ],
+  ];
+
+  test.each(SCOPES)(
+    "renders %s without a banner and preserves its table query",
+    (
+      _name: string,
+      search: string,
+      expectedQuery: InventoryScopeQuery | undefined,
+    ) => {
+      renderPage(search);
+
+      expect(
+        screen.getByRole("heading", { name: "All Items" }),
+      ).toBeInTheDocument();
+      expect(capturedTable).not.toBeNull();
+      expect(capturedTable?.query).toEqual(expectedQuery);
+      expectNoScopeBanner();
+    },
+  );
+
+  test("updates and clears the scope when only the query string changes", () => {
+    renderPage("?source=discovered&stale=true");
+    const goneQuietTable: HTMLElement = screen.getByTestId("inventory-table");
+
+    fireEvent.click(screen.getByRole("link", { name: "Pods" }));
+
+    expect(capturedTable?.query).toEqual({
+      entityType: EntityType.KubernetesPod,
+    });
+    const podsTable: HTMLElement = screen.getByTestId("inventory-table");
+    expect(podsTable).not.toBe(goneQuietTable);
+    expectNoScopeBanner();
+
+    fireEvent.click(screen.getByRole("link", { name: "Added by You" }));
+
+    expect(capturedTable?.query).toEqual({ source: EntitySource.Manual });
+    const manualTable: HTMLElement = screen.getByTestId("inventory-table");
+    expect(manualTable).not.toBe(podsTable);
+    expectNoScopeBanner();
+
+    fireEvent.click(screen.getByRole("link", { name: "All Items" }));
+
+    expect(capturedTable?.query).toBeUndefined();
+    expect(screen.getByTestId("inventory-table")).not.toBe(manualTable);
+    expectNoScopeBanner();
+  });
+});


### PR DESCRIPTION
Opening an inventory drill-down such as Gone Quiet displayed a full-width “Filtered view” banner above the table. Remove that banner and its unused description helper while preserving URL filters, table remounting, and the existing All Items navigation that clears the scope.

Add six rendered-page regression cases covering unfiltered, type, source, stale, combined scopes, and navigation between scopes. Update the inventory page invariants to match the banner-free layout.

Validation:
- 134 targeted tests passed locally: 128 inventory scope, table, facets, and summary tests plus six rendered-page regression cases.
- GitHub `compile-app`, `compile-dashboard`, and `compile-common` passed.
- Formatting and `git diff --check` passed. Root `npm run fix` and local compilation were attempted, then stopped under sustained system memory pressure; completed GitHub checks provide the full lint and compilation results.

Existing CI failures are unchanged from base `302d796fee`: [App Test](https://github.com/OneUptime/oneuptime/actions/runs/34124489800) has four monitor-template assertions failing, and [js-lint](https://github.com/OneUptime/oneuptime/actions/runs/34124489672) reports the `SSO` component naming error in `StatusPageOidcOrigin.test.tsx:199`. This PR changes none of those files.
