### PR TITLE
Improve incident, alert, and scheduled maintenance overviews

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/AffectedResources/AffectedResourcesDisplay.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AffectedResources/AffectedResourcesDisplay.tsx
@@ -25,6 +25,7 @@ import NetworkSiteElement from "../NetworkSite/NetworkSiteElement";
 import ServiceElement from "../Service/ServiceElement";
 
 export interface ComponentProps {
+  compact?: boolean | undefined;
   monitors?: Array<Monitor> | undefined;
   hosts?: Array<Host> | undefined;
   kubernetesClusters?: Array<KubernetesCluster> | undefined;
@@ -91,8 +92,8 @@ function CategoryCard<T>(props: CategoryCardProps<T>): ReactElement {
   return (
     <div className="group relative flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-all duration-200 hover:border-gray-300 hover:shadow-md">
       <div className={`h-1 w-full ${props.accentBarClass}`} />
-      <div className="flex items-center justify-between px-4 py-3">
-        <div className="flex items-center gap-3">
+      <div className="flex min-w-0 items-center justify-between gap-2 px-4 py-3">
+        <div className="flex min-w-0 items-center gap-3">
           <div
             className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${props.iconBgClass}`}
           >
@@ -101,12 +102,12 @@ function CategoryCard<T>(props: CategoryCardProps<T>): ReactElement {
               className={`h-[18px] w-[18px] ${props.iconColorClass}`}
             />
           </div>
-          <span className="text-sm font-semibold text-gray-900">
+          <span className="min-w-0 break-words text-sm font-semibold text-gray-900">
             {props.label}
           </span>
         </div>
         <span
-          className={`inline-flex h-7 min-w-[1.75rem] items-center justify-center rounded-full px-2.5 text-xs font-semibold ${props.countBgClass} ${props.countTextClass}`}
+          className={`inline-flex h-7 min-w-[1.75rem] shrink-0 items-center justify-center rounded-full px-2.5 text-xs font-semibold ${props.countBgClass} ${props.countTextClass}`}
         >
           {total.toLocaleString()}
         </span>
@@ -287,7 +288,9 @@ const AffectedResourcesDisplay: FunctionComponent<ComponentProps> = (
           across {categoryCount.toLocaleString()} {categoryWord}
         </span>
       </div>
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+      <div
+        className={`grid grid-cols-1 gap-3 ${props.compact ? "" : "md:grid-cols-2"}`}
+      >
         {showMonitors && (
           <CategoryCard<Monitor>
             icon={IconProp.AltGlobe}

--- a/App/FeatureSet/Dashboard/src/Components/Alert/AlertFeed.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Alert/AlertFeed.tsx
@@ -310,7 +310,7 @@ const AlertFeedElement: FunctionComponent<ComponentProps> = (
           <div hidden={isLoading || Boolean(error)}>
             <Feed
               visibleItemLimit={6}
-              items={feedItems}
+              items={isLoading || error ? [] : feedItems}
               noItemsMessage="Looks like there are no items in this feed for this alert."
             />
           </div>

--- a/App/FeatureSet/Dashboard/src/Components/Alert/AlertFeed.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Alert/AlertFeed.tsx
@@ -253,9 +253,7 @@ const AlertFeedElement: FunctionComponent<ComponentProps> = (
   return (
     <Card
       title={"Alert Feed"}
-      description={
-        "This is the timeline and feed for this alert. You can see all the updates and information about this alert here."
-      }
+      description={"State changes, notes, and updates in one timeline."}
       buttons={[
         <MoreMenu
           key="alert-feed-actions-menu"
@@ -308,11 +306,14 @@ const AlertFeedElement: FunctionComponent<ComponentProps> = (
       <div>
         {(isLoading || !isCurrentFeedLoaded) && <ComponentLoader />}
         {isCurrentFeedLoaded && error && <ErrorMessage message={error} />}
-        {isCurrentFeedLoaded && !isLoading && !error && (
-          <Feed
-            items={feedItems}
-            noItemsMessage="Looks like there are no items in this feed for this alert."
-          />
+        {isCurrentFeedLoaded && (
+          <div hidden={isLoading || Boolean(error)}>
+            <Feed
+              visibleItemLimit={6}
+              items={feedItems}
+              noItemsMessage="Looks like there are no items in this feed for this alert."
+            />
+          </div>
         )}
 
         {showOnCallPolicyModal && (

--- a/App/FeatureSet/Dashboard/src/Components/EventView/EventOverviewLayout.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/EventView/EventOverviewLayout.tsx
@@ -1,0 +1,85 @@
+import useTranslateValue from "Common/UI/Utils/Translation";
+import React, { FunctionComponent, ReactElement, useId } from "react";
+
+export interface ComponentProps {
+  header: ReactElement;
+  summary: ReactElement;
+  children: ReactElement;
+  sidebar: ReactElement;
+  activityTitle?: string | undefined;
+  activityDescription?: string | undefined;
+  sidebarTitle?: string | undefined;
+}
+
+// Keep the reading order consistent across incidents, alerts, and maintenance.
+const EventOverviewLayout: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const id: string = useId();
+  const { translateString } = useTranslateValue();
+  const activityId: string = `${id}-activity`;
+  const detailsId: string = `${id}-details`;
+  const skipLinkClassName: string =
+    "sr-only focus:not-sr-only focus:inline-flex focus:rounded-md focus:bg-white focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-indigo-700 focus:ring-2 focus:ring-indigo-500";
+
+  return (
+    <div className="min-w-0" data-testid="event-overview">
+      <nav aria-label={translateString("Overview shortcuts")}>
+        <a href={`#${activityId}`} className={skipLinkClassName}>
+          {translateString("Skip to activity")}
+        </a>
+        <a href={`#${detailsId}`} className={skipLinkClassName}>
+          {translateString("Skip to details")}
+        </a>
+      </nav>
+
+      <div className="space-y-4">
+        <div>{props.header}</div>
+        <section aria-label={translateString("Event summary")}>
+          {props.summary}
+        </section>
+      </div>
+
+      <div className="mt-6 grid min-w-0 grid-cols-1 items-start gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(18rem,22rem)]">
+        <section
+          id={activityId}
+          tabIndex={-1}
+          aria-labelledby={`${activityId}-heading`}
+          className="min-w-0 scroll-mt-6 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+        >
+          <div className="mb-4">
+            <h2
+              id={`${activityId}-heading`}
+              className="text-sm font-semibold text-gray-900"
+            >
+              {translateString(props.activityTitle || "Response activity")}
+            </h2>
+            {props.activityDescription && (
+              <p className="mt-1 text-sm leading-5 text-gray-500">
+                {translateString(props.activityDescription)}
+              </p>
+            )}
+          </div>
+          {props.children}
+        </section>
+
+        <aside
+          id={detailsId}
+          tabIndex={-1}
+          aria-labelledby={`${detailsId}-heading`}
+          className="min-w-0 scroll-mt-6 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+        >
+          <h2
+            id={`${detailsId}-heading`}
+            className="mb-4 text-sm font-semibold text-gray-900"
+          >
+            {translateString(props.sidebarTitle || "Details")}
+          </h2>
+          {props.sidebar}
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+export default EventOverviewLayout;

--- a/App/FeatureSet/Dashboard/src/Components/EventView/EventStatTile.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/EventView/EventStatTile.tsx
@@ -1,5 +1,6 @@
 import IconProp from "Common/Types/Icon/IconProp";
 import Icon from "Common/UI/Components/Icon/Icon";
+import useTranslateValue from "Common/UI/Utils/Translation";
 import React, { FunctionComponent, ReactElement } from "react";
 
 export interface ComponentProps {
@@ -14,26 +15,33 @@ export interface ComponentProps {
 const EventStatTile: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  const { translateString, translateValue } = useTranslateValue();
   return (
-    <div
+    <dl
       id={props.id}
-      className={`rounded-xl border border-gray-200 bg-white px-4 py-3.5 shadow-sm ${
+      className={`min-w-0 rounded-xl border border-gray-200 bg-gray-50 px-4 py-4 ${
         props.className || ""
       }`}
     >
-      <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-gray-500">
+      <dt className="flex items-start gap-2 text-xs font-medium text-gray-500">
         {props.icon && (
-          <Icon icon={props.icon} className="h-3.5 w-3.5 text-gray-400" />
+          <span aria-hidden="true" className="shrink-0">
+            <Icon icon={props.icon} className="h-4 w-4 text-gray-400" />
+          </span>
         )}
-        <span>{props.label}</span>
-      </div>
-      <div className="mt-1.5 truncate text-lg font-semibold text-gray-900">
-        {props.value}
-      </div>
+        <span className="min-w-0 break-words">
+          {translateString(props.label)}
+        </span>
+      </dt>
+      <dd className="mt-2 break-words text-lg font-semibold leading-7 tabular-nums text-gray-900">
+        {translateValue(props.value)}
+      </dd>
       {props.description && (
-        <div className="mt-0.5 text-xs text-gray-500">{props.description}</div>
+        <dd className="mt-1 break-words text-xs leading-5 text-gray-500">
+          {translateString(props.description)}
+        </dd>
       )}
-    </div>
+    </dl>
   );
 };
 

--- a/App/FeatureSet/Dashboard/src/Components/EventView/EventStatusPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/EventView/EventStatusPanel.tsx
@@ -71,48 +71,58 @@ const EventStatusPanel: FunctionComponent<ComponentProps> = (
 
   const getStepRail: () => ReactElement = (): ReactElement => {
     return (
-      <div className="flex flex-wrap items-center gap-y-1.5">
+      <ol
+        aria-label={translateString("State progression")}
+        className="flex flex-wrap items-center gap-x-3 gap-y-2"
+      >
         {props.states.map((state: EventStateItem, index: number) => {
           const isReached: boolean =
             currentStateIndex >= 0 && index <= currentStateIndex;
           const isCurrent: boolean = index === currentStateIndex;
 
           return (
-            <div key={`${state.id}-${index}`} className="flex items-center">
+            <li
+              key={`${state.id}-${index}`}
+              aria-current={isCurrent ? "step" : undefined}
+              className="flex min-w-0 max-w-full items-center"
+            >
               {index > 0 && (
                 <div
-                  className={`mx-2.5 h-px w-5 ${
+                  aria-hidden="true"
+                  className={`mr-3 h-px w-5 shrink-0 ${
                     isReached ? "bg-gray-300" : "bg-gray-200"
                   }`}
                 />
               )}
-              <div className="flex items-center gap-1.5">
+              <div className="flex min-w-0 items-center gap-2">
                 <span
-                  className={`h-2 w-2 rounded-full ${
-                    isReached && !isCurrent ? "opacity-40" : ""
+                  aria-hidden="true"
+                  className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold ${
+                    isCurrent ? "ring-2 ring-gray-200 ring-offset-2" : ""
                   }`}
                   style={{
-                    backgroundColor: isReached
-                      ? (state.color || Black).toString()
-                      : "#e5e7eb",
+                    backgroundColor: isCurrent ? "#111827" : "#f3f4f6",
+                    color: isCurrent ? "#ffffff" : "#6b7280",
                   }}
-                />
+                >
+                  {index + 1}
+                </span>
                 <span
-                  className={`text-xs ${
+                  className={`min-w-0 break-words text-xs ${
                     isCurrent
                       ? "font-semibold text-gray-900"
                       : isReached
                         ? "font-medium text-gray-500"
-                        : "font-medium text-gray-400"
+                        : "font-medium text-gray-500"
                   }`}
                 >
                   {state.name}
                 </span>
               </div>
-            </div>
+            </li>
           );
         })}
-      </div>
+      </ol>
     );
   };
 
@@ -159,7 +169,7 @@ const EventStatusPanel: FunctionComponent<ComponentProps> = (
     const translatedActionLabel: string =
       translateString(action.label) || action.label;
     const baseClassName: string =
-      "inline-flex h-9 min-w-[7rem] max-w-full flex-1 select-none items-center justify-center gap-2 whitespace-nowrap rounded-md border px-3.5 text-sm font-semibold shadow-sm transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:max-w-64 sm:flex-none";
+      "inline-flex h-9 min-w-[7rem] max-w-full flex-auto select-none items-center justify-center gap-2 whitespace-nowrap rounded-md border px-3.5 text-sm font-semibold shadow-sm transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:max-w-64 sm:flex-none";
     const variantClassName: string = isPrimary
       ? "border-indigo-600 bg-indigo-600 text-white hover:border-indigo-700 hover:bg-indigo-700"
       : "border-gray-300 bg-white text-gray-700 hover:border-gray-400 hover:bg-gray-50 hover:text-gray-900";
@@ -187,7 +197,11 @@ const EventStatusPanel: FunctionComponent<ComponentProps> = (
   // The action buttons + "change state" overflow menu, shared by both layouts.
   const actionsCluster: ReactElement = (
     <div
-      className="flex w-full flex-wrap items-center justify-end gap-2 md:w-auto"
+      className={`flex w-full min-w-0 max-w-full flex-wrap items-center justify-end gap-2 ${
+        props.title
+          ? "xl:w-auto xl:max-w-[50%] xl:shrink-0"
+          : "md:w-auto md:max-w-[60%] md:shrink-0"
+      }`}
       role="group"
       aria-label="Event actions"
     >
@@ -255,7 +269,7 @@ const EventStatusPanel: FunctionComponent<ComponentProps> = (
         />
       )}
       {props.durationStartsAt && (
-        <span className="inline-flex items-center gap-1.5 text-sm text-gray-500">
+        <span className="inline-flex max-w-full flex-wrap items-center gap-x-1.5 gap-y-1 text-sm text-gray-500">
           <Icon icon={IconProp.Clock} className="h-4 w-4 text-gray-400" />
           <span>{props.durationPrefix || "Ongoing for"}</span>
           <span className="font-medium text-gray-700">
@@ -274,22 +288,28 @@ const EventStatusPanel: FunctionComponent<ComponentProps> = (
   );
 
   return (
-    <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+    <div
+      className="min-w-0 rounded-xl border border-gray-200 bg-white shadow-sm"
+      style={{
+        borderTopWidth: "3px",
+        borderTopColor: currentState?.color?.toString() || "#e5e7eb",
+      }}
+    >
       {props.title ? (
         /* Header layout: eyebrow number + prominent title, pills on the row below. */
-        <div className="px-4 py-4 sm:px-5">
-          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-            <div className="min-w-0">
+        <div className="px-4 py-5 sm:px-6 sm:py-6">
+          <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+            <div className="min-w-0 flex-1">
               {props.identifier && (
                 <span
-                  className="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-gray-600"
+                  className="inline-flex max-w-full break-all rounded-md bg-gray-100 px-2 py-0.5 font-mono text-xs font-medium uppercase tracking-wide text-gray-600"
                   title="Number"
                 >
                   {props.identifier}
                 </span>
               )}
               <Tooltip text={props.title}>
-                <h2 className="mt-1.5 truncate text-lg font-semibold leading-tight text-gray-900 sm:text-xl">
+                <h2 className="mt-2 text-xl font-semibold leading-8 tracking-tight text-gray-900 [overflow-wrap:anywhere] sm:text-2xl">
                   {props.title}
                 </h2>
               </Tooltip>
@@ -297,7 +317,7 @@ const EventStatusPanel: FunctionComponent<ComponentProps> = (
             {actionsCluster}
           </div>
           {hasMeta && (
-            <div className="mt-3 flex flex-wrap items-center gap-2.5">
+            <div className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-2">
               {metaItems}
             </div>
           )}
@@ -323,7 +343,7 @@ const EventStatusPanel: FunctionComponent<ComponentProps> = (
         </div>
       )}
       {props.states.length > 1 && (
-        <div className="border-t border-gray-100 px-4 py-2.5 sm:px-5">
+        <div className="rounded-b-xl border-t border-gray-100 bg-gray-50 px-4 py-3.5 sm:px-6">
           {getStepRail()}
         </div>
       )}

--- a/App/FeatureSet/Dashboard/src/Components/Incident/IncidentFeed.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/IncidentFeed.tsx
@@ -375,7 +375,7 @@ const IncidentFeedElement: FunctionComponent<ComponentProps> = (
           <div hidden={isLoading || Boolean(error)}>
             <Feed
               visibleItemLimit={6}
-              items={feedItems}
+              items={isLoading || error ? [] : feedItems}
               noItemsMessage="Looks like there are no items in this feed for this incident."
             />
           </div>

--- a/App/FeatureSet/Dashboard/src/Components/Incident/IncidentFeed.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/IncidentFeed.tsx
@@ -310,9 +310,7 @@ const IncidentFeedElement: FunctionComponent<ComponentProps> = (
   return (
     <Card
       title={"Incident Feed"}
-      description={
-        "This is the timeline and feed for this incident. You can see all the updates and information about this incident here."
-      }
+      description={"State changes, notes, and updates in one timeline."}
       buttons={[
         <MoreMenu
           key="incident-feed-actions-menu"
@@ -373,11 +371,14 @@ const IncidentFeedElement: FunctionComponent<ComponentProps> = (
       <div>
         {(isLoading || !isCurrentFeedLoaded) && <ComponentLoader />}
         {isCurrentFeedLoaded && error && <ErrorMessage message={error} />}
-        {isCurrentFeedLoaded && !isLoading && !error && (
-          <Feed
-            items={feedItems}
-            noItemsMessage="Looks like there are no items in this feed for this incident."
-          />
+        {isCurrentFeedLoaded && (
+          <div hidden={isLoading || Boolean(error)}>
+            <Feed
+              visibleItemLimit={6}
+              items={feedItems}
+              noItemsMessage="Looks like there are no items in this feed for this incident."
+            />
+          </div>
         )}
 
         {showOnCallPolicyModal && (

--- a/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ChangeState.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ChangeState.tsx
@@ -363,7 +363,7 @@ const ChangeScheduledMaintenanceState: FunctionComponent<ComponentProps> = (
   };
 
   return (
-    <div className="mb-5">
+    <div>
       <EventStatusPanel
         states={scheduledMaintenanceStates.map(
           (state: ScheduledMaintenanceState): EventStateItem => {

--- a/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceFeed.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceFeed.tsx
@@ -306,7 +306,7 @@ const ScheduledMaintenanceFeedElement: FunctionComponent<ComponentProps> = (
           <Feed
             key={props.scheduledMaintenanceId.toString()}
             visibleItemLimit={6}
-            items={feedItems}
+            items={isLoading || error ? [] : feedItems}
             noItemsMessage="Looks like there are no items in this feed for this scheduled maintenance."
           />
         </div>

--- a/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceFeed.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceFeed.tsx
@@ -249,9 +249,7 @@ const ScheduledMaintenanceFeedElement: FunctionComponent<ComponentProps> = (
   return (
     <Card
       title={"Scheduled Maintenance Feed"}
-      description={
-        "This is the timeline and feed for this scheduled maintenance. You can see all the updates and information about this scheduled maintenance here."
-      }
+      description={"State changes, notes, and updates in one timeline."}
       buttons={[
         <MoreMenu
           key="scheduled-maintenance-feed-actions-menu"
@@ -304,12 +302,14 @@ const ScheduledMaintenanceFeedElement: FunctionComponent<ComponentProps> = (
       <div>
         {isLoading && <ComponentLoader />}
         {error && <ErrorMessage message={error} />}
-        {!isLoading && !error && (
+        <div hidden={isLoading || Boolean(error)}>
           <Feed
+            key={props.scheduledMaintenanceId.toString()}
+            visibleItemLimit={6}
             items={feedItems}
             noItemsMessage="Looks like there are no items in this feed for this scheduled maintenance."
           />
-        )}
+        </div>
         {showPublicNoteModal && (
           <ModelFormModal
             modalWidth={ModalWidth.Large}

--- a/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
@@ -67,6 +67,7 @@ import IconProp from "Common/Types/Icon/IconProp";
 import AlertFeedElement from "../../../Components/Alert/AlertFeed";
 import InvestigationPanel from "../../../Components/AI/InvestigationPanel";
 import EventStatTile from "../../../Components/EventView/EventStatTile";
+import EventOverviewLayout from "../../../Components/EventView/EventOverviewLayout";
 import EntityRunbooks from "../../../Components/Runbook/EntityRunbooks";
 import RemediationSuggestionCard from "../../../Components/AutoRemediation/RemediationSuggestionCard";
 import AlertAffectedResources from "./AffectedResources";
@@ -412,8 +413,8 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
     ) : undefined;
 
   return (
-    <Fragment>
-      <div className="mb-5">
+    <EventOverviewLayout
+      header={
         <ChangeAlertState
           alertId={modelId}
           eventNumber={eventNumber}
@@ -425,173 +426,50 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
             await fetchData();
           }}
         />
-      </div>
-
-      <div className="grid grid-cols-1 items-start gap-6 xl:grid-cols-3">
-        <div className="min-w-0 xl:col-span-2">
-          <div className="mb-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <EventStatTile
-              label={`${getAcknowledgeState()?.name || "Acknowledged"} in`}
-              icon={IconProp.Check}
-              value={getTimeToAcknowledge()}
-            />
-            <EventStatTile
-              label={`${getResolvedState()?.name || "Resolved"} in`}
-              icon={IconProp.CheckCircle}
-              value={getTimeToResolve()}
-            />
-            <EventStatTile
-              label="Duration"
-              icon={IconProp.Clock}
-              value={
-                durationStartDate ? (
-                  <LiveDuration
-                    startDate={durationStartDate}
-                    endDate={durationEndDate}
-                  />
-                ) : (
-                  "-"
-                )
-              }
-            />
-          </div>
-
-          {telemetryQuery && (
-            <TelemetryCompanionSignalTabs
-              telemetryQuery={telemetryQuery}
-              snapshotWindow={telemetrySnapshotWindow}
-              snapshotWindowAlert={snapshotWindowAlert}
-              eventNoun="alert"
-              primarySignalElement={
-                <Fragment>
-                  {telemetryQuery.telemetryType === TelemetryType.Log &&
-                    telemetryQuery.telemetryQuery && (
-                      <div>
-                        <Card
-                          title={"Logs"}
-                          description={"Logs for this alert."}
-                          rightElement={snapshotWindowAlert}
-                        >
-                          <DashboardLogsViewer
-                            id="logs-preview"
-                            logQuery={
-                              telemetryQuery.telemetryQuery as Query<Log>
-                            }
-                            limit={10}
-                            noLogsMessage="No logs found"
-                          />
-                        </Card>
-                      </div>
-                    )}
-
-                  {telemetryQuery.telemetryType === TelemetryType.Trace &&
-                    telemetryQuery.telemetryQuery && (
-                      <div>
-                        <Card
-                          title={"Spans"}
-                          description={"Spans for this alert."}
-                          rightElement={snapshotWindowAlert}
-                        >
-                          <TracesViewer
-                            spanQuery={
-                              telemetryQuery.telemetryQuery as Query<Span>
-                            }
-                            limit={10}
-                            /*
-                             * Pinned to the snapshot: this page owns the URL,
-                             * so the viewer neither reads a filter out of it
-                             * nor writes its own state back into it.
-                             */
-                            disableUrlSync={true}
-                            emptyMessage="No spans found"
-                          />
-                        </Card>
-                      </div>
-                    )}
-
-                  {telemetryQuery.telemetryType === TelemetryType.Metric &&
-                    telemetryQuery.metricViewData && (
-                      <Card
-                        title={"Metrics"}
-                        description={
-                          seriesSummary
-                            ? `Metrics for this alert, scoped to the affected series (${seriesSummary}).`
-                            : "Metrics for this alert."
-                        }
-                        rightElement={snapshotWindowAlert}
-                      >
-                        <MetricView
-                          data={telemetryQuery.metricViewData}
-                          hideQueryElements={true}
-                          chartCssClass="rounded-lg border border-gray-200 shadow-sm"
-                          hideStartAndEndDate={true}
-                          // Read-only host: onChange is a no-op, so zoom can't apply.
-                          disableChartZoom={true}
-                          onChange={(_data: MetricViewData) => {
-                            // do nothing!
-                          }}
-                        />
-                      </Card>
-                    )}
-
-                  {telemetryQuery.telemetryType === TelemetryType.Exception &&
-                    telemetryQuery.telemetryQuery && (
-                      <Card
-                        title={"Exceptions"}
-                        description={"Exceptions for this alert."}
-                        rightElement={snapshotWindowAlert}
-                      >
-                        <ExceptionsViewer
-                          exceptionInstanceQuery={
-                            telemetryQuery.telemetryQuery as Query<ExceptionInstance>
-                          }
-                          /*
-                           * An event shows the exceptions it fired on,
-                           * whoever has since resolved them and whatever the
-                           * classifier made of them — the explorer's
-                           * "unresolved issues" defaults would hide exactly
-                           * those.
-                           */
-                          defaultStatus="all"
-                          defaultClassScope="all"
-                          limit={10}
-                          // Pinned to the snapshot; this page owns the URL.
-                          disableUrlSync={true}
-                          emptyMessage="No exceptions found"
-                        />
-                      </Card>
-                    )}
-                </Fragment>
-              }
-            />
-          )}
-
-          <MonitorSummarySnapshotCard alertId={modelId} />
-
-          <AlertAffectedResources alertId={modelId} />
-
-          <EntityRunbooks alertId={modelId} hideIfEmpty={true} />
-
-          <RemediationSuggestionCard alertId={modelId} hideIfEmpty={true} />
-
-          <InvestigationPanel
-            subjectType="alert"
-            subjectId={modelId}
-            onAnalysisAvailable={refreshFeedAfterAnalysisAvailable}
+      }
+      summary={
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <EventStatTile
+            label={`${getAcknowledgeState()?.name || "Acknowledged"} in`}
+            icon={IconProp.Check}
+            value={getTimeToAcknowledge()}
           />
-
-          <AlertFeedElement alertId={modelId} refreshToken={feedRefreshToken} />
+          <EventStatTile
+            label={`${getResolvedState()?.name || "Resolved"} in`}
+            icon={IconProp.CheckCircle}
+            value={getTimeToResolve()}
+          />
+          <EventStatTile
+            label="Duration"
+            icon={IconProp.Clock}
+            value={
+              durationStartDate ? (
+                <LiveDuration
+                  startDate={durationStartDate}
+                  endDate={durationEndDate}
+                />
+              ) : (
+                "-"
+              )
+            }
+          />
         </div>
-
-        <div className="min-w-0 xl:col-span-1">
+      }
+      activityTitle="Response activity"
+      activityDescription="Follow updates, investigate signals, and coordinate the response."
+      sidebarTitle="Event context"
+      sidebar={
+        <Fragment>
           {/* Alert View  */}
           <CardModelDetail<Alert>
             name="Alert Details"
             cardProps={{
               title: "Alert Details",
-              description: "Here are more details for this alert.",
+              description: "Ownership and alert context.",
             }}
+            editButtonText="Edit details"
             isEditable={true}
+            compact={true}
             onSaveSuccess={() => {
               // refresh page-level state (severity/visibility pills) shown in the status panel above.
               fetchData().catch((err: Error) => {
@@ -715,32 +593,6 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
               id: "model-detail-alerts",
               fields: [
                 {
-                  field: {
-                    alertNumber: true,
-                    alertNumberWithPrefix: true,
-                  },
-                  title: "Alert Number",
-                  fieldType: FieldType.Element,
-                  getElement: (item: Alert): ReactElement => {
-                    if (!item.alertNumber) {
-                      return <>-</>;
-                    }
-
-                    return (
-                      <span className="font-medium text-gray-900">
-                        {item.alertNumberWithPrefix || `#${item.alertNumber}`}
-                      </span>
-                    );
-                  },
-                },
-                {
-                  field: {
-                    _id: true,
-                  },
-                  title: "Alert ID",
-                  fieldType: FieldType.ObjectID,
-                },
-                {
                   /*
                    * Alert.monitor is a singular relation set at creation, so it
                    * gets its own row separate from the multi-resource picker.
@@ -837,6 +689,13 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
                     return <LabelsElement labels={item["labels"] || []} />;
                   },
                 },
+                {
+                  field: {
+                    _id: true,
+                  },
+                  title: "Alert ID",
+                  fieldType: FieldType.ObjectID,
+                },
               ],
               modelId: modelId,
             }}
@@ -853,10 +712,11 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
             name="Affected Resources"
             cardProps={{
               title: "Affected Resources",
-              description:
-                "Hosts, clusters, container hosts, and services affected by this alert.",
+              description: "Resources impacted by this alert.",
             }}
+            editButtonText="Edit resources"
             isEditable={true}
+            compact={true}
             formFields={[
               {
                 /*
@@ -1058,6 +918,7 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
                   getElement: (item: Alert): ReactElement => {
                     return (
                       <AffectedResourcesDisplay
+                        compact={true}
                         hosts={item.hosts || []}
                         kubernetesClusters={item.kubernetesClusters || []}
                         dockerHosts={item.dockerHosts || []}
@@ -1076,9 +937,135 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
               modelId: modelId,
             }}
           />
-        </div>
-      </div>
-    </Fragment>
+        </Fragment>
+      }
+    >
+      <Fragment>
+        <AlertFeedElement alertId={modelId} refreshToken={feedRefreshToken} />
+
+        {telemetryQuery && (
+          <TelemetryCompanionSignalTabs
+            telemetryQuery={telemetryQuery}
+            snapshotWindow={telemetrySnapshotWindow}
+            snapshotWindowAlert={snapshotWindowAlert}
+            eventNoun="alert"
+            primarySignalElement={
+              <Fragment>
+                {telemetryQuery.telemetryType === TelemetryType.Log &&
+                  telemetryQuery.telemetryQuery && (
+                    <div>
+                      <Card
+                        title={"Logs"}
+                        description={"Logs for this alert."}
+                        rightElement={snapshotWindowAlert}
+                      >
+                        <DashboardLogsViewer
+                          id="logs-preview"
+                          logQuery={telemetryQuery.telemetryQuery as Query<Log>}
+                          limit={10}
+                          noLogsMessage="No logs found"
+                        />
+                      </Card>
+                    </div>
+                  )}
+
+                {telemetryQuery.telemetryType === TelemetryType.Trace &&
+                  telemetryQuery.telemetryQuery && (
+                    <div>
+                      <Card
+                        title={"Spans"}
+                        description={"Spans for this alert."}
+                        rightElement={snapshotWindowAlert}
+                      >
+                        <TracesViewer
+                          spanQuery={
+                            telemetryQuery.telemetryQuery as Query<Span>
+                          }
+                          limit={10}
+                          /*
+                           * Pinned to the snapshot: this page owns the URL,
+                           * so the viewer neither reads a filter out of it
+                           * nor writes its own state back into it.
+                           */
+                          disableUrlSync={true}
+                          emptyMessage="No spans found"
+                        />
+                      </Card>
+                    </div>
+                  )}
+
+                {telemetryQuery.telemetryType === TelemetryType.Metric &&
+                  telemetryQuery.metricViewData && (
+                    <Card
+                      title={"Metrics"}
+                      description={
+                        seriesSummary
+                          ? `Metrics for this alert, scoped to the affected series (${seriesSummary}).`
+                          : "Metrics for this alert."
+                      }
+                      rightElement={snapshotWindowAlert}
+                    >
+                      <MetricView
+                        data={telemetryQuery.metricViewData}
+                        hideQueryElements={true}
+                        chartCssClass="rounded-lg border border-gray-200 shadow-sm"
+                        hideStartAndEndDate={true}
+                        // Read-only host: onChange is a no-op, so zoom can't apply.
+                        disableChartZoom={true}
+                        onChange={(_data: MetricViewData) => {
+                          // do nothing!
+                        }}
+                      />
+                    </Card>
+                  )}
+
+                {telemetryQuery.telemetryType === TelemetryType.Exception &&
+                  telemetryQuery.telemetryQuery && (
+                    <Card
+                      title={"Exceptions"}
+                      description={"Exceptions for this alert."}
+                      rightElement={snapshotWindowAlert}
+                    >
+                      <ExceptionsViewer
+                        exceptionInstanceQuery={
+                          telemetryQuery.telemetryQuery as Query<ExceptionInstance>
+                        }
+                        /*
+                         * An event shows the exceptions it fired on,
+                         * whoever has since resolved them and whatever the
+                         * classifier made of them — the explorer's
+                         * "unresolved issues" defaults would hide exactly
+                         * those.
+                         */
+                        defaultStatus="all"
+                        defaultClassScope="all"
+                        limit={10}
+                        // Pinned to the snapshot; this page owns the URL.
+                        disableUrlSync={true}
+                        emptyMessage="No exceptions found"
+                      />
+                    </Card>
+                  )}
+              </Fragment>
+            }
+          />
+        )}
+
+        <MonitorSummarySnapshotCard alertId={modelId} />
+
+        <AlertAffectedResources alertId={modelId} />
+
+        <EntityRunbooks alertId={modelId} hideIfEmpty={true} />
+
+        <RemediationSuggestionCard alertId={modelId} hideIfEmpty={true} />
+
+        <InvestigationPanel
+          subjectType="alert"
+          subjectId={modelId}
+          onAnalysisAvailable={refreshFeedAfterAnalysisAvailable}
+        />
+      </Fragment>
+    </EventOverviewLayout>
   );
 };
 

--- a/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Layout.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Layout.tsx
@@ -1,5 +1,6 @@
 import { getAlertsBreadcrumbs } from "../../../Utils/Breadcrumbs/AlertBreadcrumbs";
-import { RouteUtil } from "../../../Utils/RouteMap";
+import RouteMap, { RouteUtil } from "../../../Utils/RouteMap";
+import PageMap from "../../../Utils/PageMap";
 import PageComponentProps from "../../PageComponentProps";
 import SideMenu from "./SideMenu";
 import ObjectID from "Common/Types/ObjectID";
@@ -15,12 +16,14 @@ const AlertViewLayout: FunctionComponent<
   const { id } = useParams();
   const modelId: ObjectID = new ObjectID(id || "");
   const path: string = Navigation.getRoutePath(RouteUtil.getRoutes());
+  const isOverview: boolean = path === RouteMap[PageMap.ALERT_VIEW]?.toString();
   return (
     <ModelPage
       title="Alert"
       modelType={Alert}
       modelId={modelId}
       modelNameField="title"
+      hideTitle={isOverview}
       breadcrumbLinks={getAlertsBreadcrumbs(path)}
       sideMenu={<SideMenu modelId={modelId} />}
     >

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
@@ -57,6 +57,7 @@ import IncidentAffectedResources from "./AffectedResources";
 import MonitorSummarySnapshotCard from "../../../Components/Monitor/MonitorSummarySnapshotCard";
 import IncidentMemberRoleAssignment from "../../../Components/Incident/IncidentMemberRoleAssignment";
 import EventStatTile from "../../../Components/EventView/EventStatTile";
+import EventOverviewLayout from "../../../Components/EventView/EventOverviewLayout";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import DockerHost from "Common/Models/DatabaseModels/DockerHost";
 import PodmanHost from "Common/Models/DatabaseModels/PodmanHost";
@@ -466,8 +467,8 @@ const IncidentView: FunctionComponent<
     ) : undefined;
 
   return (
-    <Fragment>
-      <div className="mb-5">
+    <EventOverviewLayout
+      header={
         <ChangeIncidentState
           incidentId={modelId}
           eventNumber={eventNumber}
@@ -480,177 +481,50 @@ const IncidentView: FunctionComponent<
             await fetchData();
           }}
         />
-      </div>
-
-      <div className="grid grid-cols-1 items-start gap-6 xl:grid-cols-3">
-        <div className="min-w-0 xl:col-span-2">
-          <div className="mb-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <EventStatTile
-              label={`${getAcknowledgeState()?.name || "Acknowledged"} in`}
-              icon={IconProp.Check}
-              value={getTimeToAcknowledge()}
-            />
-            <EventStatTile
-              label={`${getResolvedState()?.name || "Resolved"} in`}
-              icon={IconProp.CheckCircle}
-              value={getTimeToResolve()}
-            />
-            <EventStatTile
-              label="Duration"
-              icon={IconProp.Clock}
-              value={
-                durationStartDate ? (
-                  <LiveDuration
-                    startDate={durationStartDate}
-                    endDate={durationEndDate}
-                  />
-                ) : (
-                  "-"
-                )
-              }
-            />
-          </div>
-
-          {telemetryQuery && (
-            <TelemetryCompanionSignalTabs
-              telemetryQuery={telemetryQuery}
-              snapshotWindow={telemetrySnapshotWindow}
-              snapshotWindowAlert={snapshotWindowAlert}
-              eventNoun="incident"
-              primarySignalElement={
-                <Fragment>
-                  {telemetryQuery.telemetryType === TelemetryType.Log &&
-                    telemetryQuery.telemetryQuery && (
-                      <div>
-                        <Card
-                          title={"Logs"}
-                          description={"Logs for this incident."}
-                          rightElement={snapshotWindowAlert}
-                        >
-                          <DashboardLogsViewer
-                            id="logs-preview"
-                            logQuery={
-                              telemetryQuery.telemetryQuery as Query<Log>
-                            }
-                            limit={10}
-                            noLogsMessage="No logs found"
-                          />
-                        </Card>
-                      </div>
-                    )}
-
-                  {telemetryQuery.telemetryType === TelemetryType.Trace &&
-                    telemetryQuery.telemetryQuery && (
-                      <div>
-                        <Card
-                          title={"Spans"}
-                          description={"Spans for this incident."}
-                          rightElement={snapshotWindowAlert}
-                        >
-                          <TracesViewer
-                            spanQuery={
-                              telemetryQuery.telemetryQuery as Query<Span>
-                            }
-                            limit={10}
-                            /*
-                             * Pinned to the snapshot: this page owns the URL,
-                             * so the viewer neither reads a filter out of it
-                             * nor writes its own state back into it.
-                             */
-                            disableUrlSync={true}
-                            emptyMessage="No spans found"
-                          />
-                        </Card>
-                      </div>
-                    )}
-
-                  {telemetryQuery.telemetryType === TelemetryType.Metric &&
-                    telemetryQuery.metricViewData && (
-                      <Card
-                        title={"Metrics"}
-                        description={
-                          seriesSummary
-                            ? `Metrics related to this incident, scoped to the affected series (${seriesSummary}).`
-                            : "Metrics related to this incident."
-                        }
-                        rightElement={snapshotWindowAlert}
-                      >
-                        <MetricView
-                          data={telemetryQuery.metricViewData}
-                          hideQueryElements={true}
-                          chartCssClass="rounded-lg border border-gray-200 shadow-sm"
-                          hideStartAndEndDate={true}
-                          // Read-only host: onChange is a no-op, so zoom can't apply.
-                          disableChartZoom={true}
-                          onChange={(_data: MetricViewData) => {
-                            // do nothing!
-                          }}
-                        />
-                      </Card>
-                    )}
-
-                  {telemetryQuery.telemetryType === TelemetryType.Exception &&
-                    telemetryQuery.telemetryQuery && (
-                      <Card
-                        title={"Exceptions"}
-                        description={"Exceptions related to this incident."}
-                        rightElement={snapshotWindowAlert}
-                      >
-                        <ExceptionsViewer
-                          exceptionInstanceQuery={
-                            telemetryQuery.telemetryQuery as Query<ExceptionInstance>
-                          }
-                          /*
-                           * An event shows the exceptions it fired on,
-                           * whoever has since resolved them and whatever the
-                           * classifier made of them — the explorer's
-                           * "unresolved issues" defaults would hide exactly
-                           * those.
-                           */
-                          defaultStatus="all"
-                          defaultClassScope="all"
-                          limit={10}
-                          // Pinned to the snapshot; this page owns the URL.
-                          disableUrlSync={true}
-                          emptyMessage="No exceptions found"
-                        />
-                      </Card>
-                    )}
-                </Fragment>
-              }
-            />
-          )}
-
-          <MonitorSummarySnapshotCard incidentId={modelId} />
-
-          <IncidentAffectedResources incidentId={modelId} />
-
-          <EntityRunbooks incidentId={modelId} hideIfEmpty={true} />
-
-          <RemediationSuggestionCard incidentId={modelId} hideIfEmpty={true} />
-
-          <InvestigationPanel
-            subjectType="incident"
-            subjectId={modelId}
-            onStatusChange={onAIInvestigationStatusChange}
-            onAnalysisAvailable={refreshFeedAfterAnalysisAvailable}
+      }
+      summary={
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <EventStatTile
+            label={`${getAcknowledgeState()?.name || "Acknowledged"} in`}
+            icon={IconProp.Check}
+            value={getTimeToAcknowledge()}
           />
-
-          <IncidentFeedElement
-            incidentId={modelId}
-            refreshToken={feedRefreshToken}
+          <EventStatTile
+            label={`${getResolvedState()?.name || "Resolved"} in`}
+            icon={IconProp.CheckCircle}
+            value={getTimeToResolve()}
+          />
+          <EventStatTile
+            label="Duration"
+            icon={IconProp.Clock}
+            value={
+              durationStartDate ? (
+                <LiveDuration
+                  startDate={durationStartDate}
+                  endDate={durationEndDate}
+                />
+              ) : (
+                "-"
+              )
+            }
           />
         </div>
-
-        <div className="min-w-0 xl:col-span-1">
+      }
+      activityTitle="Response activity"
+      activityDescription="Follow updates, investigate signals, and coordinate the response."
+      sidebarTitle="Event context"
+      sidebar={
+        <Fragment>
           {/* Incident View  */}
           <CardModelDetail<Incident>
             name="Incident Details"
             cardProps={{
               title: "Incident Details",
-              description: "Here are more details for this incident.",
+              description: "Ownership, origin, and notifications.",
             }}
+            editButtonText="Edit details"
             isEditable={true}
+            compact={true}
             onSaveSuccess={() => {
               // refresh page-level state (severity/visibility pills) shown in the status panel above.
               fetchData().catch((err: Error) => {
@@ -764,33 +638,6 @@ const IncidentView: FunctionComponent<
               fields: [
                 {
                   field: {
-                    incidentNumber: true,
-                    incidentNumberWithPrefix: true,
-                  },
-                  title: "Incident Number",
-                  fieldType: FieldType.Element,
-                  getElement: (item: Incident): ReactElement => {
-                    if (!item.incidentNumber) {
-                      return <>-</>;
-                    }
-
-                    return (
-                      <span className="text-sm font-semibold text-gray-900">
-                        {item.incidentNumberWithPrefix ||
-                          "#" + item.incidentNumber}
-                      </span>
-                    );
-                  },
-                },
-                {
-                  field: {
-                    _id: true,
-                  },
-                  title: "Incident ID",
-                  fieldType: FieldType.ObjectID,
-                },
-                {
-                  field: {
                     onCallDutyPolicies: {
                       name: true,
                       _id: true,
@@ -868,6 +715,13 @@ const IncidentView: FunctionComponent<
                     return <LabelsElement labels={item["labels"] || []} />;
                   },
                 },
+                {
+                  field: {
+                    _id: true,
+                  },
+                  title: "Incident ID",
+                  fieldType: FieldType.ObjectID,
+                },
               ],
               modelId: modelId,
             }}
@@ -884,10 +738,11 @@ const IncidentView: FunctionComponent<
             name="Affected Resources"
             cardProps={{
               title: "Affected Resources",
-              description:
-                "Monitors, hosts, clusters, container hosts, and services affected by this incident.",
+              description: "Resources impacted by this incident.",
             }}
+            editButtonText="Edit resources"
             isEditable={true}
+            compact={true}
             formFields={[
               {
                 field: {
@@ -1119,6 +974,7 @@ const IncidentView: FunctionComponent<
                   getElement: (item: Incident): ReactElement => {
                     return (
                       <AffectedResourcesDisplay
+                        compact={true}
                         monitors={item.monitors || []}
                         hosts={item.hosts || []}
                         kubernetesClusters={item.kubernetesClusters || []}
@@ -1144,9 +1000,139 @@ const IncidentView: FunctionComponent<
               await fetchData();
             }}
           />
-        </div>
-      </div>
-    </Fragment>
+        </Fragment>
+      }
+    >
+      <Fragment>
+        <IncidentFeedElement
+          incidentId={modelId}
+          refreshToken={feedRefreshToken}
+        />
+
+        {telemetryQuery && (
+          <TelemetryCompanionSignalTabs
+            telemetryQuery={telemetryQuery}
+            snapshotWindow={telemetrySnapshotWindow}
+            snapshotWindowAlert={snapshotWindowAlert}
+            eventNoun="incident"
+            primarySignalElement={
+              <Fragment>
+                {telemetryQuery.telemetryType === TelemetryType.Log &&
+                  telemetryQuery.telemetryQuery && (
+                    <div>
+                      <Card
+                        title={"Logs"}
+                        description={"Logs for this incident."}
+                        rightElement={snapshotWindowAlert}
+                      >
+                        <DashboardLogsViewer
+                          id="logs-preview"
+                          logQuery={telemetryQuery.telemetryQuery as Query<Log>}
+                          limit={10}
+                          noLogsMessage="No logs found"
+                        />
+                      </Card>
+                    </div>
+                  )}
+
+                {telemetryQuery.telemetryType === TelemetryType.Trace &&
+                  telemetryQuery.telemetryQuery && (
+                    <div>
+                      <Card
+                        title={"Spans"}
+                        description={"Spans for this incident."}
+                        rightElement={snapshotWindowAlert}
+                      >
+                        <TracesViewer
+                          spanQuery={
+                            telemetryQuery.telemetryQuery as Query<Span>
+                          }
+                          limit={10}
+                          /*
+                           * Pinned to the snapshot: this page owns the URL,
+                           * so the viewer neither reads a filter out of it
+                           * nor writes its own state back into it.
+                           */
+                          disableUrlSync={true}
+                          emptyMessage="No spans found"
+                        />
+                      </Card>
+                    </div>
+                  )}
+
+                {telemetryQuery.telemetryType === TelemetryType.Metric &&
+                  telemetryQuery.metricViewData && (
+                    <Card
+                      title={"Metrics"}
+                      description={
+                        seriesSummary
+                          ? `Metrics related to this incident, scoped to the affected series (${seriesSummary}).`
+                          : "Metrics related to this incident."
+                      }
+                      rightElement={snapshotWindowAlert}
+                    >
+                      <MetricView
+                        data={telemetryQuery.metricViewData}
+                        hideQueryElements={true}
+                        chartCssClass="rounded-lg border border-gray-200 shadow-sm"
+                        hideStartAndEndDate={true}
+                        // Read-only host: onChange is a no-op, so zoom can't apply.
+                        disableChartZoom={true}
+                        onChange={(_data: MetricViewData) => {
+                          // do nothing!
+                        }}
+                      />
+                    </Card>
+                  )}
+
+                {telemetryQuery.telemetryType === TelemetryType.Exception &&
+                  telemetryQuery.telemetryQuery && (
+                    <Card
+                      title={"Exceptions"}
+                      description={"Exceptions related to this incident."}
+                      rightElement={snapshotWindowAlert}
+                    >
+                      <ExceptionsViewer
+                        exceptionInstanceQuery={
+                          telemetryQuery.telemetryQuery as Query<ExceptionInstance>
+                        }
+                        /*
+                         * An event shows the exceptions it fired on,
+                         * whoever has since resolved them and whatever the
+                         * classifier made of them — the explorer's
+                         * "unresolved issues" defaults would hide exactly
+                         * those.
+                         */
+                        defaultStatus="all"
+                        defaultClassScope="all"
+                        limit={10}
+                        // Pinned to the snapshot; this page owns the URL.
+                        disableUrlSync={true}
+                        emptyMessage="No exceptions found"
+                      />
+                    </Card>
+                  )}
+              </Fragment>
+            }
+          />
+        )}
+
+        <MonitorSummarySnapshotCard incidentId={modelId} />
+
+        <IncidentAffectedResources incidentId={modelId} />
+
+        <EntityRunbooks incidentId={modelId} hideIfEmpty={true} />
+
+        <RemediationSuggestionCard incidentId={modelId} hideIfEmpty={true} />
+
+        <InvestigationPanel
+          subjectType="incident"
+          subjectId={modelId}
+          onStatusChange={onAIInvestigationStatusChange}
+          onAnalysisAvailable={refreshFeedAfterAnalysisAvailable}
+        />
+      </Fragment>
+    </EventOverviewLayout>
   );
 };
 

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Layout.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Layout.tsx
@@ -1,5 +1,6 @@
 import { getIncidentsBreadcrumbs } from "../../../Utils/Breadcrumbs/IncidentBreadcrumbs";
-import { RouteUtil } from "../../../Utils/RouteMap";
+import RouteMap, { RouteUtil } from "../../../Utils/RouteMap";
+import PageMap from "../../../Utils/PageMap";
 import PageComponentProps from "../../PageComponentProps";
 import SideMenu from "./SideMenu";
 import ObjectID from "Common/Types/ObjectID";
@@ -15,12 +16,15 @@ const IncidentViewLayout: FunctionComponent<
   const { id } = useParams();
   const modelId: ObjectID = new ObjectID(id || "");
   const path: string = Navigation.getRoutePath(RouteUtil.getRoutes());
+  const isOverview: boolean =
+    path === RouteMap[PageMap.INCIDENT_VIEW]?.toString();
   return (
     <ModelPage
       title="Incident"
       modelType={Incident}
       modelId={modelId}
       modelNameField="title"
+      hideTitle={isOverview}
       breadcrumbLinks={getIncidentsBreadcrumbs(path)}
       sideMenu={<SideMenu modelId={modelId} />}
     >

--- a/App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/Index.tsx
@@ -45,6 +45,7 @@ import RecurringArrayViewElement from "Common/UI/Components/Events/RecurringArra
 import ScheduledMaintenanceFeedElement from "../../../Components/ScheduledMaintenance/ScheduledMaintenanceFeed";
 import EntityRunbooks from "../../../Components/Runbook/EntityRunbooks";
 import EventStatTile from "../../../Components/EventView/EventStatTile";
+import EventOverviewLayout from "../../../Components/EventView/EventOverviewLayout";
 import LiveDuration from "../../../Components/EventView/LiveDuration";
 import OneUptimeDate from "Common/Types/Date";
 
@@ -117,66 +118,70 @@ const ScheduledMaintenanceView: FunctionComponent<
     };
 
   return (
-    <Fragment>
-      <ChangeScheduledMaintenanceState
-        scheduledMaintenanceId={modelId}
-        eventNumber={eventNumber}
-        title={eventTitle}
-        eventStartsAt={eventStartsAt}
-        eventEndsAt={eventEndsAt}
-        onActionComplete={() => {
-          setRefreshToggle((prev: boolean) => {
-            return !prev;
-          });
-        }}
-      />
-
-      <div className="grid grid-cols-1 items-start gap-6 xl:grid-cols-3">
-        <div className="min-w-0 xl:col-span-2">
-          {eventStartsAt && eventEndsAt && (
-            <div className="mb-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
-              <EventStatTile
-                label="Starts"
-                value={OneUptimeDate.getDateAsLocalFormattedString(
-                  eventStartsAt,
-                )}
-                description={
-                  "Your local timezone (" +
-                  OneUptimeDate.getCurrentTimezoneString() +
-                  ")"
-                }
-                icon={IconProp.Clock}
-              />
-              <EventStatTile
-                label="Ends"
-                value={OneUptimeDate.getDateAsLocalFormattedString(eventEndsAt)}
-                icon={IconProp.Clock}
-              />
-              <EventStatTile
-                label="Duration"
-                value={
-                  <LiveDuration
-                    startDate={eventStartsAt}
-                    endDate={eventEndsAt}
-                  />
-                }
-                icon={IconProp.Clock}
-              />
-            </div>
-          )}
-
-          <EntityRunbooks scheduledMaintenanceId={modelId} hideIfEmpty={true} />
-
-          <ScheduledMaintenanceFeedElement scheduledMaintenanceId={modelId} />
+    <EventOverviewLayout
+      header={
+        <ChangeScheduledMaintenanceState
+          scheduledMaintenanceId={modelId}
+          eventNumber={eventNumber}
+          title={eventTitle}
+          eventStartsAt={eventStartsAt}
+          eventEndsAt={eventEndsAt}
+          onActionComplete={() => {
+            setRefreshToggle((prev: boolean) => {
+              return !prev;
+            });
+          }}
+        />
+      }
+      summary={
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <EventStatTile
+            label="Starts"
+            value={
+              eventStartsAt
+                ? OneUptimeDate.getDateAsLocalFormattedString(eventStartsAt)
+                : "Not set"
+            }
+            description={
+              "Your local timezone (" +
+              OneUptimeDate.getCurrentTimezoneString() +
+              ")"
+            }
+            icon={IconProp.Clock}
+          />
+          <EventStatTile
+            label="Ends"
+            value={
+              eventEndsAt
+                ? OneUptimeDate.getDateAsLocalFormattedString(eventEndsAt)
+                : "Not set"
+            }
+            icon={IconProp.Clock}
+          />
+          <EventStatTile
+            label="Scheduled duration"
+            value={
+              eventStartsAt && eventEndsAt ? (
+                <LiveDuration startDate={eventStartsAt} endDate={eventEndsAt} />
+              ) : (
+                "-"
+              )
+            }
+            icon={IconProp.Clock}
+          />
         </div>
-
-        <div className="min-w-0 xl:col-span-1">
+      }
+      activityTitle="Maintenance activity"
+      activityDescription="Updates and runbooks for this maintenance window."
+      sidebarTitle="Event context"
+      sidebar={
+        <Fragment>
           {/* ScheduledMaintenance View  */}
           <CardModelDetail<ScheduledMaintenance>
             name="Scheduled Maintenance Details"
             cardProps={{
-              title: "Scheduled Maintenance Details",
-              description: "Here are more details for this event.",
+              title: "Maintenance Details",
+              description: "Status pages, reminders, and notifications.",
             }}
             refresher={refreshToggle}
             formSteps={[
@@ -197,7 +202,9 @@ const ScheduledMaintenanceView: FunctionComponent<
                 id: "labels",
               },
             ]}
+            editButtonText="Edit details"
             isEditable={true}
+            compact={true}
             onSaveSuccess={() => {
               // refresh page-level state (event window stat tiles + status-panel countdown) after an in-card edit.
               setRefreshToggle((prev: boolean) => {
@@ -387,33 +394,6 @@ const ScheduledMaintenanceView: FunctionComponent<
               fields: [
                 {
                   field: {
-                    scheduledMaintenanceNumber: true,
-                    scheduledMaintenanceNumberWithPrefix: true,
-                  },
-                  title: "Scheduled Maintenance Number",
-                  fieldType: FieldType.Element,
-                  getElement: (item: ScheduledMaintenance): ReactElement => {
-                    if (!item.scheduledMaintenanceNumber) {
-                      return <>-</>;
-                    }
-
-                    return (
-                      <span className="text-sm font-semibold text-gray-900">
-                        {item.scheduledMaintenanceNumberWithPrefix ||
-                          `#${item.scheduledMaintenanceNumber}`}
-                      </span>
-                    );
-                  },
-                },
-                {
-                  field: {
-                    _id: true,
-                  },
-                  title: "Scheduled Maintenance ID",
-                  fieldType: FieldType.ObjectID,
-                },
-                {
-                  field: {
                     statusPages: {
                       name: true,
                       _id: true,
@@ -431,20 +411,6 @@ const ScheduledMaintenanceView: FunctionComponent<
                 },
                 {
                   field: {
-                    startsAt: true,
-                  },
-                  title: "Starts At",
-                  fieldType: FieldType.DateTime,
-                },
-                {
-                  field: {
-                    endsAt: true,
-                  },
-                  title: "Ends At",
-                  fieldType: FieldType.DateTime,
-                },
-                {
-                  field: {
                     createdAt: true,
                   },
                   title: "Created At",
@@ -454,7 +420,7 @@ const ScheduledMaintenanceView: FunctionComponent<
                   field: {
                     sendSubscriberNotificationsOnBeforeTheEvent: true,
                   },
-                  title: "Send reminders to subscribers before the event",
+                  title: "Subscriber Reminders",
                   fieldType: FieldType.Boolean,
                   getElement: (item: ScheduledMaintenance): ReactElement => {
                     return (
@@ -463,7 +429,7 @@ const ScheduledMaintenanceView: FunctionComponent<
                           value={
                             item.sendSubscriberNotificationsOnBeforeTheEvent
                           }
-                          postfix=" before the event is begins"
+                          postfix=" before the event begins"
                         />
                         {item.nextSubscriberNotificationBeforeTheEventAt ? (
                           <div className="mt-2">
@@ -514,6 +480,13 @@ const ScheduledMaintenanceView: FunctionComponent<
                     return <LabelsElement labels={item["labels"] || []} />;
                   },
                 },
+                {
+                  field: {
+                    _id: true,
+                  },
+                  title: "Event ID",
+                  fieldType: FieldType.ObjectID,
+                },
               ],
               modelId: modelId,
             }}
@@ -530,10 +503,11 @@ const ScheduledMaintenanceView: FunctionComponent<
             name="Affected Resources"
             cardProps={{
               title: "Affected Resources",
-              description:
-                "Monitors, hosts, Kubernetes clusters, Docker hosts, network sites, and services affected by this scheduled maintenance.",
+              description: "Resources included in this maintenance window.",
             }}
+            editButtonText="Edit resources"
             isEditable={true}
+            compact={true}
             formFields={[
               {
                 field: {
@@ -700,6 +674,7 @@ const ScheduledMaintenanceView: FunctionComponent<
                   getElement: (item: ScheduledMaintenance): ReactElement => {
                     return (
                       <AffectedResourcesDisplay
+                        compact={true}
                         monitors={item.monitors || []}
                         hosts={item.hosts || []}
                         kubernetesClusters={item.kubernetesClusters || []}
@@ -715,9 +690,14 @@ const ScheduledMaintenanceView: FunctionComponent<
               modelId: modelId,
             }}
           />
-        </div>
-      </div>
-    </Fragment>
+        </Fragment>
+      }
+    >
+      <Fragment>
+        <ScheduledMaintenanceFeedElement scheduledMaintenanceId={modelId} />
+        <EntityRunbooks scheduledMaintenanceId={modelId} hideIfEmpty={true} />
+      </Fragment>
+    </EventOverviewLayout>
   );
 };
 

--- a/App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/Layout.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/Layout.tsx
@@ -1,5 +1,6 @@
 import { getScheduleMaintenanceBreadcrumbs } from "../../../Utils/Breadcrumbs";
-import { RouteUtil } from "../../../Utils/RouteMap";
+import RouteMap, { RouteUtil } from "../../../Utils/RouteMap";
+import PageMap from "../../../Utils/PageMap";
 import PageComponentProps from "../../PageComponentProps";
 import SideMenu from "./SideMenu";
 import ObjectID from "Common/Types/ObjectID";
@@ -15,12 +16,15 @@ const ScheduledMaintenanceViewLayout: FunctionComponent<
   const { id } = useParams();
   const modelId: ObjectID = new ObjectID(id || "");
   const path: string = Navigation.getRoutePath(RouteUtil.getRoutes());
+  const isOverview: boolean =
+    path === RouteMap[PageMap.SCHEDULED_MAINTENANCE_VIEW]?.toString();
   return (
     <ModelPage
       title="Scheduled Event"
       modelType={ScheduledMaintenance}
       modelId={modelId}
       modelNameField="title"
+      hideTitle={isOverview}
       breadcrumbLinks={getScheduleMaintenanceBreadcrumbs(path)}
       sideMenu={<SideMenu modelId={modelId} />}
     >

--- a/Common/Tests/App/Dashboard/AffectedResourcesDisplay.test.tsx
+++ b/Common/Tests/App/Dashboard/AffectedResourcesDisplay.test.tsx
@@ -1,0 +1,113 @@
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+import React from "react";
+import AffectedResourcesDisplay from "../../../../App/FeatureSet/Dashboard/src/Components/AffectedResources/AffectedResourcesDisplay";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import Host from "../../../Models/DatabaseModels/Host";
+
+function makeMonitor(name: string): Monitor {
+  const monitor: Monitor = new Monitor();
+  monitor.name = name;
+  return monitor;
+}
+
+function makeHost(name: string): Host {
+  const host: Host = new Host();
+  host.name = name;
+  return host;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AffectedResourcesDisplay overview sidebar", () => {
+  test("keeps multiple resource categories in one column for a narrow details sidebar", () => {
+    const { container } = render(
+      <AffectedResourcesDisplay
+        compact={true}
+        monitors={[makeMonitor("Production API")]}
+        hosts={[makeHost("Authentication database")]}
+      />,
+    );
+
+    expect(screen.getByText("Monitors")).toBeInTheDocument();
+    expect(screen.getByText("Hosts")).toBeInTheDocument();
+    expect(screen.getByText("Production API")).toBeInTheDocument();
+    expect(screen.getByText("Authentication database")).toBeInTheDocument();
+    expect(screen.getByText("2 resources")).toBeInTheDocument();
+    expect(screen.getByText("across 2 categories")).toBeInTheDocument();
+    expect(container.querySelector(".grid")).toHaveClass("grid-cols-1");
+    expect(container.querySelector(".grid")).not.toHaveClass("md:grid-cols-2");
+  });
+
+  test("preserves the existing two-column desktop layout outside compact sidebars", () => {
+    const { container } = render(
+      <AffectedResourcesDisplay
+        monitors={[makeMonitor("Production API")]}
+        hosts={[makeHost("Authentication database")]}
+      />,
+    );
+
+    expect(container.querySelector(".grid")).toHaveClass("md:grid-cols-2");
+    expect(screen.getAllByRole("list")).toHaveLength(2);
+  });
+
+  test("retains category filtering and accurate totals in compact mode", () => {
+    render(
+      <AffectedResourcesDisplay
+        compact={true}
+        hideMonitors={true}
+        monitors={[makeMonitor("Production API")]}
+        hosts={[makeHost("Authentication database")]}
+      />,
+    );
+
+    expect(screen.queryByText("Monitors")).not.toBeInTheDocument();
+    expect(screen.queryByText("Production API")).not.toBeInTheDocument();
+    expect(screen.getByText("Authentication database")).toBeInTheDocument();
+    expect(screen.getByText("1 resource")).toBeInTheDocument();
+    expect(screen.getByText("across 1 category")).toBeInTheDocument();
+  });
+
+  test("allows responders to expand and collapse longer resource lists in compact mode", () => {
+    render(
+      <AffectedResourcesDisplay
+        compact={true}
+        monitors={Array.from({ length: 6 }, (_: unknown, index: number) => {
+          return makeMonitor(`Production API ${index + 1}`);
+        })}
+      />,
+    );
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(4);
+    expect(screen.queryByText("Production API 6")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show 2 more items" }));
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(6);
+    expect(screen.getByText("Production API 6")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show less" }));
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(4);
+    expect(screen.getByText("6 resources")).toBeInTheDocument();
+  });
+
+  test("keeps the caller's empty-state guidance when no visible resources remain", () => {
+    render(
+      <AffectedResourcesDisplay
+        compact={true}
+        hideMonitors={true}
+        monitors={[makeMonitor("Production API")]}
+        emptyMessage="No maintenance resources selected yet."
+      />,
+    );
+
+    expect(
+      screen.getByText("No maintenance resources selected yet."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+});

--- a/Common/Tests/App/Dashboard/EventOverviewPages.test.tsx
+++ b/Common/Tests/App/Dashboard/EventOverviewPages.test.tsx
@@ -1,0 +1,905 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import React, { FunctionComponent, ReactElement } from "react";
+import IncidentView from "../../../../App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index";
+import AlertView from "../../../../App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index";
+import ScheduledMaintenanceView from "../../../../App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/Index";
+import PageComponentProps from "../../../../App/FeatureSet/Dashboard/src/Pages/PageComponentProps";
+import ObjectID from "../../../Types/ObjectID";
+import Route from "../../../Types/API/Route";
+import Color from "../../../Types/Color";
+import OneUptimeDate from "../../../Types/Date";
+import Navigation from "../../../UI/Utils/Navigation";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import { MemoryRouter, Route as RouterRoute, Routes } from "react-router-dom";
+import IncidentViewLayout from "../../../../App/FeatureSet/Dashboard/src/Pages/Incidents/View/Layout";
+import AlertViewLayout from "../../../../App/FeatureSet/Dashboard/src/Pages/Alerts/View/Layout";
+import ScheduledMaintenanceViewLayout from "../../../../App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/Layout";
+
+/*
+ * Exercise the actual pages, shared layout, metric tiles, and live duration.
+ * Independent cards/dialogs are mocked at their boundary to isolate each page's
+ * layout and refresh contracts from unrelated API requests.
+ */
+interface DetailField {
+  title: string;
+  field: Record<string, unknown>;
+}
+interface DetailProps {
+  name: string;
+  cardProps: { title: string };
+  compact?: boolean | undefined;
+  isEditable?: boolean | undefined;
+  editButtonText?: string | undefined;
+  onSaveSuccess?: (() => void) | undefined;
+  formFields: Array<DetailField>;
+  modelDetailProps: {
+    fields: Array<DetailField>;
+    modelId: ObjectID;
+    selectMoreFields?: Record<string, unknown> | undefined;
+  };
+}
+interface HeaderProps {
+  title?: string | undefined;
+  eventNumber?: string | undefined;
+  isPrivate?: boolean | undefined;
+  severity?: { name: string } | undefined;
+  onActionComplete: () => Promise<void>;
+}
+const getItemMock: MockFunction = getJestMockFunction();
+const getListMock: MockFunction = getJestMockFunction();
+const detailCards: Map<string, DetailProps> = new Map();
+let currentItem: Record<string, any> = {};
+
+function MockHeader(props: HeaderProps): ReactElement {
+  return (
+    <header>
+      <h2>{props.title}</h2>
+      <span>{props.eventNumber}</span>
+      <span>{props.severity?.name}</span>
+      {props.isPrivate && <span>Private event</span>}
+      <button
+        type="button"
+        onClick={() => {
+          void props.onActionComplete();
+        }}
+      >
+        Complete state change
+      </button>
+    </header>
+  );
+}
+function MockFeed(props: { refreshToken?: number | undefined }): ReactElement {
+  return (
+    <div data-testid="activity-feed">
+      Feed revision {props.refreshToken || 0}
+    </div>
+  );
+}
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getItem: (...args: Array<any>) => {
+        return getItemMock(...args);
+      },
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+    },
+  };
+});
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      getFriendlyMessage: (error: Error) => {
+        return error.message;
+      },
+    },
+  };
+});
+jest.mock("../../../UI/Components/ModelDetail/CardModelDetail", () => {
+  return {
+    __esModule: true,
+    default: (props: DetailProps): ReactElement => {
+      detailCards.set(props.name, props);
+      return (
+        <section aria-label={props.cardProps.title}>
+          <h3>{props.cardProps.title}</h3>
+          <button type="button" onClick={props.onSaveSuccess}>
+            {props.editButtonText}
+          </button>
+          {props.modelDetailProps.fields.map(
+            (field: DetailField, index: number) => {
+              return <div key={index}>{field.title}</div>;
+            },
+          )}
+        </section>
+      );
+    },
+  };
+});
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/AI/InvestigationPanel",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: { onAnalysisAvailable: () => void }): ReactElement => {
+        return (
+          <button type="button" onClick={props.onAnalysisAvailable}>
+            Publish analysis
+          </button>
+        );
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Runbook/EntityRunbooks",
+  () => {
+    return {
+      __esModule: true,
+      default: (): ReactElement => {
+        return <div data-testid="runbooks">Runbooks</div>;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Incident/ChangeState",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: HeaderProps): ReactElement => {
+        return <MockHeader {...props} />;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Incident/IncidentFeed",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: { refreshToken?: number | undefined }): ReactElement => {
+        return <MockFeed {...props} />;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Alert/ChangeState",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: HeaderProps): ReactElement => {
+        return <MockHeader {...props} />;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Alert/AlertFeed",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: { refreshToken?: number | undefined }): ReactElement => {
+        return <MockFeed {...props} />;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ChangeState",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: HeaderProps): ReactElement => {
+        return <MockHeader {...props} />;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceFeed",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: { refreshToken?: number | undefined }): ReactElement => {
+        return <MockFeed {...props} />;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/AffectedResources/AffectedResourcesDisplay",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallPolicies",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/User/User",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Traces/TracesViewer",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/MetricView",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetrySnapshotWindowAlert",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetryCompanionSignalTabs",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/AutoRemediation/RemediationSuggestionCard",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSummarySnapshotCard",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Incident/IncidentMemberRoleAssignment",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionsViewer",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/CustomFields/OverviewCustomFields",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Monitor/Monitor",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/AlertEpisode/AlertEpisode",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/StatusPage/StatusPagesElement",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/StatusPageSubscribers/SubscriberNotificationStatus",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Pages/Incidents/View/AffectedResources",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Pages/Alerts/View/AffectedResources",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/AffectedResources/AffectedResourcesPicker",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+      isAffectedResourcesPayload: (): boolean => {
+        return false;
+      },
+    };
+  },
+);
+
+const EVENT_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+const pageProps: PageComponentProps = {
+  pageRoute: new Route("/dashboard/project/incidents/event"),
+  currentProject: null,
+  hasPaymentMethod: false,
+};
+interface EventSpec {
+  name: string;
+  Page: FunctionComponent<PageComponentProps>;
+  detailName: string;
+  detailTitle: string;
+  numberField: string;
+  severityField?: string | undefined;
+  activityTitle: string;
+  resourceFields: Array<string>;
+}
+const eventSpecs: Array<EventSpec> = [
+  {
+    name: "incident",
+    Page: IncidentView,
+    detailName: "Incident Details",
+    detailTitle: "Incident Details",
+    numberField: "incidentNumber",
+    severityField: "incidentSeverity",
+    activityTitle: "Response activity",
+    resourceFields: [
+      "monitors",
+      "hosts",
+      "kubernetesClusters",
+      "dockerHosts",
+      "podmanHosts",
+      "proxmoxClusters",
+      "cephClusters",
+      "dockerSwarmClusters",
+      "iotFleets",
+      "services",
+    ],
+  },
+  {
+    name: "alert",
+    Page: AlertView,
+    detailName: "Alert Details",
+    detailTitle: "Alert Details",
+    numberField: "alertNumber",
+    severityField: "alertSeverity",
+    activityTitle: "Response activity",
+    resourceFields: [
+      "hosts",
+      "kubernetesClusters",
+      "dockerHosts",
+      "podmanHosts",
+      "proxmoxClusters",
+      "cephClusters",
+      "dockerSwarmClusters",
+      "iotFleets",
+      "services",
+    ],
+  },
+  {
+    name: "scheduled maintenance",
+    Page: ScheduledMaintenanceView,
+    detailName: "Scheduled Maintenance Details",
+    detailTitle: "Maintenance Details",
+    numberField: "scheduledMaintenanceNumber",
+    activityTitle: "Maintenance activity",
+    resourceFields: [
+      "monitors",
+      "hosts",
+      "kubernetesClusters",
+      "dockerHosts",
+      "podmanHosts",
+      "networkSites",
+      "services",
+    ],
+  },
+];
+function setItem(spec: EventSpec): void {
+  currentItem = {
+    _id: EVENT_ID.toString(),
+    title: "Database latency in the primary region",
+    [spec.numberField]: 42,
+    [spec.numberField + "WithPrefix"]: "EVT-42",
+    declaredAt: new Date("2026-08-01T10:00:00Z"),
+    createdAt: new Date("2026-08-01T10:00:00Z"),
+    startsAt: new Date("2026-08-01T10:00:00Z"),
+    endsAt: new Date("2026-08-01T12:00:00Z"),
+  };
+  if (spec.severityField) {
+    currentItem[spec.severityField] = {
+      name: "Critical",
+      color: new Color("#dc2626"),
+    };
+  }
+}
+async function renderOverview(spec: EventSpec): Promise<void> {
+  render(<spec.Page {...pageProps} />);
+  await screen.findByRole("heading", { name: currentItem["title"] as string });
+}
+function getDetails(spec: EventSpec): DetailProps {
+  const details: DetailProps | undefined = detailCards.get(spec.detailName);
+  if (!details) {
+    throw new Error("Details card did not render");
+  }
+  return details;
+}
+beforeEach(() => {
+  getItemMock.mockReset();
+  getListMock.mockReset();
+  detailCards.clear();
+  jest.spyOn(Navigation, "getLastParamAsObjectID").mockReturnValue(EVENT_ID);
+  getItemMock.mockImplementation(async () => {
+    return currentItem;
+  });
+  getListMock.mockResolvedValue({ data: [], count: 0 });
+});
+afterEach(() => {
+  cleanup();
+  jest.restoreAllMocks();
+});
+
+describe.each(eventSpecs)("$name overview", (spec: EventSpec) => {
+  beforeEach(() => {
+    setItem(spec);
+  });
+  test("places the summary before activity and keeps context in the sidebar", async () => {
+    await renderOverview(spec);
+    const summary: HTMLElement = screen.getByRole("region", {
+      name: "Event summary",
+    });
+    const activity: HTMLElement = screen.getByRole("region", {
+      name: spec.activityTitle,
+    });
+    const context: HTMLElement = screen.getByRole("complementary", {
+      name: "Event context",
+    });
+    expect(
+      summary.compareDocumentPosition(activity) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(within(activity).getByTestId("activity-feed")).toBeVisible();
+    expect(
+      within(context).getByRole("region", { name: spec.detailTitle }),
+    ).toBeVisible();
+    expect(
+      within(activity).queryByRole("region", { name: spec.detailTitle }),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText("EVT-42")).toHaveLength(1);
+    expect(within(summary).getAllByRole("term")).toHaveLength(3);
+  });
+  test("puts updates ahead of optional runbooks", async () => {
+    await renderOverview(spec);
+    expect(
+      screen
+        .getByTestId("activity-feed")
+        .compareDocumentPosition(screen.getByTestId("runbooks")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+  test("preserves editable fields and compact, clearly named editing actions", async () => {
+    await renderOverview(spec);
+    const details: DetailProps = getDetails(spec);
+    expect(details.isEditable).toBe(true);
+    expect(details.compact).toBe(true);
+    expect(details.editButtonText).toBe("Edit details");
+    expect(details.modelDetailProps.modelId.toString()).toBe(
+      EVENT_ID.toString(),
+    );
+    expect(
+      details.formFields.some((field: DetailField) => {
+        return field.field["title"] === true;
+      }),
+    ).toBe(true);
+    const resources: DetailProps | undefined =
+      detailCards.get("Affected Resources");
+    expect(resources?.isEditable).toBe(true);
+    expect(resources?.compact).toBe(true);
+    expect(resources?.editButtonText).toBe("Edit resources");
+    const registered: Array<string> = resources!.formFields.flatMap(
+      (field: DetailField) => {
+        return Object.keys(field.field);
+      },
+    );
+    expect(registered).toEqual(expect.arrayContaining(spec.resourceFields));
+  });
+  test("refreshes the title after saving details", async () => {
+    await renderOverview(spec);
+    currentItem = { ...currentItem, title: "Database latency mitigated" };
+    fireEvent.click(screen.getByRole("button", { name: "Edit details" }));
+    await screen.findByRole("heading", { name: "Database latency mitigated" });
+    expect(getItemMock.mock.calls.length).toBeGreaterThan(1);
+  });
+  test("refreshes the page after a status action completes", async () => {
+    await renderOverview(spec);
+    currentItem = { ...currentItem, title: "Response completed" };
+    fireEvent.click(
+      screen.getByRole("button", { name: "Complete state change" }),
+    );
+    await screen.findByRole("heading", { name: "Response completed" });
+  });
+  test("falls back to a numeric identifier when no prefix is available", async () => {
+    delete currentItem[spec.numberField + "WithPrefix"];
+    await renderOverview(spec);
+    expect(screen.getByText("#42")).toBeVisible();
+  });
+});
+describe.each(eventSpecs.slice(0, 2))(
+  "$name response state",
+  (spec: EventSpec) => {
+    beforeEach(() => {
+      setItem(spec);
+    });
+    test("shows pending metrics without inventing a completion time", async () => {
+      await renderOverview(spec);
+      const summary: HTMLElement = screen.getByRole("region", {
+        name: "Event summary",
+      });
+      expect(within(summary).getByText("Not yet acknowledged")).toBeVisible();
+      expect(within(summary).getByText("Not yet resolved")).toBeVisible();
+    });
+    test("updates severity and private visibility after editing", async () => {
+      await renderOverview(spec);
+      currentItem = {
+        ...currentItem,
+        isPrivate: true,
+        [spec.severityField!]: { name: "Low", color: new Color("#16a34a") },
+      };
+      fireEvent.click(screen.getByRole("button", { name: "Edit details" }));
+      await screen.findByText("Low");
+      expect(screen.getByText("Private event")).toBeVisible();
+      expect(screen.queryByText("Critical")).not.toBeInTheDocument();
+    });
+    test("refreshes the feed when investigation publishes analysis", async () => {
+      await renderOverview(spec);
+      fireEvent.click(screen.getByRole("button", { name: "Publish analysis" }));
+      await screen.findByText("Feed revision 1");
+    });
+    test("shows a useful loading failure", async () => {
+      getItemMock.mockRejectedValue(new Error("Could not load event"));
+      render(<spec.Page {...pageProps} />);
+      await screen.findByText("Could not load event");
+      expect(screen.queryByTestId("event-overview")).not.toBeInTheDocument();
+    });
+  },
+);
+describe("maintenance window", () => {
+  const spec: EventSpec = eventSpecs[2]!;
+  beforeEach(() => {
+    setItem(spec);
+  });
+  test("shows the planned window and timezone, keeping duplicate dates out of context", async () => {
+    await renderOverview(spec);
+    const summary: HTMLElement = screen.getByRole("region", {
+      name: "Event summary",
+    });
+    expect(within(summary).getByText("Scheduled duration")).toBeVisible();
+    expect(within(summary).getByText("2 hours, 0 minutes")).toBeVisible();
+    expect(
+      within(summary).getByText(
+        "Your local timezone (" +
+          OneUptimeDate.getCurrentTimezoneString() +
+          ")",
+      ),
+    ).toBeVisible();
+    expect(
+      within(summary).getByText(
+        OneUptimeDate.getDateAsLocalFormattedString(currentItem["startsAt"]),
+      ),
+    ).toBeVisible();
+    const details: DetailProps = getDetails(spec);
+    expect(
+      details.modelDetailProps.fields.some((field: DetailField) => {
+        return Boolean(field.field["startsAt"] || field.field["endsAt"]);
+      }),
+    ).toBe(false);
+    expect(
+      details.formFields.some((field: DetailField) => {
+        return field.field["startsAt"] === true;
+      }),
+    ).toBe(true);
+    expect(
+      details.formFields.some((field: DetailField) => {
+        return field.field["endsAt"] === true;
+      }),
+    ).toBe(true);
+  });
+  test.each(["startsAt", "endsAt"])(
+    "keeps the known date when %s is absent",
+    async (missing: string) => {
+      const known: Date =
+        currentItem[missing === "startsAt" ? "endsAt" : "startsAt"];
+      delete currentItem[missing];
+      await renderOverview(spec);
+      const summary: HTMLElement = screen.getByRole("region", {
+        name: "Event summary",
+      });
+      expect(
+        within(summary).getByText(
+          OneUptimeDate.getDateAsLocalFormattedString(known),
+        ),
+      ).toBeVisible();
+      expect(within(summary).getByText("Not set")).toBeVisible();
+      expect(within(summary).getByText("-")).toBeVisible();
+    },
+  );
+  test("uses empty values when the window is unavailable", async () => {
+    delete currentItem["startsAt"];
+    delete currentItem["endsAt"];
+    await renderOverview(spec);
+    const summary: HTMLElement = screen.getByRole("region", {
+      name: "Event summary",
+    });
+    expect(within(summary).getAllByText("Not set")).toHaveLength(2);
+    expect(within(summary).getByText("-")).toBeVisible();
+  });
+  test("updates the window after editing and preserves subscriber configuration", async () => {
+    await renderOverview(spec);
+    currentItem = { ...currentItem, endsAt: new Date("2026-08-01T13:00:00Z") };
+    fireEvent.click(screen.getByRole("button", { name: "Edit details" }));
+    await screen.findByText("3 hours, 0 minutes");
+    const details: DetailProps = getDetails(spec);
+    expect(
+      details.modelDetailProps.fields.map((field: DetailField) => {
+        return field.title;
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        "Subscriber Reminders",
+        "Subscriber Notification Status",
+        "Shown on Status Pages",
+      ]),
+    );
+    expect(
+      details.modelDetailProps.selectMoreFields?.[
+        "nextSubscriberNotificationBeforeTheEventAt"
+      ],
+    ).toBe(true);
+  });
+});
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Pages/Incidents/View/SideMenu",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Pages/Alerts/View/SideMenu",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/SideMenu",
+  () => {
+    return {
+      __esModule: true,
+      default: (): null => {
+        return null;
+      },
+    };
+  },
+);
+
+jest.mock("../../../UI/Components/Page/ModelPage", () => {
+  return {
+    __esModule: true,
+    default: (props: { hideTitle?: boolean | undefined }): ReactElement => {
+      return (
+        <div data-testid="model-page-heading" data-hidden={props.hideTitle} />
+      );
+    },
+  };
+});
+
+interface LayoutSpec {
+  name: string;
+  Layout: FunctionComponent<PageComponentProps>;
+  segment: string;
+}
+
+const layouts: Array<LayoutSpec> = [
+  { name: "incident", Layout: IncidentViewLayout, segment: "incidents" },
+  { name: "alert", Layout: AlertViewLayout, segment: "alerts" },
+  {
+    name: "maintenance",
+    Layout: ScheduledMaintenanceViewLayout,
+    segment: "scheduled-maintenance-events",
+  },
+];
+
+describe.each(layouts)("$name page heading", (spec: LayoutSpec) => {
+  test.each([
+    ["", "true"],
+    ["/", "true"],
+    ["/state-timeline", "false"],
+    ["/settings", "false"],
+  ])(
+    "hides the duplicate title only on overview route suffix '%s'",
+    (suffix: string, expectedHidden: string) => {
+      const pathname: string =
+        "/dashboard/22222222-2222-4222-8222-222222222222/" +
+        spec.segment +
+        "/" +
+        EVENT_ID.toString() +
+        suffix;
+      Navigation.setLocation({
+        pathname,
+        search: "",
+        hash: "",
+        state: null,
+        key: "overview-test",
+      });
+      render(
+        <MemoryRouter initialEntries={[pathname]}>
+          <Routes>
+            <RouterRoute
+              path={"/dashboard/:projectId/" + spec.segment + "/:id/*"}
+              element={<spec.Layout {...pageProps} />}
+            />
+          </Routes>
+        </MemoryRouter>,
+      );
+      expect(screen.getByTestId("model-page-heading")).toHaveAttribute(
+        "data-hidden",
+        expectedHidden,
+      );
+    },
+  );
+});
+
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return {
+        t: (key: string, options?: { defaultValue?: string }): string => {
+          return options?.defaultValue || key;
+        },
+      };
+    },
+  };
+});

--- a/Common/Tests/App/Dashboard/EventStatusPanel.test.tsx
+++ b/Common/Tests/App/Dashboard/EventStatusPanel.test.tsx
@@ -3,6 +3,8 @@ import EventStatusPanel, {
   EventStateAction,
   EventStateItem,
 } from "../../../../App/FeatureSet/Dashboard/src/Components/EventView/EventStatusPanel";
+import EventOverviewLayout from "../../../../App/FeatureSet/Dashboard/src/Components/EventView/EventOverviewLayout";
+import EventStatTile from "../../../../App/FeatureSet/Dashboard/src/Components/EventView/EventStatTile";
 import { ButtonStyleType } from "../../../UI/Components/Button/Button";
 import "@testing-library/jest-dom";
 import {
@@ -593,6 +595,21 @@ describe("EventStatusPanel action-group layout", () => {
 });
 
 describe("EventStatusPanel header layouts", () => {
+  test("keeps long event titles readable without truncating the heading", () => {
+    const title: string =
+      "Recurring scheduled maintenance for the production authentication database and every dependent customer-facing service";
+    renderPanel({ title: title });
+
+    const heading: HTMLElement = screen.getByRole("heading", {
+      level: 2,
+      name: title,
+    });
+
+    expect(heading).toHaveTextContent(title);
+    expect(heading).not.toHaveClass("truncate", "whitespace-nowrap");
+    expect(heading.className).toMatch(/break-words|\[overflow-wrap:anywhere\]/);
+  });
+
   test("puts the title, identifier badge, and action group in the header layout", () => {
     renderPanel({ title: "Database connection failures" });
 
@@ -607,7 +624,7 @@ describe("EventStatusPanel header layouts", () => {
 
     expect(identifier).toHaveTextContent("INC-42");
     expect(identifier).toHaveClass("bg-gray-100", "uppercase");
-    expect(headerRow).toHaveClass("md:items-start", "md:justify-between");
+    expect(headerRow).toHaveClass("xl:items-start", "xl:justify-between");
     expect(headerRow).toContainElement(group);
     expect(headerRow).not.toContainElement(screen.getByTestId("pill"));
   });
@@ -644,6 +661,291 @@ describe("EventStatusPanel header layouts", () => {
     expect(screen.getByTestId("pill")).toHaveStyle({
       backgroundColor: "#000000",
     });
+  });
+});
+
+describe("EventStatusPanel state progression", () => {
+  test("announces state order and identifies only the current step", () => {
+    renderPanel({ currentStateId: "acknowledged" });
+
+    const progression: HTMLElement = screen.getByRole("list", {
+      name: "State progression",
+    });
+    const steps: Array<HTMLElement> =
+      within(progression).getAllByRole("listitem");
+
+    expect(progression.tagName).toBe("OL");
+    expect(steps).toHaveLength(4);
+    defaultStates().forEach((state: EventStateItem, index: number) => {
+      expect(within(steps[index]!).getByText(state.name)).toBeInTheDocument();
+    });
+    expect(steps[1]).toHaveAttribute("aria-current", "step");
+    expect(progression.querySelectorAll('[aria-current="step"]')).toHaveLength(
+      1,
+    );
+    expect(steps[0]).not.toHaveAttribute("aria-current");
+    expect(steps[2]).not.toHaveAttribute("aria-current");
+    expect(steps[3]).not.toHaveAttribute("aria-current");
+  });
+
+  test.each([undefined, "removed-state"])(
+    "does not invent current or completed steps for unknown state %s",
+    (currentStateId: string | undefined) => {
+      renderPanel({ currentStateId: currentStateId });
+
+      const progression: HTMLElement = screen.getByRole("list", {
+        name: "State progression",
+      });
+
+      expect(within(progression).getAllByRole("listitem")).toHaveLength(4);
+      expect(progression.querySelector('[aria-current="step"]')).toBeNull();
+      expect(progression.querySelector("svg")).toBeNull();
+    },
+  );
+
+  test("omits an unhelpful progress rail for a single state", () => {
+    renderPanel({ states: [makeState("created", "Created")], actions: [] });
+
+    expect(
+      screen.queryByRole("list", { name: "State progression" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Created")).toBeInTheDocument();
+  });
+
+  test("keeps private visibility explicit while actions are disabled", () => {
+    renderPanel({
+      title: "Private production incident",
+      isPrivate: true,
+      isDisabled: true,
+      currentStateId: "acknowledged",
+    });
+
+    expect(screen.getByText("Private")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Private production incident" }),
+    ).toBeInTheDocument();
+    within(getActionGroup())
+      .getAllByRole("button")
+      .forEach((button: HTMLElement) => {
+        expect(button).toBeDisabled();
+      });
+    expect(
+      screen.getByRole("list", { name: "State progression" }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("EventOverviewLayout", () => {
+  test("separates the summary, response activity, and details into named regions", () => {
+    render(
+      <EventOverviewLayout
+        header={<h2>Database latency</h2>}
+        summary={<EventStatTile label="Response time" value="2 minutes" />}
+        sidebar={<p>Platform on-call</p>}
+      >
+        <p>Investigating the connection pool</p>
+      </EventOverviewLayout>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Database latency" }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("region", { name: "Event summary" })).getByText(
+        "2 minutes",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByRole("region", { name: "Response activity" }),
+      ).getByText("Investigating the connection pool"),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("complementary", { name: "Details" })).getByText(
+        "Platform on-call",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("supports maintenance-specific headings and activity context", () => {
+    render(
+      <EventOverviewLayout
+        header={<h2>Database upgrade</h2>}
+        summary={<p>Starts tomorrow</p>}
+        sidebar={<p>Scheduled for 30 minutes</p>}
+        activityTitle="Maintenance activity"
+        activityDescription="Updates and conversations for this maintenance window."
+        sidebarTitle="Maintenance details"
+      >
+        <p>Upgrade checklist reviewed</p>
+      </EventOverviewLayout>,
+    );
+
+    const activity: HTMLElement = screen.getByRole("region", {
+      name: "Maintenance activity",
+    });
+
+    expect(
+      within(activity).getByRole("heading", { name: "Maintenance activity" }),
+    ).toBeInTheDocument();
+    expect(
+      within(activity).getByText(
+        "Updates and conversations for this maintenance window.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByRole("complementary", { name: "Maintenance details" }),
+      ).getByText("Scheduled for 30 minutes"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Response activity" }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("provides keyboard skip links to focusable activity and details destinations", () => {
+    render(
+      <EventOverviewLayout
+        header={<h2>Production incident</h2>}
+        summary={<p>Investigating</p>}
+        sidebar={<p>Platform team</p>}
+      >
+        <p>Latest response</p>
+      </EventOverviewLayout>,
+    );
+
+    ["Skip to activity", "Skip to details"].forEach((name: string) => {
+      const link: HTMLElement = screen.getByRole("link", { name: name });
+      const href: string | null = link.getAttribute("href");
+
+      expect(href).toMatch(/^#.+/);
+      const destination: HTMLElement | null = document.getElementById(
+        href!.slice(1),
+      );
+      expect(destination).toBeInTheDocument();
+      expect(destination).toHaveAttribute("tabindex", "-1");
+    });
+  });
+
+  test("keeps region labels and skip destinations unique when multiple layouts render", () => {
+    const { container } = render(
+      <React.Fragment>
+        <EventOverviewLayout
+          header={<h2>Incident</h2>}
+          summary={<p>Incident summary</p>}
+          sidebar={<p>Incident details</p>}
+        >
+          <p>Incident response</p>
+        </EventOverviewLayout>
+        <EventOverviewLayout
+          header={<h2>Alert</h2>}
+          summary={<p>Alert summary</p>}
+          sidebar={<p>Alert details</p>}
+        >
+          <p>Alert response</p>
+        </EventOverviewLayout>
+      </React.Fragment>,
+    );
+
+    const ids: Array<string> = Array.from(
+      container.querySelectorAll<HTMLElement>("[id]"),
+    ).map((element: HTMLElement) => {
+      return element.id;
+    });
+    const destinations: Array<string | null> = screen
+      .getAllByRole("link")
+      .map((link: HTMLElement) => {
+        return link.getAttribute("href");
+      });
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(new Set(destinations).size).toBe(4);
+    expect(
+      screen.getAllByRole("region", { name: "Response activity" }),
+    ).toHaveLength(2);
+    expect(
+      screen.getAllByRole("complementary", { name: "Details" }),
+    ).toHaveLength(2);
+  });
+});
+
+describe("EventStatTile", () => {
+  test("associates each summary value with a semantic term and optional description", () => {
+    const { container } = render(
+      <EventStatTile
+        id="incident-response-time"
+        label="Response time"
+        value="2 minutes"
+        description="From creation to acknowledgement"
+      />,
+    );
+
+    const label: HTMLElement | null = screen
+      .getByText("Response time")
+      .closest("dt");
+    const value: HTMLElement | null = screen
+      .getByText("2 minutes")
+      .closest("dd");
+
+    expect(container.querySelector("dl")).toContainElement(label);
+    expect(container.querySelector("dl")).toContainElement(value);
+    expect(
+      screen.getByText("From creation to acknowledgement"),
+    ).toBeInTheDocument();
+    expect(document.getElementById("incident-response-time")).toContainElement(
+      value,
+    );
+  });
+
+  test("wraps long labels and values so complete timing information remains readable", () => {
+    const label: string =
+      "Total scheduled maintenance duration including verification";
+    const value: string = "2 days, 15 hours, 47 minutes, and 32 seconds";
+    render(<EventStatTile label={label} value={value} />);
+
+    const term: HTMLElement = screen
+      .getByText(label)
+      .closest("dt") as HTMLElement;
+    const definition: HTMLElement = screen
+      .getByText(value)
+      .closest("dd") as HTMLElement;
+
+    expect(term).toHaveTextContent(label);
+    expect(definition).toHaveTextContent(value);
+    expect(term).not.toHaveClass("truncate", "whitespace-nowrap");
+    expect(definition).not.toHaveClass("truncate", "whitespace-nowrap");
+    expect(definition).toHaveClass("break-words");
+  });
+
+  test("preserves interactive React values and hides decorative icons from assistive technology", () => {
+    const { container } = render(
+      <EventStatTile
+        label="Affected monitor"
+        value={<a href="/monitors/production-api">Production API</a>}
+        icon={IconProp.Clock}
+      />,
+    );
+
+    const link: HTMLElement = screen.getByRole("link", {
+      name: "Production API",
+    });
+    const icon: SVGSVGElement | null = container.querySelector("svg");
+
+    expect(link).toHaveAttribute("href", "/monitors/production-api");
+    expect(link.closest("dd")).toBeInTheDocument();
+    expect(icon).toBeInTheDocument();
+    expect(icon?.closest('[aria-hidden="true"]')).toBeInTheDocument();
+  });
+
+  test("renders a value without requiring a description or an icon", () => {
+    const { container } = render(
+      <EventStatTile label="Time to acknowledge" value="Pending" />,
+    );
+
+    expect(screen.getByText("Pending").closest("dd")).toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeNull();
+    expect(container.querySelectorAll("dt")).toHaveLength(1);
+    expect(container.querySelectorAll("dd")).toHaveLength(1);
   });
 });
 

--- a/Common/Tests/App/Dashboard/InvestigationFeedRefresh.test.tsx
+++ b/Common/Tests/App/Dashboard/InvestigationFeedRefresh.test.tsx
@@ -84,8 +84,10 @@ interface RenderedFeedItem {
   safeMode?: boolean | undefined;
 }
 
-// A stateful item dialog models the lifetime of FeedItem's More Information
-// modal, including the cleanup that releases its focus trap and scroll lock.
+/*
+ * A stateful item dialog models the lifetime of FeedItem's More Information
+ * modal, including the cleanup that releases its focus trap and scroll lock.
+ */
 function MockItemDialog(): React.ReactElement {
   React.useEffect(() => {
     return () => {

--- a/Common/Tests/App/Dashboard/InvestigationFeedRefresh.test.tsx
+++ b/Common/Tests/App/Dashboard/InvestigationFeedRefresh.test.tsx
@@ -35,6 +35,7 @@ import ScheduledMaintenanceFeed, {
 
 const getListMock: MockFunction = getJestMockFunction();
 const feedRenderMock: MockFunction = getJestMockFunction();
+const itemDialogCleanupMock: MockFunction = getJestMockFunction();
 
 jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
   return {
@@ -69,11 +70,7 @@ jest.mock("../../../UI/Components/Feed/Feed", () => {
           isExpanded ? "Collapse test history" : "Expand test history",
         ),
         props.items.map((item: RenderedFeedItem): React.ReactElement => {
-          return React.createElement(
-            "div",
-            { key: item.key },
-            item.textInMarkdown,
-          );
+          return React.createElement(MockFeedItem, { key: item.key, item });
         }),
       );
     },
@@ -85,6 +82,39 @@ interface RenderedFeedItem {
   textInMarkdown: string;
   icon: IconProp;
   safeMode?: boolean | undefined;
+}
+
+// A stateful item dialog models the lifetime of FeedItem's More Information
+// modal, including the cleanup that releases its focus trap and scroll lock.
+function MockItemDialog(): React.ReactElement {
+  React.useEffect(() => {
+    return () => {
+      itemDialogCleanupMock();
+    };
+  }, []);
+  return (
+    <div role="dialog" aria-label="Feed item details">
+      Expanded details
+    </div>
+  );
+}
+
+function MockFeedItem(props: { item: RenderedFeedItem }): React.ReactElement {
+  const [showDetails, setShowDetails] = React.useState<boolean>(false);
+  return (
+    <div>
+      <span>{props.item.textInMarkdown}</span>
+      <button
+        type="button"
+        onClick={() => {
+          setShowDetails(true);
+        }}
+      >
+        Open test details
+      </button>
+      {showDetails && <MockItemDialog />}
+    </div>
+  );
 }
 
 interface RenderedFeedProps {
@@ -254,6 +284,7 @@ afterEach(() => {
   cleanup();
   getListMock.mockReset();
   feedRenderMock.mockReset();
+  itemDialogCleanupMock.mockReset();
 });
 
 describe("investigation reports in incident and alert feeds", () => {
@@ -560,7 +591,7 @@ const refreshSpecs: Array<FeedSpec> = [
 ];
 
 describe.each(refreshSpecs)("$name expanded feed history", (spec: FeedSpec) => {
-  test("retains the feed instance and expansion while hiding old content during refresh", async () => {
+  test("preserves expansion while unmounting item dialogs and their effects during refresh", async () => {
     const refreshedRequest: Deferred<ListResult<EventFeed>> =
       createDeferred<ListResult<EventFeed>>();
     getListMock
@@ -575,6 +606,10 @@ describe.each(refreshSpecs)("$name expanded feed history", (spec: FeedSpec) => {
     fireEvent.click(
       screen.getByRole("button", { name: "Expand test history" }),
     );
+    fireEvent.click(screen.getByRole("button", { name: "Open test details" }));
+    expect(
+      screen.getByRole("dialog", { name: "Feed item details" }),
+    ).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
     await waitFor(() => {
       expect(getListMock).toHaveBeenCalledTimes(2);
@@ -583,15 +618,44 @@ describe.each(refreshSpecs)("$name expanded feed history", (spec: FeedSpec) => {
     expect(originalFeed).not.toBeVisible();
     expect(screen.getByText("Collapse test history")).not.toBeVisible();
     expect(screen.getByTestId("component-loader")).toBeVisible();
+    expect(screen.queryByRole("dialog", { hidden: true })).toBeNull();
+    expect(screen.queryByText("Open test details")).toBeNull();
+    expect(itemDialogCleanupMock).toHaveBeenCalledTimes(1);
+    expect(lastRenderedFeedProps().items).toEqual([]);
     await resolveDeferred(
       refreshedRequest,
       listResult<EventFeed>([spec.item()]),
     );
     expect(screen.getByTestId("rendered-feed")).toBe(originalFeed);
     expect(originalFeed).toBeVisible();
+    expect(screen.queryByRole("dialog", { hidden: true })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Open test details" }),
+    ).toBeVisible();
     expect(
       screen.getByRole("button", { name: "Collapse test history" }),
     ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("keeps item dialogs unmounted after a failed refresh", async () => {
+    getListMock
+      .mockResolvedValueOnce(listResult<EventFeed>([spec.item()]) as never)
+      .mockRejectedValueOnce(new Error("Could not refresh feed"));
+    render(spec.element(spec.id));
+    await waitFor(() => {
+      expect(screen.getByTestId("rendered-feed")).toBeVisible();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Open test details" }));
+    expect(
+      screen.getByRole("dialog", { name: "Feed item details" }),
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await screen.findByText("Could not refresh feed");
+    expect(screen.getByTestId("rendered-feed")).not.toBeVisible();
+    expect(screen.queryByRole("dialog", { hidden: true })).toBeNull();
+    expect(screen.queryByText("Open test details")).toBeNull();
+    expect(itemDialogCleanupMock).toHaveBeenCalledTimes(1);
+    expect(lastRenderedFeedProps().items).toEqual([]);
   });
 
   test("resets expansion when navigating to a different event", async () => {

--- a/Common/Tests/App/Dashboard/InvestigationFeedRefresh.test.tsx
+++ b/Common/Tests/App/Dashboard/InvestigationFeedRefresh.test.tsx
@@ -1,8 +1,29 @@
 import { afterEach, describe, expect, jest, test } from "@jest/globals";
 import "@testing-library/jest-dom";
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import * as React from "react";
 import getJestMockFunction, { MockFunction } from "../../MockType";
+import AlertFeedElement from "../../../../App/FeatureSet/Dashboard/src/Components/Alert/AlertFeed";
+import IncidentFeedElement from "../../../../App/FeatureSet/Dashboard/src/Components/Incident/IncidentFeed";
+import AlertFeed, {
+  AlertFeedEventType,
+} from "../../../Models/DatabaseModels/AlertFeed";
+import IncidentFeed, {
+  IncidentFeedEventType,
+} from "../../../Models/DatabaseModels/IncidentFeed";
+import IconProp from "../../../Types/Icon/IconProp";
+import ObjectID from "../../../Types/ObjectID";
+import ScheduledMaintenanceFeedElement from "../../../../App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceFeed";
+import ScheduledMaintenanceFeed, {
+  ScheduledMaintenanceFeedEventType,
+} from "../../../Models/DatabaseModels/ScheduledMaintenanceFeed";
 
 /*
  * IncidentFeed and AlertFeed normally load once at page mount. An AI report is
@@ -32,9 +53,21 @@ jest.mock("../../../UI/Components/Feed/Feed", () => {
     __esModule: true,
     default: (props: RenderedFeedProps): React.ReactElement => {
       feedRenderMock(props);
+      const [isExpanded, setIsExpanded] = React.useState<boolean>(false);
       return React.createElement(
         "div",
         { "data-testid": "rendered-feed" },
+        React.createElement(
+          "button",
+          {
+            type: "button",
+            "aria-expanded": isExpanded,
+            onClick: () => {
+              setIsExpanded(!isExpanded);
+            },
+          },
+          isExpanded ? "Collapse test history" : "Expand test history",
+        ),
         props.items.map((item: RenderedFeedItem): React.ReactElement => {
           return React.createElement(
             "div",
@@ -46,17 +79,6 @@ jest.mock("../../../UI/Components/Feed/Feed", () => {
     },
   };
 });
-
-import AlertFeedElement from "../../../../App/FeatureSet/Dashboard/src/Components/Alert/AlertFeed";
-import IncidentFeedElement from "../../../../App/FeatureSet/Dashboard/src/Components/Incident/IncidentFeed";
-import AlertFeed, {
-  AlertFeedEventType,
-} from "../../../Models/DatabaseModels/AlertFeed";
-import IncidentFeed, {
-  IncidentFeedEventType,
-} from "../../../Models/DatabaseModels/IncidentFeed";
-import IconProp from "../../../Types/Icon/IconProp";
-import ObjectID from "../../../Types/ObjectID";
 
 interface RenderedFeedItem {
   key: string;
@@ -476,5 +498,120 @@ describe("investigation reports in incident and alert feeds", () => {
         safeMode: false,
       }),
     );
+  });
+});
+
+const MAINTENANCE_ID: ObjectID = new ObjectID(
+  "23232323-2323-4232-8232-232323232323",
+);
+const NEXT_MAINTENANCE_ID: ObjectID = new ObjectID(
+  "34343434-3434-4343-8343-343434343434",
+);
+type EventFeed = IncidentFeed | AlertFeed | ScheduledMaintenanceFeed;
+
+interface FeedSpec {
+  name: string;
+  element: (id: ObjectID) => React.ReactElement;
+  id: ObjectID;
+  nextId: ObjectID;
+  item: () => EventFeed;
+}
+
+function maintenanceItem(): ScheduledMaintenanceFeed {
+  const item: ScheduledMaintenanceFeed = new ScheduledMaintenanceFeed();
+  item.id = new ObjectID("45454545-4545-4454-8454-454545454545");
+  item.scheduledMaintenanceId = MAINTENANCE_ID;
+  item.scheduledMaintenanceFeedEventType =
+    ScheduledMaintenanceFeedEventType.ScheduledMaintenanceCreated;
+  item.feedInfoInMarkdown = "Maintenance window scheduled";
+  item.postedAt = POSTED_AT;
+  item.createdAt = POSTED_AT;
+  return item;
+}
+
+const refreshSpecs: Array<FeedSpec> = [
+  {
+    name: "incident",
+    id: INCIDENT_ID,
+    nextId: NEXT_INCIDENT_ID,
+    item: incidentAnalysisItem,
+    element: (id: ObjectID): React.ReactElement => {
+      return <IncidentFeedElement incidentId={id} />;
+    },
+  },
+  {
+    name: "alert",
+    id: ALERT_ID,
+    nextId: NEXT_ALERT_ID,
+    item: alertAnalysisItem,
+    element: (id: ObjectID): React.ReactElement => {
+      return <AlertFeedElement alertId={id} />;
+    },
+  },
+  {
+    name: "maintenance",
+    id: MAINTENANCE_ID,
+    nextId: NEXT_MAINTENANCE_ID,
+    item: maintenanceItem,
+    element: (id: ObjectID): React.ReactElement => {
+      return <ScheduledMaintenanceFeedElement scheduledMaintenanceId={id} />;
+    },
+  },
+];
+
+describe.each(refreshSpecs)("$name expanded feed history", (spec: FeedSpec) => {
+  test("retains the feed instance and expansion while hiding old content during refresh", async () => {
+    const refreshedRequest: Deferred<ListResult<EventFeed>> =
+      createDeferred<ListResult<EventFeed>>();
+    getListMock
+      .mockResolvedValueOnce(listResult<EventFeed>([spec.item()]) as never)
+      .mockReturnValueOnce(refreshedRequest.promise as never);
+    render(spec.element(spec.id));
+    const originalFeed: HTMLElement =
+      await screen.findByTestId("rendered-feed");
+    await waitFor(() => {
+      expect(originalFeed).toBeVisible();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Expand test history" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.getByTestId("rendered-feed")).toBe(originalFeed);
+    expect(originalFeed).not.toBeVisible();
+    expect(screen.getByText("Collapse test history")).not.toBeVisible();
+    expect(screen.getByTestId("component-loader")).toBeVisible();
+    await resolveDeferred(
+      refreshedRequest,
+      listResult<EventFeed>([spec.item()]),
+    );
+    expect(screen.getByTestId("rendered-feed")).toBe(originalFeed);
+    expect(originalFeed).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Collapse test history" }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("resets expansion when navigating to a different event", async () => {
+    const nextRequest: Deferred<ListResult<EventFeed>> =
+      createDeferred<ListResult<EventFeed>>();
+    getListMock
+      .mockResolvedValueOnce(listResult<EventFeed>([spec.item()]) as never)
+      .mockReturnValueOnce(nextRequest.promise as never);
+    const view: ReturnType<typeof render> = render(spec.element(spec.id));
+    await waitFor(() => {
+      expect(screen.getByTestId("rendered-feed")).toBeVisible();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Expand test history" }),
+    );
+    view.rerender(spec.element(spec.nextId));
+    await resolveDeferred(nextRequest, listResult<EventFeed>([spec.item()]));
+    expect(
+      screen.getByRole("button", { name: "Expand test history" }),
+    ).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Collapse test history")).toBeNull();
   });
 });

--- a/Common/Tests/App/StatusPage/StatusPageOidcOrigin.test.tsx
+++ b/Common/Tests/App/StatusPage/StatusPageOidcOrigin.test.tsx
@@ -181,7 +181,7 @@ describe("Status Page OIDC login origin", () => {
       localStorage.setItem(`isPrivateStatusPage-${statusPageId}`, "true");
 
       jest.isolateModules(() => {
-        const SSO: FunctionComponent<ComponentProps> = (
+        const Sso: FunctionComponent<ComponentProps> = (
           jest.requireActual(
             "../../../../App/FeatureSet/StatusPage/src/Pages/Accounts/SSO",
           ) as { default: FunctionComponent<ComponentProps> }
@@ -196,7 +196,7 @@ describe("Status Page OIDC login origin", () => {
           .mockImplementation(() => {});
 
         render(
-          <SSO
+          <Sso
             statusPageName="Example Status"
             logoFileId={new ObjectID(statusPageId)}
           />,

--- a/Common/Tests/UI/Components/Card.test.tsx
+++ b/Common/Tests/UI/Components/Card.test.tsx
@@ -1,4 +1,7 @@
-import { ButtonStyleType } from "../../../UI/Components/Button/Button";
+import {
+  ButtonSize,
+  ButtonStyleType,
+} from "../../../UI/Components/Button/Button";
 import Card, {
   CardButtonSchema,
   ComponentProps,
@@ -8,6 +11,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import IconProp from "../../../Types/Icon/IconProp";
 import React, { ReactElement } from "react";
 import { describe, expect, jest } from "@jest/globals";
+import getJestMockFunction, { MockFunction } from "../../MockType";
 
 describe("Card", () => {
   const props: ComponentProps = {
@@ -105,5 +109,83 @@ describe("Card", () => {
 
     expect(childComponent).toBeInTheDocument();
     expect(childComponent.parentElement).toHaveClass("mt-4");
+  });
+
+  test("keeps the title, description, content, and actions available in compact cards", () => {
+    const onEdit: MockFunction = getJestMockFunction();
+    renderComponent({
+      title: "Affected resources",
+      description: "Services impacted by this incident",
+      compact: true,
+      children: <p>Production API</p>,
+      rightElement: <span>2 monitors</span>,
+      buttons: [
+        { title: "Edit resources", icon: IconProp.Edit, onClick: onEdit },
+      ],
+    });
+
+    const title: HTMLElement = screen.getByRole("heading", {
+      name: "Affected resources",
+    });
+    const button: HTMLElement = screen.getByRole("button", {
+      name: "Edit resources",
+    });
+
+    expect(title).toHaveClass("text-sm");
+    expect(title).not.toHaveClass("truncate", "whitespace-nowrap");
+    expect(
+      screen.getByText("Services impacted by this incident"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Production API")).toBeInTheDocument();
+    expect(screen.getByText("2 monitors")).toBeInTheDocument();
+    expect(button).toHaveClass(ButtonSize.Small);
+    fireEvent.click(button);
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  test("honors explicitly requested action sizes in compact cards", () => {
+    renderComponent({
+      ...props,
+      compact: true,
+      buttons: [
+        {
+          title: "Edit",
+          icon: IconProp.Edit,
+          onClick: jest.fn(),
+          buttonSize: ButtonSize.Large,
+        },
+      ],
+    });
+
+    expect(screen.getByRole("button", { name: "Edit" })).toHaveClass(
+      ButtonSize.Large,
+    );
+  });
+
+  test("preserves disabled controls and their explanation in compact cards", () => {
+    const onEdit: MockFunction = getJestMockFunction();
+    renderComponent({
+      ...props,
+      compact: true,
+      buttons: [
+        {
+          title: "Edit",
+          icon: IconProp.Edit,
+          onClick: onEdit,
+          disabled: true,
+          tooltip: "Only incident owners can edit these details.",
+        },
+      ],
+    });
+
+    const button: HTMLElement = screen.getByRole("button", { name: "Edit" });
+
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onEdit).not.toHaveBeenCalled();
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Only incident owners can edit these details.",
+    );
   });
 });

--- a/Common/Tests/UI/Components/CardModelDetailPermissionGating.test.tsx
+++ b/Common/Tests/UI/Components/CardModelDetailPermissionGating.test.tsx
@@ -15,6 +15,12 @@ import {
   jest,
   test,
 } from "@jest/globals";
+import CardModelDetail from "../../../UI/Components/ModelDetail/CardModelDetail";
+import PermissionGate from "../../../UI/Utils/PermissionGate";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import ObjectID from "../../../Types/ObjectID";
+import Permission from "../../../Types/Permission";
+import FieldType from "../../../UI/Components/Types/FieldType";
 
 /*
  * CardModelDetail's Edit button was the only model-level permission check in
@@ -91,8 +97,10 @@ jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
   return {
     __esModule: true,
     default: {
-      getItem: async (): Promise<null> => {
-        return null;
+      getItem: async (): Promise<Monitor> => {
+        const monitor: Monitor = new Monitor();
+        monitor.name = "Production API";
+        return monitor;
       },
       getList: async (): Promise<{
         data: Array<unknown>;
@@ -105,13 +113,6 @@ jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
     },
   };
 });
-
-import CardModelDetail from "../../../UI/Components/ModelDetail/CardModelDetail";
-import PermissionGate from "../../../UI/Utils/PermissionGate";
-import Monitor from "../../../Models/DatabaseModels/Monitor";
-import ObjectID from "../../../Types/ObjectID";
-import Permission from "../../../Types/Permission";
-import FieldType from "../../../UI/Components/Types/FieldType";
 
 const MONITOR_ID: ObjectID = new ObjectID(
   "11111111-1111-4111-8111-111111111111",
@@ -129,16 +130,23 @@ const findEditButton: FindEditButtonFunction = (): HTMLButtonElement | null => {
   );
 };
 
-type RenderCardFunction = (refresher?: boolean) => ReturnType<typeof render>;
+type RenderCardFunction = (
+  refresher?: boolean,
+  compact?: boolean,
+  isEditable?: boolean,
+) => ReturnType<typeof render>;
 
 const renderCard: RenderCardFunction = (
   refresher: boolean = false,
+  compact: boolean = false,
+  isEditable: boolean = true,
 ): ReturnType<typeof render> => {
   return render(
     <CardModelDetail<Monitor>
       name="Monitor Details"
+      compact={compact}
       cardProps={{ title: "Monitor Details", description: "About it" }}
-      isEditable={true}
+      isEditable={isEditable}
       refresher={refresher}
       formFields={[
         {
@@ -164,142 +172,176 @@ const renderCard: RenderCardFunction = (
   );
 };
 
-describe("CardModelDetail permission gating", () => {
-  beforeEach(() => {
-    isMasterAdminForTest = false;
-    permissionsForTest = [];
-    PermissionGate.clearPermissionPropsCache();
-    window.localStorage.clear();
-  });
-
-  afterEach(() => {
-    cleanup();
-    jest.restoreAllMocks();
-  });
-
-  test("offers a working Edit button when the viewer may update", async () => {
-    permissionsForTest = [Permission.ProjectAdmin];
-
-    renderCard();
-
-    await waitFor(() => {
-      expect(findEditButton()).not.toBeNull();
+describe.each([false, true])(
+  "CardModelDetail permission gating (compact: %s)",
+  (compact: boolean) => {
+    beforeEach(() => {
+      isMasterAdminForTest = false;
+      permissionsForTest = [];
+      PermissionGate.clearPermissionPropsCache();
+      window.localStorage.clear();
     });
 
-    expect(findEditButton()).not.toBeDisabled();
-  });
-
-  test("locks the Edit button rather than removing it", async () => {
-    permissionsForTest = [Permission.Viewer];
-
-    renderCard();
-
-    await waitFor(() => {
-      expect(findEditButton()).not.toBeNull();
+    afterEach(() => {
+      cleanup();
+      jest.restoreAllMocks();
     });
 
-    expect(findEditButton()).toBeDisabled();
-  });
+    test("offers a working Edit button when the viewer may update", async () => {
+      permissionsForTest = [Permission.ProjectAdmin];
 
-  test("explains the locked Edit on hover", async () => {
-    permissionsForTest = [Permission.Viewer];
+      renderCard(false, compact);
 
-    renderCard();
+      await waitFor(() => {
+        expect(findEditButton()).not.toBeNull();
+      });
 
-    await waitFor(() => {
-      expect(findEditButton()).not.toBeNull();
+      expect(findEditButton()).not.toBeDisabled();
     });
 
-    fireEvent.mouseEnter(findEditButton()!.parentElement as HTMLElement);
+    test("locks the Edit button rather than removing it", async () => {
+      permissionsForTest = [Permission.Viewer];
 
-    expect(screen.getByRole("tooltip")).toHaveTextContent(
-      "You do not have permission to update this Monitor.",
-    );
-    expect(screen.getByRole("tooltip")).toHaveTextContent("Edit Monitor");
-  });
+      renderCard(false, compact);
 
-  /*
-   * The check used to run against getProjectPermissions() alone. This grant
-   * arrives through getAllPermissions(), which merges global and project - so
-   * it only passes if the component is reading the merged view.
-   */
-  test("honours a permission that is not in the project snapshot", async () => {
-    permissionsForTest = [Permission.ProjectOwner];
+      await waitFor(() => {
+        expect(findEditButton()).not.toBeNull();
+      });
 
-    renderCard();
-
-    await waitFor(() => {
-      expect(findEditButton()).not.toBeNull();
+      expect(findEditButton()).toBeDisabled();
     });
 
-    expect(findEditButton()).not.toBeDisabled();
-  });
+    test("explains the locked Edit on hover", async () => {
+      permissionsForTest = [Permission.Viewer];
 
-  /*
-   * The snapshot lands on an API response header, which can easily be after
-   * the card's first paint. A mount-only effect froze the button in whatever
-   * state that first paint implied.
-   */
-  test("re-evaluates when the permission snapshot arrives after first paint", async () => {
-    permissionsForTest = [];
+      renderCard(false, compact);
 
-    const { rerender } = renderCard(false);
+      await waitFor(() => {
+        expect(findEditButton()).not.toBeNull();
+      });
 
-    await waitFor(() => {
-      expect(screen.getByText("Monitor Details")).toBeInTheDocument();
+      fireEvent.mouseEnter(findEditButton()!.parentElement as HTMLElement);
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "You do not have permission to update this Monitor.",
+      );
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Edit Monitor");
     });
 
-    // Nothing honest to say yet, so no button at all.
-    expect(findEditButton()).toBeNull();
+    /*
+     * The check used to run against getProjectPermissions() alone. This grant
+     * arrives through getAllPermissions(), which merges global and project - so
+     * it only passes if the component is reading the merged view.
+     */
+    test("honours a permission that is not in the project snapshot", async () => {
+      permissionsForTest = [Permission.ProjectOwner];
 
-    permissionsForTest = [Permission.ProjectAdmin];
+      renderCard(false, compact);
 
-    rerender(
-      <CardModelDetail<Monitor>
-        name="Monitor Details"
-        cardProps={{ title: "Monitor Details", description: "About it" }}
-        isEditable={true}
-        refresher={true}
-        formFields={[
-          {
-            field: { name: true },
-            title: "Name",
-            fieldType: "Text" as never,
-            required: true,
-          },
-        ]}
-        modelDetailProps={{
-          modelType: Monitor,
-          id: "monitor-detail",
-          modelId: MONITOR_ID,
-          fields: [
+      await waitFor(() => {
+        expect(findEditButton()).not.toBeNull();
+      });
+
+      expect(findEditButton()).not.toBeDisabled();
+    });
+
+    /*
+     * The snapshot lands on an API response header, which can easily be after
+     * the card's first paint. A mount-only effect froze the button in whatever
+     * state that first paint implied.
+     */
+    test("re-evaluates when the permission snapshot arrives after first paint", async () => {
+      permissionsForTest = [];
+
+      const { rerender } = renderCard(false, compact);
+
+      await waitFor(() => {
+        expect(screen.getByText("Monitor Details")).toBeInTheDocument();
+      });
+
+      // Nothing honest to say yet, so no button at all.
+      expect(findEditButton()).toBeNull();
+
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      rerender(
+        <CardModelDetail<Monitor>
+          name="Monitor Details"
+          compact={compact}
+          cardProps={{ title: "Monitor Details", description: "About it" }}
+          isEditable={true}
+          refresher={true}
+          formFields={[
             {
               field: { name: true },
               title: "Name",
-              fieldType: FieldType.Text,
+              fieldType: "Text" as never,
+              required: true,
             },
-          ],
-        }}
-      />,
-    );
+          ]}
+          modelDetailProps={{
+            modelType: Monitor,
+            id: "monitor-detail",
+            modelId: MONITOR_ID,
+            fields: [
+              {
+                field: { name: true },
+                title: "Name",
+                fieldType: FieldType.Text,
+              },
+            ],
+          }}
+        />,
+      );
 
-    await waitFor(() => {
-      expect(findEditButton()).not.toBeNull();
+      await waitFor(() => {
+        expect(findEditButton()).not.toBeNull();
+      });
+
+      expect(findEditButton()).not.toBeDisabled();
     });
 
-    expect(findEditButton()).not.toBeDisabled();
-  });
+    test("works for a master admin", async () => {
+      isMasterAdminForTest = true;
+      permissionsForTest = [];
 
-  test("works for a master admin", async () => {
-    isMasterAdminForTest = true;
-    permissionsForTest = [];
+      renderCard(false, compact);
 
-    renderCard();
+      await waitFor(() => {
+        expect(findEditButton()).not.toBeNull();
+      });
 
-    await waitFor(() => {
-      expect(findEditButton()).not.toBeNull();
+      expect(findEditButton()).not.toBeDisabled();
     });
 
-    expect(findEditButton()).not.toBeDisabled();
-  });
-});
+    test("respects read-only cards even when the viewer has update permission", async () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      renderCard(false, compact, false);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Monitor Details" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(findEditButton()).toBeNull();
+      expect(screen.getByText("About it")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Monitor Details" }),
+      ).toHaveClass(compact ? "text-sm" : "text-lg");
+    });
+
+    test("renders loaded details with the appropriate density without dropping field content", async () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      renderCard(false, compact);
+
+      expect(await screen.findByText("Production API")).toBeInTheDocument();
+      expect(screen.getByText("Name")).toBeInTheDocument();
+      expect(document.getElementById("monitor-detail")).toHaveClass(
+        compact ? "py-3" : "py-5",
+      );
+    });
+  },
+);

--- a/Common/Tests/UI/Components/EventOverviewPresentation.test.tsx
+++ b/Common/Tests/UI/Components/EventOverviewPresentation.test.tsx
@@ -1,0 +1,203 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import Page from "../../../UI/Components/Page/Page";
+import ModelPage from "../../../UI/Components/Page/ModelPage";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import Label from "../../../Models/DatabaseModels/Label";
+import Route from "../../../Types/API/Route";
+import ObjectID from "../../../Types/ObjectID";
+
+let recordForTest: Monitor | null = null;
+
+jest.mock("../../../UI/Utils/Analytics", () => {
+  return { __esModule: true, default: { capture: jest.fn() } };
+});
+
+jest.mock("../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined): string | undefined => {
+          return value;
+        },
+        translateValue: (value: unknown): unknown => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getItem: async (): Promise<Monitor | null> => {
+        return recordForTest;
+      },
+    },
+  };
+});
+
+beforeEach(() => {
+  recordForTest = new Monitor();
+  recordForTest.name = "Production API";
+  document.title = "OneUptime";
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Page title visibility for event overviews", () => {
+  test("retains an accessible h1 while the event header supplies the visible title", () => {
+    render(
+      <Page
+        title="Incident overview"
+        description="Respond to this incident"
+        hideTitle={true}
+      >
+        <h2>Database connection failures</h2>
+      </Page>,
+    );
+
+    const title: HTMLElement = screen.getByRole("heading", {
+      level: 1,
+      name: "Incident overview",
+    });
+
+    expect(title.closest(".sr-only")).toBeInTheDocument();
+    expect(title).not.toHaveAttribute("aria-hidden");
+    expect(
+      screen.getByText("Respond to this incident").closest(".sr-only"),
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getByRole("heading", {
+          level: 2,
+          name: "Database connection failures",
+        })
+        .closest(".sr-only"),
+    ).toBeNull();
+    expect(document.title).toBe("OneUptime | Incident overview");
+  });
+
+  test("leaves existing page titles visible by default", () => {
+    render(
+      <Page title="Incidents">
+        <p>Incident list</p>
+      </Page>,
+    );
+
+    expect(
+      screen
+        .getByRole("heading", { level: 1, name: "Incidents" })
+        .closest(".sr-only"),
+    ).toBeNull();
+    expect(screen.getByText("Incident list")).toBeInTheDocument();
+  });
+
+  test("preserves breadcrumbs, resource labels, and header actions when the title is visually hidden", () => {
+    const label: Label = new Label();
+    label.name = "Production";
+    render(
+      <MemoryRouter>
+        <Page
+          title="Incident overview"
+          hideTitle={true}
+          breadcrumbLinks={[
+            { title: "Incidents", to: new Route("/incidents") },
+            { title: "INC-42", to: new Route("/incidents/42") },
+          ]}
+          labels={[label]}
+          headerRight={<button type="button">Subscribe</button>}
+        >
+          <p>Response activity</p>
+        </Page>
+      </MemoryRouter>,
+    );
+
+    const breadcrumbs: HTMLElement = screen.getByRole("navigation", {
+      name: "Breadcrumb",
+    });
+
+    expect(
+      within(breadcrumbs).getByRole("link", { name: "Incidents" }),
+    ).toHaveAttribute("href", "/incidents");
+    expect(within(breadcrumbs).getByText("INC-42")).toBeInTheDocument();
+    expect(screen.getByText("Production").closest(".sr-only")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Subscribe" }).closest(".sr-only"),
+    ).toBeNull();
+    expect(document.title).toBe("OneUptime | Incidents - INC-42");
+  });
+});
+
+describe("ModelPage event-overview presentation", () => {
+  test.each([false, true])(
+    "forwards hideTitle=%s without losing the loaded model title or body",
+    async (hideTitle: boolean) => {
+      render(
+        <ModelPage<Monitor>
+          modelType={Monitor}
+          modelId={new ObjectID("11111111-1111-4111-8111-111111111111")}
+          modelNameField="name"
+          title="Monitor"
+          hideTitle={hideTitle}
+        >
+          <p>Monitor overview content</p>
+        </ModelPage>,
+      );
+
+      const heading: HTMLElement = await screen.findByRole("heading", {
+        level: 1,
+        name: "Monitor - Production API",
+      });
+
+      expect(Boolean(heading.closest(".sr-only"))).toBe(hideTitle);
+      expect(screen.getByText("Monitor overview content")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(document.title).toBe("OneUptime | Monitor - Production API");
+      });
+    },
+  );
+
+  test("still reports an unavailable record instead of exposing overview content", async () => {
+    recordForTest = null;
+    render(
+      <ModelPage<Monitor>
+        modelType={Monitor}
+        modelId={new ObjectID("11111111-1111-4111-8111-111111111111")}
+        modelNameField="name"
+        title="Monitor"
+        hideTitle={true}
+      >
+        <p>Monitor overview content</p>
+      </ModelPage>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cannot load monitor/)).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("Monitor overview content"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/Common/Tests/UI/Components/FeedVisibleItemLimit.test.tsx
+++ b/Common/Tests/UI/Components/FeedVisibleItemLimit.test.tsx
@@ -1,0 +1,284 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+import React from "react";
+import Feed from "../../../UI/Components/Feed/Feed";
+import { FeedItemProps } from "../../../UI/Components/Feed/FeedItem";
+import IconProp from "../../../Types/Icon/IconProp";
+import { Black } from "../../../Types/BrandColors";
+
+function makeItems(count: number): Array<FeedItemProps> {
+  return Array.from({ length: count }, (_: unknown, index: number) => {
+    return {
+      key: `update-${index + 1}`,
+      textInMarkdown: "",
+      element: <span>{`Update ${index + 1}`}</span>,
+      itemDateTime: new Date(Date.UTC(2026, 8, 7, 12, index)),
+      icon: IconProp.Check,
+      color: Black,
+    };
+  });
+}
+
+function displayedUpdates(): Array<string | null> {
+  return screen.getAllByText(/^Update \d+$/).map((update: HTMLElement) => {
+    return update.textContent;
+  });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Feed recent activity", () => {
+  test("preserves the full chronological feed when no limit is requested", () => {
+    render(<Feed items={makeItems(7)} noItemsMessage="No updates yet." />);
+
+    expect(displayedUpdates()).toEqual([
+      "Update 1",
+      "Update 2",
+      "Update 3",
+      "Update 4",
+      "Update 5",
+      "Update 6",
+      "Update 7",
+    ]);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  test("shows the latest updates in their original chronological order", () => {
+    const items: Array<FeedItemProps> = makeItems(8);
+    render(
+      <Feed
+        items={items}
+        visibleItemLimit={3}
+        noItemsMessage="No updates yet."
+      />,
+    );
+
+    expect(displayedUpdates()).toEqual(["Update 6", "Update 7", "Update 8"]);
+    expect(screen.queryByText("Update 5")).not.toBeInTheDocument();
+    expect(items[0]?.key).toBe("update-1");
+    expect(items).toHaveLength(8);
+    expect(
+      screen.getByRole("button", { name: "Show 5 earlier updates" }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("lets responders expand history and return to recent activity", () => {
+    render(
+      <Feed
+        items={makeItems(5)}
+        visibleItemLimit={3}
+        noItemsMessage="No updates yet."
+      />,
+    );
+
+    const expand: HTMLElement = screen.getByRole("button", {
+      name: "Show 2 earlier updates",
+    });
+    const controlledListId: string | null =
+      expand.getAttribute("aria-controls");
+    expect(controlledListId).toBeTruthy();
+    expect(document.getElementById(controlledListId!)).toBe(
+      screen.getByRole("list"),
+    );
+    fireEvent.click(expand);
+
+    expect(displayedUpdates()).toEqual([
+      "Update 1",
+      "Update 2",
+      "Update 3",
+      "Update 4",
+      "Update 5",
+    ]);
+    const collapse: HTMLElement = screen.getByRole("button", {
+      name: "Show fewer updates",
+    });
+    expect(collapse).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(collapse);
+
+    expect(displayedUpdates()).toEqual(["Update 3", "Update 4", "Update 5"]);
+    expect(
+      screen.getByRole("button", { name: "Show 2 earlier updates" }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("uses a singular label when exactly one earlier update is hidden", () => {
+    render(
+      <Feed
+        items={makeItems(4)}
+        visibleItemLimit={3}
+        noItemsMessage="No updates yet."
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Show 1 earlier update" }),
+    ).toBeInTheDocument();
+  });
+
+  test.each([1, 3])(
+    "shows all %s items without unnecessary expansion controls when they fit the limit",
+    (count: number) => {
+      render(
+        <Feed
+          items={makeItems(count)}
+          visibleItemLimit={3}
+          noItemsMessage="No updates yet."
+        />,
+      );
+
+      expect(screen.getAllByRole("listitem")).toHaveLength(count);
+      expect(screen.getByText("Update 1")).toBeInTheDocument();
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    },
+  );
+
+  test("preserves empty-state guidance without adding invalid non-item list content", () => {
+    render(
+      <Feed
+        items={[]}
+        visibleItemLimit={3}
+        noItemsMessage="No maintenance updates yet."
+      />,
+    );
+
+    const emptyState: HTMLElement = screen.getByText(
+      "No maintenance updates yet.",
+    );
+    expect(emptyState).toBeInTheDocument();
+    expect(emptyState.closest("ul")).toBeNull();
+    expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  test.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "falls back to the full feed for invalid limit %s",
+    (visibleItemLimit: number) => {
+      render(
+        <Feed
+          items={makeItems(4)}
+          visibleItemLimit={visibleItemLimit}
+          noItemsMessage="No updates yet."
+        />,
+      );
+
+      expect(screen.getAllByRole("listitem")).toHaveLength(4);
+      expect(screen.getByText("Update 1")).toBeInTheDocument();
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    },
+  );
+
+  test("keeps collapsed feeds current and preserves expanded history as updates arrive", () => {
+    const { rerender } = render(
+      <Feed
+        items={makeItems(5)}
+        visibleItemLimit={3}
+        noItemsMessage="No updates yet."
+      />,
+    );
+
+    rerender(
+      <Feed
+        items={makeItems(6)}
+        visibleItemLimit={3}
+        noItemsMessage="No updates yet."
+      />,
+    );
+
+    expect(displayedUpdates()).toEqual(["Update 4", "Update 5", "Update 6"]);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show 3 earlier updates" }),
+    );
+
+    rerender(
+      <Feed
+        items={makeItems(7)}
+        visibleItemLimit={3}
+        noItemsMessage="No updates yet."
+      />,
+    );
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(7);
+    expect(screen.getByText("Update 1")).toBeInTheDocument();
+    expect(screen.getByText("Update 7")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show fewer updates" }),
+    ).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Show fewer updates" }));
+    expect(displayedUpdates()).toEqual(["Update 5", "Update 6", "Update 7"]);
+  });
+
+  test("resets expansion when the requested preview size changes", () => {
+    const { rerender } = render(
+      <Feed
+        items={makeItems(7)}
+        visibleItemLimit={3}
+        noItemsMessage="No updates yet."
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show 4 earlier updates" }),
+    );
+
+    rerender(
+      <Feed
+        items={makeItems(7)}
+        visibleItemLimit={2}
+        noItemsMessage="No updates yet."
+      />,
+    );
+
+    expect(displayedUpdates()).toEqual(["Update 6", "Update 7"]);
+    expect(
+      screen.getByRole("button", { name: "Show 5 earlier updates" }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("keeps expansion controls scoped to their own feed", () => {
+    render(
+      <React.Fragment>
+        <section aria-label="Incident history">
+          <Feed
+            items={makeItems(5)}
+            visibleItemLimit={3}
+            noItemsMessage="No updates yet."
+          />
+        </section>
+        <section aria-label="Maintenance history">
+          <Feed
+            items={makeItems(6)}
+            visibleItemLimit={3}
+            noItemsMessage="No updates yet."
+          />
+        </section>
+      </React.Fragment>,
+    );
+
+    const incident: HTMLElement = screen.getByRole("region", {
+      name: "Incident history",
+    });
+    const maintenance: HTMLElement = screen.getByRole("region", {
+      name: "Maintenance history",
+    });
+    const incidentButton: HTMLElement = within(incident).getByRole("button");
+    const maintenanceButton: HTMLElement =
+      within(maintenance).getByRole("button");
+
+    expect(incidentButton.getAttribute("aria-controls")).not.toBe(
+      maintenanceButton.getAttribute("aria-controls"),
+    );
+    fireEvent.click(incidentButton);
+    expect(within(incident).getAllByRole("listitem")).toHaveLength(5);
+    expect(within(maintenance).getAllByRole("listitem")).toHaveLength(3);
+    expect(maintenanceButton).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/Common/UI/Components/Card/Card.tsx
+++ b/Common/UI/Components/Card/Card.tsx
@@ -22,6 +22,7 @@ export interface CardButtonSchema {
 }
 
 export interface ComponentProps {
+  compact?: boolean | undefined;
   title?: string | ReactElement | undefined;
   description?: string | ReactElement | undefined;
   buttons?: undefined | Array<CardButtonSchema | ReactElement>;
@@ -47,8 +48,14 @@ const Card: FunctionComponent<ComponentProps> = (
     <React.Fragment>
       <div data-testid="card" className={`mb-5 ${props.className || ""}`}>
         <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-visible">
-          <div className="py-6 px-5 md:px-6">
-            <div className="flex flex-col md:flex-row md:justify-between md:items-start">
+          <div className={props.compact ? "p-4" : "py-6 px-5 md:px-6"}>
+            <div
+              className={
+                props.compact
+                  ? "flex flex-wrap items-start justify-between gap-3"
+                  : "flex flex-col md:flex-row md:justify-between md:items-start"
+              }
+            >
               <div
                 className={`${noRightElementsOrButtons ? "w-full" : "flex-1 min-w-0"}`}
               >
@@ -56,7 +63,7 @@ const Card: FunctionComponent<ComponentProps> = (
                   <h2
                     data-testid="card-details-heading"
                     id="card-details-heading"
-                    className="text-lg font-semibold leading-6 text-gray-900"
+                    className={`${props.compact ? "text-sm" : "text-lg"} break-words font-semibold leading-6 text-gray-900`}
                   >
                     {translatedTitle}
                   </h2>
@@ -64,7 +71,11 @@ const Card: FunctionComponent<ComponentProps> = (
                 {translatedDescription && (
                   <p
                     data-testid="card-description"
-                    className="mt-1.5 text-sm text-gray-500 w-full hidden md:block leading-relaxed"
+                    className={
+                      props.compact
+                        ? "mt-1 text-xs leading-5 text-gray-500"
+                        : "mt-1.5 text-sm text-gray-500 w-full hidden md:block leading-relaxed"
+                    }
                   >
                     {translatedDescription}
                   </p>
@@ -72,7 +83,13 @@ const Card: FunctionComponent<ComponentProps> = (
               </div>
               {(props.rightElement ||
                 (props.buttons && props.buttons.length > 0)) && (
-                <div className="flex flex-col md:flex-row md:items-center md:w-fit mt-4 md:mt-0 md:ml-4 gap-2 md:gap-0 flex-shrink-0 items-center">
+                <div
+                  className={
+                    props.compact
+                      ? "flex max-w-full flex-wrap items-center gap-2"
+                      : "flex flex-col md:flex-row md:items-center md:w-fit mt-4 md:mt-0 md:ml-4 gap-2 md:gap-0 flex-shrink-0 items-center"
+                  }
+                >
                   {props.rightElement && (
                     <div className="mb-2 md:mb-0 md:mr-3">
                       {props.rightElement}
@@ -96,7 +113,10 @@ const Card: FunctionComponent<ComponentProps> = (
                                     (button as CardButtonSchema).buttonStyle
                                   }
                                   buttonSize={
-                                    (button as CardButtonSchema).buttonSize
+                                    (button as CardButtonSchema).buttonSize ||
+                                    (props.compact
+                                      ? ButtonSize.Small
+                                      : undefined)
                                   }
                                   className={
                                     (button as CardButtonSchema).className

--- a/Common/UI/Components/Feed/Feed.tsx
+++ b/Common/UI/Components/Feed/Feed.tsx
@@ -1,26 +1,75 @@
-import React, { FunctionComponent, ReactElement } from "react";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useId,
+  useState,
+} from "react";
 import FeedItem, { FeedItemProps } from "./FeedItem";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
+import useTranslateValue from "../../Utils/Translation";
 
 export interface ComponentProps {
   items: Array<FeedItemProps>;
   noItemsMessage: string;
+  // Items arrive chronologically; an overview can start with recent updates.
+  visibleItemLimit?: number | undefined;
 }
 
 const Feed: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  const [showAllItems, setShowAllItems] = useState<boolean>(false);
+  const listId: string = useId();
+  const { translateString } = useTranslateValue();
+  const itemLimit: number =
+    Number.isInteger(props.visibleItemLimit) &&
+    (props.visibleItemLimit || 0) > 0
+      ? props.visibleItemLimit!
+      : props.items.length;
+  const earlierItemCount: number = Math.max(props.items.length - itemLimit, 0);
+  const visibleItems: Array<FeedItemProps> =
+    showAllItems || earlierItemCount === 0
+      ? props.items
+      : props.items.slice(-itemLimit);
+
+  useEffect(() => {
+    setShowAllItems(false);
+  }, [props.visibleItemLimit]);
+
   return (
     <div className="flow-root">
-      <ul role="list">
-        {props.items.length === 0 && (
-          <div>
-            <ErrorMessage message={props.noItemsMessage} />
-          </div>
-        )}
-        {props.items.map((item: FeedItemProps, index: number) => {
+      {earlierItemCount > 0 && (
+        <button
+          type="button"
+          aria-expanded={showAllItems}
+          aria-controls={listId}
+          className="mb-5 inline-flex rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+          onClick={() => {
+            setShowAllItems((current: boolean) => {
+              return !current;
+            });
+          }}
+        >
+          {translateString(
+            showAllItems
+              ? "Show fewer updates"
+              : `Show ${earlierItemCount} earlier update${earlierItemCount === 1 ? "" : "s"}`,
+          )}
+        </button>
+      )}
+      {props.items.length === 0 && (
+        <ErrorMessage message={props.noItemsMessage} />
+      )}
+      <ul id={listId} role="list">
+        {visibleItems.map((item: FeedItemProps, index: number) => {
+          const { key, ...itemProps } = item;
           return (
-            <FeedItem {...item} isLastItem={index === props.items.length - 1} />
+            <FeedItem
+              key={key}
+              {...itemProps}
+              isLastItem={index === visibleItems.length - 1}
+            />
           );
         })}
       </ul>

--- a/Common/UI/Components/ModelDetail/CardModelDetail.tsx
+++ b/Common/UI/Components/ModelDetail/CardModelDetail.tsx
@@ -15,6 +15,7 @@ import { FormStep } from "../Forms/Types/FormStep";
 import { ModalWidth } from "../Modal/Modal";
 import ModelFormModal from "../ModelFormModal/ModelFormModal";
 import ModelDetail, { ComponentProps as ModeDetailProps } from "./ModelDetail";
+import { DetailStyle } from "../Detail/Detail";
 import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import IconProp from "../../../Types/Icon/IconProp";
 import Route from "../../../Types/API/Route";
@@ -22,6 +23,7 @@ import URL from "../../../Types/API/URL";
 import React, { ReactElement, useEffect, useRef, useState } from "react";
 
 export interface ComponentProps<TBaseModel extends BaseModel> {
+  compact?: boolean | undefined;
   cardProps: CardProps;
   modelDetailProps: ModeDetailProps<TBaseModel>;
   isEditable?: undefined | boolean;
@@ -150,10 +152,17 @@ const CardModelDetail: <TBaseModel extends BaseModel>(
 
   return (
     <>
-      <Card {...props.cardProps} buttons={cardButtons}>
-        <div className="border-t border-gray-200 px-4 py-5 sm:px-6 -m-6 -mt-2">
+      <Card {...props.cardProps} compact={props.compact} buttons={cardButtons}>
+        <div
+          className={
+            props.compact
+              ? "border-t border-gray-100 pt-4"
+              : "border-t border-gray-200 px-4 py-5 sm:px-6 -m-6 -mt-2"
+          }
+        >
           <ModelDetail
             refresher={refresher}
+            detailStyle={props.compact ? DetailStyle.Minimal : undefined}
             {...props.modelDetailProps}
             modelAPI={props.modelAPI}
             onItemLoaded={(item: TBaseModel) => {

--- a/Common/UI/Components/ModelDetail/ModelDetail.tsx
+++ b/Common/UI/Components/ModelDetail/ModelDetail.tsx
@@ -2,7 +2,7 @@ import API from "../../Utils/API/API";
 import ModelAPI from "../../Utils/ModelAPI/ModelAPI";
 import PermissionUtil from "../../Utils/Permission";
 import User from "../../Utils/User";
-import Detail from "../Detail/Detail";
+import Detail, { DetailStyle } from "../Detail/Detail";
 import DetailField from "../Detail/Field";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import Loader, { LoaderType } from "../Loader/Loader";
@@ -23,6 +23,7 @@ import { useAsyncEffect } from "use-async-effect";
 import Select from "../../../Types/BaseDatabase/Select";
 
 export interface ComponentProps<TBaseModel extends BaseModel> {
+  detailStyle?: DetailStyle | undefined;
   modelType: { new (): TBaseModel };
   id: string;
   fields: Array<Field<TBaseModel>>;
@@ -311,6 +312,7 @@ const ModelDetail: <TBaseModel extends BaseModel>(
       id={props.id}
       item={item}
       fields={fields}
+      style={props.detailStyle}
       showDetailsInNumberOfColumns={props.showDetailsInNumberOfColumns}
     />
   );

--- a/Common/UI/Components/Page/ModelPage.tsx
+++ b/Common/UI/Components/Page/ModelPage.tsx
@@ -12,6 +12,7 @@ import useAsyncEffect from "use-async-effect";
 import Select from "../../../Server/Types/Database/Select";
 
 export interface ComponentProps<TBaseModel extends BaseModel> {
+  hideTitle?: boolean | undefined;
   title?: string | undefined;
   breadcrumbLinks?: Array<Link> | undefined;
   children: Array<ReactElement> | ReactElement;

--- a/Common/UI/Components/Page/Page.tsx
+++ b/Common/UI/Components/Page/Page.tsx
@@ -9,6 +9,8 @@ import useTranslateValue from "../../Utils/Translation";
 import React, { FunctionComponent, ReactElement, useEffect } from "react";
 
 export interface ComponentProps {
+  // Detail overviews provide their own visible title; retain the page h1 for navigation.
+  hideTitle?: boolean | undefined;
   title?: string | undefined;
   /*
    * Optional one-line subtitle rendered under the title. Use it to say what the
@@ -95,9 +97,13 @@ const Page: FunctionComponent<ComponentProps> = (
             </div>
           )}
           {props.title && (
-            <div className="mt-2">
+            <div className={props.hideTitle ? "" : "mt-2"}>
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:flex-wrap sm:gap-4">
-                <div className="flex flex-col gap-1 min-w-0">
+                <div
+                  className={
+                    props.hideTitle ? "sr-only" : "flex flex-col gap-1 min-w-0"
+                  }
+                >
                   <h1 className="text-xl font-semibold leading-7 text-gray-900 sm:text-xl sm:tracking-tight sm:truncate">
                     {translatedTitle}
                   </h1>

--- a/E2E/OperationsOverview/Fixture.js
+++ b/E2E/OperationsOverview/Fixture.js
@@ -1,0 +1,356 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
+import i18next from "i18next";
+import { initReactI18next } from "react-i18next";
+import IncidentView from "../../App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index";
+import AlertView from "../../App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index";
+import ScheduledMaintenanceView from "../../App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/Index";
+import IncidentLayout from "../../App/FeatureSet/Dashboard/src/Pages/Incidents/View/Layout";
+import AlertLayout from "../../App/FeatureSet/Dashboard/src/Pages/Alerts/View/Layout";
+import MaintenanceLayout from "../../App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/Layout";
+import RouteMap from "../../App/FeatureSet/Dashboard/src/Utils/RouteMap";
+import PageMap from "../../App/FeatureSet/Dashboard/src/Utils/PageMap";
+import Incident from "Common/Models/DatabaseModels/Incident";
+import Alert from "Common/Models/DatabaseModels/Alert";
+import ScheduledMaintenance from "Common/Models/DatabaseModels/ScheduledMaintenance";
+import Project from "Common/Models/DatabaseModels/Project";
+import User from "Common/Models/DatabaseModels/User";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import Label from "Common/Models/DatabaseModels/Label";
+import Color from "Common/Types/Color";
+import Name from "Common/Types/Name";
+import ObjectID from "Common/Types/ObjectID";
+import Permission from "Common/Types/Permission";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import API from "Common/UI/Utils/API/API";
+import Navigation from "Common/UI/Utils/Navigation";
+import ProjectUtil from "Common/UI/Utils/Project";
+import PermissionUtil from "Common/UI/Utils/Permission";
+import UserUtil from "Common/UI/Utils/User";
+import BlankProfilePic from "Common/UI/Images/users/blank-profile.svg";
+
+// Only session/data boundaries and the optional integrations documented in
+// server.js are replaced. The overview pages, state forms, feed, detail cards,
+// field permissions, editors, shared components and responsive CSS are real.
+const scenario =
+  new URLSearchParams(window.location.search).get("scenario") || "default";
+const eventId = "20000000-0000-4000-8000-000000000001";
+const projectId = "10000000-0000-4000-8000-000000000001";
+const fixedNow = new Date("2026-09-07T10:45:00Z");
+const startedAt = new Date("2026-09-07T10:00:00Z");
+const id = (number) =>
+  `30000000-0000-4000-8000-${String(number).padStart(12, "0")}`;
+const make = (Type, fields) => Object.assign(new Type(), fields);
+const project = make(Project, { _id: projectId, name: "Acme Production" });
+const user = make(User, { _id: id(900), name: new Name("Alex Morgan") });
+const monitor = make(Monitor, { _id: id(901), name: "Checkout API · Europe" });
+const label = make(Label, {
+  _id: id(902),
+  name: "Production",
+  color: new Color("#4f46e5"),
+});
+const types = { Incident, Alert, ScheduledMaintenance };
+const titles = {
+  Incident: "Checkout requests failing in Europe",
+  Alert: "API latency above the response time threshold",
+  ScheduledMaintenance: "Production database maintenance",
+};
+const records = Object.fromEntries(
+  Object.entries(types).map(([name, Type]) => [
+    name,
+    make(Type, {
+      _id: eventId,
+      projectId: new ObjectID(projectId),
+      title:
+        scenario === "long-title"
+          ? `${titles[name]} — affected production customers across all European regions while infrastructure recovery is in progress ${"checkout-service-".repeat(8)}`
+          : titles[name],
+      description:
+        "The response team is investigating elevated errors affecting customer checkout. Updates will be posted here as recovery progresses.",
+      createdAt: new Date("2026-09-07T09:55:00Z"),
+      declaredAt: scenario === "missing-data" ? undefined : startedAt,
+      startsAt:
+        scenario === "missing-data"
+          ? undefined
+          : new Date("2026-09-07T12:00:00Z"),
+      endsAt:
+        scenario === "missing-data"
+          ? undefined
+          : new Date("2026-09-07T14:00:00Z"),
+      incidentNumber: 142,
+      incidentNumberWithPrefix: "INC-142",
+      alertNumber: 86,
+      alertNumberWithPrefix: "ALT-86",
+      scheduledMaintenanceNumber: 24,
+      scheduledMaintenanceNumberWithPrefix: "MNT-24",
+      incidentSeverity:
+        scenario === "missing-data"
+          ? undefined
+          : { _id: id(910), name: "Critical", color: new Color("#dc2626") },
+      alertSeverity:
+        scenario === "missing-data"
+          ? undefined
+          : { _id: id(911), name: "High", color: new Color("#d97706") },
+      isPrivate: name === "Incident",
+      declaredByUser: user,
+      createdByUser: user,
+      labels: scenario === "missing-data" ? [] : [label],
+      monitors: scenario === "missing-data" ? [] : [monitor],
+      monitor:
+        name === "Alert" && scenario !== "missing-data" ? monitor : undefined,
+      hosts: [],
+      kubernetesClusters: [],
+      dockerHosts: [],
+      podmanHosts: [],
+      networkSites: [],
+      services: [],
+      onCallDutyPolicies: [],
+      statusPages: [],
+      sendSubscriberNotificationsOnBeforeTheEvent: [],
+      subscriberNotificationStatusOnIncidentCreated: "Success",
+      subscriberNotificationStatusOnEventScheduled: "Success",
+    }),
+  ]),
+);
+
+const lists = new Map();
+const requests = [];
+window.__operationsOverviewRequests = requests;
+ProjectUtil.getCurrentProject = () => project;
+ProjectUtil.getCurrentProjectId = () => project.id;
+UserUtil.getProfilePictureRoute = () => ({ toString: () => BlankProfilePic });
+PermissionUtil.getGlobalPermissions = () => ({
+  globalPermissions: Object.values(Permission),
+});
+PermissionUtil.getProjectPermissions = () => ({
+  projectId: project.id,
+  permissions: [],
+});
+
+function stateFields(name) {
+  const maintenance = name.startsWith("ScheduledMaintenance");
+  return (
+    maintenance
+      ? ["Scheduled", "Ongoing", "Completed"]
+      : ["Created", "Acknowledged", "Resolved"]
+  ).map((state, index) => ({
+    _id: id(index + 1),
+    name: state,
+    order: index,
+    color: new Color(
+      [maintenance ? "#4f46e5" : "#dc2626", "#d97706", "#059669"][index],
+    ),
+    isCreatedState: index === 0,
+    isAcknowledgedState: index === 1,
+    isResolvedState: index === 2,
+    isScheduledState: index === 0,
+    isOngoingState: index === 1,
+    isEndedState: index === 2,
+  }));
+}
+
+function getData(modelType) {
+  const name = modelType.name;
+  if (lists.has(name)) return lists.get(name);
+  let data = [];
+  if (
+    ["IncidentState", "AlertState", "ScheduledMaintenanceState"].includes(name)
+  ) {
+    data = stateFields(name).map((fields) => make(modelType, fields));
+  } else if (name.endsWith("StateTimeline")) {
+    const eventType = name.replace("StateTimeline", "");
+    const field = eventType[0].toLowerCase() + eventType.slice(1) + "State";
+    const indices =
+      scenario === "missing-data"
+        ? []
+        : scenario === "resolved"
+          ? [0, 1, 2]
+          : [0];
+    data = indices.map((index) =>
+      make(modelType, {
+        _id: id(100 + index),
+        [field + "Id"]: new ObjectID(id(index + 1)),
+        [field]: stateFields(eventType)[index],
+        startsAt: new Date(startedAt.getTime() + index * 15 * 60000),
+        createdAt: new Date(startedAt.getTime() + index * 15 * 60000),
+        createdByUser: user,
+      }),
+    );
+  } else if (
+    ["IncidentFeed", "AlertFeed", "ScheduledMaintenanceFeed"].includes(name)
+  ) {
+    const maintenance = name.startsWith("ScheduledMaintenance");
+    const feedText =
+      scenario === "long-feed"
+        ? Array.from(
+            { length: 12 },
+            (_, index) =>
+              `**Update ${String(index + 1).padStart(2, "0")}**\n\nThe response team posted a progress update.`,
+          )
+        : [
+            maintenance
+              ? "**Maintenance scheduled**\n\nDatabase indexes will be rebuilt during the maintenance window. A brief interruption to checkout is expected."
+              : "**Response started**\n\nThe on-call team is investigating increased errors from the checkout service in Europe.",
+            maintenance
+              ? "**Preparation complete**\n\nBackups are verified and the rollback plan has been reviewed."
+              : "**Update from Alex Morgan**\n\nTraffic has been shifted to the healthy region. Error rates are improving while the team verifies recovery.",
+          ];
+    data =
+      scenario === "missing-data"
+        ? []
+        : feedText.map((text, index) =>
+            make(modelType, {
+              _id: id(200 + index),
+              feedInfoInMarkdown: text,
+              postedAt: new Date(
+                startedAt.getTime() +
+                  index * (scenario === "long-feed" ? 3 : 20) * 60000,
+              ),
+              createdAt: startedAt,
+              user,
+              displayColor: new Color(index ? "#4f46e5" : "#dc2626"),
+            }),
+          );
+  } else if (name === "Label") data = [label];
+  else if (name === "Monitor") data = [monitor];
+  else if (name === "IncidentSeverity")
+    data = [
+      make(
+        modelType,
+        records.Incident.incidentSeverity || {
+          _id: id(910),
+          name: "Critical",
+          color: new Color("#dc2626"),
+        },
+      ),
+    ];
+  else if (name === "AlertSeverity")
+    data = [
+      make(
+        modelType,
+        records.Alert.alertSeverity || {
+          _id: id(911),
+          name: "High",
+          color: new Color("#d97706"),
+        },
+      ),
+    ];
+  lists.set(name, data);
+  return data;
+}
+ModelAPI.getList = async ({ modelType }) => {
+  requests.push({ operation: "list", model: modelType.name });
+  // Let React commit loading so Refresh exercises mounted-state preservation.
+  if (modelType.name.endsWith("Feed")) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  const data = getData(modelType);
+  return { data, count: data.length, skip: 0, limit: 1000 };
+};
+ModelAPI.getItem = async ({ modelType }) => {
+  requests.push({ operation: "get", model: modelType.name });
+  if (scenario === "load-error" && modelType.name === "Incident")
+    throw new Error("Fixture could not load the incident.");
+  return records[modelType.name] || null;
+};
+ModelAPI.getCommonHeaders = () => ({});
+ModelAPI.count = async () => 0;
+ModelAPI.createOrUpdate = async ({ modelType, model, formType }) => {
+  requests.push({
+    operation: "save",
+    model: modelType.name,
+    formType,
+    title: model.title,
+  });
+  if (modelType.name.endsWith("StateTimeline")) {
+    model._id = id(999);
+    model.startsAt = fixedNow;
+    model.createdAt = fixedNow;
+    getData(modelType).push(model);
+  } else if (records[modelType.name]) {
+    // Model constructors include unset columns. Apply the scalar editor fields
+    // exercised here and retain the server-owned identifiers and timestamps.
+    for (const field of ["title", "startsAt", "endsAt"]) {
+      if (model[field] !== undefined) {
+        records[modelType.name][field] = model[field];
+      }
+    }
+  }
+  return { data: model };
+};
+ModelAPI.updateById = async ({ modelType, data }) => {
+  Object.assign(records[modelType.name], data);
+  return { data: records[modelType.name] };
+};
+API.get = async () => ({ data: { data: [], count: 0 }, isSuccess: () => true });
+API.post = async () => ({
+  data: { data: [], count: 0 },
+  isSuccess: () => true,
+});
+
+await i18next.use(initReactI18next).init({
+  lng: "en",
+  fallbackLng: "en",
+  resources: { en: { translation: {} } },
+  interpolation: { escapeValue: false },
+});
+function Fixture() {
+  const location = useLocation();
+  Navigation.setNavigateHook(useNavigate());
+  Navigation.setLocation(location);
+  Navigation.setParams(useParams());
+  return (
+    <>
+      <header className="border-b border-gray-200 bg-white px-4 py-4 sm:px-8">
+        <div className="mx-auto flex max-w-screen-2xl flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-5">
+            <span className="text-lg font-semibold tracking-tight text-indigo-600">
+              OneUptime
+            </span>
+            <span className="border-l border-gray-200 pl-5 text-sm text-gray-500">
+              Acme Production
+            </span>
+          </div>
+          <span className="rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600">
+            Preview · Synthetic data
+          </span>
+        </div>
+      </header>
+      <main className="mx-auto max-w-screen-2xl pb-10">
+        <Routes>
+          <Route
+            path={RouteMap[PageMap.INCIDENT_VIEW].toString()}
+            element={<IncidentLayout />}
+          >
+            <Route index element={<IncidentView />} />
+          </Route>
+          <Route
+            path={RouteMap[PageMap.ALERT_VIEW].toString()}
+            element={<AlertLayout />}
+          >
+            <Route index element={<AlertView />} />
+          </Route>
+          <Route
+            path={RouteMap[PageMap.SCHEDULED_MAINTENANCE_VIEW].toString()}
+            element={<MaintenanceLayout />}
+          >
+            <Route index element={<ScheduledMaintenanceView />} />
+          </Route>
+        </Routes>
+      </main>
+    </>
+  );
+}
+createRoot(document.getElementById("root")).render(
+  <BrowserRouter>
+    <Fixture />
+  </BrowserRouter>,
+);

--- a/E2E/OperationsOverview/README.md
+++ b/E2E/OperationsOverview/README.md
@@ -1,0 +1,37 @@
+# Operational overview browser tests
+
+Run `npm run test-operations-overview-ui` from `E2E`. Install Chromium with
+`npx playwright install chromium` if it is not already available.
+
+This suite renders the actual incident, alert, and scheduled maintenance overview
+pages inside their actual route layouts, including `ModelPage`, breadcrumbs, side
+navigation, state transition forms, detail editors, feeds, and resource displays.
+The fixture uses the repository's browser build configuration and bundled Tailwind.
+It starts automatically without Docker, a database, or network access.
+
+The fixture supplies synthetic model records, a synthetic project session, and
+permissions. Model API reads and writes are replaced with in-memory operations.
+Optional telemetry viewers, AI investigation/remediation, runbooks, monitor
+snapshots, and incident member role assignment are omitted at their import
+boundaries; those integrations are outside this layout suite. Screenshots are
+explicitly labelled as previews with synthetic data. These tests exercise browser
+integration and presentation; they do not claim backend end-to-end coverage.
+
+Coverage includes desktop and phone layout/reading order, real detail editing,
+state transitions and cancellation, keyboard skip links, missing dates, empty
+feeds, expandable activity history, long titles, narrow viewport overflow, completed event duration, and
+visible load errors. Browser exceptions fail the tests.
+
+Desktop and phone screenshots for each event type are written to
+`output/playwright/operations-overview` and attached to Playwright results.
+Failure traces and screenshots are retained in that directory's `test-results`.
+
+For interactive inspection, start `node OperationsOverview/server.js` from `E2E`
+and open one of the following routes on `http://127.0.0.1:4201`:
+
+- `/dashboard/10000000-0000-4000-8000-000000000001/incidents/20000000-0000-4000-8000-000000000001`
+- `/dashboard/10000000-0000-4000-8000-000000000001/alerts/20000000-0000-4000-8000-000000000001`
+- `/dashboard/10000000-0000-4000-8000-000000000001/scheduled-maintenance-events/20000000-0000-4000-8000-000000000001`
+
+Add `?scenario=long-title`, `?scenario=missing-data`, `?scenario=long-feed`, or `?scenario=resolved`
+to inspect edge cases. The incident route also supports `?scenario=load-error`.

--- a/E2E/OperationsOverview/overview.spec.ts
+++ b/E2E/OperationsOverview/overview.spec.ts
@@ -1,0 +1,427 @@
+import { expect, Locator, Page, test, TestInfo } from "@playwright/test";
+import path from "path";
+
+const projectId: string = "10000000-0000-4000-8000-000000000001";
+const eventId: string = "20000000-0000-4000-8000-000000000001";
+const screenshots: string = path.resolve(
+  __dirname,
+  "../../output/playwright/operations-overview",
+);
+interface EventFixture {
+  slug: string;
+  name: string;
+  model: string;
+  title: string;
+  identifier: string;
+  action: string;
+  modal: string;
+  nextState: string;
+  activity: string;
+  titleLabel: string;
+}
+interface BrowserTest {
+  page: Page;
+}
+interface ElementBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+interface FixtureRequest {
+  operation: string;
+  model: string;
+}
+const events: [EventFixture, EventFixture, EventFixture] = [
+  {
+    slug: "incidents",
+    name: "incident",
+    model: "Incident",
+    title: "Checkout requests failing in Europe",
+    identifier: "INC-142",
+    action: "Acknowledge",
+    modal: "Acknowledge Incident",
+    nextState: "Acknowledged",
+    activity: "Response activity",
+    titleLabel: "Incident Title",
+  },
+  {
+    slug: "alerts",
+    name: "alert",
+    model: "Alert",
+    title: "API latency above the response time threshold",
+    identifier: "ALT-86",
+    action: "Acknowledge",
+    modal: "Acknowledge Alert",
+    nextState: "Acknowledged",
+    activity: "Response activity",
+    titleLabel: "Alert Title",
+  },
+  {
+    slug: "scheduled-maintenance-events",
+    name: "maintenance",
+    model: "ScheduledMaintenance",
+    title: "Production database maintenance",
+    identifier: "MNT-24",
+    action: "Mark as Ongoing",
+    modal: "Mark Scheduled Maintenance as Ongoing",
+    nextState: "Ongoing",
+    activity: "Maintenance activity",
+    titleLabel: "Scheduled Maintenance Title",
+  },
+];
+
+async function openOverview(
+  page: Page,
+  event: EventFixture,
+  scenario: string = "default",
+): Promise<void> {
+  await page.clock.setFixedTime(new Date("2026-09-07T10:45:00Z"));
+  await page.goto(
+    `/dashboard/${projectId}/${event.slug}/${eventId}?scenario=${scenario}`,
+  );
+  await expect(
+    page.getByRole("region", { name: "Event summary", exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Edit details", exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: event.activity, exact: true }),
+  ).toBeVisible();
+}
+
+async function expectNoOverflow(page: Page): Promise<void> {
+  const overflow: number = await page.evaluate((): number => {
+    return document.documentElement.scrollWidth - window.innerWidth;
+  });
+  expect(
+    overflow,
+    "The actual overview and side navigation must fit the viewport",
+  ).toBeLessThanOrEqual(1);
+}
+
+test.beforeEach(async ({ page }: BrowserTest): Promise<void> => {
+  const errors: string[] = [];
+  page.on("pageerror", (error: Error): void => {
+    errors.push(error.message);
+  });
+  (page as Page & { overviewErrors: string[] }).overviewErrors = errors;
+});
+
+test.afterEach(async ({ page }: BrowserTest): Promise<void> => {
+  expect(
+    (page as Page & { overviewErrors: string[] }).overviewErrors,
+    "No uncaught browser errors",
+  ).toEqual([]);
+});
+
+for (const event of events) {
+  for (const viewport of [
+    { name: "desktop", width: 1440, height: 1100 },
+    { name: "mobile", width: 390, height: 844 },
+  ]) {
+    test(`${event.name}: ${viewport.name} overview hierarchy and screenshot`, async ({
+      page,
+    }: BrowserTest, testInfo: TestInfo): Promise<void> => {
+      await page.setViewportSize(viewport);
+      await openOverview(page, event);
+      await expect(
+        page.getByText(event.identifier, { exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("list", { name: "State progression" }),
+      ).toBeVisible();
+      await expect(page.locator('[aria-current="step"]')).toHaveCount(1);
+      await expect(
+        page.getByRole("button", { name: event.action, exact: true }),
+      ).toBeEnabled();
+      for (const label of await page
+        .getByRole("group", { name: "Event actions", exact: true })
+        .locator("button > span")
+        .all()) {
+        const textSize: {
+          clientWidth: number;
+          scrollWidth: number;
+          clientHeight: number;
+          scrollHeight: number;
+        } = await label.evaluate((element: HTMLElement | SVGElement) => {
+          return {
+            clientWidth: element.clientWidth,
+            scrollWidth: element.scrollWidth,
+            clientHeight: element.clientHeight,
+            scrollHeight: element.scrollHeight,
+          };
+        });
+        expect(
+          textSize.scrollWidth,
+          "Action labels must remain fully readable",
+        ).toBeLessThanOrEqual(textSize.clientWidth + 1);
+        expect(
+          textSize.scrollHeight,
+          "Wrapped action labels must fit their buttons",
+        ).toBeLessThanOrEqual(textSize.clientHeight + 1);
+      }
+      await expect(page.getByRole("heading", { level: 1 })).toHaveCount(1);
+      const title: Locator = page.getByRole("heading", {
+        name: event.title,
+        exact: true,
+      });
+      await expect(title).toBeVisible();
+      await expect(
+        page.getByRole("complementary", { name: "Event context" }),
+      ).toBeVisible();
+      const summary: ElementBox | null = await page
+        .getByRole("region", { name: "Event summary" })
+        .boundingBox();
+      const activity: ElementBox | null = await page
+        .getByRole("region", { name: event.activity, exact: true })
+        .boundingBox();
+      const details: ElementBox | null = await page
+        .getByRole("complementary", { name: "Event context" })
+        .boundingBox();
+      expect(summary).not.toBeNull();
+      expect(activity).not.toBeNull();
+      expect(details).not.toBeNull();
+      expect(summary!.y + summary!.height).toBeLessThan(activity!.y);
+      if (viewport.name === "desktop") {
+        expect(details!.x).toBeGreaterThan(activity!.x + activity!.width);
+        expect(summary!.width).toBeGreaterThan(activity!.width);
+      } else {
+        expect(details!.y).toBeGreaterThan(activity!.y + activity!.height);
+      }
+      await expectNoOverflow(page);
+      const file: string = path.join(
+        screenshots,
+        `${event.name}-${viewport.name}.png`,
+      );
+      await page.screenshot({
+        path: file,
+        fullPage: true,
+        animations: "disabled",
+      });
+      await testInfo.attach(`${event.name}-${viewport.name}`, {
+        path: file,
+        contentType: "image/png",
+      });
+    });
+  }
+
+  test(`${event.name}: state action saves through the real modal and refreshes summary`, async ({
+    page,
+  }: BrowserTest): Promise<void> => {
+    await openOverview(page, event);
+    await page.getByRole("button", { name: event.action, exact: true }).click();
+    const dialog: Locator = page.getByRole("dialog", {
+      name: event.modal,
+      exact: true,
+    });
+    await expect(dialog).toBeVisible();
+    await dialog
+      .getByRole("button", { name: event.action, exact: true })
+      .click();
+    await expect(dialog).toBeHidden();
+    await expect(page.locator('[aria-current="step"]')).toContainText(
+      event.nextState,
+    );
+    await expect(
+      page.getByRole("button", { name: event.action, exact: true }),
+    ).toHaveCount(0);
+    const saves: Array<FixtureRequest> = await page.evaluate(
+      (): Array<FixtureRequest> => {
+        return (
+          window as unknown as {
+            __operationsOverviewRequests: Array<FixtureRequest>;
+          }
+        ).__operationsOverviewRequests.filter(
+          (request: FixtureRequest): boolean => {
+            return request.operation === "save";
+          },
+        );
+      },
+    );
+    expect(saves).toEqual([
+      expect.objectContaining({ model: `${event.model}StateTimeline` }),
+    ]);
+  });
+
+  test(`${event.name}: edit details retains the form and updates the visible title`, async ({
+    page,
+  }: BrowserTest): Promise<void> => {
+    await openOverview(page, event);
+    await page
+      .getByRole("button", { name: "Edit details", exact: true })
+      .click();
+    const dialog: Locator = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    const editedTitle: string = `${event.title} — recovery verified`;
+    await dialog
+      .getByLabel(event.titleLabel, { exact: true })
+      .fill(editedTitle);
+    for (let step: number = 0; step < 5; step++) {
+      const next: Locator = dialog.getByRole("button", {
+        name: "Next",
+        exact: true,
+      });
+      if (!(await next.isVisible())) {
+        break;
+      }
+      await next.click();
+    }
+    await dialog
+      .getByRole("button", { name: "Save Changes", exact: true })
+      .click();
+    await expect(dialog).toBeHidden();
+    await expect(
+      page.getByRole("heading", { name: editedTitle, exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(event.identifier, { exact: true }),
+    ).toBeVisible();
+  });
+
+  for (const scenario of ["long-title", "missing-data"]) {
+    test(`${event.name}: ${scenario} stays usable on a narrow phone`, async ({
+      page,
+    }: BrowserTest): Promise<void> => {
+      await page.setViewportSize({ width: 320, height: 812 });
+      await openOverview(page, event, scenario);
+      await expectNoOverflow(page);
+      await expect(
+        page.getByRole("button", {
+          name:
+            scenario === "missing-data" && event.name === "maintenance"
+              ? "More actions"
+              : event.action,
+          exact: true,
+        }),
+      ).toBeEnabled();
+      if (scenario === "missing-data") {
+        await expect(
+          page.getByRole("region", { name: "Event summary" }),
+        ).not.toContainText("Invalid");
+        await expect(page.getByText(/no items in this feed/i)).toBeVisible();
+      } else {
+        const title: Locator = page.getByRole("heading", {
+          name: /checkout-service-checkout-service/,
+        });
+        await expect(title).toHaveCount(2); // Semantic page h1 plus the visible event heading.
+        const visibleTitle: Locator = title.last();
+        const metrics: { client: number; scroll: number } =
+          await visibleTitle.evaluate(
+            (
+              element: HTMLElement | SVGElement,
+            ): { client: number; scroll: number } => {
+              return {
+                client: element.clientHeight,
+                scroll: element.scrollHeight,
+              };
+            },
+          );
+        expect(metrics.scroll).toBeLessThanOrEqual(metrics.client + 1);
+      }
+    });
+  }
+
+  test(`${event.name}: tablet long titles fit alongside the real navigation`, async ({
+    page,
+  }: BrowserTest): Promise<void> => {
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await openOverview(page, event, "long-title");
+    await expectNoOverflow(page);
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await expectNoOverflow(page);
+    await expect(
+      page.getByRole("button", { name: event.action, exact: true }),
+    ).toBeEnabled();
+  });
+}
+
+test("keyboard shortcuts focus activity and details and state cancellation preserves the event", async ({
+  page,
+}: BrowserTest): Promise<void> => {
+  await openOverview(page, events[0]);
+  const skip: Locator = page.getByRole("link", {
+    name: "Skip to activity",
+    exact: true,
+  });
+  await skip.focus();
+  await page.keyboard.press("Enter");
+  await expect(
+    page.getByRole("region", { name: "Response activity", exact: true }),
+  ).toBeFocused();
+  await page
+    .getByRole("link", { name: "Skip to details", exact: true })
+    .focus();
+  await page.keyboard.press("Enter");
+  await expect(
+    page.getByRole("complementary", { name: "Event context" }),
+  ).toBeFocused();
+  await page.getByRole("button", { name: "Acknowledge", exact: true }).click();
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "Cancel", exact: true })
+    .click();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page.locator('[aria-current="step"]')).toContainText("Created");
+});
+
+test("resolved incidents have completed progression and a fixed final duration", async ({
+  page,
+}: BrowserTest): Promise<void> => {
+  await openOverview(page, events[0], "resolved");
+  await expect(page.locator('[aria-current="step"]')).toContainText("Resolved");
+  await expect(
+    page.getByRole("button", { name: "Resolve", exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("region", { name: "Event summary" }),
+  ).toContainText("30 minutes");
+});
+
+test("load errors remain visible through the actual model page", async ({
+  page,
+}: BrowserTest): Promise<void> => {
+  await page.goto(
+    `/dashboard/${projectId}/incidents/${eventId}?scenario=load-error`,
+  );
+  await expect(
+    page.getByText("Fixture could not load the incident.", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Acknowledge", exact: true }),
+  ).toHaveCount(0);
+});
+
+test("long activity feeds reveal earlier history and keep recent updates when collapsed", async ({
+  page,
+}: BrowserTest): Promise<void> => {
+  await openOverview(page, events[0], "long-feed");
+  const activity: Locator = page.getByRole("region", {
+    name: "Response activity",
+    exact: true,
+  });
+  const disclosure: Locator = activity.getByRole("button", {
+    name: "Show 6 earlier updates",
+    exact: true,
+  });
+  await expect(disclosure).toHaveAttribute("aria-expanded", "false");
+  await expect(activity.getByText("Update 01", { exact: true })).toHaveCount(0);
+  await expect(activity.getByText("Update 07", { exact: true })).toBeVisible();
+  await expect(activity.getByText("Update 12", { exact: true })).toBeVisible();
+  await disclosure.click();
+  const collapse: Locator = activity.getByRole("button", {
+    name: "Show fewer updates",
+    exact: true,
+  });
+  await expect(collapse).toHaveAttribute("aria-expanded", "true");
+  await expect(activity.getByText("Update 01", { exact: true })).toBeVisible();
+  await expect(activity.getByText("Update 12", { exact: true })).toBeVisible();
+  await activity.getByRole("button", { name: "Refresh", exact: true }).click();
+  await expect(activity.getByText("Update 01", { exact: true })).toBeVisible();
+  await expect(collapse).toHaveAttribute("aria-expanded", "true");
+  await collapse.click();
+  await expect(activity.getByText("Update 01", { exact: true })).toHaveCount(0);
+  await expect(activity.getByText("Update 12", { exact: true })).toBeVisible();
+  await expect(disclosure).toHaveAttribute("aria-expanded", "false");
+});

--- a/E2E/OperationsOverview/server.js
+++ b/E2E/OperationsOverview/server.js
@@ -1,0 +1,92 @@
+/* Offline browser fixture for the actual operational overview pages. */
+const fs = require("fs");
+const http = require("http");
+const path = require("path");
+const { createConfig } = require("../../Common/UI/esbuild-config.js");
+const esbuild = require("../../Common/node_modules/esbuild");
+const repository = path.resolve(__dirname, "../..");
+const output = path.join(
+  repository,
+  "output/playwright/operations-overview/fixture",
+);
+const port = Number(process.env.OPERATIONS_OVERVIEW_FIXTURE_PORT || 4201);
+const config = createConfig({
+  serviceName: "operations-overview-fixture",
+  publicPath: "/dist/",
+  entryPoint: path.join(__dirname, "Fixture.js"),
+  outdir: output,
+  additionalAlias: {
+    Common: path.join(repository, "Common"),
+    react: path.join(repository, "Common/node_modules/react"),
+    "react-dom": path.join(repository, "Common/node_modules/react-dom"),
+  },
+});
+config.target = "es2022";
+config.loader[".js"] = "jsx";
+config.sourcemap = false;
+config.minify = false;
+config.logLevel = "warning";
+// These optional integrations are outside this layout test. Their real page
+// slots remain, but the fixture has no telemetry, AI investigations or runbooks.
+config.plugins.unshift({
+  name: "optional-overview-integrations",
+  setup(build) {
+    build.onResolve(
+      {
+        filter:
+          /\/(LogsViewer|TracesViewer|MetricView|ExceptionsViewer|InvestigationPanel|EntityRunbooks|RemediationSuggestionCard|MonitorSummarySnapshotCard|IncidentMemberRoleAssignment)$/,
+      },
+      () => ({ path: "empty", namespace: "overview-optional" }),
+    );
+    build.onLoad({ filter: /.*/, namespace: "overview-optional" }, () => ({
+      contents:
+        "export default function OptionalIntegration() { return null; }",
+      loader: "js",
+    }));
+  },
+});
+const tailwind = path.join(
+  repository,
+  "Common/Server/Static/Vendor/tailwind/tailwind-3.4.5.js",
+);
+const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Operations overview preview</title><script>window.process={env:{HOST:"localhost",HTTP_PROTOCOL:"http",BILLING_ENABLED:"false",VERSION:"1.0.0",NODE_ENV:"development"}};window.global=window;</script><script src="/tailwind.js"></script><style>body{margin:0;background:#f8fafc;font-family:Inter,ui-sans-serif,system-ui,sans-serif}*{box-sizing:border-box}</style></head><body><div id="root"></div><script type="module" src="/dist/Fixture.js"></script></body></html>`;
+async function main() {
+  fs.mkdirSync(output, { recursive: true });
+  await esbuild.build(config);
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url, `http://127.0.0.1:${port}`);
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader(
+      "Content-Security-Policy",
+      "connect-src 'self'; font-src 'self' data:;",
+    );
+    if (url.pathname === "/tailwind.js") {
+      response.setHeader("Content-Type", "application/javascript");
+      fs.createReadStream(tailwind).pipe(response);
+      return;
+    }
+    if (url.pathname.startsWith("/dist/")) {
+      const file = path.resolve(output, url.pathname.slice(6));
+      if (!file.startsWith(output + path.sep) || !fs.existsSync(file)) {
+        response.writeHead(404).end();
+        return;
+      }
+      response.setHeader("Content-Type", "application/javascript");
+      fs.createReadStream(file).pipe(response);
+      return;
+    }
+    response.setHeader("Content-Type", "text/html");
+    response.end(html);
+  });
+  server.listen(port, "127.0.0.1", () =>
+    console.log(
+      `Operations overview fixture ready at http://127.0.0.1:${port}`,
+    ),
+  );
+  process.on("SIGTERM", () => server.close());
+  process.on("SIGINT", () => server.close());
+}
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/E2E/package.json
+++ b/E2E/package.json
@@ -13,7 +13,8 @@
     "dep-check": "npm install -g depcheck && depcheck ./ --skip-missing=true",
     "clear-modules": "rm -rf node_modules && rm package-lock.json && npm install",
     "compile": "tsc",
-    "debug-tests": "playwright test --debug"
+    "debug-tests": "playwright test --debug",
+    "test-operations-overview-ui": "playwright test --config playwright.operations-overview.config.ts"
   },
   "keywords": [],
   "author": "OneUptime <hello@oneuptime.com> (https://oneuptime.com/)",

--- a/E2E/playwright.operations-overview.config.ts
+++ b/E2E/playwright.operations-overview.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "@playwright/test";
+import path from "path";
+
+export default defineConfig({
+  testDir: "./OperationsOverview",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: false,
+  workers: 1,
+  timeout: 60000,
+  expect: { timeout: 15000 },
+  retries: 0,
+  reporter: [["list"]],
+  outputDir: "../output/playwright/operations-overview/test-results",
+  use: {
+    baseURL: "http://127.0.0.1:4201",
+    browserName: "chromium",
+    viewport: { width: 1440, height: 1100 },
+    timezoneId: "UTC",
+    locale: "en-GB",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  webServer: {
+    command: "node OperationsOverview/server.js",
+    cwd: path.resolve(__dirname),
+    url: "http://127.0.0.1:4201",
+    timeout: 300000,
+    reuseExistingServer: false,
+  },
+});


### PR DESCRIPTION
Incident, alert, and scheduled maintenance overviews repeat headings and metadata while squeezing key dates and response activity into competing cards. This change gives all three a consistent responsive layout: status and actions first, timings next, a wide activity column, and compact event context.

## Changes

- Improve title wrapping, action spacing, state progression, and timing tiles. Phone actions wrap without clipping their labels.
- Show each maintenance date independently, including a clear missing-date state.
- Start feeds with the latest six updates and allow earlier history to expand. Preserve that choice across refreshes, reset it between events, and release open item dialogs during loading or errors.
- Keep resource categories readable in the narrow context column. Move identifiers below operational details and shorten edit labels.
- Preserve existing edit fields, permissions, state transitions, breadcrumbs, and accessible page headings. Add keyboard shortcuts to activity and details.

Created in an isolated worktree from `master` at `e23d909319b`.

## Validation

- **160 focused Common tests passed across ten suites**, covering page composition, metadata/edit contracts, permissions, state actions, accessibility, responsive component structure, feed history, refresh races, dialog cleanup, and safe-mode rendering. All passed under normal type-checking ts-jest (`--runInBand`, no isolated-module override), with no TypeScript diagnostics. This includes 154 overview/component regressions and six existing SSO-origin tests following a local test-component naming cleanup required by lint.
- **25 browser integration scenarios passed** across focused runs: desktop, phone, and tablet layouts; long titles; readable action labels; real detail editors; state changes/cancellation; missing dates; completed duration; keyboard navigation; load errors; and feed expansion/refresh. The error and refresh scenarios were rerun successfully after the final fix. One earlier Chromium stall passed on an isolated rerun.
- **Common, Dashboard, and E2E `npm run compile` passed.**
- **Root `npm run fix` passed** after checking the full repository.

The configured Docker development endpoint was unavailable. Browser tests and screenshots render the actual overview pages and route layouts with synthetic records and in-memory model APIs. Optional integrations are stubbed, as documented in `E2E/OperationsOverview/README.md`; this suite does not cover backend integration. Run it with `cd E2E && npm run test-operations-overview-ui`.

## Screenshots

All previews explicitly use synthetic data. The incident before/after comparison uses the same records and viewport. Images are pinned to a separate screenshot commit so binary artifacts stay out of the application diff.

### Incident: before

![Incident overview before](https://raw.githubusercontent.com/OneUptime/oneuptime/572838df156c6f3e56b37b0db090874cb11ea830/incident-before.png)

### Incident: after

![Incident overview after](https://raw.githubusercontent.com/OneUptime/oneuptime/572838df156c6f3e56b37b0db090874cb11ea830/incident-desktop.png)

### Alert

![Alert overview after](https://raw.githubusercontent.com/OneUptime/oneuptime/572838df156c6f3e56b37b0db090874cb11ea830/alert-desktop.png)

### Scheduled maintenance

![Scheduled maintenance overview after](https://raw.githubusercontent.com/OneUptime/oneuptime/572838df156c6f3e56b37b0db090874cb11ea830/maintenance-desktop.png)

<details>
<summary>Phone screenshots for all three overviews</summary>

| Incident | Alert | Scheduled maintenance |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/OneUptime/oneuptime/572838df156c6f3e56b37b0db090874cb11ea830/incident-mobile.png" alt="Incident overview on a phone" width="260"> | <img src="https://raw.githubusercontent.com/OneUptime/oneuptime/572838df156c6f3e56b37b0db090874cb11ea830/alert-mobile.png" alt="Alert overview on a phone" width="260"> | <img src="https://raw.githubusercontent.com/OneUptime/oneuptime/572838df156c6f3e56b37b0db090874cb11ea830/maintenance-mobile.png" alt="Scheduled maintenance overview on a phone" width="260"> |

</details>
