### PR TITLE
fix(ci): repair the eight failures holding master red

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceHoneycomb.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceHoneycomb.tsx
@@ -84,8 +84,17 @@ interface HexProps {
 
 const Hex: FunctionComponent<HexProps> = (props: HexProps): ReactElement => {
   const { tile, width, height, onHoverStart, onHoverEnd } = props;
-  const ref: React.RefObject<HTMLDivElement | null> =
-    useRef<HTMLDivElement | null>(null);
+  /*
+   * A DOM ref is RefObject<HTMLDivElement>, not RefObject<HTMLDivElement |
+   * null>. RefObject<T> already declares `current` as `T | null`, so spelling
+   * the null out again in T gives a type that is structurally identical but
+   * NOT assignable: T is covariant in RefObject, and TypeScript compares two
+   * references to the same generic type by variance rather than structurally,
+   * so it checks `HTMLDivElement | null` against `HTMLDivElement` and rejects
+   * it on the `ref` prop below. Keep the element type here; RefObject adds the
+   * null on its own.
+   */
+  const ref: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
 
   const textColor: string =
     tile.textColor || getReadableTextColor(tile.color || "#9ca3af");
@@ -175,8 +184,7 @@ const HoneycombTooltip: FunctionComponent<{ state: TooltipState }> = ({
     top: number;
     placement: "above" | "below";
   }>({ left: 0, top: 0, placement: "above" });
-  const ref: React.RefObject<HTMLDivElement | null> =
-    useRef<HTMLDivElement | null>(null);
+  const ref: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     const tooltipHeight: number = ref.current?.offsetHeight || 100;
@@ -256,8 +264,8 @@ const HoneycombTooltip: FunctionComponent<{ state: TooltipState }> = ({
 const DashboardResourceHoneycomb: FunctionComponent<
   DashboardResourceHoneycombProps
 > = (props: DashboardResourceHoneycombProps): ReactElement => {
-  const containerRef: React.RefObject<HTMLDivElement | null> =
-    useRef<HTMLDivElement | null>(null);
+  const containerRef: React.RefObject<HTMLDivElement> =
+    useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState<number>(0);
   const [tooltipState, setTooltipState] = useState<TooltipState | null>(null);
 

--- a/App/FeatureSet/Dashboard/src/Components/Traces/FlameGraph.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Traces/FlameGraph.tsx
@@ -37,7 +37,13 @@ const FlameGraph: FunctionComponent<FlameGraphProps> = (
 
   const [hoveredSpanId, setHoveredSpanId] = React.useState<string | null>(null);
   const [focusedSpanId, setFocusedSpanId] = React.useState<string | null>(null);
-  const containerRef: React.RefObject<HTMLDivElement | null> =
+  /*
+   * The element type goes in T on its own: RefObject<T> already declares
+   * `current` as `T | null`, and RefObject<HTMLDivElement | null> is a
+   * structurally identical but non-assignable type, rejected on the `ref`
+   * prop below because RefObject is covariant in T.
+   */
+  const containerRef: React.RefObject<HTMLDivElement> =
     React.useRef<HTMLDivElement>(null);
 
   // Build span data for critical path utility

--- a/App/Tests/Dashboard/MonitorCreateLabels.test.ts
+++ b/App/Tests/Dashboard/MonitorCreateLabels.test.ts
@@ -6,8 +6,7 @@ import path from "path";
  * The monitor-create form is declared inline in a page component, while the
  * App test suite runs in a plain Node environment with no renderer. These
  * source invariants cover the load-bearing form wiring in the same style as
- * MonitorProbeSelectionPages.test.ts. Whitespace is squashed first so prettier
- * re-wrapping cannot turn a real regression check into a formatting failure.
+ * MonitorProbeSelectionPages.test.ts.
  *
  * Labels must be a real Monitor relation rather than misc form data, and the
  * dedicated step must remain last for every monitor type. The latter matters
@@ -30,9 +29,30 @@ function squash(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }
 
-const source: string = squash(
-  fs.readFileSync(MONITOR_CREATE_SOURCE_PATH, "utf8"),
-);
+/*
+ * Prose is removed before anything below is matched against the page, the way
+ * the siblings that read this same file already do it (stripComments in
+ * MonitorCreateNetworkDeviceDeepLink.test.ts, readCode in
+ * MonitorTemplateCustomFieldDefaults.test.ts). This page explains itself at
+ * length, and once whitespace is squashed a comment is indistinguishable from
+ * the code around it: with comments left in, deleting `labels: true` from the
+ * template read and writing the words "labels: true" in a comment above the
+ * call kept every assertion in this file green, so the file went on passing
+ * while the behaviour it exists to guard was gone. The `[^:]` guard keeps a
+ * `https://` inside a string literal from being read as the start of a line
+ * comment. Whitespace is squashed afterwards so prettier re-wrapping the page
+ * cannot turn a real regression check into a formatting failure.
+ */
+function readMonitorCreateSource(): string {
+  return squash(
+    fs
+      .readFileSync(MONITOR_CREATE_SOURCE_PATH, "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, " ")
+      .replace(/(^|[^:])\/\/[^\n]*/g, "$1"),
+  );
+}
+
+const source: string = readMonitorCreateSource();
 
 function sourceBetween(startMarker: string, endMarker: string): string {
   const start: number = source.indexOf(startMarker);
@@ -42,6 +62,108 @@ function sourceBetween(startMarker: string, endMarker: string): string {
   expect(end).toBeGreaterThan(start);
 
   return source.slice(start + startMarker.length, end);
+}
+
+/*
+ * The balanced `{ ... }` text that starts at `openIndex`, so an assertion can
+ * be scoped to ONE object rather than to a whole file that contains many
+ * lookalikes. Brace matched rather than regex matched because these literals
+ * nest: a `select` can carry a nested select for a related model.
+ */
+function balancedBlockAt(text: string, openIndex: number): string | null {
+  let depth: number = 0;
+
+  for (let index: number = openIndex; index < text.length; index++) {
+    const character: string = text.charAt(index);
+
+    if (character === "{") {
+      depth++;
+    } else if (character === "}") {
+      depth--;
+
+      if (depth === 0) {
+        return text.slice(openIndex, index + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+/*
+ * The argument object of every ModelAPI.getItem call in `code`, in the shape
+ * MonitorTemplateCustomFieldDefaults.test.ts reads the same page with, so that
+ * a read is picked out by what it asks for rather than by being the first one
+ * in the function. Fetching something else ahead of the template — the project
+ * that owns it, say — is a benign refactor, and "the object after the first
+ * ModelAPI.getItem" would report that refactor as a missing template read.
+ */
+function getItemArguments(code: string): Array<string> {
+  const marker: RegExp =
+    /(?<![A-Za-z0-9_$])ModelAPI\.getItem(?:<[^>]*>)?\(\s*\{/g;
+  const calls: Array<string> = [];
+
+  let match: RegExpExecArray | null = marker.exec(code);
+
+  while (match !== null) {
+    const openIndex: number = code.indexOf("{", match.index);
+    const call: string | null = balancedBlockAt(code, openIndex);
+
+    if (call === null) {
+      break;
+    }
+
+    calls.push(call);
+    marker.lastIndex = openIndex + call.length;
+    match = marker.exec(code);
+  }
+
+  return calls;
+}
+
+/*
+ * Matched on the whole model name, so a future MonitorTemplateSomething read
+ * cannot answer for the template read this test is about.
+ */
+const MONITOR_TEMPLATE_READ: RegExp =
+  /(?<![A-Za-z0-9_$])modelType:\s*MonitorTemplate(?![A-Za-z0-9_$])/;
+
+function monitorTemplateReads(code: string): Array<string> {
+  return getItemArguments(code).filter((call: string): boolean => {
+    return MONITOR_TEMPLATE_READ.test(call);
+  });
+}
+
+/*
+ * The `select` literal inside one read's arguments, keyed on the whole word so
+ * a longer key that happens to end in "select" cannot be taken for it.
+ */
+function selectOf(call: string): string | null {
+  const match: RegExpMatchArray | null = call.match(
+    /(?<![A-Za-z0-9_$])select\s*:\s*\{/,
+  );
+
+  if (match === null || match.index === undefined) {
+    return null;
+  }
+
+  return balancedBlockAt(call, call.indexOf("{", match.index));
+}
+
+/*
+ * Whether `select` asks the API for `column`. Both spellings of a selected
+ * relation count: `column: true`, and the nested `column: { ... }` form that
+ * RelationSelectColumnsWiring.test.ts describes as the ordinary way a relation
+ * is selected. Which of the two this page uses is the page's business, so
+ * rewriting `labels: true` as `labels: { _id: true }` is a refactor that must
+ * stay green — dropping the key, or turning it off with `false`, is the
+ * regression. The leading boundary is what stops a neighbouring
+ * `notLabels: true` from standing in for the key that was removed.
+ */
+function selectsColumn(select: string, column: string): boolean {
+  return new RegExp(`(?<![A-Za-z0-9_$])${column}\\s*:\\s*(?:true|\\{)`).test(
+    select,
+  );
 }
 
 describe("Monitor create labels", () => {
@@ -120,12 +242,33 @@ describe("Monitor create labels", () => {
       "return (",
     );
 
-    expect(templateLoader).toContain(
-      squash(`
-        monitoringInterval: true,
-        labels: true,
-      `),
-    );
+    /*
+     * Scoped to the arguments of the template read itself — the page issues
+     * several other reads, each with a select of its own — and then asserted
+     * one column at a time. What is load bearing is that this read ASKS the
+     * API for these two columns; where they sit in the literal is not.
+     * Pinning them as adjacent lines instead made every unrelated key added
+     * to the read a failure, which is precisely what happened when
+     * `customFields` joined it for the monitor template custom field defaults
+     * (issue #3548).
+     */
+    const templateReads: Array<string> = monitorTemplateReads(templateLoader);
+
+    expect(templateReads).toHaveLength(1);
+
+    const templateSelect: string | null = selectOf(templateReads[0]!);
+
+    expect(templateSelect).not.toBeNull();
+
+    const readColumns: Array<string> = ["monitoringInterval", "labels"];
+
+    for (const column of readColumns) {
+      expect({
+        column: column,
+        isSelected: selectsColumn(templateSelect!, column),
+      }).toEqual({ column: column, isSelected: true });
+    }
+
     expect(templateLoader).toContain(
       squash(`
         labels: template.labels?.map((label: Label) => {

--- a/App/Tests/Dashboard/MonitorTemplateSyncResultUtil.test.ts
+++ b/App/Tests/Dashboard/MonitorTemplateSyncResultUtil.test.ts
@@ -19,6 +19,288 @@ const TEMPLATES_VIEW_SOURCE: string = path.join(
   "MonitorTemplatesView.tsx",
 );
 
+const BULK_SYNC_ROUTE: string = "/sync-to-linked-monitors";
+
+/*
+ * Hoisted rather than written inline at their use sites: eslint's `wrap-regex`
+ * wants a literal used as the object of a member expression parenthesised,
+ * while `prettier/prettier` strips those parentheses straight back out, so the
+ * two rules cannot both be satisfied in place. A named constant sidesteps the
+ * fight and reads better anyway. `no-div-regex` is why the second one opens
+ * with a character class instead of a bare `=`.
+ */
+const IDENTIFIER_ONLY: RegExp = /^[A-Za-z_$][\w$]*$/;
+const STRING_INITIALISER: RegExp = /[=]\s*"([^"]*)"/;
+
+/*
+ * Prose is stripped before anything below counts call sites. This view explains
+ * itself at length — each sync card carries a paragraph saying what it writes —
+ * and a comment that mentions the route or the helper by name would otherwise
+ * be counted as a call to it, failing the wiring tests over an explanation.
+ */
+function readTemplatesViewCode(): string {
+  return fs
+    .readFileSync(TEMPLATES_VIEW_SOURCE, "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/.*$/gm, " ")
+    .replace(/\s+/g, " ");
+}
+
+const TEMPLATES_VIEW_CODE: string = readTemplatesViewCode();
+
+/*
+ * The index of the brace that closes the one at `openIndex`. Nested objects and
+ * the `${...}` of a template literal both balance, so a depth walk is enough;
+ * running off the end means the scanner has lost the shape of the file, which
+ * it says out loud rather than quietly returning a truncated slice that would
+ * make every check below read less than it thinks it is reading.
+ */
+function readClosingBrace(code: string, openIndex: number): number {
+  let depth: number = 0;
+
+  for (let index: number = openIndex; index < code.length; index++) {
+    if (code[index] === "{") {
+      depth++;
+    } else if (code[index] === "}") {
+      depth--;
+
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  throw new Error(
+    `Unbalanced braces from index ${openIndex} in MonitorTemplatesView.`,
+  );
+}
+
+/*
+ * The `{ ... }` argument of every call the marker matches, as source text.
+ */
+function readCallArguments(code: string, marker: RegExp): Array<string> {
+  const args: Array<string> = [];
+
+  let match: RegExpExecArray | null = marker.exec(code);
+
+  while (match !== null) {
+    const openIndex: number = code.indexOf("{", match.index);
+
+    args.push(code.slice(openIndex, readClosingBrace(code, openIndex) + 1));
+    match = marker.exec(code);
+  }
+
+  return args;
+}
+
+/*
+ * Raw `API.post` calls, with or without an explicit generic argument. The
+ * lookbehind keeps `ModelAPI.post` out — that one is model CRUD and never
+ * carries these routes.
+ */
+function readApiPostArguments(code: string): Array<string> {
+  return readCallArguments(
+    code,
+    /(?<![A-Za-z])API\.post\s*(?:<[^();{}]*>)?\s*\(\s*\{/g,
+  );
+}
+
+/*
+ * One expression, from `start` up to the character that ends it at the top
+ * level — `stop` itself, or a closing bracket belonging to something that
+ * encloses it. Read by walking rather than by regex so a nested object, a call
+ * argument or a template literal inside the value cannot truncate it.
+ */
+function readExpression(text: string, start: number, stop: string): string {
+  let depth: number = 0;
+
+  for (let index: number = start; index < text.length; index++) {
+    const character: string = text[index]!;
+
+    if (character === "(" || character === "[" || character === "{") {
+      depth++;
+    } else if (character === ")" || character === "]" || character === "}") {
+      if (depth === 0) {
+        return text.slice(start, index).trim();
+      }
+
+      depth--;
+    } else if (character === stop && depth === 0) {
+      return text.slice(start, index).trim();
+    }
+  }
+
+  return text.slice(start).trim();
+}
+
+/*
+ * The source text of one property of an object literal, or null when the
+ * object does not set it. Only the object's own top level is considered, so a
+ * `subject:` belonging to something nested inside `data:` is not mistaken for
+ * the call's own.
+ */
+function readProperty(objectText: string, name: string): string | null {
+  let depth: number = 0;
+
+  for (let index: number = 0; index < objectText.length; index++) {
+    const character: string = objectText[index]!;
+
+    if (character === "(" || character === "[" || character === "{") {
+      depth++;
+    } else if (character === ")" || character === "]" || character === "}") {
+      depth--;
+    } else if (depth === 1 && objectText.startsWith(`${name}:`, index)) {
+      const before: string = objectText.slice(0, index).trimEnd().slice(-1);
+
+      if (before === "{" || before === ",") {
+        return readExpression(objectText, index + name.length + 1, ",");
+      }
+    }
+  }
+
+  return null;
+}
+
+/*
+ * What an identifier is bound to in this file, as source text — or null when
+ * the file does not declare it (an import, a prop, a destructured hook result)
+ * or declares it more than once. Ambiguity has to read as "cannot tell": two
+ * handlers that each keep a local named `subject` would otherwise both resolve
+ * to whichever one happens to appear first, and the checks below would then
+ * pin a sentence the page never shows.
+ */
+function readDeclaration(code: string, identifier: string): string | null {
+  const pattern: string = `\\b(?:const|let|var|function)\\s+${identifier}\\b`;
+  const declarations: RegExpMatchArray | null = code.match(
+    new RegExp(pattern, "g"),
+  );
+
+  if (declarations === null || declarations.length !== 1) {
+    return null;
+  }
+
+  const start: number = new RegExp(pattern).exec(code)!.index;
+
+  if (code.startsWith("function", start)) {
+    const bodyStart: number = code.indexOf("{", start);
+
+    return code.slice(start, readClosingBrace(code, bodyStart) + 1);
+  }
+
+  return readExpression(code, start, ";");
+}
+
+/*
+ * Whether one `API.post` argument object posts to `route`.
+ *
+ * The route is normally written inline in the `url:` template literal, and the
+ * first version of this file simply counted occurrences of the route string.
+ * That was wrong in a way worth spelling out: the four bulk-sync URLs are
+ * spelled identically today, so hoisting them into one shared const or builder
+ * — a pure refactor that improves the view — would have reported one bulk sync
+ * against four helper calls and turned this suite red. So when the route is
+ * not in the call itself, every identifier the `url:` expression mentions is
+ * resolved once against this file's own declarations and the route is looked
+ * for there.
+ *
+ * One level of indirection, because that is as far as source text can honestly
+ * be followed. A URL assembled through two hops leaves its call unattributed
+ * and the count below then fails — loudly and in the right place, rather than
+ * silently reporting one sync fewer than the page really has.
+ */
+function postsToRoute(call: string, code: string, route: string): boolean {
+  const url: string | null = readProperty(call, "url");
+
+  if (url === null) {
+    return false;
+  }
+
+  if (url.includes(route)) {
+    return true;
+  }
+
+  const identifiers: Array<string> = url.match(/[A-Za-z_$][\w$]*/g) || [];
+
+  return identifiers.some((identifier: string) => {
+    const declaration: string | null = readDeclaration(code, identifier);
+
+    return declaration !== null && declaration.includes(route);
+  });
+}
+
+type BulkSyncSubject = {
+  call: number;
+  expression: string;
+  name: string | null;
+};
+
+/*
+ * The subject as a plain string when the source says so outright, and null
+ * when it is built at runtime. A quoted literal, an uninterpolated template
+ * literal and an identifier this file binds to one are all readable; a call
+ * result or an interpolation is not, and saying so is the point. The version
+ * of this that only understood a double-quoted literal reported anything else
+ * as the empty string, which reads as "the developer forgot the subject" and
+ * would have failed a legitimate change to a translated or derived label.
+ */
+function readSubjectName(expression: string, code: string): string | null {
+  const literal: RegExpMatchArray | null =
+    expression.match(/^"([^"]*)"$/) ||
+    expression.match(/^'([^']*)'$/) ||
+    expression.match(/^`([^`$]*)`$/);
+
+  if (literal !== null) {
+    return literal[1]!;
+  }
+
+  if (!IDENTIFIER_ONLY.test(expression)) {
+    return null;
+  }
+
+  const declaration: string | null = readDeclaration(code, expression);
+
+  if (declaration === null) {
+    return null;
+  }
+
+  const bound: RegExpMatchArray | null = declaration.match(STRING_INITIALISER);
+
+  return bound === null ? null : bound[1]!;
+}
+
+/*
+ * The subjects the view actually reports on, read out of its
+ * buildSyncResultSummary calls rather than listed here. A sync added later is
+ * then exercised by these tests the day it lands, and one that forgets its
+ * subject arrives as an empty expression against a call number the failure can
+ * name — a list copied into this file would simply have gone quietly out of
+ * date instead.
+ */
+function readBulkSyncSubjects(code: string): Array<BulkSyncSubject> {
+  return readCallArguments(code, /buildSyncResultSummary\(\s*\{/g).map(
+    (call: string, index: number): BulkSyncSubject => {
+      const expression: string | null = readProperty(call, "subject");
+
+      return {
+        call: index + 1,
+        expression: expression === null ? "" : expression,
+        name: expression === null ? null : readSubjectName(expression, code),
+      };
+    },
+  );
+}
+
+const BULK_SYNC_SUBJECTS: Array<BulkSyncSubject> =
+  readBulkSyncSubjects(TEMPLATES_VIEW_CODE);
+
+const NAMED_BULK_SYNC_SUBJECTS: Array<string> = BULK_SYNC_SUBJECTS.filter(
+  (subject: BulkSyncSubject) => {
+    return subject.name !== null;
+  },
+).map((subject: BulkSyncSubject) => {
+  return subject.name!;
+});
+
 describe("Monitor template sync result summary", () => {
   it("reports a complete sync as done", () => {
     const summary: SyncResultSummary = buildSyncResultSummary({
@@ -100,15 +382,22 @@ describe("Monitor template sync result summary", () => {
     expect(summary.message).not.toContain("still");
   });
 
+  /*
+   * Runs on the subjects the view really passes rather than a sample of them,
+   * so the sentence an operator sees is pinned for every sync that exists, not
+   * for the three that existed when this was written.
+   */
   it("names the subject it was asked to report on", () => {
-    for (const subject of ["criteria", "monitoring interval", "labels"]) {
+    expect(NAMED_BULK_SYNC_SUBJECTS.length).toBeGreaterThan(0);
+
+    for (const subject of NAMED_BULK_SYNC_SUBJECTS) {
       expect(
         buildSyncResultSummary({
           subject: subject,
           syncedMonitors: 2,
           totalLinkedMonitors: 2,
         }).message,
-      ).toContain(`Synced ${subject} onto`);
+      ).toBe(`Synced ${subject} onto 2 monitors (2 linked to this template).`);
     }
   });
 
@@ -162,13 +451,71 @@ describe("Monitor template result modal title wiring", () => {
     expect(titles).toBeGreaterThanOrEqual(contentMessages);
   });
 
-  it("routes all three bulk syncs through the shared summary helper", () => {
-    const source: string = fs.readFileSync(TEMPLATES_VIEW_SOURCE, "utf8");
+  /*
+   * One bulk sync is one POST to the bulk-sync route, so the number of those
+   * posts is what the number of helper calls has to match. Both sides are read
+   * off the view: a card added later brings its own expectation with it, while
+   * a sync that formats its own message drifts the two apart and fails.
+   *
+   * The posts are identified by resolving each call's `url:`, not by counting
+   * occurrences of the route string — see postsToRoute for why that difference
+   * is what keeps a DRY cleanup of those four identical URLs green.
+   *
+   * The single-monitor sync and the link/unlink paths are deliberately not in
+   * this count — they set a plain "Done" because they have no synced-versus-
+   * linked totals to report, which is the whole subject of the helper.
+   */
+  it("routes every bulk sync through the shared summary helper", () => {
+    const bulkSyncs: number = readApiPostArguments(TEMPLATES_VIEW_CODE).filter(
+      (call: string) => {
+        return postsToRoute(call, TEMPLATES_VIEW_CODE, BULK_SYNC_ROUTE);
+      },
+    ).length;
 
-    expect((source.match(/buildSyncResultSummary\(/g) || []).length).toBe(3);
-    for (const subject of ["criteria", "monitoring interval", "labels"]) {
-      expect(source).toContain(`subject: "${subject}"`);
-    }
+    /*
+     * Zero here means the page still posts to the bulk-sync route but this
+     * file can no longer see which calls do — teach postsToRoute the new
+     * shape, because everything below it is then counting nothing.
+     */
+    expect(bulkSyncs).toBeGreaterThan(0);
+    expect(BULK_SYNC_SUBJECTS.length).toBe(bulkSyncs);
+  });
+
+  /*
+   * Every one of those calls has to name what it synced, and name it
+   * distinctly: the modal is shared, so a card that reports the subject of the
+   * card next to it tells the operator the wrong fields were written to their
+   * fleet — and does it in a sentence that reads as a clean success.
+   */
+  it("gives every bulk sync its own subject to report on", () => {
+    expect(BULK_SYNC_SUBJECTS.length).toBeGreaterThan(0);
+
+    const unnamed: Array<string> = BULK_SYNC_SUBJECTS.filter(
+      (subject: BulkSyncSubject) => {
+        return subject.expression === "";
+      },
+    ).map((subject: BulkSyncSubject) => {
+      return `buildSyncResultSummary call ${subject.call} passes no subject`;
+    });
+
+    expect(unnamed).toEqual([]);
+
+    /*
+     * Distinctness is judged only on the subjects the source states outright.
+     * One assembled at runtime is exempt because no reading of the text can
+     * decide what it will say — it is still required above to be passed at
+     * all, and at least one has to stay readable or this check would quietly
+     * become a no-op the day the last literal is replaced.
+     */
+    expect(NAMED_BULK_SYNC_SUBJECTS.length).toBeGreaterThan(0);
+
+    const reused: Array<string> = NAMED_BULK_SYNC_SUBJECTS.filter(
+      (subject: string, index: number) => {
+        return NAMED_BULK_SYNC_SUBJECTS.indexOf(subject) !== index;
+      },
+    );
+
+    expect(reused).toEqual([]);
   });
 
   it("renders the modal from the title state rather than a hardcoded string", () => {

--- a/App/Tests/Dashboard/MonitorTemplateSyncTenantHeader.test.ts
+++ b/App/Tests/Dashboard/MonitorTemplateSyncTenantHeader.test.ts
@@ -20,12 +20,18 @@ import path from "path";
  * of these permissions: Project Owner, ..." — a message that sends project
  * owners hunting for a role they already hold.
  *
- * All six calls the page had at the time shipped without the header, and the
- * count below moves with the page as sync buttons are added — a new post is
- * exactly the thing that reintroduces this. This pins every one of them: the
- * component is a React page with no extractable logic, and the App suite runs
- * in a plain Node environment with no renderer, so this reads the source the
- * same way the sibling *Invariants tests do.
+ * All six calls the page had at the time shipped without the header, and a new
+ * sync button is exactly the thing that reintroduces it. This pins every one
+ * of them: the component is a React page with no extractable logic, and the
+ * App suite runs in a plain Node environment with no renderer, so this reads
+ * the source the same way the sibling *Invariants tests do.
+ *
+ * Nothing below is a tally of how many calls the page happens to have today.
+ * An earlier version of this file asserted `toBe(7)` and had already been
+ * hand-edited from 6 to 7 by the commit that added a sync card — a test that
+ * every unrelated feature has to come and correct is a test that will be
+ * corrected without being read. What is pinned instead is that every raw post
+ * the file contains is one this suite could parse and did check.
  */
 
 const MONITOR_TEMPLATES_VIEW: string = path.join(
@@ -40,6 +46,13 @@ const MONITOR_TEMPLATES_VIEW: string = path.join(
   "Settings",
   "MonitorTemplatesView.tsx",
 );
+
+const MONITOR_TEMPLATE_ROUTES: Array<string> = [
+  "/sync-to-linked-monitors",
+  "/sync-to-monitor/",
+  "/link-monitor/",
+  "/unlink-monitor/",
+];
 
 /*
  * Comments are stripped so the prose above (which quotes both the endpoint
@@ -60,11 +73,13 @@ function readCode(): string {
  * Brace-matched rather than regex-matched so nested objects (`data: {...}`)
  * do not truncate the capture. The lookbehind keeps `ModelAPI.post` out of the
  * results — that one attaches the tenant header itself, so requiring an
- * explicit `headers` on it would be wrong.
+ * explicit `headers` on it would be wrong. The generic argument is optional
+ * because dropping it is a legal way to write the same call, and a call this
+ * function skips is a call nothing below checks.
  */
 function getApiPostArguments(code: string): Array<string> {
   const calls: Array<string> = [];
-  const marker: RegExp = /(?<![A-Za-z])API\.post<[^>]*>\(\s*\{/g;
+  const marker: RegExp = /(?<![A-Za-z])API\.post\s*(?:<[^();{}]*>)?\s*\(\s*\{/g;
 
   let match: RegExpExecArray | null = marker.exec(code);
 
@@ -96,21 +111,157 @@ function getApiPostArguments(code: string): Array<string> {
   return calls;
 }
 
+/*
+ * One expression, from `start` up to the character that ends it at the top
+ * level — `stop` itself, or a closing bracket belonging to something that
+ * encloses it. Walked rather than regexed so a nested object, a call argument
+ * or a template literal inside the value cannot truncate it.
+ */
+function readExpression(text: string, start: number, stop: string): string {
+  let depth: number = 0;
+
+  for (let index: number = start; index < text.length; index++) {
+    const character: string = text[index]!;
+
+    if (character === "(" || character === "[" || character === "{") {
+      depth++;
+    } else if (character === ")" || character === "]" || character === "}") {
+      if (depth === 0) {
+        return text.slice(start, index).trim();
+      }
+
+      depth--;
+    } else if (character === stop && depth === 0) {
+      return text.slice(start, index).trim();
+    }
+  }
+
+  return text.slice(start).trim();
+}
+
+/*
+ * The source text of one property of an object literal, or null when the
+ * object does not set it. Only the object's own top level is considered, so a
+ * `url:` nested inside `data:` could not be mistaken for the call's own.
+ */
+function readProperty(objectText: string, name: string): string | null {
+  let depth: number = 0;
+
+  for (let index: number = 0; index < objectText.length; index++) {
+    const character: string = objectText[index]!;
+
+    if (character === "(" || character === "[" || character === "{") {
+      depth++;
+    } else if (character === ")" || character === "]" || character === "}") {
+      depth--;
+    } else if (depth === 1 && objectText.startsWith(`${name}:`, index)) {
+      const before: string = objectText.slice(0, index).trimEnd().slice(-1);
+
+      if (before === "{" || before === ",") {
+        return readExpression(objectText, index + name.length + 1, ",");
+      }
+    }
+  }
+
+  return null;
+}
+
+/*
+ * What an identifier is bound to in this file, as source text — or null when
+ * the file does not declare it (an import, a prop, a destructured hook result)
+ * or declares it more than once. Ambiguity has to read as "cannot tell", since
+ * resolving to whichever declaration happens to come first would attribute a
+ * call to a route it never posts to.
+ */
+function readDeclaration(code: string, identifier: string): string | null {
+  const pattern: string = `\\b(?:const|let|var|function)\\s+${identifier}\\b`;
+  const declarations: RegExpMatchArray | null = code.match(
+    new RegExp(pattern, "g"),
+  );
+
+  if (declarations === null || declarations.length !== 1) {
+    return null;
+  }
+
+  const start: number = new RegExp(pattern).exec(code)!.index;
+
+  if (code.startsWith("function", start)) {
+    const bodyStart: number = code.indexOf("{", start);
+    let depth: number = 0;
+
+    for (let i: number = bodyStart; i < code.length; i++) {
+      if (code[i] === "{") {
+        depth++;
+      } else if (code[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          return code.slice(start, i + 1);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  return readExpression(code, start, ";");
+}
+
+/*
+ * Whether one `API.post` argument object posts to `route`.
+ *
+ * The route is normally spelled inline in the `url:` template literal, which
+ * is why a plain `call.includes(route)` used to be enough. It is not enough to
+ * rely on: the four bulk-sync calls build byte-identical URLs, and hoisting
+ * that into one shared const or builder is an obvious cleanup that must not
+ * cost this page its header coverage. So when the route is not in the call
+ * itself, each identifier the `url:` expression mentions is resolved once
+ * against this file's declarations and the route is looked for there.
+ */
+function postsToRoute(call: string, code: string, route: string): boolean {
+  const url: string | null = readProperty(call, "url");
+
+  if (url === null) {
+    return false;
+  }
+
+  if (url.includes(route)) {
+    return true;
+  }
+
+  const identifiers: Array<string> = url.match(/[A-Za-z_$][\w$]*/g) || [];
+
+  return identifiers.some((identifier: string) => {
+    const declaration: string | null = readDeclaration(code, identifier);
+
+    return declaration !== null && declaration.includes(route);
+  });
+}
+
 describe("Monitor Template sync/link endpoints send the tenant header", () => {
   test("the file still drives these endpoints through raw API.post", () => {
     const code: string = readCode();
 
     /*
-     * Guard the guard: if the page is ever migrated off raw API.post, the
-     * assertions below would vacuously pass over an empty list.
+     * Guard the guard. Two ways this suite could go quiet: the page migrates
+     * off raw API.post entirely, and the assertions below pass vacuously over
+     * an empty list; or a post is written in a shape getApiPostArguments does
+     * not match, and that one call slips past the header check while the rest
+     * keep the suite green. The second is the one that actually happened to
+     * the sibling route sweep, so both are pinned here — every mention of
+     * `API.post` in the file has to be a call this suite parsed and will
+     * check, and there have to be at least as many of them as there are
+     * routes. Neither number needs editing when a sync card is added.
      */
     const calls: Array<string> = getApiPostArguments(code);
+    const mentions: number = (code.match(/(?<![A-Za-z])API\.post\b/g) || [])
+      .length;
 
-    expect(calls.length).toBe(7);
-    expect(code).toContain("/sync-to-linked-monitors");
-    expect(code).toContain("/sync-to-monitor/");
-    expect(code).toContain("/link-monitor/");
-    expect(code).toContain("/unlink-monitor/");
+    expect(mentions).toBeGreaterThanOrEqual(MONITOR_TEMPLATE_ROUTES.length);
+    expect(calls.length).toBe(mentions);
+
+    for (const route of MONITOR_TEMPLATE_ROUTES) {
+      expect(code).toContain(route);
+    }
   });
 
   test("every API.post passes ModelAPI.getCommonHeaders() so tenantid is sent", () => {
@@ -127,19 +278,21 @@ describe("Monitor Template sync/link endpoints send the tenant header", () => {
     expect(missing).toEqual([]);
   });
 
+  /*
+   * The per-route pass says the same thing from the other side: it is not
+   * enough that the calls this suite happened to find all carry the header —
+   * each of the four endpoints has to still be reachable from a call that
+   * does. A route left with no attributable call means either the feature was
+   * removed or its URL is now built somewhere this file cannot follow, and
+   * both deserve a look.
+   */
   test("each of the four monitor-template routes is covered", () => {
-    const calls: Array<string> = getApiPostArguments(readCode());
+    const code: string = readCode();
+    const calls: Array<string> = getApiPostArguments(code);
 
-    const routes: Array<string> = [
-      "/sync-to-linked-monitors",
-      "/sync-to-monitor/",
-      "/link-monitor/",
-      "/unlink-monitor/",
-    ];
-
-    for (const route of routes) {
+    for (const route of MONITOR_TEMPLATE_ROUTES) {
       const callsForRoute: Array<string> = calls.filter((call: string) => {
-        return call.includes(route);
+        return postsToRoute(call, code, route);
       });
 
       expect(callsForRoute.length).toBeGreaterThan(0);

--- a/App/Tests/Dashboard/ProjectScopedApiTenantHeader.test.ts
+++ b/App/Tests/Dashboard/ProjectScopedApiTenantHeader.test.ts
@@ -52,14 +52,83 @@ const PROJECT_SCOPED_ROUTES: Array<string> = [
   "/incident-episode/generate-postmortem-from-ai/",
 ];
 
+/*
+ * The pages known to reach one of those routes. These name FILES rather than
+ * counting calls: a page that grows a fourth sync button is the normal way this
+ * feature area changes, and the new call is then checked for the header like
+ * the rest. What the list is here to catch is the opposite — a page dropping
+ * out of the sweep entirely, which is the shape a broken scanner takes and
+ * which would otherwise let every assertion below pass over an empty set.
+ *
+ * `routePrefix` belongs to the per-page describe at the bottom of this file and
+ * to nothing else. It is the prefix that covers every raw call the page makes,
+ * which is what lets that describe demand a resolved route for all of them
+ * rather than only for the ones the scanner happened to recognise. It is
+ * deliberately not a member of PROJECT_SCOPED_ROUTES: "/monitor-template/"
+ * stands for a whole family of routes, so a new /monitor-template/... call is
+ * covered the day it lands. The sweep matches PROJECT_SCOPED_ROUTES itself and
+ * never reads this field.
+ */
+interface GuardedPage {
+  page: Array<string>;
+  routePrefix: string;
+}
+
+const GUARDED_PAGES: Array<GuardedPage> = [
+  {
+    page: ["Pages", "Monitor", "Settings", "MonitorTemplatesView.tsx"],
+    routePrefix: "/monitor-template/",
+  },
+  {
+    page: ["Pages", "Alerts", "View", "InternalNote.tsx"],
+    routePrefix: "/alert/generate-note-from-ai/",
+  },
+  {
+    page: ["Pages", "Incidents", "View", "InternalNote.tsx"],
+    routePrefix: "/incident/generate-note-from-ai/",
+  },
+  {
+    page: ["Pages", "Incidents", "View", "PublicNote.tsx"],
+    routePrefix: "/incident/generate-note-from-ai/",
+  },
+  {
+    page: ["Pages", "Incidents", "View", "Postmortem.tsx"],
+    routePrefix: "/incident/generate-postmortem-from-ai/",
+  },
+  {
+    page: ["Pages", "Incidents", "EpisodeView", "Postmortem.tsx"],
+    routePrefix: "/incident-episode/generate-postmortem-from-ai/",
+  },
+  {
+    page: ["Pages", "ScheduledMaintenanceEvents", "View", "InternalNote.tsx"],
+    routePrefix: "/scheduled-maintenance/generate-note-from-ai/",
+  },
+  {
+    page: ["Pages", "ScheduledMaintenanceEvents", "View", "PublicNote.tsx"],
+    routePrefix: "/scheduled-maintenance/generate-note-from-ai/",
+  },
+];
+
 interface RawApiCall {
   file: string;
   verb: string;
   body: string;
+
+  /*
+   * False when the paren walk below ran off the end of the file without
+   * closing the argument list. Such a call still gets pushed — dropping it
+   * would take it out of the sweep silently — but its `body` is then the whole
+   * rest of the file, which will contain some other call's `headers:` line and
+   * would turn the header assertions into a false pass. So it is reported
+   * instead, by the scanner-health test.
+   */
+  balanced: boolean;
 }
 
 const SOURCE_FILE: RegExp = /\.tsx?$/;
 const WHITESPACE: RegExp = /\s/;
+const RAW_API_CALL_SITE: string =
+  "(^|[^A-Za-z0-9_])API\\.(post|get|put|delete|patch)\\s*[<(]";
 
 function squash(text: string): string {
   return text.replace(/\s+/g, " ");
@@ -88,12 +157,16 @@ function listSourceFiles(dir: string): Array<string> {
  *
  * The argument object is matched by balancing parentheses rather than by
  * regex so that nested calls inside `url:`/`data:` cannot end the match early.
+ * The walk counts parentheses without understanding string literals, so an
+ * unmatched "(" inside a string would read as an argument list that never
+ * closes. Nothing in the Dashboard sources does that today, and if something
+ * ever does it is reported by the scanner-health test rather than quietly
+ * changing what the header assertions see.
  */
 function readRawApiCalls(file: string): Array<RawApiCall> {
   const source: string = fs.readFileSync(file, "utf8");
   const calls: Array<RawApiCall> = [];
-  const callSite: RegExp =
-    /(^|[^A-Za-z0-9_])API\.(post|get|put|delete|patch)\s*[<(]/g;
+  const callSite: RegExp = new RegExp(RAW_API_CALL_SITE, "g");
 
   let match: RegExpExecArray | null = callSite.exec(source);
 
@@ -127,6 +200,7 @@ function readRawApiCalls(file: string): Array<RawApiCall> {
     if (source[index] === "(") {
       let parenDepth: number = 0;
       let end: number = index;
+      let balanced: boolean = false;
 
       for (; end < source.length; end++) {
         if (source[end] === "(") {
@@ -136,6 +210,7 @@ function readRawApiCalls(file: string): Array<RawApiCall> {
 
           if (parenDepth === 0) {
             end++;
+            balanced = true;
             break;
           }
         }
@@ -145,6 +220,7 @@ function readRawApiCalls(file: string): Array<RawApiCall> {
         file: path.relative(DASHBOARD_SRC, file),
         verb: match[2]!,
         body: squash(source.slice(index, end)),
+        balanced,
       });
     }
 
@@ -152,6 +228,19 @@ function readRawApiCalls(file: string): Array<RawApiCall> {
   }
 
   return calls;
+}
+
+/*
+ * How many raw call sites the matcher can see, before any of the parsing above
+ * runs. readRawApiCalls emits a call only once it has stepped over any generic
+ * argument and landed on the opening paren, so a call whose generic argument
+ * the stepper cannot walk is dropped from the results with nothing else to
+ * show for it. Comparing this count against the emitted calls is how that
+ * shows up; the `balanced` flag covers the other half, a call site that is
+ * reached but whose argument list is never closed.
+ */
+function countRawApiCallSites(text: string): number {
+  return (text.match(new RegExp(RAW_API_CALL_SITE, "g")) || []).length;
 }
 
 /*
@@ -184,45 +273,169 @@ function callsRoute(
   return Boolean(declaration && declaration[1]!.includes(route));
 }
 
+interface GuardedCall {
+  call: RawApiCall;
+  routes: Array<string>;
+}
+
 describe("every raw API call to a project-scoped route sends the tenant header", () => {
-  const allCalls: Array<{ call: RawApiCall; route: string }> = [];
+  const allCalls: Array<GuardedCall> = [];
 
   for (const file of listSourceFiles(DASHBOARD_SRC)) {
     const fileText: string = fs.readFileSync(file, "utf8");
 
     for (const call of readRawApiCalls(file)) {
-      for (const route of PROJECT_SCOPED_ROUTES) {
-        if (callsRoute(call, route, fileText)) {
-          allCalls.push({ call, route });
-        }
+      const routes: Array<string> = PROJECT_SCOPED_ROUTES.filter(
+        (route: string) => {
+          return callsRoute(call, route, fileText);
+        },
+      );
+
+      if (routes.length > 0) {
+        allCalls.push({ call, routes });
       }
     }
   }
 
+  /*
+   * The header assertions below are shaped as "every call the sweep found",
+   * which is what keeps a sync button added next month covered without anyone
+   * editing this file. The price is that they say nothing about a call the
+   * sweep never found — a call whose route callsRoute cannot resolve, say
+   * because the URL is built by a helper, drops out of the sweep and out of
+   * the header check together. An exact total used to catch that by arithmetic
+   * and no longer does, so it is caught by construction instead: this test
+   * pins the floors, the test after it pins the set of files that may reach a
+   * guarded route at all, and the per-page describe at the bottom requires a
+   * resolved route for every raw call in each of those files. Between them
+   * there is nowhere for an unresolvable call to a guarded route to hide.
+   *
+   * The floors themselves are the coarsest of the three: every guarded route,
+   * and every page named above, has to still be represented. Neither goes up
+   * when a call site is added, so neither needs hand-editing.
+   */
   test("the sweep still finds the call sites it is meant to guard", () => {
-    /*
-     * Guards the scanner itself: if readRawApiCalls stops matching, every
-     * assertion below would pass vacuously.
-     */
-    expect(allCalls.length).toBe(13);
+    const coveredRoutes: Array<string> = [];
+    const coveredFiles: Array<string> = [];
+
+    for (const entry of allCalls) {
+      for (const route of entry.routes) {
+        if (!coveredRoutes.includes(route)) {
+          coveredRoutes.push(route);
+        }
+      }
+
+      if (!coveredFiles.includes(entry.call.file)) {
+        coveredFiles.push(entry.call.file);
+      }
+    }
 
     for (const route of PROJECT_SCOPED_ROUTES) {
-      expect(
-        allCalls.some((entry: { call: RawApiCall; route: string }) => {
-          return entry.route === route;
-        }),
-      ).toBe(true);
+      expect(coveredRoutes).toContain(route);
     }
+
+    for (const { page } of GUARDED_PAGES) {
+      expect(coveredFiles).toContain(path.join(...page));
+    }
+  });
+
+  /*
+   * The per-page describe at the bottom can only require a resolved route for
+   * every raw call in a guarded file if GUARDED_PAGES actually lists every
+   * file that reaches a guarded route. That is what this pins, by deriving the
+   * list back out of the sources: a page that starts calling one of these
+   * routes fails here, naming itself, rather than sitting outside the sweep
+   * with no header on it.
+   *
+   * This is the one assertion in the file that a new call site can turn red,
+   * and only when the call site is on a page not listed above. That is the
+   * trade being made deliberately: adding a file to a list of files is the
+   * edit the comment on GUARDED_PAGES already asks for, and it is what buys
+   * the per-page describe the right to be exhaustive.
+   */
+  test("only the guarded pages reach a project-scoped route", () => {
+    const pagesReachingGuardedRoutes: Array<string> = [];
+
+    for (const file of listSourceFiles(DASHBOARD_SRC)) {
+      const fileText: string = fs.readFileSync(file, "utf8");
+
+      const mentionsGuardedRoute: boolean = PROJECT_SCOPED_ROUTES.some(
+        (route: string) => {
+          return fileText.includes(route);
+        },
+      );
+
+      if (mentionsGuardedRoute) {
+        pagesReachingGuardedRoutes.push(path.relative(DASHBOARD_SRC, file));
+      }
+    }
+
+    expect(pagesReachingGuardedRoutes.sort()).toEqual(
+      GUARDED_PAGES.map(({ page }: GuardedPage) => {
+        return path.join(...page);
+      }).sort(),
+    );
+  });
+
+  /*
+   * The other way the sweep can go quiet is one call at a time, inside the
+   * scanner. A call site whose generic argument the stepper cannot walk never
+   * reaches an argument list and is dropped from the results entirely; a call
+   * whose argument list never closes is kept, but with the rest of the file as
+   * its body, so it matches TENANT_HEADER off some later call and passes the
+   * header assertions without ever having been read. Both are checked here,
+   * over every file that mentions a guarded route — which is a superset of the
+   * files the sweep draws calls from, since callsRoute can only resolve a
+   * route that appears in the file's own text.
+   *
+   * This does not catch a scanner that matches nothing at all: with no calls
+   * found there is nothing to disagree about and it passes. The route and page
+   * floors above are what fail in that case, which is why both tests exist.
+   */
+  test("the scanner reads every raw API call in the files it guards", () => {
+    const unread: Array<string> = [];
+
+    for (const file of listSourceFiles(DASHBOARD_SRC)) {
+      const fileText: string = fs.readFileSync(file, "utf8");
+
+      const mentionsGuardedRoute: boolean = PROJECT_SCOPED_ROUTES.some(
+        (route: string) => {
+          return fileText.includes(route);
+        },
+      );
+
+      if (!mentionsGuardedRoute) {
+        continue;
+      }
+
+      const name: string = path.relative(DASHBOARD_SRC, file);
+      const parsed: Array<RawApiCall> = readRawApiCalls(file);
+      const found: number = countRawApiCallSites(fileText);
+
+      if (parsed.length !== found) {
+        unread.push(
+          `${name}: reached the arguments of ${parsed.length} of ${found}`,
+        );
+      }
+
+      for (const call of parsed) {
+        if (!call.balanced) {
+          unread.push(`${name}: [${call.verb}] argument list never closes`);
+        }
+      }
+    }
+
+    expect(unread).toEqual([]);
   });
 
   test.each(PROJECT_SCOPED_ROUTES)(
     "%s is only ever called with ModelAPI.getCommonHeaders()",
     (route: string) => {
       const callsForRoute: Array<RawApiCall> = allCalls
-        .filter((entry: { call: RawApiCall; route: string }) => {
-          return entry.route === route;
+        .filter((entry: GuardedCall) => {
+          return entry.routes.includes(route);
         })
-        .map((entry: { call: RawApiCall; route: string }) => {
+        .map((entry: GuardedCall) => {
           return entry.call;
         });
 
@@ -240,75 +453,44 @@ describe("every raw API call to a project-scoped route sends the tenant header",
 /*
  * Per-page pins. The sweep above catches a header dropped from any call site;
  * these name the pages so a failure points straight at the file that
- * regressed.
+ * regressed, and they are the part of the file that is exhaustive rather than
+ * a floor.
  */
 describe("the pages that call project-scoped custom routes", () => {
-  const PAGES: Array<{ page: Array<string>; route: string; calls: number }> = [
-    {
-      page: ["Pages", "Monitor", "Settings", "MonitorTemplatesView.tsx"],
-      route: "/monitor-template/",
-      calls: 6,
-    },
-    {
-      page: ["Pages", "Alerts", "View", "InternalNote.tsx"],
-      route: "/alert/generate-note-from-ai/",
-      calls: 1,
-    },
-    {
-      page: ["Pages", "Incidents", "View", "InternalNote.tsx"],
-      route: "/incident/generate-note-from-ai/",
-      calls: 1,
-    },
-    {
-      page: ["Pages", "Incidents", "View", "PublicNote.tsx"],
-      route: "/incident/generate-note-from-ai/",
-      calls: 1,
-    },
-    {
-      page: ["Pages", "Incidents", "View", "Postmortem.tsx"],
-      route: "/incident/generate-postmortem-from-ai/",
-      calls: 1,
-    },
-    {
-      page: ["Pages", "Incidents", "EpisodeView", "Postmortem.tsx"],
-      route: "/incident-episode/generate-postmortem-from-ai/",
-      calls: 1,
-    },
-    {
-      page: ["Pages", "ScheduledMaintenanceEvents", "View", "InternalNote.tsx"],
-      route: "/scheduled-maintenance/generate-note-from-ai/",
-      calls: 1,
-    },
-    {
-      page: ["Pages", "ScheduledMaintenanceEvents", "View", "PublicNote.tsx"],
-      route: "/scheduled-maintenance/generate-note-from-ai/",
-      calls: 1,
-    },
-  ];
-
-  test.each(PAGES)(
+  test.each(GUARDED_PAGES)(
     "$page sends the tenant header on every raw call",
-    ({
-      page,
-      route,
-      calls,
-    }: {
-      page: Array<string>;
-      route: string;
-      calls: number;
-    }) => {
+    ({ page, routePrefix }: GuardedPage) => {
       const file: string = path.join(DASHBOARD_SRC, ...page);
       const fileText: string = fs.readFileSync(file, "utf8");
-      const matching: Array<RawApiCall> = readRawApiCalls(file).filter(
-        (call: RawApiCall) => {
-          return callsRoute(call, route, fileText);
-        },
-      );
+      const parsed: Array<RawApiCall> = readRawApiCalls(file);
+      const matching: Array<RawApiCall> = parsed.filter((call: RawApiCall) => {
+        return callsRoute(call, routePrefix, fileText);
+      });
 
-      expect(matching.length).toBe(calls);
+      /*
+       * routePrefix covers the whole page, so every raw call in the file has
+       * to resolve to it. Asserting that — rather than only that some call
+       * did — is what stops a call from leaving the header check by becoming
+       * invisible to callsRoute: hoisting a URL into a helper the 300-character
+       * lookback cannot follow used to drop the call out of both the sweep and
+       * this test at once, and now fails here with the call body in the
+       * message. Nothing about it needs hand-editing when a sync or link
+       * button is added; a call to some other route from one of these pages
+       * does need the prefix widened or the page split, which is the point.
+       */
+      expect(parsed.length).toBeGreaterThan(0);
+      expect(
+        parsed
+          .filter((call: RawApiCall) => {
+            return !matching.includes(call);
+          })
+          .map((call: RawApiCall) => {
+            return `[${call.verb}] ${call.body}`;
+          }),
+      ).toEqual([]);
 
       for (const call of matching) {
-        expect(call.body).toContain(TENANT_HEADER);
+        expect(`[${call.verb}] ${call.body}`).toContain(TENANT_HEADER);
       }
     },
   );

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -1636,12 +1636,28 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
    * A query builder scoped to exactly the rows this read may see, and — this
    * is the whole point — scoped so that each of them appears ONCE.
    *
-   * The permission pipeline expresses a label-scoped read as a condition on
-   * the access-control RELATION: `{ labels: [permittedIds] }` for an allow
-   * permission, `{ labels: { _id: NotIn([...]) } }` for a block. Handed to
-   * TypeORM's FindOptions machinery those become a join through the
-   * many-to-many junction table — and a join multiplies rows. A device
-   * carrying two permitted labels comes back twice.
+   * The permission pipeline expresses a label-scoped ALLOW as a condition on
+   * the access-control RELATION — `{ labels: [permittedIds] }`, which
+   * QueryUtil.serializeQuery then nests into `{ labels: { _id: <a set
+   * membership operator> } }`. Handed to TypeORM's FindOptions machinery that
+   * becomes a join through the many-to-many junction table — and a join
+   * multiplies rows. A device carrying two permitted labels comes back twice.
+   *
+   * A label BLOCK no longer takes that route, and it is worth being precise
+   * about why, because the shape reads like the allow half's mirror image and
+   * is not. A relation condition cannot express "has NONE of these labels" at
+   * all: a device labelled {blocked, other} still matches the join through its
+   * "other" row. So ReadPermission writes the block as a flat predicate on the
+   * owner's own id instead — `_id NOT IN (SELECT ownerId FROM the junction
+   * table WHERE labelId IN (...))`. Flat means no join, which means no
+   * duplicate rows, which means the block half needs nothing from this method
+   * beyond the cheap path below.
+   *
+   * The allow half is not the only producer of relation-keyed conditions
+   * either. `@CanAccessIfCanReadOn` makes BasePermission write
+   * `query[relation] = { <the related model's access-control column>: ids }`
+   * for StatusPageResource, IncidentInternalNote, AlertEpisodeMember and
+   * others, and that arrives here indistinguishable from a label allow.
    *
    * `findBy` never notices, because entity hydration de-duplicates by primary
    * key on the way out. An aggregate has no such step: COUNT(*) would report
@@ -1656,9 +1672,10 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
    * by a DISTINCT subquery of ids. The joins live inside that subquery, where
    * duplicate rows collapse before anything is added up.
    *
-   * The subquery is skipped when the query is flat — which is every read by a
-   * user whose permissions are not label-scoped, i.e. the hot path — so the
-   * ordinary full-fleet aggregate stays a single sequential scan.
+   * The subquery is skipped when the query is flat — every read by a user with
+   * no label-scoped allow grant and no `@CanAccessIfCanReadOn` relation, which
+   * is the hot path, and the block half above with it — so the ordinary
+   * full-fleet aggregate stays a single sequential scan.
    */
   private buildAggregateScope(
     query: Query<TBaseModel>,
@@ -1698,10 +1715,14 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
       `"${this.modelName}"."_id" IN (${scopeBuilder.getQuery()})`,
     );
     /*
-     * The subquery's own bound values. Its placeholders are auto-named
-     * (`orm_param_N`) and the outer builder generates none of its own here —
-     * its only WHERE is the raw string above — so there is nothing to clash
-     * with. Caller-supplied parameters are named and applied later.
+     * The subquery's own bound values, copied across under whatever names they
+     * already carry. Two naming schemes reach this line: TypeORM auto-names
+     * the parameters it creates itself (`orm_param_N`), but a label predicate
+     * arrives as a `Raw` operator carrying its own object-literal parameters,
+     * and TypeORM registers those verbatim — QueryHelper names them with ten
+     * random characters apiece. Neither can clash with the outer builder,
+     * which generates no parameters of its own here: its only WHERE is the raw
+     * string above. Caller-supplied parameters are named and applied later.
      */
     queryBuilder.setParameters(scopeBuilder.getParameters());
 

--- a/Common/Tests/App/StatusPage/StatusPageOidcOrigin.test.tsx
+++ b/Common/Tests/App/StatusPage/StatusPageOidcOrigin.test.tsx
@@ -181,6 +181,11 @@ describe("Status Page OIDC login origin", () => {
       localStorage.setItem(`isPrivateStatusPage-${statusPageId}`, "true");
 
       jest.isolateModules(() => {
+        /*
+         * The page's default export is bound as `Sso` rather than `SSO` so the
+         * JSX tag stays PascalCase; the status page app renders this same
+         * component under the same name in App/FeatureSet/StatusPage/src/App.tsx.
+         */
         const Sso: FunctionComponent<ComponentProps> = (
           jest.requireActual(
             "../../../../App/FeatureSet/StatusPage/src/Pages/Accounts/SSO",

--- a/Common/Tests/Server/Services/DatabaseServiceAggregateBy.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServiceAggregateBy.test.ts
@@ -1,9 +1,20 @@
 import NetworkDeviceService from "../../../Server/Services/NetworkDeviceService";
 import AggregateBy from "../../../Server/Types/Database/AggregateBy";
+import ModelPermission from "../../../Server/Types/Database/Permissions/Index";
+import { CheckReadPermissionType } from "../../../Server/Types/Database/Permissions/ReadPermission";
 import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { TableColumnMetadata } from "../../../Types/Database/TableColumn";
+import TableColumnType from "../../../Types/Database/TableColumnType";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import DatabaseNotConnectedException from "../../../Types/Exception/DatabaseNotConnectedException";
+import ObjectID from "../../../Types/ObjectID";
+import Permission, {
+  UserTenantAccessPermission,
+} from "../../../Types/Permission";
 import { describe, expect, it } from "@jest/globals";
+import { FindOperator } from "typeorm";
 import fs from "fs";
 import path from "path";
 
@@ -318,20 +329,38 @@ describe("aggregateBy rejects an expression carrying a statement separator", () 
     }
   });
 
-  /*
-   * NOT tested here, deliberately: the same semicolon inside an `orderBy`
-   * expression. aggregateBy validates orderBy expressions in a loop that runs
-   * AFTER `this.buildAggregateScope(...)`, which calls getQueryBuilder, which
-   * throws DatabaseNotConnectedException when Postgres is not up — so with no
-   * database the call never reaches the orderBy check, and an assertion here
-   * would be green for the wrong reason.
-   *
-   * Faking a connection would mean standing up half of TypeORM's DataSource,
-   * which buys a test of the mock rather than of the method. Instead, the
-   * source-text block at the bottom pins that the orderBy loop still calls
-   * assertSafeAggregateExpression — deleting that call is the regression, and
-   * that IS detectable from here.
-   */
+  it("rejects a semicolon in an orderBy expression", async () => {
+    /*
+     * This case used to carry a comment here explaining that it could not be
+     * tested: the orderBy check ran inside the loop that APPLIES the order
+     * clauses, below `this.buildAggregateScope(...)`, so with no Postgres the
+     * call died on DatabaseNotConnectedException before ever reaching it.
+     *
+     * Production moved. aggregateBy now validates every orderBy expression in
+     * a loop of its own, above the permission call and above the query
+     * builder, with a comment saying it is placed there precisely so the
+     * guard is reachable without a live connection. So the gap closes by
+     * actually calling the method, which is worth more than the source-text
+     * substitute further down: this fails if the check is deleted, if it
+     * stops covering orderBy, or if it starts accepting a separator.
+     *
+     * The ordering that makes it reachable is itself asserted at the bottom
+     * of the file, so this cannot quietly start passing for the wrong reason.
+     */
+    const error: Error = await aggregateError({
+      orderBy: [
+        {
+          expression: `COUNT(*); DROP TABLE "NetworkDevice"`,
+          sortOrder: SortOrder.Ascending,
+        },
+      ],
+    });
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(error.message).toBe(
+      "Aggregate expressions cannot contain statement separators.",
+    );
+  });
 });
 
 describe("aggregateBy rejects an empty expression", () => {
@@ -432,21 +461,6 @@ const DATABASE_SERVICE_SOURCE: string = fs.readFileSync(
   "utf8",
 );
 
-const READ_PERMISSION_SOURCE: string = fs.readFileSync(
-  path.join(
-    __dirname,
-    "..",
-    "..",
-    "..",
-    "Server",
-    "Types",
-    "Database",
-    "Permissions",
-    "ReadPermission.ts",
-  ),
-  "utf8",
-);
-
 /*
  * Just the body of aggregateBy, and just the body of the helper that builds
  * its scoped query builder. DatabaseService.ts is ~2,600 lines and uses
@@ -473,16 +487,101 @@ const BUILD_AGGREGATE_SCOPE_BODY: string = squash(
   ),
 );
 
+/*
+ * A reader whose grant on this model is LABEL-SCOPED: one tenant permission
+ * row carrying labelIds, and nothing else. That is the only kind of caller for
+ * whom the permission pipeline produces a condition on the access-control
+ * relation, which is the shape the assertions below are about.
+ *
+ * Built the way ReadBlockPermission.test.ts builds its props, and deliberately
+ * ProjectMember rather than a granular ReadNetworkDevice: ProjectMember is in
+ * the read list of the table AND of every column the query below names, so a
+ * failure here is a failure about the SHAPE of the returned query rather than
+ * about a column-permission detail that has nothing to do with aggregates.
+ *
+ * That is a coupling to NetworkDevice's permission lists, so the caller
+ * asserts it as an explicit precondition before calling the pipeline. A
+ * tightening of those lists then reports itself as "ProjectMember is no longer
+ * in the read list" rather than as a NotAuthorizedException from four files
+ * away.
+ */
+function labelScopedReaderProps(
+  projectId: ObjectID,
+  permittedLabelId: ObjectID,
+): DatabaseCommonInteractionProps {
+  const tenantPermission: UserTenantAccessPermission = {
+    projectId: projectId,
+    _type: "UserTenantAccessPermission",
+    permissions: [
+      {
+        _type: "UserPermission",
+        permission: Permission.ProjectMember,
+        labelIds: [permittedLabelId],
+        isBlockPermission: false,
+      },
+    ],
+  };
+
+  return {
+    userId: ObjectID.generate(),
+    tenantId: projectId,
+    userTenantAccessPermission: {
+      [projectId.toString()]: tenantPermission,
+    },
+  };
+}
+
+/**
+ * Every id a find operator carries, whatever slot the operator keeps them in.
+ *
+ * The point is to assert WHICH labels the permission pipeline let through
+ * without asserting how the operator spells itself in SQL. QueryHelper builds
+ * set membership as a TypeORM `Raw` today, whose ids live in
+ * `objectLiteralParameters` and whose `value` is an empty array; TypeORM's own
+ * `In([...])` would put the same ids in `value` and leave
+ * `objectLiteralParameters` undefined. Both are the same invariant. Reading
+ * both slots means a change of spelling inside QueryHelper — a file this suite
+ * does not own, and whose rendered SQL an earlier version of the test below
+ * pinned, to its cost — cannot redden this test while the invariant holds,
+ * while anything that changes which ids are bound still does.
+ *
+ * Only strings are collected: an id is the one thing these operators bind as a
+ * string, and a helper that also bound, say, a match count would bind that as
+ * a number.
+ */
+function boundIdsOf(operator: FindOperator<unknown>): Array<string> {
+  const parameters: Record<string, unknown> =
+    (operator.objectLiteralParameters as Record<string, unknown> | undefined) ||
+    {};
+
+  const carried: Array<unknown> = [
+    ...Object.values(parameters),
+    operator.value,
+  ];
+
+  const ids: Array<string> = [];
+
+  for (const entry of carried) {
+    for (const value of Array.isArray(entry) ? entry : [entry]) {
+      if (typeof value === "string") {
+        ids.push(value);
+      }
+    }
+  }
+
+  return ids.sort();
+}
+
 describe("the contract aggregateBy's own comments claim", () => {
   it("applies the permission query through setFindOptions, never by handing the object to .where()", () => {
     /*
      * This is the security-relevant one, and it is invisible from a black-box
      * call because both spellings produce a query that runs.
      *
-     * ReadPermission.checkReadBlockPermission (asserted below) can hand back a
-     * NESTED condition on the access-control relation — for a user holding a
-     * label-blocked read permission it writes
-     * `query[accessControlColumn] = { _id: notInOrNull(labelIds) }`.
+     * The permission pipeline (run for real below) can hand back a NESTED
+     * condition on the access-control relation — for a user whose read grant
+     * is label-scoped, the query comes back carrying
+     * `query[accessControlColumn] = { _id: <the permitted labels> }`.
      * TypeORM's `.where(object)` renders FLAT conditions only: it has no
      * relation to join the nested object against, so it drops the clause
      * rather than erroring. The aggregate would then count rows the equivalent
@@ -515,20 +614,150 @@ describe("the contract aggregateBy's own comments claim", () => {
     );
   });
 
-  it("still has a nested access-control condition to protect", () => {
+  it("still has a nested access-control condition to protect", async () => {
     /*
-     * The assertion above is only worth having while checkReadBlockPermission
-     * really does write a nested condition. If that ever became a flat clause,
-     * the setFindOptions requirement would stop being load-bearing and the
-     * comment explaining it would become folklore.
+     * The assertion above is only worth having while the permission pipeline
+     * really does hand back a condition keyed on the access-control RELATION.
+     * If every access-control predicate became a flat clause on a column of
+     * the table itself, `.where(object)` would apply it perfectly well, the
+     * de-duplicating subquery in buildAggregateScope would have nothing left
+     * to de-duplicate, and the comment above would become folklore.
+     *
+     * This used to be a source-text match on ReadPermission.ts, pinned to the
+     * exact expression checkReadBlockPermission wrote. That expression is
+     * gone: a label BLOCK is now a flat `_id NOT IN (SELECT ... FROM the join
+     * table)` predicate. That was a fix, not a regression — a relation join
+     * cannot express "has none of these labels" at all (a device labelled
+     * {blocked, other} still matches the join through its "other" row) — and
+     * a flat predicate needs no join, so the block half cannot inflate an
+     * aggregate either way.
+     *
+     * So nothing in this file asserts the block half any more, and that is a
+     * decision rather than an oversight. There is no aggregate-specific
+     * behaviour left to assert about it: with no relation key in the query,
+     * queryTouchesARelation says no, buildAggregateScope takes the flat
+     * `setFindOptions` branch, the same FindOptions machinery findBy uses
+     * applies the predicate, and there is no join to de-duplicate. A reader
+     * who holds a block AND a label-scoped allow puts the relation key back
+     * in, which is the case this test already covers. The block predicate
+     * itself belongs to ReadBlockPermission.test.ts, which owns it, and which
+     * has to mock QueryUtil.getManyToManyRelationMetadata to reach it —
+     * that helper returns null whenever Postgres is not connected, so a block
+     * assertion here would have to bring the mock with it, into a suite whose
+     * whole point is that it needs no database.
+     *
+     * The nested shape did not leave with it. It belongs to the ALLOW half,
+     * which is the half that has always produced the join aggregateBy has to
+     * survive: AccessControlPermission.addAccessControlIdsToQuery puts the
+     * permitted label ids on the access-control column, and
+     * QueryUtil.serializeQuery turns an id array on an EntityArray column
+     * into `{ _id: <operator> }`.
+     *
+     * So this asks the pipeline rather than grepping whichever file happens
+     * to spell it today: run the same call aggregateBy makes and look at what
+     * comes back. It goes red if the label-scoped read stops producing a
+     * relation-keyed condition — whether because the allow path moves to a
+     * flat `_id` predicate the way the block path did, because serializeQuery
+     * stops nesting the id filter under the relation, or because NetworkDevice
+     * loses its access-control relation.
+     *
+     * If that day comes, a red here is NOT permission to delete the
+     * setFindOptions requirement above, and it is not permission to quietly
+     * rewrite this expectation either. This test watches ONE producer of
+     * relation-keyed conditions, and there is at least one more:
+     * `@CanAccessIfCanReadOn` makes BasePermission write
+     * `query[relation] = { <the related model's access-control column>: ids }`
+     * for StatusPageResource, IncidentInternalNote, AlertEpisodeMember,
+     * OnCallDutyPolicyExecutionLogTimeline and others. queryTouchesARelation
+     * cannot tell that key apart from this one, and `.where(object)` would
+     * drop it just as silently — no exception, no log line, an aggregate over
+     * rows the caller may not read.
+     *
+     * What has to be RE-ESTABLISHED before anything here is deleted is
+     * therefore the whole claim rather than this one case: that NO read path —
+     * label allow, label block, `@CanAccessIfCanReadOn`, owner scoping,
+     * whatever has been added since — can still put a relation key in the
+     * permitted query. Nobody has shown that. Until somebody does, a red here
+     * means this particular case moved, and the test should follow it to
+     * wherever the nested condition is produced now.
+     *
+     * No database is needed: the permission pipeline is pure right up to the
+     * point DatabaseService hands the query to TypeORM.
      */
-    const READ_PERMISSION_CODE: string = squash(
-      stripComments(READ_PERMISSION_SOURCE),
+    const projectId: ObjectID = ObjectID.generate();
+    const permittedLabelId: ObjectID = ObjectID.generate();
+    const model: NetworkDevice = new NetworkDevice();
+
+    /*
+     * The two preconditions this test rests on, asserted rather than assumed.
+     * ProjectMember is the permission the reader below is given; the moment it
+     * stops being enough to read this table or the projectId column the query
+     * filters on, checkReadQueryPermission throws NotAuthorizedException with
+     * a message about permission names and nothing about aggregates. Whoever
+     * tightens those lists should learn it from one line here rather than from
+     * a confusing exception inside a test named after access-control
+     * conditions — and the fix then is to give this reader a permission that
+     * IS in both lists, not to change the lists back.
+     */
+    expect(model.getReadPermissions()).toContain(Permission.ProjectMember);
+    expect(model.getColumnAccessControlFor("projectId")?.read || []).toContain(
+      Permission.ProjectMember,
     );
 
-    expect(READ_PERMISSION_CODE).toContain(
-      "[model.getAccessControlColumn() as string] = { _id: QueryHelper.notInOrNull(labelIds)",
+    const permitted: CheckReadPermissionType<NetworkDevice> =
+      await ModelPermission.checkReadQueryPermission(
+        NetworkDevice,
+        { projectId: projectId },
+        null,
+        labelScopedReaderProps(projectId, permittedLabelId),
+      );
+
+    const accessControlColumn: string | null = model.getAccessControlColumn();
+
+    expect(accessControlColumn).toBeTruthy();
+
+    /*
+     * The key names a RELATION, not a column of this table. That is the whole
+     * reason `.where(object)` cannot apply the condition and FindOptions has
+     * to join for it.
+     */
+    const columnMetadata: TableColumnMetadata = model.getTableColumnMetadata(
+      accessControlColumn as string,
     );
+
+    expect(columnMetadata.type).toBe(TableColumnType.EntityArray);
+
+    // And the condition under that key is NESTED: a filter on the RELATED row.
+    const accessControlCondition: Record<string, unknown> = (
+      permitted.query as any
+    )[accessControlColumn as string];
+
+    /*
+     * `toBeTruthy`, not `toBeDefined`: the latter passes on null, and a null
+     * under that key is one of the ways this could break. The `typeof` check
+     * is the load-bearing half — a plain id string here instead of an object
+     * would BE the "it went flat" regression this test exists to catch, and
+     * a truthiness check alone would sail past it.
+     */
+    expect(accessControlCondition).toBeTruthy();
+    expect(typeof accessControlCondition).toBe("object");
+
+    const nestedIdFilter: unknown = accessControlCondition["_id"];
+
+    expect(nestedIdFilter).toBeInstanceOf(FindOperator);
+
+    /*
+     * The identity above and the payload below, and deliberately nothing in
+     * between. An earlier version of this assertion also read
+     * `getSql("probe")` and pinned the substring `probe IN (`, which is
+     * QueryHelper.in's chosen spelling — in a file this suite does not own.
+     * Rendering the same set membership as `= ANY(:x)` would have reddened
+     * this test with the invariant perfectly intact, which is precisely the
+     * kind of coupling that made this test red once already.
+     */
+    expect(boundIdsOf(nestedIdFilter as FindOperator<unknown>)).toEqual([
+      permittedLabelId.toString(),
+    ]);
   });
 
   it("runs the query through ModelPermission.checkReadQueryPermission, like findBy and countBy", () => {
@@ -543,24 +772,30 @@ describe("the contract aggregateBy's own comments claim", () => {
     expect(AGGREGATE_BY_BODY).toContain("checkReadPermissionType.query");
   });
 
-  it("validates orderBy expressions too", () => {
+  it("validates orderBy expressions above the permission call, which is what makes them testable", () => {
     /*
-     * The one guard this suite cannot exercise, because it sits after
-     * buildAggregateScope() — which calls getQueryBuilder() and so needs a
-     * live connection to reach (see the note in the statement-separator
-     * block). Deleting the call is the regression; that much is visible from
-     * here.
+     * The black-box test in the statement-separator block calls aggregateBy
+     * with a semicolon in an orderBy expression and expects BadDataException.
+     * It only reaches that check because the orderBy validation loop sits
+     * ABOVE checkReadQueryPermission and above buildAggregateScope, which is
+     * what keeps this suite database-free. Move the loop back down beside
+     * addOrderBy and that test starts failing on a missing connection instead
+     * — a confusing failure about jest rather than about the guard — so the
+     * position is pinned here, where the message is about the position.
      */
-    const orderByLoopStart: number = AGGREGATE_BY_BODY.indexOf(
-      "aggregateBy.orderBy",
-    );
-    const orderByLoopEnd: number = AGGREGATE_BY_BODY.indexOf("addOrderBy");
-
-    expect(orderByLoopStart).toBeGreaterThan(-1);
-    expect(orderByLoopEnd).toBeGreaterThan(orderByLoopStart);
-    expect(AGGREGATE_BY_BODY.slice(orderByLoopStart, orderByLoopEnd)).toContain(
+    const orderByValidationAt: number = AGGREGATE_BY_BODY.indexOf(
       "assertSafeAggregateExpression(order.expression)",
     );
+    const permissionAt: number = AGGREGATE_BY_BODY.indexOf(
+      "checkReadQueryPermission",
+    );
+    const applyLoopAt: number = AGGREGATE_BY_BODY.indexOf("addOrderBy");
+
+    expect(orderByValidationAt).toBeGreaterThan(-1);
+    expect(permissionAt).toBeGreaterThan(-1);
+    expect(applyLoopAt).toBeGreaterThan(-1);
+    expect(orderByValidationAt).toBeLessThan(permissionAt);
+    expect(applyLoopAt).toBeGreaterThan(permissionAt);
   });
 
   it("validates aliases and expressions before it touches permissions or the database", () => {

--- a/Common/Tests/Server/Utils/EventLoop.test.ts
+++ b/Common/Tests/Server/Utils/EventLoop.test.ts
@@ -40,30 +40,113 @@ if (
  *
  * So the tests below are comparative on purpose. Asserting that
  * yieldToEventLoop resolves would pass equally well for the broken
- * implementation this file was written to rule out; asserting that a pending
- * timer runs across it, and does NOT run across a microtask drain, is what
- * distinguishes them.
+ * implementation this file was written to rule out; asserting that a timer
+ * already past its deadline runs across it, and does NOT run across a
+ * microtask drain, is what distinguishes them.
  */
+
+/**
+ * Hold the event loop for at least `milliseconds` without ever yielding -
+ * exactly what a chunk of synchronous OTLP transformation does to it. There
+ * is no await in here, so no callback of any kind can run while it spins,
+ * which is what lets the tests below assert on a timer being OVERDUE rather
+ * than on how much wall clock a handful of loop turns happens to cover.
+ *
+ * Timed off the monotonic clock rather than Date.now(), because that is the
+ * clock family libuv computes timer deadlines from: a wall-clock reading can
+ * be stepped by NTP mid-spin, which would quietly turn "the timer is due now"
+ * back into the guess this file exists to get rid of.
+ */
+function blockEventLoopFor(milliseconds: number): void {
+  const startedAtNs: bigint = process.hrtime.bigint();
+  const spinForNs: number = milliseconds * 1000 * 1000;
+
+  while (Number(process.hrtime.bigint() - startedAtNs) < spinForNs) {
+    // Holding the thread IS the work here.
+  }
+}
+
+/*
+ * Five milliseconds, and the arithmetic behind it:
+ *
+ * setTimeout(fn, 0) is not a zero millisecond timer. Node's timers
+ * documentation is explicit that when the delay is "less than 1 [...] the
+ * delay will be set to 1", so the deadline these tests block past is 1 ms.
+ *
+ * libuv checks that deadline against the loop's cached clock rather than a
+ * fresh reading, and it only adopts the coarse monotonic clock when
+ * clock_getres reports a resolution of 1 ms or better - otherwise it keeps
+ * fine-grained CLOCK_MONOTONIC. So the worst case granularity of the loop
+ * clock is 1 ms; it is NOT the kernel tick (4 ms at HZ=250) that the word
+ * "coarse" suggests.
+ *
+ * 1 ms of deadline plus 1 ms of clock granularity is a 2 ms worst case. Five
+ * is more than double that, and a 5 ms spin costs a test nothing.
+ */
+const BLOCK_UNTIL_TIMER_IS_OVERDUE_MS: number = 5;
+
+/*
+ * A ceiling for the starvation test below - a bound on how long that test may
+ * spend failing, not a prediction of how many turns it needs. The reasoning
+ * for the number, and for why the loop is bounded at all, is with the test.
+ */
+const MAX_YIELDS_BEFORE_A_TIMER_MUST_HAVE_FIRED: number = 100000;
 
 describe("yieldToEventLoop actually advances the event loop", () => {
   /*
-   * Bounded rather than single-shot on purpose. Node does not order
-   * setImmediate against a due-but-not-yet-elapsed setTimeout(0), so
-   * asserting the timer runs after EXACTLY one yield would be a coin flip.
-   * The honest claim - and the one that matters - is that yielding lets the
-   * timer through promptly, which the microtask control case below shows it
-   * never does.
+   * This test used to schedule a 0 ms timer and yield up to ten times hoping
+   * to catch it, which was a wall-clock bet that lost on CI. Node floors
+   * setTimeout(fn, 0) at 1 ms, while a setImmediate ping-pong turns the loop
+   * over in single-digit microseconds, so the timer needs however many turns
+   * fit inside a millisecond: measured on this machine (Node 22, idle) that
+   * is 44 to 324 turns, median around 170. The exact figure is a property of
+   * the hardware, not of Node - the point is that it is hundreds of turns and
+   * ten was never going to be enough. The old version only passed when the
+   * process happened to be descheduled, or the loop's cached time happened to
+   * be stale, inside those ten turns.
+   *
+   * The defect was in the test, not in the helper. yieldToEventLoop hands
+   * control back to the loop, and that is all it can do: it cannot make
+   * wall-clock time pass, and the one thing that could - setTimeout(resolve,
+   * 1) - would be a real pessimisation, capping an ingest loop at a thousand
+   * chunks a second to satisfy a test. So this test asserts the guarantee the
+   * helper genuinely provides, which is also the one the liveness probe
+   * needs: work that is ALREADY due - a timer past its deadline, a queued I/O
+   * callback - runs across a yield instead of waiting out the synchronous
+   * batch.
+   *
+   * Two yields rather than one, because the phase the test body resumes in is
+   * not ours to choose. The documented rule for setImmediate is that "if an
+   * immediate timer is queued from inside an executing callback, that timer
+   * will not be triggered until the next event loop iteration", so the second
+   * yield's immediate cannot run until an iteration boundary has been crossed
+   * - and every iteration runs its timers phase exactly once. Note that this
+   * argument deliberately does not depend on WHERE in the iteration timers
+   * sit: libuv 1.45 (Node 20) moved them to after the poll phase, and the
+   * guarantee survives that move because it only counts iterations. It is a
+   * phase-ordering guarantee rather than a timing one, so it holds on a
+   * loaded CI runner exactly as well as on an idle laptop. Measured here, one
+   * yield was in fact enough 500 times out of 500; two is the bound that
+   * needs no assumption about where the loop was when the test resumed.
    */
-  test("lets a pending timer callback run", async () => {
+  test("lets a timer that came due during blocking work run", async () => {
     let timerFired: boolean = false;
 
     setTimeout((): void => {
       timerFired = true;
     }, 0);
 
-    for (let i: number = 0; i < 10 && !timerFired; i++) {
-      await EventLoop.yieldToEventLoop();
-    }
+    blockEventLoopFor(BLOCK_UNTIL_TIMER_IS_OVERDUE_MS);
+
+    /*
+     * Nothing ran while the loop was blocked - that starvation is the whole
+     * problem the helper exists to relieve, and pinning it here is what keeps
+     * the assertion below about the yield rather than about elapsed time.
+     */
+    expect(timerFired).toBe(false);
+
+    await EventLoop.yieldToEventLoop();
+    await EventLoop.yieldToEventLoop();
 
     expect(timerFired).toBe(true);
   });
@@ -72,25 +155,112 @@ describe("yieldToEventLoop actually advances the event loop", () => {
    * The control case, and the reason the helper is not just `await
    * Promise.resolve()`. Draining the microtask queue - however many times -
    * never reaches the phase where timers and I/O are serviced.
+   *
+   * There is deliberately no "and now yield it through" tail here any more:
+   * that used to repeat the previous test byte for byte, and the property it
+   * was standing in for - that the timer is genuinely still pending rather
+   * than lost - is pinned by the starvation test below, which drives the same
+   * construct until it fires. Only the first assertion is this test's own.
    */
   test("a microtask drain, by contrast, does not", async () => {
+    let timerFired: boolean = false;
+
+    const timer: NodeJS.Timeout = setTimeout((): void => {
+      timerFired = true;
+    }, 0);
+
+    try {
+      for (let i: number = 0; i < 100000; i++) {
+        await Promise.resolve();
+      }
+
+      expect(timerFired).toBe(false);
+    } finally {
+      // Nothing else in the file should inherit a live timer from this one.
+      clearTimeout(timer);
+    }
+  });
+
+  /*
+   * The weaker but still real property the original ten-iteration test was
+   * reaching for, restored with a bound it can actually keep: a yield loop
+   * does not STARVE a timer that is not yet due. A setImmediate ping-pong
+   * could in principle keep re-entering the check phase and never let the
+   * loop clock advance past the deadline; it does not, and an ingest job that
+   * yields in a tight loop depends on it not doing so.
+   *
+   * The bound here is temporal, not countable. Each yield turns the loop over
+   * once, so the timer comes due after however many turns fit in its 1 ms
+   * deadline - and that count goes DOWN on a slower or busier machine,
+   * because each turn then costs more wall clock. The direction of error is
+   * the friendly one: 100,000 is roughly three hundred times the worst case
+   * measured here, and CI load only makes it more generous.
+   *
+   * The loop is capped rather than written `while (!timerFired)` for a
+   * reason that is easy to get backwards. Against a microtask-based
+   * implementation - the exact regression this file exists to catch - an
+   * uncapped loop would never advance the loop clock, so the timer would
+   * never fire AND jest's own testTimeout, which is itself a timer, could
+   * never fire either: the worker would hang until the job timeout instead of
+   * going red. Measured: the uncapped form outlived a 5 second watchdog and
+   * had to be killed, while the capped form exhausts 100,000 microtask turns
+   * and fails in about 6 ms.
+   */
+  test("a yield loop lets a timer that is not yet due through", async () => {
     let timerFired: boolean = false;
 
     setTimeout((): void => {
       timerFired = true;
     }, 0);
 
-    for (let i: number = 0; i < 100000; i++) {
-      await Promise.resolve();
-    }
+    let yields: number = 0;
 
-    expect(timerFired).toBe(false);
-
-    // And the timer is genuinely still pending, not lost.
-    for (let i: number = 0; i < 10 && !timerFired; i++) {
+    while (!timerFired && yields < MAX_YIELDS_BEFORE_A_TIMER_MUST_HAVE_FIRED) {
       await EventLoop.yieldToEventLoop();
+      yields++;
     }
+
+    // False here means the cap was exhausted: the yield never let it through.
     expect(timerFired).toBe(true);
+  });
+
+  /*
+   * What separates setImmediate from setTimeout(resolve, 0), which every
+   * other test in this file is blind to - a mutant helper built on a 0 ms
+   * timer passes all of them, and the comment above argues against exactly
+   * that substitution, so something has to hold the line.
+   *
+   * setImmediate resolves in the check phase of the loop iteration it is
+   * queued for, and immediates run in the order they were created, so an
+   * immediate queued AFTER the yield cannot have run by the time the yield's
+   * continuation does. A timer-based helper cannot manage that: its resolve
+   * waits out a 1 ms deadline, which is several hundred check phases away, so
+   * the later immediate wins.
+   *
+   * Repeated a handful of times because a single probe is not quite decisive:
+   * measured, setTimeout(resolve, 0) survives one probe about 3 times in 200
+   * (when the process is descheduled past the 1 ms floor between the two
+   * scheduling calls), but never survives five in a row - 0/200 for both
+   * setTimeout(resolve, 0) and setTimeout(resolve, 1), against 200/200 for
+   * the real implementation. Repetition costs five loop turns and buys the
+   * distinction outright.
+   */
+  test("resolves ahead of an immediate queued after it", async () => {
+    const probes: number = 5;
+
+    for (let probe: number = 0; probe < probes; probe++) {
+      let laterImmediateFired: boolean = false;
+
+      const yielded: Promise<void> = EventLoop.yieldToEventLoop();
+
+      setImmediate((): void => {
+        laterImmediateFired = true;
+      });
+
+      await yielded;
+
+      expect(laterImmediateFired).toBe(false);
+    }
   });
 
   test("lets a pending immediate callback run", async () => {
@@ -159,12 +329,22 @@ describe("the shape of the helper itself", () => {
     return pending;
   });
 
+  /*
+   * The real subject here is termination - a yield that never resolved would
+   * hang this loop until jest's testTimeout, not fail an assertion - so the
+   * count is asserted rather than a bare `expect(true)`: it at least pins
+   * that every one of the fifty awaits settled and the loop body ran each
+   * time.
+   */
   test("can be awaited many times in a row", async () => {
+    let completedYields: number = 0;
+
     for (let i: number = 0; i < 50; i++) {
       await EventLoop.yieldToEventLoop();
+      completedYields++;
     }
 
-    expect(true).toBe(true);
+    expect(completedYields).toBe(50);
   });
 
   test("several concurrent yields all resolve", async () => {

--- a/Common/UI/Components/CSVFileUpload/CSVFileUpload.tsx
+++ b/Common/UI/Components/CSVFileUpload/CSVFileUpload.tsx
@@ -93,7 +93,14 @@ const CSVFileUpload: FunctionComponent<ComponentProps> = (
   const [error, setError] = useState<string>("");
   const [parsedRows, setParsedRows] = useState<Array<CSVRow>>([]);
   const [fileName, setFileName] = useState<string>("");
-  const fileInputRef: React.RefObject<HTMLInputElement | null> =
+  /*
+   * The element type goes in T on its own: RefObject<T> already declares
+   * `current` as `T | null`, and RefObject<HTMLInputElement | null> is a
+   * structurally identical but non-assignable type, rejected on the `ref`
+   * prop below because RefObject is covariant in T. That mismatch is what
+   * used to need a cast there.
+   */
+  const fileInputRef: React.RefObject<HTMLInputElement> =
     useRef<HTMLInputElement>(null);
 
   const downloadTemplate: DownloadTemplateFunction = (): void => {
@@ -270,7 +277,7 @@ const CSVFileUpload: FunctionComponent<ComponentProps> = (
           </div>
           <p className="text-xs text-gray-500">CSV files only</p>
           <input
-            ref={fileInputRef as React.RefObject<HTMLInputElement>}
+            ref={fileInputRef}
             type="file"
             accept=".csv"
             className="sr-only"

--- a/Common/jest.config.json
+++ b/Common/jest.config.json
@@ -33,6 +33,8 @@
     "^use-async-effect$": "<rootDir>/node_modules/use-async-effect",
     "^reactflow$": "<rootDir>/node_modules/reactflow",
     "^react-beautiful-dnd$": "<rootDir>/node_modules/react-beautiful-dnd",
+    "^recharts$": "<rootDir>/node_modules/recharts",
+    "^recharts/(.*)$": "<rootDir>/node_modules/recharts/$1",
     "^i18next-browser-languagedetector$": "<rootDir>/Tests/__mocks__/i18next-browser-languagedetector.js",
     "^react-markdown$": "<rootDir>/Tests/__mocks__/react-markdown.js",
     "^remark-gfm$": "<rootDir>/Tests/__mocks__/remark-gfm.js",

--- a/Common/tsconfig.json
+++ b/Common/tsconfig.json
@@ -47,16 +47,54 @@
      * NOT in the Common Test CI job, which installs Common alone. The result
      * was a suite that passed locally and failed in CI.
      *
-     * "react-router-dom" and "react-i18next" are here for the same reason,
-     * one level out: those same App sources import them, and unlike "react"
-     * they are not covered by anything the type checker can already reach from
-     * Common. Node resolution walks up from the importing FILE, so from
-     * App/FeatureSet/<app>/src/... it only ever looks in App's and the repo
-     * root's node_modules - never in Common's, which is the only one installed
-     * in the Common Test CI job AND, for react-i18next, the only place it is
-     * installed at all. Common's jest moduleNameMapper already maps these
-     * specifiers to this same directory at runtime; this is the type checker's
-     * half of that.
+     * Everything below "Common/*" is a third-party package, here for the same
+     * reason one level out: those same App sources import it. Node resolution
+     * walks up from the importing FILE, so from App/FeatureSet/<app>/src/...
+     * it only ever looks in App's and the repo root's node_modules - never in
+     * Common's, which is the only one installed in the Common Test CI job.
+     *
+     * Which packages need an entry is not obvious, so the rule: a package
+     * lands here only if it SHIPS ITS OWN TYPES. When the node_modules walk
+     * comes up empty, TypeScript makes one last attempt out of `typeRoots`
+     * (./node_modules/@types, below) - a declaration-only fallback. That is
+     * why "react", "react-dom", "react-beautiful-dnd" and every other
+     * @types-backed package resolve from an App file with nothing here. A
+     * self-typed package - react-router-dom, react-i18next, i18next,
+     * use-async-effect, reactflow, recharts - never reaches that fallback, so
+     * without an entry it is TS2307 in CI and clean locally. A package Common
+     * does not install AT ALL is a third case and belongs in
+     * Typings/Index.d.ts as an ambient `declare module` instead (see
+     * i18next-browser-languagedetector there).
+     *
+     * The pairing with Common/jest.config.json's moduleNameMapper runs ONE
+     * WAY: every entry here needs a twin there, never the reverse. Most of
+     * that file's entries have no twin here and should not gain one - the
+     * @types-backed packages above, and every Tests/__mocks__ redirect.
+     *
+     * That asymmetry is the dangerous half, because it fails silently.
+     * typeRoots rescues an @types-backed package for the type CHECKER only;
+     * nothing rescues it at RUNTIME, where the App file still calls require()
+     * from a directory that cannot see Common/node_modules. An App file that
+     * imports react-big-calendar, react-color or react-toggle therefore
+     * compiles clean here and then throws "Cannot find module" from inside a
+     * render. The fix for that is a moduleNameMapper entry on its own - which
+     * is what "react", "react-dom" and "react-beautiful-dnd" already have.
+     *
+     * Which is why there is no catch-all `"*": ["./node_modules/*"]` here:
+     * resolving every specifier for the type checker would delete the TS2307
+     * that is the only early warning the runtime half is missing, turning
+     * every case above into the silent one. moduleNameMapper could not mirror
+     * a catch-all anyway - its regexes see the specifier, not the importing
+     * file - though jest's `resolver` hook could, being handed the importer as
+     * options.basedir; it would just take over resolution for every module in
+     * the suite, which these few pairs do not warrant.
+     *
+     * Both halves are exact-anchored, so a subpath needs its own entry:
+     * "recharts" does not cover "recharts/types/util/types", which four
+     * Common charts import and which is TS2307 from an App file - hence
+     * "recharts/*". A side-effect-only import needs neither half, since
+     * TypeScript does not report `import "reactflow/dist/style.css"` as
+     * unresolved and the mapper's css rule already catches it at runtime.
      *
      * Deliberately `paths` WITHOUT `baseUrl` (supported since TS 4.4, and
      * paths here are relative to this file). Setting baseUrl would change how
@@ -69,7 +107,9 @@
       "react-i18next": ["./node_modules/react-i18next"],
       "i18next": ["./node_modules/i18next"],
       "use-async-effect": ["./node_modules/use-async-effect"],
-      "reactflow": ["./node_modules/reactflow"]
+      "reactflow": ["./node_modules/reactflow"],
+      "recharts": ["./node_modules/recharts"],
+      "recharts/*": ["./node_modules/recharts/*"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     "typeRoots": [


### PR DESCRIPTION
Master has been red since this morning. Three jobs — **App Test**, **Common Test** (6 of 8 shards) and **Common Jobs / js-lint** — were failing across **eight distinct root causes**. None were flaky. Each is fixed where it was caused rather than where it was reported.

## Common Test

**1. Five suites failed to compile: `TracesAnalyticsView.tsx:22 TS2307: Cannot find module 'recharts'`**

The Common Test job runs `cd Common && npm install` and nothing else, so neither `App/node_modules` nor the repo-root `node_modules` exists on the runner. Module resolution walks up from the *importing* file, and from `App/FeatureSet/...` it never reaches `Common/node_modules`. `recharts` is already a Common dependency — it was simply missing from the two escape hatches `Common/tsconfig.json` and `Common/jest.config.json` already keep for exactly this case. Both halves added, plus the `recharts/*` subpath that four Common charts import.

The comment above `paths` was rewritten. It enumerated a stale list of packages, never said *why* `react` needs no entry (TypeScript's `typeRoots` fallback), and hid the dangerous asymmetry: that fallback rescues an `@types`-backed package for the type checker, but nothing rescues it at runtime — so that variant fails *silently*, from inside a render, instead of loudly at compile time.

**2. `DashboardMonitorLabelVariable` failed on three `TS2322`s in `DashboardResourceHoneycomb.tsx`**

The refs were annotated `React.RefObject<HTMLDivElement | null>` when `RefObject<T>` already declares `current` as `T | null`. The two types are structurally identical, but TypeScript compares references to the *same* generic type by variance, and `T` is covariant in `RefObject` — so it checks `HTMLDivElement | null` against `HTMLDivElement` and rejects it on the `ref` prop. The Dashboard's own compile stays green because its program carries two `@types/react` copies, which makes the two `RefObject`s different targets and sends the check down the structural path.

The same bug was latent in `FlameGraph.tsx`, and had been silenced in `CSVFileUpload.tsx` with a cast back in April. Both are fixed properly and the cast is gone.

**3. `DatabaseServiceAggregateBy` asserted the source *text* of `ReadPermission.ts`**

which #3627's label-variable work legitimately rewrote: a label BLOCK is now a flat `_id NOT IN (SELECT ...)` predicate, because a relation join cannot express "has none of these labels" at all. The nested relation condition `aggregateBy` has to survive belongs to the ALLOW half and is still there. The assertion now **runs the permission pipeline** instead of grepping a file it does not own, and reads the operator's bound ids rather than `QueryHelper`'s chosen SQL spelling. `buildAggregateScope`'s own doc comment described the old shape and is brought up to date.

**4. `EventLoop`'s "lets a pending timer callback run" was a wall-clock bet**

It gave a 0 ms timer (floored to 1 ms by Node) ten `setImmediate` round trips, which cover a small fraction of that deadline. It now blocks the loop past the deadline and relies on phase ordering — an immediate queued from inside an executing immediate is deferred to the next iteration, and every iteration opens with the timers phase — so two yields are a guarantee rather than a race. The property the old test was reaching for (a yield loop does not starve a not-yet-due timer) is restored as its own test.

## Common Jobs / js-lint

`StatusPageOidcOrigin` bound the status page's SSO component to an all-caps `SSO`, which `react/jsx-pascal-case` rejects. (Fixed on master in parallel while this branch was in flight; the rebase keeps the rename and adds a comment saying why the binding is `Sso`, so nobody renames it back.)

## App Test

Three suites failed on hardcoded tallies that #3627/#3628's fourth bulk-sync card walked into (13 → 14 raw calls, 3 → 4 helper calls), and on an adjacency pin that broke when `customFields` was inserted between two keys of a `select`.

**The new call site was verified correct first** — it sends the tenant header and routes through `buildSyncResultSummary` with its own subject — so the magic numbers, not the page, were the defect. Those assertions now derive their expectations from the source:

- every discovered raw call to a project-scoped route must carry the tenant header;
- every guarded page must still be discovered, and **no page outside the guarded list may reach a project-scoped route** (this is what earns the per-page check the right to be exhaustive);
- every bulk sync must route through the shared helper with a distinct, non-empty subject.

`MonitorTemplateSyncTenantHeader`'s `toBe(7)` is fixed the same way before it breaks too, and `MonitorCreateLabels` now strips comments before matching — without that, deleting `labels: true` and leaving a comment in its place passed.

## Verification

- The five recharts suites, the honeycomb suite, and **every other Common suite that touches recharts — 27 suites, 459 tests** — run green with `App/node_modules` and the root `node_modules` hidden, which is what the CI runner actually looks like.
- **Negative control:** backing the fixes out under that same harness reproduces the exact CI failures, so the green is not vacuous.
- App's affected suites pass (115 tests, including the new Inventory suites from master).
- `Common` and `App` `tsc` are clean; the Dashboard package's own `tsc` reports nothing in the changed files.
- `eslint` and `prettier` are clean on every file touched.

Each rewritten assertion was mutation-tested: the source it guards was temporarily broken to confirm the test still goes red, then restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kjDdDnCbwpD3uCsks2tu5
