### PR TITLE
fix(ci): repair the two failures the topology and inventory merges left

### DIFF
--- a/App/Tests/Dashboard/NetworkHealthFilterWiring.test.ts
+++ b/App/Tests/Dashboard/NetworkHealthFilterWiring.test.ts
@@ -86,6 +86,72 @@ const CHIP_GROUP: string = readSource(
   "StatusChipGroup.tsx",
 );
 
+const HEALTH_FILTER_TEST_ID: string = "network-topology-health-filter";
+
+/*
+ * Every .tsx under the topology tree, so the assertion below can FIND the
+ * component that mounts the health chip group instead of being told which one
+ * it is. #3639 moved that mount out of the live view and into
+ * NetworkTopologyToolbar; the old version of this test pinned the live view's
+ * import line and went red for a refactor that kept the feature working
+ * exactly as before. What is load bearing is that the shared chip group is
+ * mounted once, bound to the live view's state - not which file holds the JSX.
+ */
+function listTopologySources(directory: string): Array<string> {
+  const found: Array<string> = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const full: string = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      found.push(...listTopologySources(full));
+    } else if (entry.name.endsWith(".tsx")) {
+      found.push(full);
+    }
+  }
+
+  return found;
+}
+
+interface ChipGroupMount {
+  file: string;
+  source: string;
+  mount: string;
+}
+
+/*
+ * The `<StatusChipGroup ... />` element carrying the health filter's test id,
+ * sliced out of whichever file renders it. Read as an element rather than as
+ * a whole file so the bindings asserted below belong to THIS mount and not to
+ * some other chip group the same file might grow later.
+ */
+function findHealthChipGroupMounts(): Array<ChipGroupMount> {
+  const mounts: Array<ChipGroupMount> = [];
+
+  for (const file of listTopologySources(
+    path.join(DASHBOARD_SRC, "Components", "Topology"),
+  )) {
+    const source: string = stripComments(fs.readFileSync(file, "utf8"));
+    const element: RegExp = /<StatusChipGroup\b[\s\S]*?\/>/g;
+
+    let match: RegExpExecArray | null = element.exec(source);
+
+    while (match !== null) {
+      if (match[0].includes(`dataTestId="${HEALTH_FILTER_TEST_ID}"`)) {
+        mounts.push({
+          file: path.relative(DASHBOARD_SRC, file),
+          source: source,
+          mount: flatten(match[0]),
+        });
+      }
+
+      match = element.exec(source);
+    }
+  }
+
+  return mounts;
+}
+
 describe("the device topology's health filter is wired end to end", () => {
   test("the live view owns the filter state", () => {
     expect(LIVE_VIEW).toContain("useState<TopologyHealthFilterMode>");
@@ -101,11 +167,59 @@ describe("the device topology's health filter is wired end to end", () => {
     );
   });
 
-  test("the live view renders the shared chip group for it", () => {
-    expect(flatten(LIVE_VIEW)).toContain(
-      'import StatusChipGroup, { StatusChipOption } from "../Filters/StatusChipGroup";',
+  test("the shared chip group is mounted for it, exactly once", () => {
+    const mounts: Array<ChipGroupMount> = findHealthChipGroupMounts();
+
+    /*
+     * Named in the failure rather than counted, because "0 !== 1" over a
+     * scanned tree is indistinguishable from a broken scanner.
+     */
+    expect(
+      mounts.map((mount: ChipGroupMount) => {
+        return mount.file;
+      }),
+    ).toHaveLength(1);
+
+    const mount: ChipGroupMount = mounts[0]!;
+
+    /*
+     * The SHARED group, not a local lookalike: the chips carry counts and a
+     * selected state that the Filters component owns, and a second copy would
+     * drift from the one the site pages use.
+     */
+    expect(flatten(mount.source)).toContain(
+      'from "../Filters/StatusChipGroup"',
     );
-    expect(LIVE_VIEW).toContain('dataTestId="network-topology-health-filter"');
+
+    /*
+     * The options come from the builder, and the selection is the live
+     * view's mode travelling back out as a change.
+     */
+    expect(mount.mount).toContain("healthChipOptions");
+    expect(mount.mount).toContain("healthFilterMode");
+    expect(mount.mount).toContain("onHealthChange");
+  });
+
+  test("the live view's state and handler reach that mount", () => {
+    /*
+     * The other half of the same claim. The mount above binds names from
+     * ITS OWN props, so if the mount lives in a child component, this is
+     * what stops the live view from simply never rendering that child or
+     * never handing it the filter - a chip group wired to nothing.
+     */
+    const mount: ChipGroupMount = findHealthChipGroupMounts()[0]!;
+    const owner: string = path.basename(mount.file, ".tsx");
+
+    if (owner === "NetworkTopologyLiveView") {
+      return;
+    }
+
+    const flatLiveView: string = flatten(LIVE_VIEW);
+
+    expect(flatLiveView).toContain(`<${owner}`);
+    expect(flatLiveView).toContain("healthChipOptions={healthChipOptions}");
+    expect(flatLiveView).toContain("healthFilterMode={healthFilterMode}");
+    expect(flatLiveView).toContain("onHealthChange={setHealthFilterMode}");
   });
 
   test("the chips are built from the pure options builder, not hand-rolled", () => {

--- a/Common/Tests/App/Dashboard/InventoryItems.test.tsx
+++ b/Common/Tests/App/Dashboard/InventoryItems.test.tsx
@@ -35,8 +35,10 @@ interface InventoryTableProps {
 let capturedTable: InventoryTableProps | null = null;
 let capturedFacetStates: Array<FacetSelectionState> = [];
 
-// Exercise the real page and browser navigation without fetching table rows.
-// Capture the same URL state the table's facet hook reads on its first render.
+/*
+ * Exercise the real page and browser navigation without fetching table rows.
+ * Capture the same URL state the table's facet hook reads on its first render.
+ */
 jest.mock(
   "../../../../App/FeatureSet/Dashboard/src/Components/Inventory/InventoryTable",
   () => {


### PR DESCRIPTION
Follow-up to #3644. Two PRs merged minutes apart this afternoon each left master red in a way their own CI runs could not have shown, because both were queued against an older master.

## App Test — `NetworkHealthFilterWiring`

The test *"the live view renders the shared chip group for it"* asserted, as a literal string, that `NetworkTopologyLiveView.tsx` contains:

```ts
import StatusChipGroup, { StatusChipOption } from "../Filters/StatusChipGroup";
```

The topology redesign moved that mount into `NetworkTopologyToolbar`, which now receives `healthChipOptions`, `healthFilterMode` and `onHealthChange` from the live view and renders the same shared `StatusChipGroup` under the same `dataTestId`. **Nothing about the feature changed** — the test pinned *which file holds the JSX*, which was never the claim it was written to make.

It now **scans** `Components/Topology` for the element carrying the health filter's test id, and asserts what is actually load-bearing:

- the **shared** group (not a local lookalike) is mounted **exactly once** — reported by filename, so "0 mounts" can't be mistaken for a broken scanner;
- that mount binds the options, the mode and the change handler;
- when the mount lives in a child — as it now does — the live view really renders that child and hands it all three.

Moving the mount again passes. Dropping it, or leaving the live view rendering a chip group wired to nothing, still fails.

**Mutation-checked**, by breaking the real sources rather than the test's inputs:

| Mutation | Result |
|---|---|
| Toolbar's chip group loses the health `dataTestId` | both new tests go red |
| Live view stops handing `healthChipOptions` to the toolbar | the second test goes red |
| Restored | 28/28 green |

## Common Jobs / js-lint

`InventoryItems.test.tsx` opened a two-line explanation with consecutive `//` comments, which eslint's `multiline-comment-style` rejects. `npx eslint .` is repo-wide, so that single error failed the job for the entire repository. Converted to a starred block.

## Verification

`NetworkHealthFilterWiring` passes 28/28; eslint and prettier are clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kjDdDnCbwpD3uCsks2tu5
