### PR TITLE
fix(inventory): stop one object becoming two discovered inventory items

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,8 +188,12 @@ jobs:
           helm template oneuptime --values oneuptime/values.yaml
           helm package --sign --key 'key@oneuptime.com' --keyring ~/.gnupg/secring.gpg oneuptime --version ${{needs.read-version.outputs.major_minor}} --app-version ${{needs.read-version.outputs.major_minor}}
           echo "OneUptime Helm Chart Package created successfully"
-          helm lint kubernetes-agent
-          helm template kubernetes-agent --values kubernetes-agent/values.yaml
+          # clusterName has no default and cannot have one -- it is what keeps
+          # one cluster's nodes and namespaces distinct from another's in
+          # OneUptime, so the chart refuses to render without it. Supply a
+          # throwaway value here; this only proves the templates render.
+          helm lint kubernetes-agent --set clusterName=ci-render-check
+          helm template kubernetes-agent --values kubernetes-agent/values.yaml --set clusterName=ci-render-check
           helm package --sign --key 'key@oneuptime.com' --keyring ~/.gnupg/secring.gpg kubernetes-agent --version ${{needs.read-version.outputs.major_minor}} --app-version ${{needs.read-version.outputs.major_minor}}
           echo "Kubernetes Agent Helm Chart Package created successfully"
           cd ..

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,15 @@ There are a lot of tests in the app, please do not run all of them, run only the
 
 ### Helm chart
 
-The chart lives in `HelmChart/Public/oneuptime`. It has cluster-free unit tests in
-`HelmChart/Public/oneuptime/tests` (helm-unittest); run them with `npm run test-helm-chart`
+Two charts are published: the product itself in `HelmChart/Public/oneuptime`, and the
+Kubernetes agent in `HelmChart/Public/kubernetes-agent`. Both have cluster-free unit tests
+in their own `tests/` directory (helm-unittest); run them with `npm run test-helm-chart`
 (it installs the plugin for you through the runner, or install it yourself with
 `helm plugin install https://github.com/helm-unittest/helm-unittest`).
+
+The agent chart writes the OpenTelemetry collector configuration, which decides what
+resource attributes ingest actually sees — so a mistake there surfaces as wrong data
+rather than as a failed deploy. Prefer a render assertion over a careful reading.
 
 `npm run test-helm-chart-all` runs every chart test — lint, those unit tests, and the
 cluster-backed suites that install the chart on a throwaway KinD cluster. That is the

--- a/App/FeatureSet/Workers/Jobs/TelemetryEntity/PruneStaleEntities.ts
+++ b/App/FeatureSet/Workers/Jobs/TelemetryEntity/PruneStaleEntities.ts
@@ -60,6 +60,17 @@ const ENTITY_TTL_HOURS: ReadonlyMap<EntityType, number> = new Map<
   [EntityType.KubernetesCluster, 30 * 24],
   [EntityType.ProxmoxCluster, 30 * 24],
   [EntityType.CephCluster, 30 * 24],
+  /*
+   * Discovered from `docker.swarm.cluster.name` on agent telemetry, so it is
+   * bumped like any other discovered row and has to age out like one. It was
+   * simply missed when the Docker Swarm types were added after this map, and
+   * a type that is promoted but absent here is unreachable by the sweep —
+   * meaning a decommissioned swarm, or a row left behind by an identity
+   * change, stays in Inventory forever. The other three swarm types are
+   * declared but never resolved from a resource (their inventory arrives as
+   * JSON-line logs), so they mint no discovered rows and need no TTL.
+   */
+  [EntityType.DockerSwarmCluster, 30 * 24],
 ]);
 
 // Edges carry no entity type, so they get the longest entity TTL.

--- a/App/Tests/Workers/Jobs/TelemetryEntity/PruneStaleEntities.test.ts
+++ b/App/Tests/Workers/Jobs/TelemetryEntity/PruneStaleEntities.test.ts
@@ -209,6 +209,49 @@ describe("entity pruning is scoped to discovered rows", () => {
     expect(swept).toContain(EntityType.Service);
     expect(swept).toContain(EntityType.Host);
   });
+
+  test("every telemetry-discovered type the resolvers can emit is swept", async () => {
+    /*
+     * A type that ingest promotes but this map omits is unreachable by the
+     * sweep, so a row of that type lives forever — including one left behind
+     * by an identity change, which is exactly the shape of a duplicate that
+     * never goes away. `docker.swarm.cluster` was missed this way when the
+     * Docker Swarm types were added after the map.
+     *
+     * The list is the promoted types a heuristic resolver can actually derive
+     * from resource attributes. The other three Docker Swarm types are
+     * declared but never resolved from a resource (their inventory arrives as
+     * JSON-line logs), so they mint no discovered rows and need no TTL.
+     */
+    await runTick();
+
+    const swept: Array<EntityType | undefined> = entityDeleteCalls().map(
+      (call: DeleteCall) => {
+        return call.query.entityType;
+      },
+    );
+
+    for (const entityType of [
+      EntityType.Service,
+      EntityType.ServiceInstance,
+      EntityType.Host,
+      EntityType.Container,
+      EntityType.Process,
+      EntityType.KubernetesCluster,
+      EntityType.KubernetesNamespace,
+      EntityType.KubernetesNode,
+      EntityType.KubernetesPod,
+      EntityType.KubernetesDeployment,
+      EntityType.ProxmoxCluster,
+      EntityType.ProxmoxNode,
+      EntityType.ProxmoxGuest,
+      EntityType.CephCluster,
+      EntityType.DockerSwarmCluster,
+      EntityType.TelemetrySdk,
+    ]) {
+      expect(swept).toContain(entityType);
+    }
+  });
 });
 
 describe("relationship pruning is scoped to discovered edges", () => {

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -46,6 +46,7 @@ import Protocol from "../../Types/API/Protocol";
 import Route from "../../Types/API/Route";
 import URL from "../../Types/API/URL";
 import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Sort from "../../Types/BaseDatabase/Sort";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import { getMaxLengthFromTableColumnType } from "../../Types/Database/ColumnLength";
 import Columns from "../../Types/Database/Columns";
@@ -2147,6 +2148,36 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
         Object.keys(onBeforeFind.groupBy).length > 0
       ) {
         throw new BadDataException("GroupBy is currently not supported");
+      }
+
+      /*
+       * Complete the caller's sort into a TOTAL order.
+       *
+       * Everything here pages with LIMIT/OFFSET, and OFFSET only means
+       * anything against an ordering that has no ties: rows that compare
+       * equal may come back in any order, and Postgres is free to return them
+       * differently for the two queries that fetch page 1 and page 2. A tied
+       * row can therefore be served on both pages while another is served on
+       * neither — the same row apparently listed twice.
+       *
+       * Ties are not exotic. The Inventory list sorts on `lastSeenAt`, which
+       * the entity reconciler rewrites for every live entity every few
+       * minutes, and the inventory mirror stamps one identical timestamp
+       * across a whole page of rows; "created at" sorts tie for anything
+       * bulk-inserted in one statement. Appending the primary key breaks
+       * every tie deterministically and costs nothing — `_id` is the PK, and
+       * it is already in the select (see above), so this adds no column to
+       * the projection and nothing to strip afterwards.
+       */
+      const sortSoFar: Dictionary<SortOrder> =
+        (onBeforeFind.sort as Dictionary<SortOrder> | undefined) || {};
+
+      if (!sortSoFar["_id"]) {
+        // Copied, never mutated: callers reuse their sort objects across queries.
+        onBeforeFind.sort = {
+          ...sortSoFar,
+          _id: SortOrder.Ascending,
+        } as Sort<TBaseModel>;
       }
 
       const items: Array<TBaseModel> = await this.getRepository().find({

--- a/Common/Server/Services/InventoryItemService.ts
+++ b/Common/Server/Services/InventoryItemService.ts
@@ -57,6 +57,27 @@ export class InventoryItemService extends DatabaseService<Model> {
   ): Promise<OnCreate<Model>> {
     const data: Model = createBy.data;
 
+    /*
+     * Who is calling decides this, not what they sent.
+     *
+     * The two machine writers — the ingest reconciler and the inventory
+     * mirror — construct the model themselves and create it with
+     * `props: { isRoot: true }`. Everything else is a person or an API
+     * client. Keying the branch on "did the payload include an entityKey"
+     * instead let any caller opt out of every check below simply by sending
+     * one: the manual-type restriction, the required display name, the
+     * canonicalize-then-hash identity derivation and the firstSeenAt /
+     * lastSeenAt stamp were all skipped, and a hand-supplied
+     * `source: "discovered"` was taken at face value — putting a row in
+     * Inventory that claims to have been discovered from telemetry, of a type
+     * only ingest is supposed to create, which the prune sweep then treats as
+     * TTL-reapable.
+     */
+    if (createBy.props.isRoot !== true) {
+      delete data.entityKey;
+      data.source = EntitySource.Manual;
+    }
+
     if (!data.entityKey) {
       data.source = EntitySource.Manual;
     }
@@ -150,7 +171,16 @@ export class InventoryItemService extends DatabaseService<Model> {
     const countByType: Map<EntityType, number> = new Map<EntityType, number>();
 
     for (const entity of data.entities) {
-      if (!REGISTRY_PROMOTED_TYPES.has(entity.entityType)) {
+      /*
+       * Both promotion gates, repeated at the write boundary. The caller
+       * applies them too, but this method is public and the cost of a missed
+       * gate here is a registry row that should never have existed — see
+       * `ExtractedEntity.membershipOnly` for what the per-entity flag means.
+       */
+      if (
+        entity.membershipOnly ||
+        !REGISTRY_PROMOTED_TYPES.has(entity.entityType)
+      ) {
         continue;
       }
       try {

--- a/Common/Server/Utils/Telemetry/EntityRegistry.ts
+++ b/Common/Server/Utils/Telemetry/EntityRegistry.ts
@@ -217,7 +217,17 @@ export async function reconcileEntityRegistryThrottled(data: {
   try {
     const promoted: Array<ExtractedEntity> = data.entities.filter(
       (entity: ExtractedEntity) => {
-        return REGISTRY_PROMOTED_TYPES.has(entity.entityType);
+        /*
+         * Two gates, and they answer different questions. The type gate asks
+         * "does this KIND of thing belong in the registry"; the per-entity
+         * flag asks "is this particular observation the resource's entity of
+         * that type, or a duplicate the producer sent alongside it". See
+         * `ExtractedEntity.membershipOnly`.
+         */
+        return (
+          !entity.membershipOnly &&
+          REGISTRY_PROMOTED_TYPES.has(entity.entityType)
+        );
       },
     );
     const retiredHosts: Array<RetiredEntityIdentity> = (

--- a/Common/Server/Utils/Telemetry/TelemetryEntity.ts
+++ b/Common/Server/Utils/Telemetry/TelemetryEntity.ts
@@ -82,6 +82,20 @@ export interface ExtractedEntity {
    * the registry attaches them via the existing project label system.
    */
   labels?: Array<string>;
+  /**
+   * When true this entity contributes its key to `entityKeys` on signals but
+   * must never mint a registry row.
+   *
+   * One OTLP resource describes ONE object of any given type — it is a single
+   * pod, on a single node, in a single cluster — and the rest of the pipeline
+   * relies on that: `scalarEntityKeysFromEntities` keeps the first key per
+   * type, and the heuristic resolvers emit at most one entity per type by
+   * construction. A producer can nonetheless send two `entity_refs` of the
+   * same type on one resource, and promoting both put two rows in Inventory
+   * from a single batch. The extra refs stay queryable as membership keys and
+   * stop there.
+   */
+  membershipOnly?: boolean;
 }
 
 /**
@@ -302,6 +316,12 @@ export default class InventoryItem {
   }): Array<ExtractedEntity> {
     const out: Array<ExtractedEntity> = [];
     const seen: Set<string> = new Set<string>();
+    /*
+     * First usable ref of a type is the one that gets a registry row; any
+     * later ref of that same type is demoted to membership-only. See
+     * `ExtractedEntity.membershipOnly`.
+     */
+    const promotedTypes: Set<EntityType> = new Set<EntityType>();
 
     for (const ref of data.entityRefs) {
       const refType: string =
@@ -381,6 +401,15 @@ export default class InventoryItem {
         }
       }
 
+      const alreadyPromoted: boolean = promotedTypes.has(entityType);
+      if (alreadyPromoted) {
+        logger.debug(
+          `OTLP resource declares more than one entity_ref of type "${refType}"; keeping the first as the entity and the rest as membership keys only.`,
+        );
+      } else {
+        promotedTypes.add(entityType);
+      }
+
       out.push({
         entityType,
         entityKey,
@@ -388,6 +417,7 @@ export default class InventoryItem {
         ...(Object.keys(descriptiveAttributes).length > 0
           ? { descriptiveAttributes }
           : {}),
+        ...(alreadyPromoted ? { membershipOnly: true } : {}),
       });
     }
 
@@ -570,7 +600,32 @@ export default class InventoryItem {
       return { entityType: EntityType.KubernetesNamespace, id };
     },
 
-    // k8s.node — cluster + k8s.node.uid/k8s.node.name.
+    /*
+     * k8s.node — cluster + k8s.node.name, falling back to k8s.node.uid only
+     * when no name is available.
+     *
+     * The name is preferred BECAUSE the uid is not universally reported and
+     * identity must not depend on which optional attributes a particular
+     * producer happens to carry. The shipped Kubernetes agent proves the
+     * point: its Deployment collector's `k8s_cluster` receiver reports node
+     * metrics with uid AND name, while its DaemonSet collector
+     * (kubeletstats / hostmetrics / cAdvisor / filelog) only ever has the
+     * name — the kubelet summary API carries no node uid and `k8sattributes`
+     * is not asked to extract one. A uid-first rule therefore hashed the same
+     * node two ways and put two rows in Inventory, both `discovered`, both
+     * displaying the same node name (`k8s.node.name` is a descriptive
+     * attribute on the uid-keyed row, so the two were indistinguishable in
+     * the list). Neither row aged out, because both pipelines keep reporting.
+     *
+     * Name-keying is also what the rest of OneUptime already assumes: the
+     * chart's own comment at configmap-daemonset.yaml says "OneUptime keys the
+     * k8s.node entity on k8s.cluster.name + k8s.node.name", and cluster and
+     * host identity are name-based for the same reason (see
+     * k8sClusterIdentity and the host resolver above).
+     *
+     * The uid stays available as a descriptive attribute, and remains the
+     * identity for the one resource that genuinely has nothing else.
+     */
     (attrs: EntityAttributes) => {
       const nodeUid: string | null = InventoryItem.str(attrs, "k8s.node.uid");
       const nodeName: string | null = InventoryItem.str(attrs, "k8s.node.name");
@@ -580,15 +635,27 @@ export default class InventoryItem {
       const id: Dictionary<string> = {
         ...(InventoryItem.k8sClusterIdentity(attrs) || {}),
       };
-      if (nodeUid) {
-        id["k8s.node.uid"] = nodeUid;
-      } else if (nodeName) {
+      if (nodeName) {
         id["k8s.node.name"] = nodeName;
+      } else {
+        id["k8s.node.uid"] = nodeUid!;
       }
       return { entityType: EntityType.KubernetesNode, id };
     },
 
-    // k8s.pod — cluster + namespace + k8s.pod.uid/k8s.pod.name.
+    /*
+     * k8s.pod — cluster + namespace + k8s.pod.name, falling back to
+     * k8s.pod.uid only when no name is available. Name-preferring for the
+     * same reason as k8s.node above: a pod observed by one pipeline that
+     * resolves its uid and another that does not is one pod, not two.
+     *
+     * A pod name is unique within a namespace at any instant, so this also
+     * makes a restarted StatefulSet pod (same name, new uid) stay one
+     * inventory row instead of minting a fresh one per incarnation — which
+     * is the behaviour an inventory wants. Incarnations remain separable on
+     * the signals themselves, which still carry `k8s.pod.uid` as a resource
+     * attribute, and the 24h pod TTL still reaps a name that stops reporting.
+     */
     (attrs: EntityAttributes) => {
       const podUid: string | null = InventoryItem.str(attrs, "k8s.pod.uid");
       const podName: string | null = InventoryItem.str(attrs, "k8s.pod.name");
@@ -599,10 +666,10 @@ export default class InventoryItem {
         ...(InventoryItem.k8sClusterIdentity(attrs) || {}),
       };
       InventoryItem.addIfPresent(id, attrs, "k8s.namespace.name");
-      if (podUid) {
-        id["k8s.pod.uid"] = podUid;
-      } else if (podName) {
+      if (podName) {
         id["k8s.pod.name"] = podName;
+      } else {
+        id["k8s.pod.uid"] = podUid!;
       }
       return { entityType: EntityType.KubernetesPod, id };
     },
@@ -820,11 +887,18 @@ export default class InventoryItem {
       "telemetry.sdk.name",
       "telemetry.sdk.version",
     ],
+    /*
+     * The uids are descriptive rather than identifying (see the node / pod
+     * resolvers): keeping them here means the Inventory row still shows the
+     * uid of the object it is currently tracking, without that uid being able
+     * to fork the row's identity.
+     */
     [EntityType.KubernetesNode]: [
       "k8s.node.name",
+      "k8s.node.uid",
       "node.kubernetes.io/instance-type",
     ],
-    [EntityType.KubernetesPod]: ["k8s.pod.name"],
+    [EntityType.KubernetesPod]: ["k8s.pod.name", "k8s.pod.uid"],
     [EntityType.Container]: [
       "container.image.name",
       "container.image.tag",

--- a/Common/Tests/Server/Services/DatabaseServiceSortTiebreaker.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServiceSortTiebreaker.test.ts
@@ -1,0 +1,151 @@
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import InventoryItem from "../../../Models/DatabaseModels/InventoryItem";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * Every paged read here is LIMIT/OFFSET, and OFFSET only means anything
+ * against an ordering with no ties. Rows that compare equal may come back in
+ * any order, and nothing obliges Postgres to pick the same order for the query
+ * that fetches page 1 and the query that fetches page 2 — so a tied row can be
+ * served on both pages while another is served on neither. The user sees one
+ * item listed twice.
+ *
+ * The Inventory list is where this bites hardest, and it is why it belongs in
+ * the duplicate-items fix: it sorts on `lastSeenAt`, which the entity
+ * reconciler rewrites for every live entity every few minutes, so the sort key
+ * is being mutated between the two fetches by design rather than by bad luck.
+ * The inventory mirror also stamps one identical `lastSeenAt` across a whole
+ * page of rows at a time, which produces large exact-tie groups outright.
+ *
+ * The fix is to complete whatever sort the caller asked for into a total order
+ * by appending the primary key, in the one place every paged read goes
+ * through.
+ */
+
+type FindArgs = {
+  order?: Record<string, unknown> | undefined;
+  select?: Record<string, unknown> | undefined;
+};
+
+describe("DatabaseService._findBy completes a partial sort into a total order", () => {
+  let service: DatabaseService<InventoryItem>;
+  let find: jest.Mock;
+
+  type FindByFunction = (
+    sort?: Record<string, unknown> | undefined,
+  ) => Promise<Array<InventoryItem>>;
+
+  const findBy: FindByFunction = (
+    sort?: Record<string, unknown> | undefined,
+  ): Promise<Array<InventoryItem>> => {
+    return service.findBy({
+      query: {},
+      limit: 10,
+      skip: 0,
+      select: { displayName: true } as any,
+      ...(sort ? { sort: sort as any } : {}),
+      props: { isRoot: true },
+    });
+  };
+
+  const orderPassedToDatabase: () => Record<string, unknown> = (): Record<
+    string,
+    unknown
+  > => {
+    return (find.mock.calls[0]![0] as FindArgs).order || {};
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+
+    service = new DatabaseService<InventoryItem>(InventoryItem);
+
+    find = jest
+      .fn()
+      .mockImplementation(async (): Promise<Array<InventoryItem>> => {
+        return [];
+      });
+
+    jest.spyOn(service, "getRepository").mockReturnValue({ find: find } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("appends the primary key to a single-column sort", async () => {
+    await findBy({ lastSeenAt: SortOrder.Descending });
+
+    expect(orderPassedToDatabase()).toEqual({
+      lastSeenAt: SortOrder.Descending,
+      _id: SortOrder.Ascending,
+    });
+  });
+
+  it("keeps the caller's column first so the requested ordering is unchanged", async () => {
+    await findBy({ lastSeenAt: SortOrder.Descending });
+
+    expect(Object.keys(orderPassedToDatabase())).toEqual(["lastSeenAt", "_id"]);
+  });
+
+  it("appends the primary key to a multi-column sort", async () => {
+    await findBy({
+      entityType: SortOrder.Ascending,
+      lastSeenAt: SortOrder.Descending,
+    });
+
+    expect(Object.keys(orderPassedToDatabase())).toEqual([
+      "entityType",
+      "lastSeenAt",
+      "_id",
+    ]);
+  });
+
+  it("appends the primary key to the default sort as well", async () => {
+    await findBy(undefined);
+
+    expect(orderPassedToDatabase()).toEqual({
+      createdAt: SortOrder.Descending,
+      _id: SortOrder.Ascending,
+    });
+  });
+
+  it("leaves an explicit primary-key sort alone", async () => {
+    await findBy({ _id: SortOrder.Descending });
+
+    expect(orderPassedToDatabase()).toEqual({ _id: SortOrder.Descending });
+  });
+
+  it("does not add the primary key twice when it is already the tiebreaker", async () => {
+    await findBy({
+      lastSeenAt: SortOrder.Descending,
+      _id: SortOrder.Descending,
+    });
+
+    expect(orderPassedToDatabase()).toEqual({
+      lastSeenAt: SortOrder.Descending,
+      _id: SortOrder.Descending,
+    });
+  });
+
+  it("does not widen the projection — the primary key is already selected", async () => {
+    await findBy({ lastSeenAt: SortOrder.Descending });
+
+    const select: Record<string, unknown> = (find.mock.calls[0]![0] as FindArgs)
+      .select as Record<string, unknown>;
+
+    expect(select["_id"]).toBe(true);
+    expect(select["displayName"]).toBe(true);
+  });
+
+  it("does not mutate the caller's own sort object", async () => {
+    const callerSort: Record<string, unknown> = {
+      lastSeenAt: SortOrder.Descending,
+    };
+
+    await findBy(callerSort);
+
+    expect(callerSort).toEqual({ lastSeenAt: SortOrder.Descending });
+  });
+});

--- a/Common/Tests/Server/Services/InventoryItemManualCreate.test.ts
+++ b/Common/Tests/Server/Services/InventoryItemManualCreate.test.ts
@@ -246,3 +246,108 @@ describe("machine creates are left alone", () => {
     expect(createBy.data.source).toBe(EntitySource.Inventory);
   });
 });
+
+/*
+ * The escape hatch above is for the two machine writers, which reach the
+ * service directly with `props: { isRoot: true }`. It used to be keyed on the
+ * PAYLOAD instead — "did the caller send an entityKey" — which let anyone
+ * posting to the public CRUD endpoint skip every check in the hook simply by
+ * inventing one, and claim a source only ingest is supposed to write. A row
+ * that says `discovered` is a row the prune sweep is entitled to delete on a
+ * TTL, so this was not only a lie in the Source column.
+ */
+describe("non-root creates cannot impersonate a machine writer", () => {
+  function apiCreate(data: InventoryItem): CreateBy<InventoryItem> {
+    return { data, props: {} } as CreateBy<InventoryItem>;
+  }
+
+  function externalService(): InventoryItem {
+    const data: InventoryItem = new InventoryItem();
+    data.projectId = PROJECT_ID;
+    data.entityType = EntityType.ExternalService;
+    data.displayName = "Stripe Payments API";
+    return data;
+  }
+
+  test("a client-supplied entity key is discarded and the key re-derived", async () => {
+    const data: InventoryItem = externalService();
+    data.entityKey = "deadbeefdeadbeef";
+
+    const createBy: CreateBy<InventoryItem> = apiCreate(data);
+    await callOnBeforeCreate(createBy);
+
+    expect(createBy.data.entityKey).toBe(
+      keyForManualEntity(
+        PROJECT_ID.toString(),
+        EntityType.ExternalService,
+        "Stripe Payments API",
+      ),
+    );
+    expect(createBy.data.source).toBe(EntitySource.Manual);
+  });
+
+  test("a client-supplied source of discovered is overridden to manual", async () => {
+    const data: InventoryItem = externalService();
+    data.entityKey = "deadbeefdeadbeef";
+    data.source = EntitySource.Discovered;
+
+    const createBy: CreateBy<InventoryItem> = apiCreate(data);
+    await callOnBeforeCreate(createBy);
+
+    expect(createBy.data.source).toBe(EntitySource.Manual);
+  });
+
+  test("a client-supplied source of inventory is overridden to manual", async () => {
+    const data: InventoryItem = externalService();
+    data.entityKey = "deadbeefdeadbeef";
+    data.source = EntitySource.Inventory;
+
+    const createBy: CreateBy<InventoryItem> = apiCreate(data);
+    await callOnBeforeCreate(createBy);
+
+    expect(createBy.data.source).toBe(EntitySource.Manual);
+  });
+
+  test.each([
+    EntityType.Service,
+    EntityType.Host,
+    EntityType.KubernetesPod,
+    EntityType.KubernetesNode,
+    EntityType.NetworkDevice,
+  ])(
+    "the manual-type restriction still applies to %s when a key is supplied",
+    async (entityType: EntityType) => {
+      const data: InventoryItem = externalService();
+      data.entityType = entityType;
+      data.entityKey = "deadbeefdeadbeef";
+      data.source = EntitySource.Discovered;
+
+      await expect(callOnBeforeCreate(apiCreate(data))).rejects.toThrow(
+        /discovered automatically and cannot be created manually/,
+      );
+    },
+  );
+
+  test("the display-name requirement still applies when a key is supplied", async () => {
+    const data: InventoryItem = externalService();
+    data.displayName = "   ";
+    data.entityKey = "deadbeefdeadbeef";
+    data.source = EntitySource.Discovered;
+
+    await expect(callOnBeforeCreate(apiCreate(data))).rejects.toThrow(
+      /Name is required/,
+    );
+  });
+
+  test("firstSeenAt and lastSeenAt are stamped rather than left to the caller", async () => {
+    const data: InventoryItem = externalService();
+    data.entityKey = "deadbeefdeadbeef";
+    data.source = EntitySource.Discovered;
+
+    const createBy: CreateBy<InventoryItem> = apiCreate(data);
+    await callOnBeforeCreate(createBy);
+
+    expect(createBy.data.firstSeenAt).toBeInstanceOf(Date);
+    expect(createBy.data.lastSeenAt).toBeInstanceOf(Date);
+  });
+});

--- a/Common/Tests/Server/Services/InventoryItemPromotionGate.test.ts
+++ b/Common/Tests/Server/Services/InventoryItemPromotionGate.test.ts
@@ -1,0 +1,178 @@
+import GlobalCache from "../../../Server/Infrastructure/GlobalCache";
+import InventoryItem from "../../../Models/DatabaseModels/InventoryItem";
+import InventoryItemService from "../../../Server/Services/InventoryItemService";
+import Service from "../../../Models/DatabaseModels/Service";
+import ServiceService from "../../../Server/Services/ServiceService";
+import ObjectID from "../../../Types/ObjectID";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import EntitySource from "../../../Types/Telemetry/EntitySource";
+import EntityType from "../../../Types/Telemetry/EntityType";
+import { ExtractedEntity } from "../../../Server/Utils/Telemetry/TelemetryEntity";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * What may become a row in the Inventory registry.
+ *
+ * Two gates decide it, and they answer different questions. The TYPE gate asks
+ * whether this kind of thing belongs in the registry at all — containers,
+ * processes, service instances and SDKs are high-churn, so their keys travel on
+ * signals but never mint rows. The per-entity `membershipOnly` flag asks
+ * whether this particular observation is the resource's entity of that type or
+ * a duplicate the producer sent alongside it: one OTLP resource describes one
+ * pod, on one node, in one cluster, but nothing stops a producer emitting two
+ * `entity_refs` of the same type, and promoting both put two rows in Inventory
+ * from a single batch.
+ *
+ * `reconcileEntities` is public, so it repeats both gates rather than trusting
+ * its caller — the cost of a missed gate here is a row that should never have
+ * existed, and once created nothing removes it until its TTL expires.
+ *
+ * Everything external is mocked — no Postgres, no Redis.
+ */
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const SERVICE_ROW_ID: ObjectID = ObjectID.generate();
+
+let createdRows: Array<InventoryItem>;
+let bumps: Array<ObjectID>;
+
+function entity(
+  entityType: EntityType,
+  overrides: Partial<ExtractedEntity> = {},
+): ExtractedEntity {
+  return {
+    entityType,
+    entityKey: "0123456789abcdef",
+    identifyingAttributes: { "some.name": "thing" },
+    ...overrides,
+  };
+}
+
+function reconcile(entities: Array<ExtractedEntity>): Promise<void> {
+  return InventoryItemService.reconcileEntities({
+    projectId: PROJECT_ID,
+    entities,
+  });
+}
+
+beforeEach(() => {
+  createdRows = [];
+  bumps = [];
+
+  // Both fences open, so every reconcile actually does its work.
+  jest
+    .spyOn(GlobalCache, "setStringIfNotExists")
+    .mockImplementation(async () => {
+      return true;
+    });
+  jest.spyOn(GlobalCache, "deleteKey").mockImplementation(async () => {
+    return undefined as never;
+  });
+
+  const serviceRow: Service = new Service();
+  serviceRow.id = SERVICE_ROW_ID;
+  serviceRow._id = SERVICE_ROW_ID.toString();
+  jest
+    .spyOn(ServiceService, "findOneBy")
+    .mockImplementation(async (): Promise<Service | null> => {
+      return serviceRow;
+    });
+
+  jest
+    .spyOn(InventoryItemService, "findOneBy")
+    .mockImplementation(async (): Promise<InventoryItem | null> => {
+      return null;
+    });
+
+  jest
+    .spyOn(InventoryItemService, "countBy")
+    .mockImplementation(async (): Promise<PositiveNumber> => {
+      return new PositiveNumber(0);
+    });
+
+  jest
+    .spyOn(InventoryItemService, "create")
+    .mockImplementation(async (createBy: unknown): Promise<InventoryItem> => {
+      const data: InventoryItem = (createBy as { data: InventoryItem }).data;
+      createdRows.push(data);
+      return data;
+    });
+
+  jest
+    .spyOn(InventoryItemService, "updateColumnsByIdIfUnlockedWithoutHooks")
+    .mockImplementation(async (data: unknown): Promise<boolean> => {
+      bumps.push((data as { id: ObjectID }).id);
+      return true;
+    });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("membership-only entities never become rows", () => {
+  test.each([
+    EntityType.Container,
+    EntityType.Process,
+    EntityType.ServiceInstance,
+    EntityType.TelemetrySdk,
+  ])("%s is not promoted by type", async (entityType: EntityType) => {
+    await reconcile([entity(entityType)]);
+
+    expect(createdRows).toHaveLength(0);
+    expect(bumps).toHaveLength(0);
+  });
+
+  test.each([
+    EntityType.KubernetesPod,
+    EntityType.KubernetesNode,
+    EntityType.Service,
+    EntityType.Host,
+  ])(
+    "%s flagged membershipOnly is not promoted even though its type is",
+    async (entityType: EntityType) => {
+      await reconcile([entity(entityType, { membershipOnly: true })]);
+
+      expect(createdRows).toHaveLength(0);
+      expect(bumps).toHaveLength(0);
+    },
+  );
+
+  test("a demoted duplicate does not suppress the promoted entity beside it", async () => {
+    /*
+     * The shape `entitiesFromRefs` produces when a producer sends two refs of
+     * one type: the first is the entity, the rest are membership keys.
+     */
+    await reconcile([
+      entity(EntityType.KubernetesPod, { entityKey: "aaaaaaaaaaaaaaaa" }),
+      entity(EntityType.KubernetesPod, {
+        entityKey: "bbbbbbbbbbbbbbbb",
+        membershipOnly: true,
+      }),
+    ]);
+
+    expect(createdRows).toHaveLength(1);
+    expect(createdRows[0]!.entityKey).toBe("aaaaaaaaaaaaaaaa");
+  });
+});
+
+describe("promoted entities still become rows", () => {
+  test.each([
+    EntityType.Service,
+    EntityType.Host,
+    EntityType.KubernetesPod,
+    EntityType.KubernetesNode,
+    EntityType.KubernetesCluster,
+    EntityType.KubernetesNamespace,
+    EntityType.KubernetesDeployment,
+    EntityType.ProxmoxCluster,
+    EntityType.CephCluster,
+    EntityType.DockerSwarmCluster,
+  ])("%s is created as a discovered row", async (entityType: EntityType) => {
+    await reconcile([entity(entityType)]);
+
+    expect(createdRows).toHaveLength(1);
+    expect(createdRows[0]!.source).toBe(EntitySource.Discovered);
+    expect(createdRows[0]!.entityType).toBe(entityType);
+  });
+});

--- a/Common/Tests/Server/Utils/Telemetry/InventoryDuplicateIdentity.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/InventoryDuplicateIdentity.test.ts
@@ -1,0 +1,316 @@
+import InventoryItem, {
+  EntityAttributes,
+  ExtractedEntity,
+  ResourceEntityRef,
+} from "../../../../Server/Utils/Telemetry/TelemetryEntity";
+import EntityType from "../../../../Types/Telemetry/EntityType";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Regression suite for duplicate Inventory items.
+ *
+ * `InventoryItem` has a unique index on (projectId, entityType, entityKey),
+ * so two rows of the same type in one project can only mean one thing: the
+ * same real object hashed to two different keys. Nothing downstream can undo
+ * that — the two rows are, as far as the registry is concerned, two things —
+ * and because both keep being observed, neither ever ages out. The Inventory
+ * list then shows a node, pod or service twice, both marked Discovered, both
+ * with the same name, because the display name is derived from the attributes
+ * the two identities SHARE rather than the ones that differ.
+ *
+ * The rule these tests exist to hold: an entity's identity must depend only on
+ * WHICH OBJECT is being described, never on WHICH PIPELINE is describing it.
+ * Every case below is a pair of resources that our own shipped configuration
+ * produces for one object, differing only in what the producing collector was
+ * able to resolve.
+ */
+
+const PROJECT: string = "proj-dup-1";
+
+function entitiesFor(
+  attrs: EntityAttributes,
+  entityRefs?: Array<ResourceEntityRef>,
+): Array<ExtractedEntity> {
+  return InventoryItem.extractEntities({
+    projectId: PROJECT,
+    attributes: attrs,
+    ...(entityRefs ? { entityRefs } : {}),
+  });
+}
+
+function entityOfType(
+  attrs: EntityAttributes,
+  type: EntityType,
+): ExtractedEntity | undefined {
+  return entitiesFor(attrs).find((e: ExtractedEntity) => {
+    return e.entityType === type;
+  });
+}
+
+function keyOfType(attrs: EntityAttributes, type: EntityType): string {
+  const entity: ExtractedEntity | undefined = entityOfType(attrs, type);
+  expect(entity).toBeDefined();
+  return entity!.entityKey;
+}
+
+const CLUSTER: string = "prod-us";
+
+/*
+ * The two collectors the `kubernetes-agent` chart installs, reduced to the
+ * resource attributes each actually carries for the SAME node.
+ *
+ * Deployment / metrics-collector: the `k8s_cluster` receiver reports node
+ * metrics (`k8s.node.condition_ready`, allocatable cpu/memory/storage) and
+ * resolves node uids from the Kubernetes API.
+ *
+ * DaemonSet / node-collector: kubeletstats, hostmetrics, the cAdvisor scrape
+ * and the pod filelog receiver. None of them can produce a node uid — the
+ * kubelet summary API has no such field and `k8sattributes` is not asked to
+ * extract one — so the chart stamps `k8s.node.name` from the downward API
+ * instead.
+ */
+const NODE_FROM_K8S_CLUSTER_RECEIVER: EntityAttributes = {
+  "k8s.cluster.name": CLUSTER,
+  "k8s.node.name": "ip-10-0-1-23.ec2.internal",
+  "k8s.node.uid": "a8170da5-c826-49b0-b48b-a35af366e689",
+  "service.name": `kubernetes-agent-${CLUSTER}`,
+};
+
+const NODE_FROM_DAEMONSET: EntityAttributes = {
+  "k8s.cluster.name": CLUSTER,
+  "k8s.node.name": "ip-10-0-1-23.ec2.internal",
+  "service.name": `kubernetes-agent-${CLUSTER}`,
+};
+
+/*
+ * The same pod as seen by the deployment collector (k8sattributes resolves
+ * `k8s.pod.uid`) and by a pod-log record that only carries the pod name.
+ */
+const POD_WITH_UID: EntityAttributes = {
+  "k8s.cluster.name": CLUSTER,
+  "k8s.namespace.name": "shop",
+  "k8s.pod.name": "checkout-api-7d9f884c7d-q5bz2",
+  "k8s.pod.uid": "7c2f9dd0-8400-4c47-9c54-321ebeb9543b",
+};
+
+const POD_WITHOUT_UID: EntityAttributes = {
+  "k8s.cluster.name": CLUSTER,
+  "k8s.namespace.name": "shop",
+  "k8s.pod.name": "checkout-api-7d9f884c7d-q5bz2",
+};
+
+describe("one object, one identity, whichever collector saw it", () => {
+  test("a node reported with a uid and the same node reported without one are one entity", () => {
+    expect(
+      keyOfType(NODE_FROM_K8S_CLUSTER_RECEIVER, EntityType.KubernetesNode),
+    ).toBe(keyOfType(NODE_FROM_DAEMONSET, EntityType.KubernetesNode));
+  });
+
+  test("a pod reported with a uid and the same pod reported without one are one entity", () => {
+    expect(keyOfType(POD_WITH_UID, EntityType.KubernetesPod)).toBe(
+      keyOfType(POD_WITHOUT_UID, EntityType.KubernetesPod),
+    );
+  });
+
+  test("node identity is the cluster plus the node name, and nothing else", () => {
+    expect(
+      entityOfType(NODE_FROM_K8S_CLUSTER_RECEIVER, EntityType.KubernetesNode)!
+        .identifyingAttributes,
+    ).toEqual({
+      "k8s.cluster.name": CLUSTER,
+      "k8s.node.name": "ip-10-0-1-23.ec2.internal",
+    });
+  });
+
+  test("pod identity is the cluster, namespace and pod name, and nothing else", () => {
+    expect(
+      entityOfType(POD_WITH_UID, EntityType.KubernetesPod)!
+        .identifyingAttributes,
+    ).toEqual({
+      "k8s.cluster.name": CLUSTER,
+      "k8s.namespace.name": "shop",
+      "k8s.pod.name": "checkout-api-7d9f884c7d-q5bz2",
+    });
+  });
+
+  test("the uid is still recorded, just not as identity", () => {
+    expect(
+      entityOfType(NODE_FROM_K8S_CLUSTER_RECEIVER, EntityType.KubernetesNode)!
+        .descriptiveAttributes,
+    ).toMatchObject({
+      "k8s.node.uid": "a8170da5-c826-49b0-b48b-a35af366e689",
+    });
+    expect(
+      entityOfType(POD_WITH_UID, EntityType.KubernetesPod)!
+        .descriptiveAttributes,
+    ).toMatchObject({
+      "k8s.pod.uid": "7c2f9dd0-8400-4c47-9c54-321ebeb9543b",
+    });
+  });
+
+  test("a pod that keeps its name across a restart keeps its inventory row", () => {
+    /*
+     * A StatefulSet pod is recreated under the same name with a fresh uid.
+     * Under uid identity that minted a new registry row per incarnation; the
+     * name is what an inventory is actually tracking.
+     */
+    const before: string = keyOfType(POD_WITH_UID, EntityType.KubernetesPod);
+    const after: string = keyOfType(
+      {
+        ...POD_WITH_UID,
+        "k8s.pod.uid": "0000aaaa-1111-2222-3333-444455556666",
+      },
+      EntityType.KubernetesPod,
+    );
+
+    expect(after).toBe(before);
+  });
+});
+
+describe("identity that genuinely differs must stay different", () => {
+  test("the same node name in two clusters is two entities", () => {
+    expect(keyOfType(NODE_FROM_DAEMONSET, EntityType.KubernetesNode)).not.toBe(
+      keyOfType(
+        { ...NODE_FROM_DAEMONSET, "k8s.cluster.name": "prod-eu" },
+        EntityType.KubernetesNode,
+      ),
+    );
+  });
+
+  test("the same pod name in two namespaces is two entities", () => {
+    expect(keyOfType(POD_WITHOUT_UID, EntityType.KubernetesPod)).not.toBe(
+      keyOfType(
+        { ...POD_WITHOUT_UID, "k8s.namespace.name": "checkout" },
+        EntityType.KubernetesPod,
+      ),
+    );
+  });
+
+  test("the same pod name in two clusters is two entities", () => {
+    expect(keyOfType(POD_WITHOUT_UID, EntityType.KubernetesPod)).not.toBe(
+      keyOfType(
+        { ...POD_WITHOUT_UID, "k8s.cluster.name": "prod-eu" },
+        EntityType.KubernetesPod,
+      ),
+    );
+  });
+
+  test("two different nodes in one cluster are two entities", () => {
+    expect(keyOfType(NODE_FROM_DAEMONSET, EntityType.KubernetesNode)).not.toBe(
+      keyOfType(
+        {
+          ...NODE_FROM_DAEMONSET,
+          "k8s.node.name": "ip-10-0-1-24.ec2.internal",
+        },
+        EntityType.KubernetesNode,
+      ),
+    );
+  });
+
+  test("a uid-only node and a named node are not silently merged", () => {
+    /*
+     * Nothing can prove these are the same object from the resource alone, so
+     * they stay distinct. The uid-only shape exists only for a producer that
+     * carries no name at all.
+     */
+    expect(
+      keyOfType(
+        { "k8s.cluster.name": CLUSTER, "k8s.node.uid": "node-uid-only" },
+        EntityType.KubernetesNode,
+      ),
+    ).not.toBe(keyOfType(NODE_FROM_DAEMONSET, EntityType.KubernetesNode));
+  });
+});
+
+describe("casing and whitespace do not fork identity", () => {
+  test.each([
+    ["upper-cased node name", { "k8s.node.name": "IP-10-0-1-23.EC2.INTERNAL" }],
+    ["padded node name", { "k8s.node.name": "  ip-10-0-1-23.ec2.internal  " }],
+    ["upper-cased cluster", { "k8s.cluster.name": "PROD-US" }],
+  ])(
+    "%s resolves to the same node entity",
+    (_label: string, override: EntityAttributes) => {
+      expect(
+        keyOfType(
+          { ...NODE_FROM_DAEMONSET, ...override },
+          EntityType.KubernetesNode,
+        ),
+      ).toBe(keyOfType(NODE_FROM_DAEMONSET, EntityType.KubernetesNode));
+    },
+  );
+});
+
+describe("one resource describes at most one entity per type", () => {
+  /*
+   * A resource is one pod, on one node, in one cluster. `entity_refs` are
+   * producer-supplied and nothing stops a producer sending two refs of the
+   * same type on one resource; promoting both put two Inventory rows in from
+   * a single batch. The extra ref stays a membership key so no signal loses
+   * its queryable identity.
+   */
+  const TWO_POD_REFS: Array<ResourceEntityRef> = [
+    { type: "k8s.pod", idKeys: ["k8s.pod.name"] },
+    { type: "k8s.pod", idKeys: ["k8s.pod.uid"] },
+  ];
+
+  test("only the first ref of a type is promoted to a registry row", () => {
+    const pods: Array<ExtractedEntity> = entitiesFor(
+      POD_WITH_UID,
+      TWO_POD_REFS,
+    ).filter((e: ExtractedEntity) => {
+      return e.entityType === EntityType.KubernetesPod;
+    });
+
+    expect(pods).toHaveLength(2);
+    expect(
+      pods.filter((p: ExtractedEntity) => {
+        return !p.membershipOnly;
+      }),
+    ).toHaveLength(1);
+  });
+
+  test("the demoted ref keeps its key so signals stay queryable by it", () => {
+    const pods: Array<ExtractedEntity> = entitiesFor(
+      POD_WITH_UID,
+      TWO_POD_REFS,
+    ).filter((e: ExtractedEntity) => {
+      return e.entityType === EntityType.KubernetesPod;
+    });
+
+    const keys: Array<string> = pods.map((p: ExtractedEntity) => {
+      return p.entityKey;
+    });
+
+    expect(new Set(keys).size).toBe(2);
+    expect(
+      InventoryItem.extractEntityKeys({
+        projectId: PROJECT,
+        attributes: POD_WITH_UID,
+        entityRefs: TWO_POD_REFS,
+      }),
+    ).toEqual(expect.arrayContaining(keys));
+  });
+
+  test("refs of different types are all promoted", () => {
+    const entities: Array<ExtractedEntity> = entitiesFor(POD_WITH_UID, [
+      { type: "k8s.pod", idKeys: ["k8s.pod.name"] },
+      { type: "k8s.namespace", idKeys: ["k8s.namespace.name"] },
+    ]);
+
+    expect(
+      entities.filter((e: ExtractedEntity) => {
+        return !e.membershipOnly;
+      }),
+    ).toHaveLength(2);
+  });
+
+  test("the heuristic resolvers already emit one entity per type", () => {
+    const types: Array<EntityType> = entitiesFor(POD_WITH_UID).map(
+      (e: ExtractedEntity) => {
+        return e.entityType;
+      },
+    );
+
+    expect(new Set(types).size).toBe(types.length);
+  });
+});

--- a/Common/Tests/Server/Utils/Telemetry/TelemetryEntity.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/TelemetryEntity.test.ts
@@ -750,7 +750,7 @@ describe("descriptive attributes & labels (never identity-bearing)", () => {
       name: "worker-1",
     },
   ])(
-    "k8s.$label: keeps the stable UID identity and carries the name descriptively",
+    "k8s.$label: keys on the name and carries the UID descriptively",
     ({
       type,
       uidKey,
@@ -765,19 +765,122 @@ describe("descriptive attributes & labels (never identity-bearing)", () => {
       nameKey: string;
       name: string;
     }) => {
-      const uidOnly: ExtractedEntity | undefined = entityOfType(
-        { [uidKey]: uid },
-        type,
-      );
       const named: ExtractedEntity | undefined = entityOfType(
         { [uidKey]: uid, [nameKey]: name },
         type,
       );
 
       expect(named).toBeDefined();
-      expect(named!.entityKey).toBe(uidOnly!.entityKey);
-      expect(named!.identifyingAttributes).toEqual({ [uidKey]: uid });
-      expect(named!.descriptiveAttributes).toEqual({ [nameKey]: name });
+      expect(named!.identifyingAttributes).toEqual({ [nameKey]: name });
+      /*
+       * The name is carried descriptively as well as identifying it. That is
+       * deliberate: `buildDescriptiveUpdate` reads the display name out of
+       * the descriptive bag first, so a row whose identity later changes
+       * shape still has a name to show.
+       */
+      expect(named!.descriptiveAttributes).toEqual({
+        [nameKey]: name,
+        [uidKey]: uid,
+      });
+    },
+  );
+
+  /*
+   * The regression test for duplicate Inventory rows.
+   *
+   * The shipped Kubernetes agent runs two collectors over the same nodes and
+   * pods. The Deployment's `k8s_cluster` receiver resolves uids; the
+   * DaemonSet's kubeletstats / hostmetrics / cAdvisor / filelog receivers
+   * never do. Identity must not depend on which of them is talking.
+   */
+  test.each([
+    {
+      label: "node",
+      type: EntityType.KubernetesNode,
+      withUid: {
+        "k8s.cluster.name": "prod-us",
+        "k8s.node.name": "worker-1",
+        "k8s.node.uid": "node-uid-1",
+      },
+      withoutUid: {
+        "k8s.cluster.name": "prod-us",
+        "k8s.node.name": "worker-1",
+      },
+    },
+    {
+      label: "pod",
+      type: EntityType.KubernetesPod,
+      withUid: {
+        "k8s.cluster.name": "prod-us",
+        "k8s.namespace.name": "shop",
+        "k8s.pod.name": "checkout-7d9f",
+        "k8s.pod.uid": "pod-uid-1",
+      },
+      withoutUid: {
+        "k8s.cluster.name": "prod-us",
+        "k8s.namespace.name": "shop",
+        "k8s.pod.name": "checkout-7d9f",
+      },
+    },
+  ])(
+    "k8s.$label: a producer that resolves the UID and one that does not agree on identity",
+    ({
+      type,
+      withUid,
+      withoutUid,
+    }: {
+      label: string;
+      type: EntityType;
+      withUid: EntityAttributes;
+      withoutUid: EntityAttributes;
+    }) => {
+      const resolved: ExtractedEntity | undefined = entityOfType(withUid, type);
+      const unresolved: ExtractedEntity | undefined = entityOfType(
+        withoutUid,
+        type,
+      );
+
+      expect(resolved).toBeDefined();
+      expect(unresolved).toBeDefined();
+      expect(resolved!.entityKey).toBe(unresolved!.entityKey);
+      expect(resolved!.identifyingAttributes).toEqual(
+        unresolved!.identifyingAttributes,
+      );
+    },
+  );
+
+  test.each([
+    {
+      label: "node",
+      type: EntityType.KubernetesNode,
+      uidKey: "k8s.node.uid",
+      uid: "node-uid-1",
+    },
+    {
+      label: "pod",
+      type: EntityType.KubernetesPod,
+      uidKey: "k8s.pod.uid",
+      uid: "pod-uid-1",
+    },
+  ])(
+    "k8s.$label: falls back to the UID when the resource carries no name",
+    ({
+      type,
+      uidKey,
+      uid,
+    }: {
+      label: string;
+      type: EntityType;
+      uidKey: string;
+      uid: string;
+    }) => {
+      const entity: ExtractedEntity | undefined = entityOfType(
+        { [uidKey]: uid },
+        type,
+      );
+
+      expect(entity).toBeDefined();
+      expect(entity!.identifyingAttributes).toEqual({ [uidKey]: uid });
     },
   );
 

--- a/HelmChart/Public/kubernetes-agent/templates/_helpers.tpl
+++ b/HelmChart/Public/kubernetes-agent/templates/_helpers.tpl
@@ -6,6 +6,25 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+The cluster name, refusing to render if it is missing.
+
+This is not merely a label. OneUptime folds `k8s.cluster.name` into the identity
+of every Kubernetes entity it derives, so it is the only thing separating this
+cluster's `worker-1` and `default` namespace from every other cluster's. Ship
+without it and two clusters reporting into one project silently become one
+estate -- nodes, namespaces, pods and deployments merged pairwise by name, with
+no error anywhere to say so.
+
+`required` is deliberate: values.schema.json already lists clusterName in its
+`required` set, but JSON Schema `required` only checks that the key is PRESENT,
+and the chart's default value is the empty string, so it passes. Failing at
+render is the only place this can be caught before the data is wrong.
+*/}}
+{{- define "kubernetes-agent.clusterName" -}}
+{{- required "clusterName is required: it identifies this cluster's nodes, namespaces, pods and deployments in OneUptime, and two clusters installed without it will be merged into one. Set it with --set clusterName=<name>." (.Values.clusterName | trim) -}}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 */}}
 {{- define "kubernetes-agent.fullname" -}}

--- a/HelmChart/Public/kubernetes-agent/templates/configmap-daemonset.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/configmap-daemonset.yaml
@@ -420,7 +420,7 @@ data:
       resource:
         attributes:
           - key: k8s.cluster.name
-            value: {{ .Values.clusterName | quote }}
+            value: {{ include "kubernetes-agent.clusterName" . | quote }}
             action: upsert
           - key: service.name
             value: "kubernetes-agent-{{ .Values.clusterName }}"

--- a/HelmChart/Public/kubernetes-agent/templates/configmap-deployment.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/configmap-deployment.yaml
@@ -355,7 +355,7 @@ data:
       resource:
         attributes:
           - key: k8s.cluster.name
-            value: {{ .Values.clusterName | quote }}
+            value: {{ include "kubernetes-agent.clusterName" . | quote }}
             action: insert
           - key: service.name
             value: "kubernetes-agent-{{ .Values.clusterName }}"
@@ -486,16 +486,27 @@ data:
         {{- if .Values.ebpf.enabled }}
         # Traces pipeline: accept OTLP spans from the eBPF DaemonSet, enrich
         # with k8s attributes, stamp cluster name, and forward to OneUptime.
-        # We deliberately omit the `resource` processor's service.name
-        # override here — OBI sets a per-process service.name from k8s
-        # workload metadata, and we want to preserve it so each app shows up
-        # under its own service in the dashboard.
+        #
+        # `resource` belongs here for the same reason it does on the metrics
+        # and logs pipelines: OneUptime folds `k8s.cluster.name` into the
+        # identity of every Kubernetes entity it derives, so a span that
+        # arrives with a pod, node and namespace but no cluster describes a
+        # DIFFERENT pod, node and namespace than the metrics do — and the same
+        # objects end up listed twice in Inventory. This receiver takes spans
+        # from anything in the cluster that points at the agent's OTLP
+        # service, not just from OBI, and an application SDK has no way to
+        # know the cluster's name.
+        #
+        # It cannot clobber OBI's per-process `service.name`: every attribute
+        # in that processor uses `action: insert`, which fills in only what is
+        # missing, so each app still shows up under its own service.
         traces:
           receivers:
             - otlp
           processors:
             - memory_limiter
             - k8sattributes
+            - resource
             {{- if and .Values.ebpf.enabled (eq (include "kubernetes-agent.traceFiltersEnabled" .) "true") }}
             # k8sattributes resolves the sending pod to a namespace, so this
             # must stay after it — before it, every span looks namespace-less.

--- a/HelmChart/Public/kubernetes-agent/templates/configmap-profiling.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/configmap-profiling.yaml
@@ -47,7 +47,7 @@ data:
       resource:
         attributes:
           - key: k8s.cluster.name
-            value: {{ .Values.clusterName | quote }}
+            value: {{ include "kubernetes-agent.clusterName" . | quote }}
             action: insert
           - key: k8s.node.name
             value: "${env:NODE_NAME}"

--- a/HelmChart/Public/kubernetes-agent/tests/traces-cluster-name_test.yaml
+++ b/HelmChart/Public/kubernetes-agent/tests/traces-cluster-name_test.yaml
@@ -1,0 +1,102 @@
+# OneUptime folds `k8s.cluster.name` into the identity of every Kubernetes
+# entity it derives — a pod, node, namespace or deployment reported WITHOUT it
+# is a different entity from the same object reported WITH it. So a pipeline
+# that enriches spans with pod and namespace metadata but never stamps the
+# cluster name puts a second copy of every one of those objects in the customer's
+# Inventory, both marked Discovered, both showing the same name.
+#
+# That is what the traces pipeline did: it ran `k8sattributes` (which resolves
+# the pod, namespace, node and workload) but not `resource` (which stamps the
+# cluster name), while the metrics and logs pipelines ran both. The OTLP
+# receiver it feeds from accepts spans from anything in the cluster pointing at
+# the agent's OTLP service, not just from the eBPF DaemonSet, and an
+# application SDK has no way to know what the cluster is called.
+#
+# These assertions keep the three pipelines' enrichment in step.
+suite: collector pipelines stamp the cluster name
+release:
+  name: oneuptime-agent
+  namespace: oneuptime
+tests:
+  - it: enriches traces with the cluster name, not just with pod metadata
+    templates:
+      - templates/configmap-deployment.yaml
+    set:
+      clusterName: prod-us
+      ebpf.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["otel-collector-config.yaml"]
+          pattern: "traces:\\s*\\n\\s*receivers:\\s*\\n\\s*- otlp\\s*\\n\\s*processors:\\s*\\n\\s*- memory_limiter\\s*\\n\\s*- k8sattributes\\s*\\n\\s*- resource"
+
+  - it: stamps the cluster name without overwriting a producer's own service name
+    templates:
+      - templates/configmap-deployment.yaml
+    set:
+      clusterName: prod-us
+      ebpf.enabled: true
+    asserts:
+      # `insert` is what makes it safe to add `resource` to the traces
+      # pipeline: OBI sets a real per-process service.name from workload
+      # metadata, and insert fills in only what is missing.
+      - matchRegex:
+          path: data["otel-collector-config.yaml"]
+          pattern: "- key: k8s.cluster.name\\s*\\n\\s*value: \"?prod-us\"?\\s*\\n\\s*action: insert"
+
+  # The two below are written as strict line-by-line chains rather than with
+  # `[\s\S]*?` between `processors:` and `- resource`. A lazy gap is unbounded:
+  # it happily runs out of the pipeline it names and matches the `- resource`
+  # belonging to the NEXT one, so the assertion passes however the pipeline it
+  # claims to check is configured, and cannot fail.
+  - it: keeps the cluster name on the metrics pipeline
+    templates:
+      - templates/configmap-deployment.yaml
+    set:
+      clusterName: prod-us
+    asserts:
+      - matchRegex:
+          path: data["otel-collector-config.yaml"]
+          # `filter/telemetry` is optional (metricFilters), so it is allowed
+          # for explicitly rather than by a `[\s\S]*?` gap that would also
+          # swallow the end of this pipeline and match the next one's.
+          pattern: "\\n\\s*metrics:\\n\\s*receivers:\\n(?:\\s*(?:#[^\\n]*|- \\w[^\\n]*)\\n)+\\s*processors:\\n\\s*- memory_limiter\\n\\s*- k8sattributes\\n(?:\\s*- filter/telemetry\\n)?\\s*- resource\\n"
+
+  - it: keeps the cluster name on the logs pipeline
+    templates:
+      - templates/configmap-deployment.yaml
+    set:
+      clusterName: prod-us
+    asserts:
+      - matchRegex:
+          path: data["otel-collector-config.yaml"]
+          pattern: "\\n\\s*logs:\\n\\s*receivers:\\n\\s*- k8sobjects\\n\\s*processors:\\n\\s*- memory_limiter\\n\\s*- k8sattributes\\n\\s*- resource\\n"
+
+  - it: refuses to render at all without a cluster name
+    set:
+      clusterName: ""
+    asserts:
+      # values.schema.json lists clusterName as required, but JSON Schema
+      # `required` only checks the key is present and the chart's default is
+      # the empty string — so it passes. Rendering is the only place this can
+      # be caught before the estate is silently merged.
+      - failedTemplate:
+          errorMessage: "clusterName is required: it identifies this cluster's nodes, namespaces, pods and deployments in OneUptime, and two clusters installed without it will be merged into one. Set it with --set clusterName=<name>."
+
+  - it: refuses to render when the cluster name is only whitespace
+    set:
+      clusterName: "   "
+    asserts:
+      - failedTemplate: {}
+
+  - it: stamps the node name on the DaemonSet so node identity is never blank
+    templates:
+      - templates/configmap-daemonset.yaml
+    set:
+      clusterName: prod-us
+    asserts:
+      # The DaemonSet's receivers cannot produce a node uid, so the node name
+      # is the only identity its telemetry carries. OneUptime keys the
+      # k8s.node entity on cluster + node name for exactly that reason.
+      - matchRegex:
+          path: data["otel-collector-config.yaml"]
+          pattern: "- key: k8s.node.name\\s*\\n\\s*value: \"?\\$\\{env:NODE_NAME\\}\"?\\s*\\n\\s*action: insert"

--- a/HelmChart/Public/kubernetes-agent/values.schema.json
+++ b/HelmChart/Public/kubernetes-agent/values.schema.json
@@ -45,7 +45,7 @@
     },
     "clusterName": {
       "type": "string",
-      "description": "Unique name for this cluster (used as k8s.cluster.name attribute)"
+      "description": "Unique name for this cluster (used as k8s.cluster.name attribute). Set it: OneUptime folds k8s.cluster.name into the identity of every Kubernetes entity, so an empty value keys this cluster's pods, nodes and namespaces cluster-lessly and lets them collide with another cluster's."
     },
     "namespaceFilters": {
       "type": "object",

--- a/HelmChart/Public/kubernetes-agent/values.yaml
+++ b/HelmChart/Public/kubernetes-agent/values.yaml
@@ -45,7 +45,13 @@ oneuptime:
   # Labels added in the OneUptime UI are never removed by the agent.
   labels: {}
 
-# Required: Unique name for this cluster (used as k8s.cluster.name attribute)
+# Required: Unique name for this cluster (used as k8s.cluster.name attribute).
+#
+# Enforced at render time — the chart refuses to install without it. This is not
+# just a label: OneUptime folds k8s.cluster.name into the identity of every
+# Kubernetes entity it derives, so it is the only thing separating this
+# cluster's `worker-1` and `default` namespace from another cluster's. Two
+# clusters installed without it are silently merged into one estate.
 clusterName: ""
 
 # Namespace filters — scoped rules for deciding which namespaces are observed.

--- a/HelmChart/Tests/suites/unit.sh
+++ b/HelmChart/Tests/suites/unit.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 #
-# The helm-unittest suites in HelmChart/Public/oneuptime/tests. They render the
-# templates and assert on the result, so they need no cluster -- which also
-# means `lookup` always comes back empty for them; the behaviour that depends on
-# a real API server is covered by the secrets-lifecycle suite instead.
+# The helm-unittest suites in each published chart's own tests/ directory. They
+# render the templates and assert on the result, so they need no cluster --
+# which also means `lookup` always comes back empty for them; the behaviour that
+# depends on a real API server is covered by the secrets-lifecycle suite
+# instead.
+#
+# Both published charts are covered, the same way `lint` covers both: the
+# kubernetes-agent chart writes the collector configuration that decides what
+# resource attributes OneUptime's ingest sees, so a mistake in it shows up as
+# wrong data rather than as a broken deploy -- which is exactly the kind of
+# thing a cluster-free render test catches and a human review does not.
 
 # shellcheck source=../lib/harness.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/harness.sh"
@@ -11,10 +18,19 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/harness.sh"
 harness_install_helm
 harness_install_unittest_plugin
 
-if helm unittest "$HELM_CHART_DIR"; then
-    pass "helm unittest"
-else
-    fail "helm unittest reported failing assertions (see the output above)"
-fi
+for chart in "$HELM_CHART_DIR" "$KUBERNETES_AGENT_CHART_DIR"; do
+    chart_name="$(basename "$chart")"
+
+    # A chart with no tests/ directory is not a failure, just nothing to run.
+    if [ ! -d "${chart}/tests" ]; then
+        continue
+    fi
+
+    if helm unittest "$chart"; then
+        pass "helm unittest (${chart_name})"
+    else
+        fail "helm unittest reported failing assertions for ${chart_name} (see the output above)"
+    fi
+done
 
 harness_report

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "deploy-test": "gcloud container clusters get-credentials gke-test-cluster --zone us-central1-a --project oneuptime-k8s && kubectl config use-context gke_oneuptime-k8s_us-central1-a_gke-test-cluster && helm upgrade oneuptime ./HelmChart/Public/oneuptime -f ./HelmChart/Public/oneuptime/values.yaml  -f ./HelmChart/Values/test.values.yaml",
         "template-deploy-test": "kubectl config use-context oneuptime-test && helm template  oneuptime ./HelmChart/Public/oneuptime -f ./HelmChart/Public/oneuptime/values.yaml  -f ./HelmChart/Values/test.values.yaml --debug",
         "test-gha-scripts": "bash ./Scripts/GHA/Tests/run.sh",
-        "test-helm-chart": "helm unittest ./HelmChart/Public/oneuptime",
+        "test-helm-chart": "helm unittest ./HelmChart/Public/oneuptime && helm unittest ./HelmChart/Public/kubernetes-agent",
         "test-helm-chart-all": "bash ./HelmChart/Tests/run.sh",
         "deploy-prod": "gcloud container clusters get-credentials gke-prod-cluster --zone us-central1-a --project oneuptime-k8s && kubectl config use-context gke_oneuptime-k8s_us-central1-a_gke-prod-cluster && helm upgrade oneuptime ./HelmChart/Public/oneuptime -f ./HelmChart/Public/oneuptime/values.yaml  -f ./HelmChart/Values/gke.prod.values.yaml",
         "generate-postgres-migration": "export $(grep -v '^#' config.env | xargs) && node --require ts-node/register ./node_modules/typeorm/cli.js migration:generate ./Common/Server/Infrastructure/Postgres/SchemaMigrations/MigrationName -d ./Common/Server/Infrastructure/Postgres/LocalMigrationGenerationDataSource.ts",


### PR DESCRIPTION
Fixes duplicate items appearing in Inventory, where the same thing is listed twice and both rows say **Discovered**.

## What was wrong

`InventoryItem` is uniquely indexed on `(projectId, entityType, entityKey)`, so two rows of the same type can only mean one thing: **the same real object hashed to two different keys**. Identity was being derived from whatever attributes an observation happened to carry — which makes it a property of the *pipeline*, not of the object.

The rows are indistinguishable in the list because the display name is derived from the attributes the two identities **share**, not the ones that differ. Only the Identity Key column tells them apart, and it is hidden by default.

### The main one is ours, and it is on every default install

`k8s.node` and `k8s.pod` keyed on the uid **if present else** the name. The `kubernetes-agent` chart runs both halves by default:

| Collector | Receivers | Carries |
|---|---|---|
| Deployment | `k8s_cluster` | `k8s.node.uid` **and** `k8s.node.name` |
| DaemonSet | kubeletstats, hostmetrics, cAdvisor, filelog | `k8s.node.name` only |

The DaemonSet side *cannot* produce a node uid — the kubelet summary API has no such field and `k8sattributes` is not asked to extract one — so the chart stamps the node name from the downward API instead. Result: two rows per node, forever, since both pipelines keep bumping `lastSeenAt` so the 7-day TTL never reaps either.

The chart's own comment already stated the invariant the resolver broke:

> OneUptime keys the k8s.node entity on k8s.cluster.name + k8s.node.name

Verified numerically — same node, two keys:

```
{cluster, node.uid}   -> 3138f70f99eda40c
{cluster, node.name}  -> 487368eb2ca81941
```

## The fixes

**Identity is the name.** `k8s.node` / `k8s.pod` key on the name, falling back to the uid only when a resource carries no name at all; the uid becomes a descriptive attribute. This also stops a restarted StatefulSet pod minting a row per incarnation.

**`clusterName` is now enforced.** Name-keyed identity makes `k8s.cluster.name` load-bearing — it is the only thing separating one cluster's `worker-1` from another's. `values.schema.json` already listed it as required, but JSON Schema `required` only checks the key is *present* and the chart's default is `""`, so it always passed. The chart now refuses to render without it.

**The traces pipeline stamps the cluster name.** It ran `k8sattributes` but not `resource`, so spans arrived with a pod, node and namespace but no cluster — describing *different* objects than the metrics and logs do. The OTLP receiver takes spans from anything in the cluster pointing at the agent's service, and an application SDK cannot know the cluster's name. `resource` cannot clobber OBI's per-process `service.name`: every attribute in it is `action: insert`.

**One entity per type per resource.** `entity_refs` were deduped by key rather than by type, so a producer sending two refs of one type on one resource minted two rows from a single batch. Extra refs stay membership keys, so no signal loses its queryable identity.

Two things that made a single row *look* like two, or a fake one look real:

**Paged lists had no sort tiebreaker.** `OFFSET` only means anything against a total order. The Inventory list sorts on `lastSeenAt` — the column the reconciler rewrites for every live entity every few minutes — so a row could be served on page 1 and again on page 2. `_findBy` now completes any sort into a total order with the primary key.

**The create path trusted the payload, not the caller.** `onBeforeCreate` decided a create was a machine write by asking "did it include an `entityKey`", so anyone posting to the CRUD endpoint could skip the manual-type restriction, the display-name requirement and the identity derivation, and claim `source: discovered` — which the prune sweep then treats as TTL-reapable. It now keys on `props.isRoot`; both machine writers already pass it.

Also: `docker.swarm.cluster` is registry-promoted but was missing from `ENTITY_TTL_HOURS`, so a stale or forked swarm row was unreachable by the prune sweep forever.

## Upgrade behaviour

**No migration and no schema change.** Existing uid-keyed node and pod rows stop being bumped the moment this ships — the uid-bearing collectors carry the name too, so they now write the name-keyed row — and the existing prune TTLs reap them (24h pods, 7 days nodes). A standard install already runs both collectors, so the surviving row is the one that was already there.

Two bounded costs during that window: the old row's historical telemetry is reachable only from the old row, and a project already near its per-type entity budget may briefly hold both.

**Breaking:** an agent installed with an empty `clusterName` will now fail to render. That was always a misconfiguration — it silently merged that cluster's estate with every other cluster's — and the chart has always documented the value as required.

## Deliberately not fixed here

The `service` entity forks on `service.namespace` between OTLP and the name-only ingest paths (syslog, fluent, SNMP, source maps, security and change events). **I implemented the fix and then removed it**: converging the two rows through the typed `Service` row leaves one pipeline's `serviceEntityKey` with no registry row, and `MetricService.lookupServiceEntityKeys` builds the metric MV routing set from registry rows — a partial set makes a routed query silently return *less data* than the raw predicate it replaces. That is the invariant `MetricService` documents and already guards for the budget-capped case. It also stranded one pipeline's telemetry on the surviving row's detail tabs. That fork needs an alias-key design rather than a lookup; filing as follow-up.

Also out of scope: duplicate rows in the typed inventory tables that the mirror faithfully reflects — `DockerHost`/`PodmanHost` have no unique constraint on `(projectId, hostIdentifier)`, `IoTDevice` folds an un-canonicalized `kind`, `NetworkDevice` keys on a literal address string. Those carry `source: inventory` rather than `discovered` and each needs its own dedup migration.

## Tests

A regression suite driven by the exact attribute sets the shipped chart's two collectors produce — including the cases that must **stay distinct** (same node name in two clusters, same pod name in two namespaces, a uid-only node beside a named one). Plus the registry promotion gates, the sort tiebreaker, the create-path guard, and helm-unittest render assertions.

The agent chart now has its own `tests/` directory, wired into `npm run test-helm-chart` and the `unit` suite — it writes the collector configuration that decides what ingest actually sees, so a mistake there surfaces as wrong data rather than a failed deploy.

Every new chart assertion was checked against the un-fixed template to confirm it actually fails; two of them initially could not, because an unbounded lazy regex matched a neighbouring pipeline's `- resource`.

**Verified:** `Common` + `App` `tsc` clean, eslint clean, 1065 Common suites / 28974 tests, 555 App suites / 15224 tests, 7 chart tests.

Two failures seen locally are pre-existing on master and unrelated: `DatabaseServiceAggregateBy.test.ts` (asserts on a substring of `ReadPermission.ts` that `41a5d5533b` refactored away) and three `Tests/Dashboard` source-wiring suites that assert on `Dashboard/src` files this branch does not contain. `EventLoop.test.ts` is flaky under parallel load and passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxyAXNDwP8xGoh8b4VSEwj
