### PR TITLE
fix(ci): stop the value-mapping migration test failing on the next migration

### DIFF
--- a/Common/Tests/Server/Infrastructure/Postgres/CustomFieldValueMappingMigration.test.ts
+++ b/Common/Tests/Server/Infrastructure/Postgres/CustomFieldValueMappingMigration.test.ts
@@ -64,8 +64,25 @@ const MAPPING_COLUMNS: ReadonlyArray<string> = [
   "mapFromCustomFieldName",
 ];
 
-/** The `<timestamp>-<Name>.ts` prefix TypeORM orders migrations by. */
-const MIGRATION_TIMESTAMP_PREFIX: RegExp = /^(\d+)-/;
+/*
+ * The timestamp read off the CLASS name, which is what TypeORM actually sorts
+ * by and what the migrations table records. Null for the one registered class
+ * that predates the convention (InitialMigration).
+ */
+const MIGRATION_CLASS_TIMESTAMP: RegExp = /(\d{10,})$/;
+
+const OWN_CLASS_NAME: string = "AddCustomFieldValueMapping1791600000000";
+
+type TimestampOfClassNameFunction = (className: string) => number | null;
+
+const timestampOfClassName: TimestampOfClassNameFunction = (
+  className: string,
+): number | null => {
+  const match: RegExpExecArray | null =
+    MIGRATION_CLASS_TIMESTAMP.exec(className);
+
+  return match ? parseInt(match[1]!, 10) : null;
+};
 
 /*
  * What TypeORM's metadata storage keys entities by: the class itself. Only
@@ -174,29 +191,51 @@ describe("the value-mapping migration", () => {
 
   /*
    * TypeORM orders migrations by the timestamp in the class name, not by the
-   * order of the array. A timestamp below one already registered would run
-   * this migration before migrations that shipped earlier — harmless here, but
-   * the convention in this directory is a monotonic timestamp and breaking it
-   * makes the ordering unreadable.
+   * position in SchemaMigrations/Index.ts. A timestamp BELOW one already
+   * registered would run this migration ahead of migrations that shipped
+   * before it — against a schema that does not yet have the columns those
+   * migrations added.
+   *
+   * This used to assert the timestamp was the newest in the whole DIRECTORY,
+   * which is a claim any later migration falsifies: the next one to land
+   * (AddMacAddressToNetworkDevice, 1791700000000) turned it red without going
+   * anywhere near the value-mapping columns it guards. The migrations
+   * registered AFTER this one run after it whichever way round they are, and
+   * are none of this test's business; the ones registered BEFORE it are the
+   * queue it must not jump.
+   *
+   * Note this is deliberately not a claim that the whole registry is
+   * monotonic. It is not — eleven adjacent pairs are already inverted, from
+   * branches that landed out of order — and asserting otherwise here would be
+   * failing this suite for somebody else's history.
    */
-  test("its timestamp is the newest in the directory", () => {
-    const timestamps: Array<number> = fs
-      .readdirSync(MIGRATIONS_DIRECTORY)
-      .map((fileName: string) => {
-        return MIGRATION_TIMESTAMP_PREFIX.exec(fileName);
-      })
-      .filter((match: RegExpExecArray | null): match is RegExpExecArray => {
-        return Boolean(match);
-      })
-      .map((match: RegExpExecArray) => {
-        return parseInt(match[1]!, 10);
-      });
-
-    const ownTimestamp: number = parseInt(
-      MIGRATION_TIMESTAMP_PREFIX.exec(path.basename(MIGRATION_PATH))![1]!,
-      10,
+  test("its timestamp keeps it behind every migration registered before it", () => {
+    const registered: Array<string> = SchemaMigrations.map(
+      (migration: { name: string }): string => {
+        return migration.name;
+      },
     );
 
-    expect(Math.max(...timestamps)).toBe(ownTimestamp);
+    const ownIndex: number = registered.indexOf(OWN_CLASS_NAME);
+
+    /*
+     * Asserted rather than assumed: indexOf returning -1 would silently make
+     * the slice below empty and the whole test vacuous. Registration itself
+     * has its own test above; this is about the failure MODE of this one.
+     */
+    expect(ownIndex).toBeGreaterThan(0);
+
+    const ownTimestamp: number = timestampOfClassName(OWN_CLASS_NAME)!;
+
+    const laterThanUs: Array<string> = registered
+      .slice(0, ownIndex)
+      .filter((className: string): boolean => {
+        const timestamp: number | null = timestampOfClassName(className);
+
+        return timestamp !== null && timestamp >= ownTimestamp;
+      });
+
+    // Named, not counted, so a failure says which migration it would jump.
+    expect(laterThanUs).toEqual([]);
   });
 });


### PR DESCRIPTION
Third in the run of master-red fixes today (after #3644 and #3646). Common Test shard 4 is failing:

```
the value-mapping migration › its timestamp is the newest in the directory
  Expected: 1791600000000
  Received: 1791700000000
```

`AddMacAddressToNetworkDevice1791700000000` landed, so `AddCustomFieldValueMapping` is no longer the newest file in `SchemaMigrations`. **Nothing it guards changed.** The assertion was a claim about the whole directory that every subsequent migration falsifies — it was going to fail on the next migration whoever wrote it, and the next one after that.

## What it actually meant to say

Its own comment already says it: TypeORM runs migrations in **class-name timestamp order**, not registration order, so a timestamp *below* one already registered would run this migration ahead of migrations that shipped before it — against a schema that doesn't yet have the columns they added.

Only the migrations registered **before** this one matter to that claim. The ones after it run after it either way, and are none of this test's business.

The test now asserts exactly that, reading class names off the `SchemaMigrations` registry it already imports, and **names the migration it would jump** rather than printing two bare timestamps.

## What it deliberately does not assert

Not that the whole registry is monotonic. **It isn't** — eleven adjacent pairs are already inverted, from branches that landed out of order (e.g. `MigrationName1767979448478` → `MigrationName1767896933148`). Asserting that here would fail this suite for somebody else's history, which is the same mistake in a new coat.

## Verification

| Check | Result |
|---|---|
| Suite | 31/31 pass |
| Falsifiability — swap the last two registry entries so the later migration is registered first | fails, naming `AddMacAddressToNetworkDevice1791700000000` |
| Restored | 31/31 green |
| eslint + prettier | clean |

The now-unused `MIGRATION_TIMESTAMP_PREFIX` is removed (`noUnusedLocals`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kjDdDnCbwpD3uCsks2tu5
