### PR TITLE
fix(terraform-provider): link the Full Changelog to the actual previous release

### DIFF
--- a/Scripts/TerraformProvider/publish-terraform-provider.sh
+++ b/Scripts/TerraformProvider/publish-terraform-provider.sh
@@ -692,6 +692,41 @@ push_repository_changes() {
     print_success "Code and tag pushed to terraform-provider-oneuptime repository"
 }
 
+# Function to look up the tag of the most recent existing release in the
+# provider repo — the release this one actually follows. Used for the
+# "Full Changelog" compare link; deriving the previous tag arithmetically
+# (patch - 1) produces v13.0.-1 on a x.y.0 release and simply points at the
+# wrong tag after any minor or major bump.
+#
+# Prints the tag on stdout, or nothing when there is no previous release.
+# Deliberately never fails: the changelog link is cosmetic, so a lookup error,
+# a gh too old for --json, or a repo with no releases yet all degrade to an
+# empty result (and the caller omits the line) instead of aborting a release
+# that has already pushed its tag.
+get_previous_release_tag() {
+    local tags=""
+
+    # Drafts are skipped: a draft from an earlier --test-release run is not
+    # something a compare link should point at. `|| true` keeps `set -e` out
+    # of it if gh errors or the repo has no releases.
+    tags=$(gh release list \
+        --repo "$GITHUB_ORG/$PROVIDER_REPO" \
+        --limit 10 \
+        --json tagName,isDraft \
+        --jq '.[] | select(.isDraft | not) | .tagName' 2>/dev/null) || true
+
+    local tag
+    while IFS= read -r tag; do
+        # Skip blanks and the release being created right now — a re-run can
+        # see its own tag if a previous attempt got as far as the release.
+        [[ -n "$tag" && "$tag" != "v$VERSION" ]] || continue
+        printf '%s\n' "$tag"
+        return 0
+    done <<< "$tags"
+
+    return 0
+}
+
 # Function to create GitHub release (gh CLI)
 create_github_release() {
     if [[ "$DRY_RUN" == true ]]; then
@@ -755,9 +790,20 @@ terraform {
 \`\`\`
 
 For detailed documentation and examples, visit: https://registry.terraform.io/providers/oneuptime/oneuptime/latest/docs
-
-**Full Changelog**: https://github.com/$GITHUB_ORG/$PROVIDER_REPO/compare/v$(echo $VERSION | awk -F. '{print $1"."$2"."($3-1)}')...v$VERSION
 EOF
+
+    # Append the "Full Changelog" compare link only when there is a real
+    # previous release to compare against. No previous release (or a failed
+    # lookup) means no line, rather than a link to a tag that does not exist.
+    local previous_tag
+    previous_tag=$(get_previous_release_tag)
+    if [[ -n "$previous_tag" ]]; then
+        print_status "Full Changelog will compare $previous_tag...v$VERSION"
+        printf '\n**Full Changelog**: https://github.com/%s/%s/compare/%s...v%s\n' \
+            "$GITHUB_ORG" "$PROVIDER_REPO" "$previous_tag" "$VERSION" >> "$release_notes_file"
+    else
+        print_warning "No previous release found in $GITHUB_ORG/$PROVIDER_REPO - omitting the Full Changelog link"
+    fi
 
     # Create the release. The tag was already pushed, so the release attaches
     # to the exact tagged commit.


### PR DESCRIPTION
## Problem

`Scripts/TerraformProvider/publish-terraform-provider.sh` built the "Full Changelog" compare link in the provider's GitHub release notes by subtracting one from the patch component:

```
compare/v$(echo $VERSION | awk -F. '{print $1"."$2"."($3-1)}')...v$VERSION
```

- On any `x.y.0` release the patch goes negative and the link 404s — the 13.0.0 release rendered as `v13.0.-1...v13.0.0`.
- After any minor or major bump it produces a *wrong* (not just broken) link, pointing at a tag that isn't the release this one follows.

Worth noting: the provider repo's releases actually go `v12.0.34` → `v13.0.0`, so even a corrected "patch minus one" would have pointed at a nonexistent tag here.

## Fix

- New `get_previous_release_tag()` queries the provider repo for the newest existing release (`gh release list --limit 10 --json tagName,isDraft --jq …`), skipping drafts and any tag equal to `v$VERSION` (a re-run can otherwise see its own release).
- The changelog line moved out of the heredoc and is appended only when a previous tag was found; otherwise it is omitted with a warning, rather than emitting a broken URL.
- The lookup can never abort a release: `2>/dev/null … || true` around the `gh` call and the function always returns 0, so an API failure or a `gh` too old for `--json` degrades to "no changelog line" instead of killing a run that has already pushed its tag.

## Verification

`bash -n` passes. A harness sourced the script's functions (minus `main`), stubbed `gh`, and piped the script's own `--jq` expression through real jq so the filter itself was under test:

```
PASS  13.0.0 (major bump; used to render v13.0.-1) -> compare/v12.0.35...v13.0.0
PASS  13.0.1 (plain patch bump)                    -> compare/v13.0.0...v13.0.1
PASS  13.1.0 (minor bump; arithmetic said v13.1.-1)-> compare/v13.0.9...v13.1.0
PASS  no releases in the repo yet                  (no Full Changelog line)
PASS  gh lookup fails                              (no line, release still created)
PASS  draft of the same version is skipped         -> compare/v12.0.35...v13.0.0
PASS  re-run: own release tag is skipped           -> compare/v12.0.35...v13.0.0
```

The real query was also confirmed against the live repo, returning newest-first as expected.

Cosmetic (release notes text only) — does not block a release, which is why it was kept out of the 13.0.0 version-bump PR.