### PR TITLE
fix(identity): accept a security key that cannot verify its user

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Global/UserProfile/TwoFactorAuth.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Global/UserProfile/TwoFactorAuth.tsx
@@ -444,6 +444,27 @@ const Home: FunctionComponent<PageComponentProps> = (): ReactElement => {
                         clientDataJSON: Base64.uint8ArrayToBase64Url(
                           new Uint8Array(attestationResponse.clientDataJSON),
                         ),
+
+                        /*
+                         * How this key can be reached -- "usb", "nfc", "ble",
+                         * "internal", "hybrid". The server cannot work this
+                         * out for itself: @simplewebauthn reads it straight
+                         * off this field, so a registration that omits it
+                         * stores no transports and every later sign-in prompt
+                         * has to offer every way a credential might be
+                         * reachable.
+                         *
+                         * Called defensively. getTransports() is not in the
+                         * original Level 1 API and older Safari and Firefox
+                         * builds do not have it; a missing hint is a worse
+                         * prompt, and a TypeError here would be a failed
+                         * registration.
+                         */
+                        transports:
+                          typeof attestationResponse.getTransports ===
+                          "function"
+                            ? attestationResponse.getTransports()
+                            : [],
                       },
                       type: credential.type,
                     },

--- a/App/Tests/FeatureSet/Identity/BackupCodeRateLimitBucket.test.ts
+++ b/App/Tests/FeatureSet/Identity/BackupCodeRateLimitBucket.test.ts
@@ -799,6 +799,7 @@ describe("the backup-code bucket configuration", () => {
     login: BucketConfigShape;
     twoFactor: BucketConfigShape;
     backupCode: BucketConfigShape;
+    webAuthnChallenge: BucketConfigShape;
   };
 
   interface IdentityRateLimitModule {
@@ -817,6 +818,9 @@ describe("the backup-code bucket configuration", () => {
     "IDENTITY_BACKUP_CODE_RATE_LIMIT_WINDOW_SECONDS",
     "IDENTITY_BACKUP_CODE_RATE_LIMIT_PER_ACCOUNT_PER_WINDOW",
     "IDENTITY_BACKUP_CODE_RATE_LIMIT_PER_IP_PER_WINDOW",
+    "IDENTITY_WEBAUTHN_CHALLENGE_RATE_LIMIT_WINDOW_SECONDS",
+    "IDENTITY_WEBAUTHN_CHALLENGE_RATE_LIMIT_PER_ACCOUNT_PER_WINDOW",
+    "IDENTITY_WEBAUTHN_CHALLENGE_RATE_LIMIT_PER_IP_PER_WINDOW",
   ];
 
   type ConfigsUnderEnvFunction = (
@@ -864,6 +868,9 @@ describe("the backup-code bucket configuration", () => {
           backupCode: freshModule.default.getBucketConfig(
             IdentityRateLimitBucket.BackupCode,
           ),
+          webAuthnChallenge: freshModule.default.getBucketConfig(
+            IdentityRateLimitBucket.WebAuthnChallenge,
+          ),
         };
       });
     } finally {
@@ -903,6 +910,23 @@ describe("the backup-code bucket configuration", () => {
       IDENTITY_BACKUP_CODE_RATE_LIMIT_WINDOW_SECONDS: "333",
       IDENTITY_BACKUP_CODE_RATE_LIMIT_PER_ACCOUNT_PER_WINDOW: "33",
       IDENTITY_BACKUP_CODE_RATE_LIMIT_PER_IP_PER_WINDOW: "3333",
+      IDENTITY_WEBAUTHN_CHALLENGE_RATE_LIMIT_WINDOW_SECONDS: "444",
+      IDENTITY_WEBAUTHN_CHALLENGE_RATE_LIMIT_PER_ACCOUNT_PER_WINDOW: "44",
+      IDENTITY_WEBAUTHN_CHALLENGE_RATE_LIMIT_PER_IP_PER_WINDOW: "4444",
+    });
+
+    /*
+     * The challenge-issuing bucket, added when
+     * /user-webauthn/generate-authentication-options stopped being unmetered.
+     * It is the newest name in the switch and therefore the likeliest to be
+     * the one that was forgotten -- a bucket with no branch silently receives
+     * the PASSWORD budget, and under the shipped defaults nothing about the
+     * numbers would give that away.
+     */
+    expect(configs.webAuthnChallenge).toEqual({
+      windowSeconds: 444,
+      perAccountLimit: 44,
+      perIpLimit: 4444,
     });
 
     expect(configs.backupCode).toEqual({
@@ -949,6 +973,32 @@ describe("the backup-code bucket configuration", () => {
    * budget instead -- the same class of bug this change fixed, one bucket
    * over.
    */
+  /*
+   * The same guard for the challenge bucket. Its defaults deliberately differ
+   * from its siblings' on the per-account number, so a fallthrough to the
+   * login budget IS visible by value here -- but the identity assertion is
+   * what keeps that true if the numbers are ever aligned again.
+   */
+  it("does not hand the challenge bucket the login or two-factor config object", () => {
+    const challengeConfig: ReturnType<
+      typeof IdentityRateLimit.getBucketConfig
+    > = IdentityRateLimit.getBucketConfig(
+      IdentityRateLimitBucket.WebAuthnChallenge,
+    );
+
+    expect(challengeConfig).not.toBe(
+      IdentityRateLimit.getBucketConfig(IdentityRateLimitBucket.Login),
+    );
+
+    expect(challengeConfig).not.toBe(
+      IdentityRateLimit.getBucketConfig(IdentityRateLimitBucket.TwoFactor),
+    );
+
+    expect(challengeConfig).not.toBe(
+      IdentityRateLimit.getBucketConfig(IdentityRateLimitBucket.BackupCode),
+    );
+  });
+
   it("does not hand the recovery bucket the login or two-factor config object", () => {
     const backupCodeConfig: ReturnType<
       typeof IdentityRateLimit.getBucketConfig

--- a/App/Tests/FeatureSet/Identity/WebAuthnUserVerification.test.ts
+++ b/App/Tests/FeatureSet/Identity/WebAuthnUserVerification.test.ts
@@ -1,0 +1,806 @@
+import UserWebAuthnService from "Common/Server/Services/UserWebAuthnService";
+import UserService from "Common/Server/Services/UserService";
+import Base64 from "Common/Utils/Base64";
+import User from "Common/Models/DatabaseModels/User";
+import UserWebAuthn from "Common/Models/DatabaseModels/UserWebAuthn";
+import Email from "Common/Types/Email";
+import ObjectID from "Common/Types/ObjectID";
+import OneUptimeDate from "Common/Types/Date";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import Exception from "Common/Types/Exception/Exception";
+import StatusCode from "Common/Types/API/StatusCode";
+import {
+  AuthenticationResponse,
+  RegistrationResponse,
+  SecurityKey,
+  createSecurityKey,
+} from "Common/Tests/Server/TestingUtils/SecurityKey";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * ---------------------------------------------------------------------------
+ * Issue #3652 — "Passkey registration fails in clamshell mode".
+ *
+ * A MacBook running folded shut on an external display cannot reach its Touch
+ * ID sensor. The server asks for `userVerification: "preferred"`, which tells
+ * the authenticator in so many words that going ahead WITHOUT verifying the
+ * user is acceptable, so the browser returns a perfectly valid credential with
+ * the UV bit in the authenticator data left clear. The server then threw
+ *
+ *     User verification was required, but user could not be verified
+ *
+ * out of @simplewebauthn/server and rendered it as an unexplained
+ * "Server Error". The user could not enrol a passkey at all.
+ *
+ * The cause was a policy split across two places that had drifted apart:
+ * `generateRegistrationOptions` asked for "preferred", while
+ * `verifyRegistrationResponse` was left to its own default of
+ * `requireUserVerification: true` and refused exactly what we had asked for.
+ * The identical default sits on `verifyAuthenticationResponse`, so the bug was
+ * never only about registration — a key enrolled at a desk could not SIGN IN
+ * from the same laptop later, which is a lockout rather than an annoyance.
+ *
+ * WHY THIS FILE LIVES IN App/Tests AND NOT Common/Tests
+ *
+ * Common's jest config maps `@simplewebauthn/server` to a hand-written stub
+ * (Common/Tests/__mocks__/simplewebauthn.js), so a test written there cannot
+ * see the library default that caused the bug — it would assert against a
+ * stub that has no such default and would have passed before the fix. App's
+ * jest config does not map the package, so everything here runs against the
+ * REAL v13 library. That is the whole point: the defect was in what the
+ * library does when we say nothing, and only the real library exhibits it.
+ *
+ * WHAT IS REAL AND WHAT IS STUBBED
+ *
+ * Real: @simplewebauthn/server, the ES256 signatures, the CBOR attestation,
+ * the authenticator-data flags, and `Common/Utils/Base64` — the same helper
+ * the browser code uses to turn the challenge the server issued back into the
+ * bytes the authenticator signs.
+ *
+ * Stubbed: Postgres only. `UserService` and the four `DatabaseService` methods
+ * the service reaches for are replaced; nothing else is.
+ *
+ * The credentials come from Common/Tests/Server/TestingUtils/SecurityKey,
+ * which builds them from the WebAuthn/CTAP specs with Node crypto and imports
+ * nothing from @simplewebauthn/server. A fixture produced by the library under
+ * test would only prove the library agrees with itself.
+ * ---------------------------------------------------------------------------
+ */
+
+/*
+ * Written out as a literal inside the factory as well as in RP_ID below:
+ * jest hoists this call above every const in the file, so the factory runs
+ * while RP_ID is still in its temporal dead zone.
+ */
+jest.mock("Common/Server/EnvironmentConfig", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/EnvironmentConfig",
+  ) as Record<string, unknown>;
+
+  /*
+   * Host is the relying party id and, with the protocol in front of it, the
+   * expected origin. Both have to be something a credential can plausibly be
+   * scoped to, and the default in a test process is the empty string.
+   */
+  return {
+    ...actual,
+    __esModule: true,
+    Host: "oneuptime.example.com",
+    HttpProtocol: "https://",
+  };
+});
+
+const RP_ID: string = "oneuptime.example.com";
+const ORIGIN: string = `https://${RP_ID}`;
+
+const USER_ID: ObjectID = new ObjectID("6f9d4a1e-2b3c-4d5e-8f10-112233445566");
+const USER_EMAIL: Email = new Email("clamshell.user@example.com");
+
+const KEY_NAME: string = "MacBook Touch ID";
+
+/*
+ * Whatever the last call to generateRegistrationOptions /
+ * generateAuthenticationOptions asked the database to remember. The service
+ * stores the challenge on the User row and reads it back at verification, so
+ * this is the seam that carries a challenge from one half of a flow to the
+ * other -- exactly as the real column does.
+ */
+let storedChallenge: string | null = null;
+let storedChallengeExpiresAt: Date | null = null;
+
+/* Rows the stubbed database will answer with. */
+let existingCredentials: Array<UserWebAuthn> = [];
+let createdCredential: UserWebAuthn | null = null;
+let counterUpdates: Array<string> = [];
+
+type BuildUserFunction = () => User;
+
+const buildUser: BuildUserFunction = (): User => {
+  const user: User = new User();
+  user.id = USER_ID;
+  user.email = USER_EMAIL;
+
+  /*
+   * `findOneById` is used for two different reads — the profile lookup when
+   * options are generated, and the challenge lookup when a response is
+   * verified — so the same object has to answer both.
+   */
+  user.webauthnChallenge = storedChallenge as string;
+  user.webauthnChallengeExpiresAt = storedChallengeExpiresAt as unknown as Date;
+
+  return user;
+};
+
+beforeEach(() => {
+  storedChallenge = null;
+  storedChallengeExpiresAt = null;
+  existingCredentials = [];
+  createdCredential = null;
+  counterUpdates = [];
+
+  UserService.findOneById = jest.fn().mockImplementation(async () => {
+    return buildUser();
+  }) as never;
+
+  UserService.findOneBy = jest.fn().mockImplementation(async () => {
+    return buildUser();
+  }) as never;
+
+  UserService.updateOneById = jest
+    .fn()
+    .mockImplementation(async (data: { data: Record<string, unknown> }) => {
+      if ("webauthnChallenge" in data.data) {
+        storedChallenge = data.data["webauthnChallenge"] as string | null;
+        storedChallengeExpiresAt = data.data[
+          "webauthnChallengeExpiresAt"
+        ] as Date | null;
+      }
+      return undefined;
+    }) as never;
+
+  UserWebAuthnService.findBy = jest.fn().mockImplementation(async () => {
+    return existingCredentials;
+  }) as never;
+
+  UserWebAuthnService.findOneBy = jest.fn().mockImplementation(async () => {
+    return existingCredentials[0] || null;
+  }) as never;
+
+  UserWebAuthnService.create = jest
+    .fn()
+    .mockImplementation(async (data: { data: UserWebAuthn }) => {
+      createdCredential = data.data;
+      return data.data;
+    }) as never;
+
+  UserWebAuthnService.updateOneById = jest
+    .fn()
+    .mockImplementation(async (data: { data: Record<string, unknown> }) => {
+      if (data.data["counter"] !== undefined) {
+        counterUpdates.push(data.data["counter"] as string);
+      }
+      return undefined;
+    }) as never;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+type MakeKeyFunction = (performsUserVerification: boolean) => SecurityKey;
+
+const makeKey: MakeKeyFunction = (
+  performsUserVerification: boolean,
+): SecurityKey => {
+  return createSecurityKey({
+    rpId: RP_ID,
+    origin: ORIGIN,
+    performsUserVerification: performsUserVerification,
+    isMultiDevice: true,
+  });
+};
+
+/*
+ * The registration half of the flow, driven exactly as the browser drives it:
+ * ask the server for options, decode the challenge with the same helper
+ * App/FeatureSet/Dashboard/.../TwoFactorAuth.tsx uses, hand it to the
+ * authenticator, post the result back.
+ */
+type RegisterFunction = (key: SecurityKey) => Promise<void>;
+
+const register: RegisterFunction = async (key: SecurityKey): Promise<void> => {
+  const { options } = await UserWebAuthnService.generateRegistrationOptions({
+    userId: USER_ID,
+  });
+
+  const challengeTheAuthenticatorSigns: string = Buffer.from(
+    Base64.base64UrlToUint8Array(options.challenge),
+  ).toString("base64url");
+
+  const credential: RegistrationResponse = key.register({
+    challenge: challengeTheAuthenticatorSigns,
+  });
+
+  await UserWebAuthnService.verifyRegistration({
+    credential: credential,
+    name: KEY_NAME,
+    props: { userId: USER_ID },
+  });
+};
+
+/* The same, for signing in. Requires a credential row to already exist. */
+type AuthenticateFunction = (key: SecurityKey) => Promise<User>;
+
+const authenticate: AuthenticateFunction = async (
+  key: SecurityKey,
+): Promise<User> => {
+  const { options } = await UserWebAuthnService.generateAuthenticationOptions({
+    email: USER_EMAIL.toString(),
+  });
+
+  const challengeTheAuthenticatorSigns: string = Buffer.from(
+    Base64.base64UrlToUint8Array(options.challenge),
+  ).toString("base64url");
+
+  const assertion: AuthenticationResponse = key.authenticate({
+    challenge: challengeTheAuthenticatorSigns,
+  });
+
+  return UserWebAuthnService.verifyAuthentication({
+    userId: USER_ID.toString(),
+    credential: assertion,
+  });
+};
+
+/* Put a key on the account as if it had already been registered. */
+type SeedRegisteredKeyFunction = (key: SecurityKey) => void;
+
+const seedRegisteredKey: SeedRegisteredKeyFunction = (
+  key: SecurityKey,
+): void => {
+  const row: UserWebAuthn = new UserWebAuthn();
+  row.id = new ObjectID("11112222-3333-4444-8555-666677778888");
+  row.credentialId = key.credentialId;
+  row.publicKey = key.publicKeyAsStored;
+  row.counter = "0";
+  row.isVerified = true;
+  row.userId = USER_ID;
+
+  existingCredentials = [row];
+};
+
+describe("WebAuthn user verification (issue #3652)", () => {
+  describe("registering a passkey on an authenticator that cannot verify its user", () => {
+    it("accepts a credential whose UV flag is clear", async () => {
+      /*
+       * THE REGRESSION TEST. Before the fix this rejected with
+       * "User verification was required, but user could not be verified",
+       * which is precisely the bug report: a folded-shut MacBook cannot reach
+       * Touch ID, so the browser returns a credential with UV clear -- as our
+       * own "preferred" policy invited it to -- and the server refused it.
+       */
+      await expect(register(makeKey(false))).resolves.toBeUndefined();
+
+      expect(createdCredential).not.toBeNull();
+    });
+
+    it("saves the credential the authenticator actually returned", async () => {
+      /*
+       * "Did not throw" is not the same as "enrolled". If the credential id or
+       * the public key that lands in the row is not the authenticator's own,
+       * the user has a security key the account will never recognise again --
+       * a registration that reports success and produces a factor that cannot
+       * sign in.
+       */
+      const key: SecurityKey = makeKey(false);
+
+      await register(key);
+
+      expect(createdCredential!.credentialId).toBe(key.credentialId);
+      expect(createdCredential!.publicKey).toBe(key.publicKeyAsStored);
+      expect(createdCredential!.name).toBe(KEY_NAME);
+      expect(createdCredential!.userId!.toString()).toBe(USER_ID.toString());
+    });
+
+    it("still accepts a credential from an authenticator that DID verify", async () => {
+      /*
+       * The other half of "preferred", asserted so the fix cannot be read as
+       * "user verification is now rejected". A laptop at a desk with the lid
+       * open sets the UV bit, and that has to keep working.
+       */
+      await expect(register(makeKey(true))).resolves.toBeUndefined();
+
+      expect(createdCredential).not.toBeNull();
+    });
+  });
+
+  describe("signing in with an authenticator that cannot verify its user", () => {
+    it("accepts an assertion whose UV flag is clear", async () => {
+      /*
+       * The half of the bug nobody reported, because nobody got far enough to
+       * hit it. `verifyAuthenticationResponse` carries the SAME
+       * requireUserVerification default, so a key enrolled at a desk failed to
+       * sign in from the same laptop in clamshell mode -- and the password has
+       * already been accepted by then, so there is no way back into the
+       * account from the browser. Fixing registration alone would have moved
+       * the lockout rather than removed it.
+       */
+      const key: SecurityKey = makeKey(false);
+      seedRegisteredKey(key);
+
+      const user: User = await authenticate(key);
+
+      expect(user.id!.toString()).toBe(USER_ID.toString());
+    });
+
+    it("still accepts an assertion from an authenticator that DID verify", async () => {
+      const key: SecurityKey = makeKey(true);
+      seedRegisteredKey(key);
+
+      const user: User = await authenticate(key);
+
+      expect(user.id!.toString()).toBe(USER_ID.toString());
+    });
+
+    it("writes the authenticator's signature counter back", async () => {
+      /*
+       * Cheap, and it keeps the assertions above honest: if verification were
+       * somehow short-circuiting rather than really running, nothing would
+       * reach the counter write that follows it.
+       */
+      const key: SecurityKey = makeKey(false);
+      seedRegisteredKey(key);
+
+      await authenticate(key);
+
+      expect(counterUpdates).toEqual(["0"]);
+    });
+  });
+
+  describe("the policy the browser is asked for", () => {
+    it("asks for preferred user verification when registering", async () => {
+      /*
+       * The ask and the check are two halves of one policy, and the bug was
+       * that they disagreed. This pins the ask, so a future change that
+       * tightens verification without tightening the options -- recreating the
+       * exact defect -- fails here as well as in the tests above.
+       */
+      const { options } = await UserWebAuthnService.generateRegistrationOptions(
+        {
+          userId: USER_ID,
+        },
+      );
+
+      expect(options.authenticatorSelection.userVerification).toBe("preferred");
+    });
+
+    it("asks for preferred user verification when signing in", async () => {
+      seedRegisteredKey(makeKey(false));
+
+      const { options } =
+        await UserWebAuthnService.generateAuthenticationOptions({
+          email: USER_EMAIL.toString(),
+        });
+
+      expect(options.userVerification).toBe("preferred");
+    });
+  });
+
+  describe("what relaxing user verification does NOT relax", () => {
+    /*
+     * The fix removes ONE check, and a fix that quietly removed more than one
+     * would look identical from the tests above. Each of these is a property
+     * that has to survive: they are what make a security key a factor at all,
+     * and they do not depend on the user being verified.
+     */
+
+    it("still rejects a response signed over a different challenge", async () => {
+      const key: SecurityKey = makeKey(false);
+
+      await UserWebAuthnService.generateRegistrationOptions({
+        userId: USER_ID,
+      });
+
+      const credential: RegistrationResponse = key.register({
+        challenge: Buffer.from("a challenge nobody issued").toString(
+          "base64url",
+        ),
+      });
+
+      await expect(
+        UserWebAuthnService.verifyRegistration({
+          credential: credential,
+          name: KEY_NAME,
+          props: { userId: USER_ID },
+        }),
+      ).rejects.toThrow(/challenge/i);
+    });
+
+    it("still rejects a response from another origin", async () => {
+      /*
+       * A credential minted by a phishing page on a look-alike domain. The
+       * origin is bound into the client data the authenticator signs, so this
+       * is the check that makes WebAuthn phishing-resistant -- the single most
+       * valuable property it has, and entirely independent of UV.
+       */
+      const phishedKey: SecurityKey = createSecurityKey({
+        rpId: RP_ID,
+        origin: "https://oneuptime.example.com.evil.test",
+        performsUserVerification: false,
+      });
+
+      const { options } = await UserWebAuthnService.generateRegistrationOptions(
+        {
+          userId: USER_ID,
+        },
+      );
+
+      const credential: RegistrationResponse = phishedKey.register({
+        challenge: options.challenge,
+      });
+
+      await expect(
+        UserWebAuthnService.verifyRegistration({
+          credential: credential,
+          name: KEY_NAME,
+          props: { userId: USER_ID },
+        }),
+      ).rejects.toThrow(/origin/i);
+    });
+
+    it("still rejects a response scoped to another relying party", async () => {
+      const wrongRpKey: SecurityKey = createSecurityKey({
+        rpId: "evil.test",
+        origin: ORIGIN,
+        performsUserVerification: false,
+      });
+
+      const { options } = await UserWebAuthnService.generateRegistrationOptions(
+        {
+          userId: USER_ID,
+        },
+      );
+
+      const credential: RegistrationResponse = wrongRpKey.register({
+        challenge: options.challenge,
+      });
+
+      await expect(
+        UserWebAuthnService.verifyRegistration({
+          credential: credential,
+          name: KEY_NAME,
+          props: { userId: USER_ID },
+        }),
+      ).rejects.toThrow(/RP ID/i);
+    });
+
+    it("still rejects an assertion signed by a different key", async () => {
+      /*
+       * Possession of the private key is the entire factor. An impostor
+       * authenticator replaying the right credential id must fail on the
+       * signature, and the UV bit has nothing to do with it.
+       */
+      const enrolled: SecurityKey = makeKey(false);
+      seedRegisteredKey(enrolled);
+
+      const impostor: SecurityKey = makeKey(false);
+
+      const { options } =
+        await UserWebAuthnService.generateAuthenticationOptions({
+          email: USER_EMAIL.toString(),
+        });
+
+      const assertion: AuthenticationResponse = impostor.authenticate({
+        challenge: options.challenge,
+      });
+
+      /* Answer to the enrolled credential's id, so only the signature differs. */
+      assertion.id = enrolled.credentialId;
+      assertion.rawId = enrolled.credentialId;
+
+      await expect(
+        UserWebAuthnService.verifyAuthentication({
+          userId: USER_ID.toString(),
+          credential: assertion,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("still rejects a response once its challenge has expired", async () => {
+      const key: SecurityKey = makeKey(false);
+
+      const { options } = await UserWebAuthnService.generateRegistrationOptions(
+        {
+          userId: USER_ID,
+        },
+      );
+
+      storedChallengeExpiresAt = OneUptimeDate.addRemoveMinutes(
+        OneUptimeDate.getCurrentDate(),
+        -1,
+      );
+
+      const credential: RegistrationResponse = key.register({
+        challenge: options.challenge,
+      });
+
+      await expect(
+        UserWebAuthnService.verifyRegistration({
+          credential: credential,
+          name: KEY_NAME,
+          props: { userId: USER_ID },
+        }),
+      ).rejects.toThrow(/expired/i);
+    });
+
+    it("still refuses to reuse a challenge that has already been spent", async () => {
+      /*
+       * The challenge is cleared as it is read, so a replay of the very same
+       * credential -- captured off the wire -- finds nothing to verify
+       * against. Registering twice in a row exercises exactly that.
+       */
+      const key: SecurityKey = makeKey(false);
+
+      const { options } = await UserWebAuthnService.generateRegistrationOptions(
+        {
+          userId: USER_ID,
+        },
+      );
+
+      const credential: RegistrationResponse = key.register({
+        challenge: options.challenge,
+      });
+
+      await UserWebAuthnService.verifyRegistration({
+        credential: credential,
+        name: KEY_NAME,
+        props: { userId: USER_ID },
+      });
+
+      await expect(
+        UserWebAuthnService.verifyRegistration({
+          credential: credential,
+          name: KEY_NAME,
+          props: { userId: USER_ID },
+        }),
+      ).rejects.toThrow(/no pending webauthn challenge/i);
+    });
+  });
+
+  describe("the challenge the server issues and the challenge the key signs", () => {
+    it("survives the browser's base64url round trip unchanged", async () => {
+      /*
+       * The dashboard turns the issued challenge into bytes with
+       * `Base64.base64UrlToUint8Array` before handing it to
+       * navigator.credentials, and the browser then base64url-encodes those
+       * same bytes back into client data. The server compares that against the
+       * string it stored, so the two encodings have to agree exactly.
+       *
+       * Asserted with the REAL helper the dashboard imports, because a change
+       * to either end of this -- the `Buffer.from(...).toString("base64url")`
+       * re-encoding in the service, or the helper -- breaks every registration
+       * and every sign-in at once, with a "challenge" error that says nothing
+       * about encodings.
+       */
+      const { options, challenge } =
+        await UserWebAuthnService.generateRegistrationOptions({
+          userId: USER_ID,
+        });
+
+      const asTheBrowserSendsItBack: string = Buffer.from(
+        Base64.base64UrlToUint8Array(options.challenge),
+      ).toString("base64url");
+
+      expect(asTheBrowserSendsItBack).toBe(options.challenge);
+      expect(challenge).toBe(options.challenge);
+      expect(storedChallenge).toBe(options.challenge);
+    });
+
+    it("issues a different challenge every time", async () => {
+      const first: { challenge: string } =
+        await UserWebAuthnService.generateRegistrationOptions({
+          userId: USER_ID,
+        });
+
+      const second: { challenge: string } =
+        await UserWebAuthnService.generateRegistrationOptions({
+          userId: USER_ID,
+        });
+
+      expect(first.challenge).not.toBe(second.challenge);
+    });
+  });
+
+  describe("what the browser is told when verification fails", () => {
+    /*
+     * The other half of the bug report: "Get a 'Server Error' message, and the
+     * above error in the console". @simplewebauthn/server signals every
+     * refusal by throwing a plain `Error`, and the last-resort handler in
+     * Common/Server/Utils/StartServer.ts has no branch for one -- it falls
+     * through to `res.status(500).send({ error: "Server Error" })` and throws
+     * the sentence away. So the diagnosis existed and simply never left the
+     * server, which is why this took a bug report to find rather than a glance
+     * at the screen.
+     *
+     * These assertions are about the SHAPE the failure arrives in, not about
+     * the fix to user verification -- and they matter more now, not less. With
+     * UV no longer able to fail, the remaining causes are configuration ones
+     * a self-hoster has to be able to read: a reverse proxy serving an origin
+     * that does not match HOST, or a relying party id that moved.
+     */
+
+    type ThrownByFunction = (run: () => Promise<unknown>) => Promise<unknown>;
+
+    const thrownBy: ThrownByFunction = async (
+      run: () => Promise<unknown>,
+    ): Promise<unknown> => {
+      try {
+        await run();
+      } catch (error) {
+        return error;
+      }
+
+      throw new Error("Expected this to reject, and it resolved");
+    };
+
+    it("reports a mismatched origin as bad data, not as a server error", async () => {
+      const phishedKey: SecurityKey = createSecurityKey({
+        rpId: RP_ID,
+        origin: "https://oneuptime.example.com.evil.test",
+        performsUserVerification: true,
+      });
+
+      const { options } = await UserWebAuthnService.generateRegistrationOptions(
+        {
+          userId: USER_ID,
+        },
+      );
+
+      const thrown: unknown = await thrownBy(() => {
+        return UserWebAuthnService.verifyRegistration({
+          credential: phishedKey.register({ challenge: options.challenge }),
+          name: KEY_NAME,
+          props: { userId: USER_ID },
+        });
+      });
+
+      /*
+       * `instanceof Exception` is the property the handler branches on. A
+       * plain Error -- what the library throws and what this code path used to
+       * let through -- takes the final `else` and is answered with a bare 500.
+       */
+      expect(thrown).toBeInstanceOf(Exception);
+      expect(thrown).toBeInstanceOf(BadDataException);
+
+      /* And a status the handler will actually accept, rather than falling back to 500. */
+      expect(StatusCode.isValidStatusCode((thrown as Exception).code)).toBe(
+        true,
+      );
+    });
+
+    it("keeps the library's own explanation of what went wrong", async () => {
+      /*
+       * The message is the whole point. "Server Error" is indistinguishable
+       * from a database outage; naming the origin the server expected tells a
+       * self-hoster their proxy is rewriting it, which nothing else in the
+       * product will tell them.
+       */
+      const wrongRpKey: SecurityKey = createSecurityKey({
+        rpId: "evil.test",
+        origin: ORIGIN,
+        performsUserVerification: true,
+      });
+
+      const { options } = await UserWebAuthnService.generateRegistrationOptions(
+        {
+          userId: USER_ID,
+        },
+      );
+
+      const thrown: unknown = await thrownBy(() => {
+        return UserWebAuthnService.verifyRegistration({
+          credential: wrongRpKey.register({ challenge: options.challenge }),
+          name: KEY_NAME,
+          props: { userId: USER_ID },
+        });
+      });
+
+      expect((thrown as Exception).message).toMatch(/RP ID/i);
+      expect((thrown as Exception).message).not.toBe("Server Error");
+    });
+
+    it("does the same for a failed sign-in", async () => {
+      const enrolled: SecurityKey = makeKey(true);
+      seedRegisteredKey(enrolled);
+
+      const impostor: SecurityKey = makeKey(true);
+
+      const { options } =
+        await UserWebAuthnService.generateAuthenticationOptions({
+          email: USER_EMAIL.toString(),
+        });
+
+      const assertion: AuthenticationResponse = impostor.authenticate({
+        challenge: options.challenge,
+      });
+
+      assertion.id = enrolled.credentialId;
+      assertion.rawId = enrolled.credentialId;
+
+      const thrown: unknown = await thrownBy(() => {
+        return UserWebAuthnService.verifyAuthentication({
+          userId: USER_ID.toString(),
+          credential: assertion,
+        });
+      });
+
+      expect(thrown).toBeInstanceOf(Exception);
+      expect((thrown as Exception).message).not.toBe("Server Error");
+    });
+
+    it("does not flatten the errors this service raises itself", async () => {
+      /*
+       * The wrapper turns library Errors into Exceptions and must leave our
+       * own alone. "WebAuthn challenge has expired. Please initiate the
+       * WebAuthn flow again." is actionable in a way no library message is,
+       * and re-wrapping it would replace it with whatever the library said
+       * next -- or with the generic fallback.
+       */
+      const key: SecurityKey = makeKey(true);
+
+      const { options } = await UserWebAuthnService.generateRegistrationOptions(
+        {
+          userId: USER_ID,
+        },
+      );
+
+      storedChallengeExpiresAt = OneUptimeDate.addRemoveMinutes(
+        OneUptimeDate.getCurrentDate(),
+        -1,
+      );
+
+      const thrown: unknown = await thrownBy(() => {
+        return UserWebAuthnService.verifyRegistration({
+          credential: key.register({ challenge: options.challenge }),
+          name: KEY_NAME,
+          props: { userId: USER_ID },
+        });
+      });
+
+      expect(thrown).toBeInstanceOf(BadDataException);
+      expect((thrown as Exception).message).toMatch(/challenge has expired/i);
+    });
+  });
+
+  describe("a full enrol-then-sign-in journey from one clamshell laptop", () => {
+    it("registers a key with UV clear and then signs in with it", async () => {
+      /*
+       * The two halves of the bug in one test, in the order the user meets
+       * them. Neither half alone is the user's problem: what they wanted was
+       * to set up a passkey and then use it, and before the fix the first
+       * step failed -- and had it not, the second would have.
+       *
+       * The credential row is built from what registration actually persisted
+       * rather than from the fixture, so the public key really does make the
+       * round trip through the base64 the column stores.
+       */
+      const key: SecurityKey = makeKey(false);
+
+      await register(key);
+
+      const persisted: UserWebAuthn = new UserWebAuthn();
+      persisted.id = new ObjectID("99998888-7777-6666-8555-444433332222");
+      persisted.credentialId = createdCredential!.credentialId!;
+      persisted.publicKey = createdCredential!.publicKey!;
+      persisted.counter = createdCredential!.counter!;
+      persisted.isVerified = true;
+      persisted.userId = USER_ID;
+
+      existingCredentials = [persisted];
+
+      const user: User = await authenticate(key);
+
+      expect(user.id!.toString()).toBe(USER_ID.toString());
+    });
+  });
+});

--- a/App/Tests/FeatureSet/Identity/WebAuthnUserVerification.test.ts
+++ b/App/Tests/FeatureSet/Identity/WebAuthnUserVerification.test.ts
@@ -99,14 +99,34 @@ const USER_EMAIL: Email = new Email("clamshell.user@example.com");
 const KEY_NAME: string = "MacBook Touch ID";
 
 /*
- * Whatever the last call to generateRegistrationOptions /
- * generateAuthenticationOptions asked the database to remember. The service
- * stores the challenge on the User row and reads it back at verification, so
- * this is the seam that carries a challenge from one half of a flow to the
- * other -- exactly as the real column does.
+ * The User row's two challenge slots, modelled as the columns actually are:
+ * one for registering a key and a SEPARATE one for signing in with it. They
+ * used to be a single pair, and this harness used to have a single pair of
+ * variables to match -- which is exactly why a test could not have caught the
+ * two flows overwriting each other.
+ *
+ * This is the seam that carries a challenge from the generate half of a flow
+ * to the verify half, so keeping the two apart here is what lets the
+ * independence tests below mean anything.
  */
-let storedChallenge: string | null = null;
-let storedChallengeExpiresAt: Date | null = null;
+type ChallengeSlot = {
+  challenge: string | null;
+  expiresAt: Date | null;
+};
+
+type ChallengeSlots = {
+  registration: ChallengeSlot;
+  authentication: ChallengeSlot;
+};
+
+const emptySlots: () => ChallengeSlots = (): ChallengeSlots => {
+  return {
+    registration: { challenge: null, expiresAt: null },
+    authentication: { challenge: null, expiresAt: null },
+  };
+};
+
+let slots: ChallengeSlots = emptySlots();
 
 /* Rows the stubbed database will answer with. */
 let existingCredentials: Array<UserWebAuthn> = [];
@@ -123,17 +143,22 @@ const buildUser: BuildUserFunction = (): User => {
   /*
    * `findOneById` is used for two different reads — the profile lookup when
    * options are generated, and the challenge lookup when a response is
-   * verified — so the same object has to answer both.
+   * verified — so the same object has to answer both, for both slots.
    */
-  user.webauthnChallenge = storedChallenge as string;
-  user.webauthnChallengeExpiresAt = storedChallengeExpiresAt as unknown as Date;
+  user.webauthnRegistrationChallenge = slots.registration
+    .challenge as unknown as string;
+  user.webauthnRegistrationChallengeExpiresAt = slots.registration
+    .expiresAt as unknown as Date;
+  user.webauthnAuthenticationChallenge = slots.authentication
+    .challenge as unknown as string;
+  user.webauthnAuthenticationChallengeExpiresAt = slots.authentication
+    .expiresAt as unknown as Date;
 
   return user;
 };
 
 beforeEach(() => {
-  storedChallenge = null;
-  storedChallengeExpiresAt = null;
+  slots = emptySlots();
   existingCredentials = [];
   createdCredential = null;
   counterUpdates = [];
@@ -149,12 +174,32 @@ beforeEach(() => {
   UserService.updateOneById = jest
     .fn()
     .mockImplementation(async (data: { data: Record<string, unknown> }) => {
-      if ("webauthnChallenge" in data.data) {
-        storedChallenge = data.data["webauthnChallenge"] as string | null;
-        storedChallengeExpiresAt = data.data[
-          "webauthnChallengeExpiresAt"
-        ] as Date | null;
+      /*
+       * Each write names exactly one slot, which is the property under test:
+       * a write that touched both would be the bug this split removed.
+       */
+      if ("webauthnRegistrationChallenge" in data.data) {
+        slots.registration = {
+          challenge: data.data["webauthnRegistrationChallenge"] as
+            | string
+            | null,
+          expiresAt: data.data[
+            "webauthnRegistrationChallengeExpiresAt"
+          ] as Date | null,
+        };
       }
+
+      if ("webauthnAuthenticationChallenge" in data.data) {
+        slots.authentication = {
+          challenge: data.data["webauthnAuthenticationChallenge"] as
+            | string
+            | null,
+          expiresAt: data.data[
+            "webauthnAuthenticationChallengeExpiresAt"
+          ] as Date | null,
+        };
+      }
+
       return undefined;
     }) as never;
 
@@ -515,7 +560,7 @@ describe("WebAuthn user verification (issue #3652)", () => {
         },
       );
 
-      storedChallengeExpiresAt = OneUptimeDate.addRemoveMinutes(
+      slots.registration.expiresAt = OneUptimeDate.addRemoveMinutes(
         OneUptimeDate.getCurrentDate(),
         -1,
       );
@@ -593,7 +638,7 @@ describe("WebAuthn user verification (issue #3652)", () => {
 
       expect(asTheBrowserSendsItBack).toBe(options.challenge);
       expect(challenge).toBe(options.challenge);
-      expect(storedChallenge).toBe(options.challenge);
+      expect(slots.registration.challenge).toBe(options.challenge);
     });
 
     it("issues a different challenge every time", async () => {
@@ -754,7 +799,7 @@ describe("WebAuthn user verification (issue #3652)", () => {
         },
       );
 
-      storedChallengeExpiresAt = OneUptimeDate.addRemoveMinutes(
+      slots.registration.expiresAt = OneUptimeDate.addRemoveMinutes(
         OneUptimeDate.getCurrentDate(),
         -1,
       );
@@ -769,6 +814,485 @@ describe("WebAuthn user verification (issue #3652)", () => {
 
       expect(thrown).toBeInstanceOf(BadDataException);
       expect((thrown as Exception).message).toMatch(/challenge has expired/i);
+    });
+  });
+
+  describe("the two challenge slots are independent", () => {
+    /*
+     * The property the split exists for, and one no end-to-end assertion about
+     * a single flow can catch.
+     *
+     * Registration is keyed by the session's user and signing in is keyed by
+     * an email address, and both land on the same User row. While they shared
+     * one column, whichever wrote last destroyed the other's challenge -- so a
+     * user adding a second key in one tab, with a stale sign-in page open in
+     * another, lost the registration they were halfway through and got
+     * "No pending WebAuthn challenge found" for a key they were holding.
+     *
+     * These drive both flows through the REAL service against one row, which
+     * is the only way to show they no longer collide.
+     */
+
+    it("issuing a sign-in challenge does not destroy a registration in progress", async () => {
+      const key: SecurityKey = makeKey(false);
+
+      /* Tab one: the user starts adding a key. */
+      const { options: registrationOptions } =
+        await UserWebAuthnService.generateRegistrationOptions({
+          userId: USER_ID,
+        });
+
+      /* Tab two -- or an anonymous caller -- asks for a sign-in challenge. */
+      seedRegisteredKey(key);
+      await UserWebAuthnService.generateAuthenticationOptions({
+        email: USER_EMAIL.toString(),
+      });
+
+      /* Tab one finishes. Before the split this threw. */
+      await expect(
+        UserWebAuthnService.verifyRegistration({
+          credential: key.register({
+            challenge: registrationOptions.challenge,
+          }),
+          name: KEY_NAME,
+          props: { userId: USER_ID },
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("issuing a registration challenge does not destroy a sign-in in progress", async () => {
+      /*
+       * The mirror image, and the more damaging direction: the password has
+       * already been accepted by the time a sign-in challenge is outstanding,
+       * so losing it strands the user at the second step.
+       */
+      const key: SecurityKey = makeKey(false);
+      seedRegisteredKey(key);
+
+      const { options: authenticationOptions } =
+        await UserWebAuthnService.generateAuthenticationOptions({
+          email: USER_EMAIL.toString(),
+        });
+
+      await UserWebAuthnService.generateRegistrationOptions({
+        userId: USER_ID,
+      });
+
+      const user: User = await UserWebAuthnService.verifyAuthentication({
+        userId: USER_ID.toString(),
+        credential: key.authenticate({
+          challenge: authenticationOptions.challenge,
+        }),
+      });
+
+      expect(user.id!.toString()).toBe(USER_ID.toString());
+    });
+
+    it("spending one slot leaves the other one loaded", async () => {
+      /*
+       * Stated on the row itself rather than through a flow, because the
+       * clearing is what used to do the damage: `getAndClearStoredChallenge`
+       * empties the slot it read, and while there was one slot that meant
+       * every completed ceremony wiped the other flow's pending one.
+       */
+      const key: SecurityKey = makeKey(false);
+      seedRegisteredKey(key);
+
+      const { options: authenticationOptions } =
+        await UserWebAuthnService.generateAuthenticationOptions({
+          email: USER_EMAIL.toString(),
+        });
+
+      const { options: registrationOptions } =
+        await UserWebAuthnService.generateRegistrationOptions({
+          userId: USER_ID,
+        });
+
+      expect(slots.registration.challenge).toBe(registrationOptions.challenge);
+      expect(slots.authentication.challenge).toBe(
+        authenticationOptions.challenge,
+      );
+
+      await UserWebAuthnService.verifyRegistration({
+        credential: key.register({ challenge: registrationOptions.challenge }),
+        name: KEY_NAME,
+        props: { userId: USER_ID },
+      });
+
+      expect(slots.registration.challenge).toBeNull();
+      expect(slots.authentication.challenge).toBe(
+        authenticationOptions.challenge,
+      );
+    });
+
+    it("a sign-in challenge cannot be spent as a registration one", async () => {
+      /*
+       * The slots are separate, so a response signed over the wrong flow's
+       * challenge finds nothing to match rather than matching by accident.
+       * A single shared slot would have accepted this.
+       */
+      const key: SecurityKey = makeKey(false);
+      seedRegisteredKey(key);
+
+      const { options: authenticationOptions } =
+        await UserWebAuthnService.generateAuthenticationOptions({
+          email: USER_EMAIL.toString(),
+        });
+
+      await expect(
+        UserWebAuthnService.verifyRegistration({
+          credential: key.register({
+            challenge: authenticationOptions.challenge,
+          }),
+          name: KEY_NAME,
+          props: { userId: USER_ID },
+        }),
+      ).rejects.toThrow(/no pending webauthn challenge/i);
+    });
+  });
+
+  describe("the relying party id the browser is given", () => {
+    /*
+     * An RP ID and an origin are built from the same HOST here and are NOT the
+     * same string. The origin must carry the port -- it is what the browser
+     * puts in its client data -- and the RP ID must not, because the spec
+     * defines it as a domain and a browser handed "host:port" refuses the call
+     * outright. HOST carries a port on every self-hosted instance that is not
+     * on 80/443, and those deployments could not use WebAuthn at all.
+     */
+
+    type WithHostFunction = (
+      host: string,
+      run: () => Promise<void>,
+    ) => Promise<void>;
+
+    const withHost: WithHostFunction = async (
+      host: string,
+      run: () => Promise<void>,
+    ): Promise<void> => {
+      /*
+       * The service reads Host at CALL time off the module object, so
+       * redefining the property is enough and nothing has to be re-imported.
+       */
+      const environmentConfig: Record<string, unknown> = jest.requireMock(
+        "Common/Server/EnvironmentConfig",
+      ) as Record<string, unknown>;
+
+      const original: unknown = environmentConfig["Host"];
+
+      Object.defineProperty(environmentConfig, "Host", {
+        value: host,
+        configurable: true,
+        writable: true,
+      });
+
+      try {
+        await run();
+      } finally {
+        Object.defineProperty(environmentConfig, "Host", {
+          value: original,
+          configurable: true,
+          writable: true,
+        });
+      }
+    };
+
+    it("drops the port from the relying party id", async () => {
+      await withHost("oneuptime.example.com:8443", async () => {
+        const { options } =
+          await UserWebAuthnService.generateRegistrationOptions({
+            userId: USER_ID,
+          });
+
+        expect(options.rp.id).toBe("oneuptime.example.com");
+      });
+    });
+
+    it("drops the port on the sign-in options too", async () => {
+      seedRegisteredKey(makeKey(false));
+
+      await withHost("oneuptime.example.com:8443", async () => {
+        const { options } =
+          await UserWebAuthnService.generateAuthenticationOptions({
+            email: USER_EMAIL.toString(),
+          });
+
+        expect(options.rpId).toBe("oneuptime.example.com");
+      });
+    });
+
+    it("leaves a portless host exactly as it is", async () => {
+      /*
+       * The deployments that work today must not move. A credential is scoped
+       * to its RP ID, so a change here would silently orphan every key already
+       * registered against the hosted product.
+       */
+      const { options } = await UserWebAuthnService.generateRegistrationOptions(
+        {
+          userId: USER_ID,
+        },
+      );
+
+      expect(options.rp.id).toBe(RP_ID);
+    });
+
+    it("accepts a credential from a browser on the ported origin", async () => {
+      /*
+       * The two halves together, which is the only way to show the pair is
+       * consistent: the authenticator scopes itself to the bare domain, the
+       * browser reports the full origin WITH the port, and verification has to
+       * accept both at once. Getting either side wrong fails here.
+       */
+      await withHost("oneuptime.example.com:8443", async () => {
+        const portedKey: SecurityKey = createSecurityKey({
+          rpId: "oneuptime.example.com",
+          origin: "https://oneuptime.example.com:8443",
+          performsUserVerification: false,
+        });
+
+        const { options } =
+          await UserWebAuthnService.generateRegistrationOptions({
+            userId: USER_ID,
+          });
+
+        await expect(
+          UserWebAuthnService.verifyRegistration({
+            credential: portedKey.register({ challenge: options.challenge }),
+            name: KEY_NAME,
+            props: { userId: USER_ID },
+          }),
+        ).resolves.toBeUndefined();
+      });
+    });
+  });
+
+  describe("what the credential row records about the authenticator", () => {
+    it("stores the signature counter the authenticator reported", async () => {
+      /*
+       * It used to be written as "0" whatever the key said. The library only
+       * compares counters when at least one side is above zero, so a discarded
+       * non-zero counter is exactly the clone detection that credential was
+       * eligible for -- a key registered at 40 and a clone replaying 12 both
+       * looked fine against a stored 0.
+       */
+      const key: SecurityKey = createSecurityKey({
+        rpId: RP_ID,
+        origin: ORIGIN,
+        performsUserVerification: false,
+        signCount: 40,
+      });
+
+      await register(key);
+
+      expect(createdCredential!.counter).toBe("40");
+    });
+
+    it("stores 0 when that is what the authenticator reported", async () => {
+      /* A synced passkey counts nothing, forever, and that is not an error. */
+      await register(makeKey(true));
+
+      expect(createdCredential!.counter).toBe("0");
+    });
+
+    it("stores the transports the browser reported", async () => {
+      /*
+       * The value comes from the CLIENT: @simplewebauthn reads it straight off
+       * `response.response.transports`, which is populated in
+       * App/FeatureSet/Dashboard/src/Pages/Global/UserProfile/TwoFactorAuth.tsx
+       * from AuthenticatorAttestationResponse.getTransports(). The fixture
+       * stands in for that line.
+       */
+      await register(makeKey(false));
+
+      expect(createdCredential!.transports).toBe(JSON.stringify(["internal"]));
+    });
+
+    it("registers successfully when the browser reports no transports", async () => {
+      /*
+       * getTransports() is not in the original API and older Safari and
+       * Firefox builds do not have it, so the frontend calls it defensively
+       * and a registration can legitimately arrive with the field missing.
+       * A missing hint must cost the user a hint, not their registration.
+       */
+      const key: SecurityKey = makeKey(false);
+
+      const { options } = await UserWebAuthnService.generateRegistrationOptions(
+        {
+          userId: USER_ID,
+        },
+      );
+
+      const credential: RegistrationResponse = key.register({
+        challenge: options.challenge,
+      });
+
+      delete (credential.response as { transports?: Array<string> | undefined })
+        .transports;
+
+      await expect(
+        UserWebAuthnService.verifyRegistration({
+          credential: credential,
+          name: KEY_NAME,
+          props: { userId: USER_ID },
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(createdCredential!.transports).toBe(JSON.stringify([]));
+    });
+
+    it("hands the stored transports back as a sign-in hint", async () => {
+      /*
+       * Recording them buys nothing unless they reach the browser, and
+       * `allowCredentials` is the only place it reads them.
+       */
+      const key: SecurityKey = makeKey(false);
+
+      await register(key);
+
+      const persisted: UserWebAuthn = new UserWebAuthn();
+      persisted.id = new ObjectID("12341234-5678-4901-8234-567890123456");
+      persisted.credentialId = createdCredential!.credentialId!;
+      persisted.publicKey = createdCredential!.publicKey!;
+      persisted.counter = createdCredential!.counter!;
+      persisted.transports = createdCredential!.transports!;
+      persisted.isVerified = true;
+      persisted.userId = USER_ID;
+
+      existingCredentials = [persisted];
+
+      const { options } =
+        await UserWebAuthnService.generateAuthenticationOptions({
+          email: USER_EMAIL.toString(),
+        });
+
+      expect(options.allowCredentials[0].transports).toEqual(["internal"]);
+    });
+
+    it("sends no hint at all for a credential registered before transports were recorded", async () => {
+      /*
+       * Every existing row holds the literal "[]". An EMPTY array is not the
+       * same as no array: it is a hint that excludes every transport, where
+       * those credentials have always sent nothing. Chromium filters on the
+       * hint when it is present, so an empty one could hide a key that works.
+       */
+      const legacy: UserWebAuthn = new UserWebAuthn();
+      legacy.id = new ObjectID("22223333-4444-4555-8666-777788889999");
+      legacy.credentialId = makeKey(false).credentialId;
+      legacy.publicKey = Buffer.from("legacy").toString("base64");
+      legacy.counter = "0";
+      legacy.transports = JSON.stringify([]);
+      legacy.isVerified = true;
+      legacy.userId = USER_ID;
+
+      existingCredentials = [legacy];
+
+      const { options } =
+        await UserWebAuthnService.generateAuthenticationOptions({
+          email: USER_EMAIL.toString(),
+        });
+
+      expect(options.allowCredentials[0].transports).toBeUndefined();
+    });
+
+    it("sends no hint for a row whose transports column is unreadable", async () => {
+      /*
+       * Rows written before the column existed hold null, and nothing stops a
+       * hand-edited row holding nonsense. Neither is worth an exception on a
+       * sign-in path.
+       */
+      const broken: UserWebAuthn = new UserWebAuthn();
+      broken.id = new ObjectID("33334444-5555-4666-8777-888899990000");
+      broken.credentialId = makeKey(false).credentialId;
+      broken.publicKey = Buffer.from("broken").toString("base64");
+      broken.counter = "0";
+      broken.transports = "not json at all";
+      broken.isVerified = true;
+      broken.userId = USER_ID;
+
+      existingCredentials = [broken];
+
+      const { options } =
+        await UserWebAuthnService.generateAuthenticationOptions({
+          email: USER_EMAIL.toString(),
+        });
+
+      expect(options.allowCredentials[0].transports).toBeUndefined();
+    });
+  });
+
+  describe("what the anonymous sign-in options route will say about an account", () => {
+    /*
+     * POST /user-webauthn/generate-authentication-options takes an email and
+     * nothing else, from anyone. It used to answer "User not found" for an
+     * address nobody has registered and "No WebAuthn credentials found for
+     * this user" for one that exists without a key -- an account-existence
+     * oracle, plus a second one saying which accounts are protected by
+     * hardware, free to anybody who can send a POST.
+     */
+
+    it("answers identically for an unknown account and one with no security key", async () => {
+      const unknownAccount: unknown = await (async (): Promise<unknown> => {
+        UserService.findOneBy = jest.fn().mockResolvedValue(null) as never;
+
+        try {
+          await UserWebAuthnService.generateAuthenticationOptions({
+            email: "nobody@example.com",
+          });
+        } catch (error) {
+          return error;
+        }
+
+        throw new Error("Expected this to reject");
+      })();
+
+      const knownAccountWithoutAKey: unknown =
+        await (async (): Promise<unknown> => {
+          UserService.findOneBy = jest.fn().mockImplementation(async () => {
+            return buildUser();
+          }) as never;
+          existingCredentials = [];
+
+          try {
+            await UserWebAuthnService.generateAuthenticationOptions({
+              email: USER_EMAIL.toString(),
+            });
+          } catch (error) {
+            return error;
+          }
+
+          throw new Error("Expected this to reject");
+        })();
+
+      /*
+       * Identical text is the whole point -- a caller must not be able to tell
+       * the two apart -- and both must still be Exceptions so the handler
+       * answers 400 rather than the 500 that would itself be a tell.
+       */
+      expect((unknownAccount as Exception).message).toBe(
+        (knownAccountWithoutAKey as Exception).message,
+      );
+      expect(unknownAccount).toBeInstanceOf(BadDataException);
+      expect(knownAccountWithoutAKey).toBeInstanceOf(BadDataException);
+    });
+
+    it("does not name the account in what it says", async () => {
+      UserService.findOneBy = jest.fn().mockResolvedValue(null) as never;
+
+      let thrown: unknown = null;
+
+      try {
+        await UserWebAuthnService.generateAuthenticationOptions({
+          email: USER_EMAIL.toString(),
+        });
+      } catch (error) {
+        thrown = error;
+      }
+
+      const message: string = (thrown as Exception).message;
+
+      expect(message).not.toContain(USER_EMAIL.toString());
+      expect(message).not.toMatch(/user not found/i);
+      expect(message).not.toMatch(/no webauthn credentials/i);
     });
   });
 

--- a/App/Tests/FeatureSet/Identity/WebAuthnUserVerification.test.ts
+++ b/App/Tests/FeatureSet/Identity/WebAuthnUserVerification.test.ts
@@ -1275,6 +1275,31 @@ describe("WebAuthn user verification (issue #3652)", () => {
       expect(knownAccountWithoutAKey).toBeInstanceOf(BadDataException);
     });
 
+    it("hands back the ceremony and nothing else on success", async () => {
+      /*
+       * Unifying the two refusals stops a caller learning whether an account
+       * exists; a SUCCESS that carries the account's internal row id tells
+       * them rather more than that, so the two halves have to move together.
+       *
+       * The id was also simply dead weight. The browser posts the assertion to
+       * /verify-webauthn-auth with the email and password again, and that
+       * route takes the user from the password it has just verified -- never
+       * from the body -- so nothing ever read this.
+       *
+       * Asserted on the WHOLE key set rather than on `userId` alone, because
+       * the next field somebody adds here reaches anonymous callers too.
+       */
+      seedRegisteredKey(makeKey(false));
+
+      const result: Record<string, unknown> =
+        (await UserWebAuthnService.generateAuthenticationOptions({
+          email: USER_EMAIL.toString(),
+        })) as unknown as Record<string, unknown>;
+
+      expect(Object.keys(result).sort()).toEqual(["challenge", "options"]);
+      expect(JSON.stringify(result)).not.toContain(USER_ID.toString());
+    });
+
     it("does not name the account in what it says", async () => {
       UserService.findOneBy = jest.fn().mockResolvedValue(null) as never;
 

--- a/Common/Models/DatabaseModels/User.ts
+++ b/Common/Models/DatabaseModels/User.ts
@@ -384,6 +384,28 @@ class User extends UserModel {
   })
   public resetPasswordExpires?: Date = undefined;
 
+  /*
+   * TWO challenge slots, not one, and the split is the whole point.
+   *
+   * A WebAuthn challenge is a one-shot value: the server issues it, the
+   * authenticator signs it, and the server compares what came back against
+   * what it stored. Registration and signing in are separate flows that each
+   * need one, and they used to share a single `webauthnChallenge` column --
+   * so whichever flow wrote last silently destroyed the other's.
+   *
+   * That is not a theoretical race. Registration is keyed by the session's
+   * user and signing in is keyed by an email address, so both land on the
+   * SAME row: a user adding a second key in one tab while a stale sign-in page
+   * in another asks for a fresh challenge loses the registration they were
+   * halfway through, and gets "No pending WebAuthn challenge found" for a key
+   * they are holding and touching. The anonymous
+   * /generate-authentication-options route made it reachable by strangers as
+   * well as by the user's own second tab.
+   *
+   * Named for their purposes rather than one being left as the bare
+   * `webauthnChallenge`, because a slot whose name does not say which flow
+   * owns it is exactly how the two came to share one.
+   */
   @ColumnAccessControl({
     create: [],
     read: [],
@@ -396,7 +418,7 @@ class User extends UserModel {
     nullable: true,
     unique: false,
   })
-  public webauthnChallenge?: string = undefined;
+  public webauthnRegistrationChallenge?: string = undefined;
 
   @ColumnAccessControl({
     create: [],
@@ -409,7 +431,34 @@ class User extends UserModel {
     nullable: true,
     unique: false,
   })
-  public webauthnChallengeExpiresAt?: Date = undefined;
+  public webauthnRegistrationChallengeExpiresAt?: Date = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({ type: TableColumnType.ShortText })
+  @Column({
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+    nullable: true,
+    unique: false,
+  })
+  public webauthnAuthenticationChallenge?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({ type: TableColumnType.Date })
+  @Column({
+    type: ColumnType.Date,
+    nullable: true,
+    unique: false,
+  })
+  public webauthnAuthenticationChallengeExpiresAt?: Date = undefined;
 
   @ColumnAccessControl({
     create: [],

--- a/Common/Server/API/UserWebAuthnAPI.ts
+++ b/Common/Server/API/UserWebAuthnAPI.ts
@@ -20,6 +20,9 @@ import UserTwoFactorBackupCodeService from "../Services/UserTwoFactorBackupCodeS
 import TwoFactorBackupCode from "../Utils/TwoFactorBackupCode";
 import logger from "../Utils/Logger";
 import TwoFactorBackupCodeNotification from "../Utils/TwoFactorBackupCodeNotification";
+import IdentityRateLimit, {
+  IdentityRateLimitBucket,
+} from "../Middleware/IdentityRateLimit";
 
 export default class UserWebAuthnAPI extends BaseAPI<
   UserWebAuthn,
@@ -113,8 +116,24 @@ export default class UserWebAuthnAPI extends BaseAPI<
       },
     );
 
+    /*
+     * The only route on this class that no signed-in user stands behind. It
+     * has to be anonymous -- this is where the challenge a security key signs
+     * comes from, and it is needed before there is any assertion to prove who
+     * is asking -- but "anonymous" and "unmetered" are different things, and
+     * it was both.
+     *
+     * What an unmetered version hands out: a database write against any email
+     * address the caller cares to name, as fast as the process will answer.
+     * The limiter keys on the submitted address AND the caller's own address
+     * (see IdentityRateLimit), so a flood spends the attacker's budget rather
+     * than the victim's -- the same trade every other identity route makes.
+     */
     this.router.post(
       `${new this.entityType().getCrudApiPath()?.toString()}/generate-authentication-options`,
+      IdentityRateLimit.getMiddleware(
+        IdentityRateLimitBucket.WebAuthnChallenge,
+      ),
       async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
         try {
           const data: JSONObject = req.body["data"] as JSONObject;

--- a/Common/Server/API/UserWebAuthnAPI.ts
+++ b/Common/Server/API/UserWebAuthnAPI.ts
@@ -148,7 +148,7 @@ export default class UserWebAuthnAPI extends BaseAPI<
             throw new BadDataException("Email is required");
           }
 
-          const result: { options: any; challenge: string; userId: string } =
+          const result: { options: any; challenge: string } =
             await UserWebAuthnService.generateAuthenticationOptions({
               email: email,
             });

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1791800000000-SplitWebAuthnChallengeByPurpose.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1791800000000-SplitWebAuthnChallengeByPurpose.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * Registering a security key and signing in with one each need a challenge,
+ * and they used to write the same pair of columns -- so whichever ceremony
+ * wrote last silently destroyed the other's. Registration is keyed by the
+ * session's user and signing in by an email address, but both land on the same
+ * User row, so a second browser tab was enough to lose a registration that was
+ * already halfway through.
+ *
+ * The old pair is dropped rather than kept as the sign-in slot. A column named
+ * `webauthnChallenge` that in fact means "the sign-in one" is exactly the
+ * ambiguity that let the two flows share it, and leaving it would also leave a
+ * value written by a pre-deploy REGISTRATION to be read afterwards as a
+ * sign-in challenge.
+ *
+ * Nothing durable is lost. These columns hold a single-use value with a
+ * five-minute TTL, so the worst case is a user who was mid-ceremony as the
+ * deploy landed being told to start again -- which is what the message already
+ * says, and which retrying fixes.
+ */
+export class SplitWebAuthnChallengeByPurpose1791800000000
+  implements MigrationInterface
+{
+  public name: string = "SplitWebAuthnChallengeByPurpose1791800000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "User" DROP COLUMN "webauthnChallenge"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "User" DROP COLUMN "webauthnChallengeExpiresAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "User" ADD "webauthnRegistrationChallenge" character varying(100)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "User" ADD "webauthnRegistrationChallengeExpiresAt" TIMESTAMP WITH TIME ZONE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "User" ADD "webauthnAuthenticationChallenge" character varying(100)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "User" ADD "webauthnAuthenticationChallengeExpiresAt" TIMESTAMP WITH TIME ZONE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "User" DROP COLUMN "webauthnAuthenticationChallengeExpiresAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "User" DROP COLUMN "webauthnAuthenticationChallenge"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "User" DROP COLUMN "webauthnRegistrationChallengeExpiresAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "User" DROP COLUMN "webauthnRegistrationChallenge"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "User" ADD "webauthnChallengeExpiresAt" TIMESTAMP WITH TIME ZONE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "User" ADD "webauthnChallenge" character varying(100)`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -578,6 +578,7 @@ import { SessionReplayRecordEverySessionByDefault1791400000000 } from "./1791400
 import { WidenCustomFieldDropdownOptions1791500000000 } from "./1791500000000-WidenCustomFieldDropdownOptions";
 import { AddCustomFieldValueMapping1791600000000 } from "./1791600000000-AddCustomFieldValueMapping";
 import { AddMacAddressToNetworkDevice1791700000000 } from "./1791700000000-AddMacAddressToNetworkDevice";
+import { SplitWebAuthnChallengeByPurpose1791800000000 } from "./1791800000000-SplitWebAuthnChallengeByPurpose";
 
 export default [
   InitialMigration,
@@ -1160,4 +1161,5 @@ export default [
   WidenCustomFieldDropdownOptions1791500000000,
   AddCustomFieldValueMapping1791600000000,
   AddMacAddressToNetworkDevice1791700000000,
+  SplitWebAuthnChallengeByPurpose1791800000000,
 ];

--- a/Common/Server/Middleware/IdentityRateLimit.ts
+++ b/Common/Server/Middleware/IdentityRateLimit.ts
@@ -312,6 +312,27 @@ const BACKUP_CODE_BUCKET: BucketConfig = {
  * request is one free database write against any address the caller cares to
  * name, and a flood of them is a flood of writes nobody asked for.
  *
+ * And the write is not junk. It is the challenge that user's key is about to
+ * sign, in the single slot that holds it, so an overwrite landing between
+ * somebody's generate and their verify makes the library reject an assertion
+ * that was perfectly correct -- a targeted refusal of security-key sign-in
+ * against any address a caller can name, rather than a resource cost.
+ *
+ * WHAT THIS COUNTER THEREFORE BOUNDS BUT DOES NOT CLOSE. The account counter
+ * is keyed on the address the request came FROM, as it must be -- see the note
+ * at the top of this file: a bare per-account counter is itself a lockout
+ * weapon -- so an attacker with several source addresses gets this budget from
+ * each one. Splitting the registration and authentication challenge slots
+ * (Common/Models/DatabaseModels/User.ts) stopped the two FLOWS destroying each
+ * other; it does not stop two authentication requests for one account, which
+ * still land on one slot, last write wins.
+ *
+ * Closing that properly means the challenge ceasing to be a single
+ * overwritable row -- one row per attempt, or a short-lived per-ceremony key
+ * -- which is a larger change than this one and is not attempted here. What
+ * this bucket buys is that the cheap version of the attack now costs an
+ * address per thirty attempts instead of nothing at all.
+ *
  * A SEPARATE counter from the two-factor one, for exactly the reason the
  * recovery bucket is separate. This route is the step immediately BEFORE
  * /verify-webauthn-auth in the same sign-in. Sharing a pool would mean every

--- a/Common/Server/Middleware/IdentityRateLimit.ts
+++ b/Common/Server/Middleware/IdentityRateLimit.ts
@@ -124,6 +124,13 @@ export enum IdentityRateLimitBucket {
    * the recovery route already spent. See BACKUP_CODE_BUCKET.
    */
   BackupCode = "backup-code",
+
+  /*
+   * POST /user-webauthn/generate-authentication-options -- the step that hands
+   * out the challenge a security key is about to sign. Its own counter for the
+   * same reason the recovery step has one; see WEBAUTHN_CHALLENGE_BUCKET.
+   */
+  WebAuthnChallenge = "webauthn-challenge",
 }
 
 export enum IdentityRateLimitScope {
@@ -291,6 +298,50 @@ const BACKUP_CODE_BUCKET: BucketConfig = {
   ),
 };
 
+/*
+ * Challenge-issuing budget.
+ *
+ * POST /user-webauthn/generate-authentication-options is the odd one out on
+ * this list: it accepts no credential and can refuse nobody, so it is not a
+ * guessing oracle and a limit here is not what stops an attacker signing in.
+ * It needed one anyway, because of what it DOES rather than what it checks.
+ *
+ * It is anonymous -- the challenge has to exist before the assertion that
+ * proves anything does, so there is nothing to authenticate it with -- and it
+ * takes an email address and WRITES to that user's row. Unlimited, one
+ * request is one free database write against any address the caller cares to
+ * name, and a flood of them is a flood of writes nobody asked for.
+ *
+ * A SEPARATE counter from the two-factor one, for exactly the reason the
+ * recovery bucket is separate. This route is the step immediately BEFORE
+ * /verify-webauthn-auth in the same sign-in. Sharing a pool would mean every
+ * challenge a user asked for spent an attempt they had not yet made, halving
+ * a ten-attempt allowance to five real tries -- and, worse, a user who had
+ * just used up the shared budget failing at the key could not obtain a fresh
+ * challenge to try again with. The step that exists to enable an attempt must
+ * not be spendable by the attempts it enables.
+ *
+ * More generous than its siblings on the account counter, because nothing is
+ * being guessed and abandoning a prompt is ordinary: a user who touches the
+ * wrong key, closes the dialog, or reloads the page asks for another
+ * challenge each time, and none of that is suspicious. The per-address
+ * ceiling is what actually bounds the writes.
+ */
+const WEBAUTHN_CHALLENGE_BUCKET: BucketConfig = {
+  windowSeconds: parsePositiveIntFromEnv(
+    "IDENTITY_WEBAUTHN_CHALLENGE_RATE_LIMIT_WINDOW_SECONDS",
+    15 * 60,
+  ),
+  perAccountLimit: parsePositiveIntFromEnv(
+    "IDENTITY_WEBAUTHN_CHALLENGE_RATE_LIMIT_PER_ACCOUNT_PER_WINDOW",
+    30,
+  ),
+  perIpLimit: parsePositiveIntFromEnv(
+    "IDENTITY_WEBAUTHN_CHALLENGE_RATE_LIMIT_PER_IP_PER_WINDOW",
+    150,
+  ),
+};
+
 const KEY_PREFIX: string = "identity:rl:";
 
 /*
@@ -438,6 +489,10 @@ export default class IdentityRateLimit {
 
     if (bucket === IdentityRateLimitBucket.BackupCode) {
       return BACKUP_CODE_BUCKET;
+    }
+
+    if (bucket === IdentityRateLimitBucket.WebAuthnChallenge) {
+      return WEBAUTHN_CHALLENGE_BUCKET;
     }
 
     return LOGIN_BUCKET;

--- a/Common/Server/Services/UserWebAuthnService.ts
+++ b/Common/Server/Services/UserWebAuthnService.ts
@@ -18,8 +18,48 @@ import { Host, HttpProtocol } from "../EnvironmentConfig";
 import ObjectID from "../../Types/ObjectID";
 import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import OneUptimeDate from "../../Types/Date";
+import Hostname from "../../Types/API/Hostname";
 
 const WEBAUTHN_CHALLENGE_TTL_MINUTES: number = 5;
+
+/*
+ * Which of the two flows a stored challenge belongs to.
+ *
+ * They used to share one slot on the User row, so whichever wrote last
+ * destroyed the other's -- see the columns on
+ * Common/Models/DatabaseModels/User.ts for what that cost a user with two tabs
+ * open. Every read and write of a challenge now names its purpose, and a
+ * challenge issued for one flow is simply invisible to the other.
+ */
+enum WebAuthnChallengePurpose {
+  Registration = "registration",
+  Authentication = "authentication",
+}
+
+/*
+ * One answer for both ways of having no security key to offer, because the
+ * route that asks is anonymous.
+ *
+ * `generateAuthenticationOptions` is reached by POSTing an email address and
+ * nothing else. It used to answer "User not found" for an address nobody has
+ * registered and "No WebAuthn credentials found for this user" for one that
+ * exists but has no key -- two distinguishable replies, which together are a
+ * free account-existence oracle for anyone who can send a request, and a
+ * second oracle telling them which of those accounts is protected by hardware.
+ *
+ * Every other door on this surface already refuses to say that much: the login
+ * routes deliberately do not reveal which half of a credential was wrong, and
+ * IdentityRateLimit answers identically for a real address and an invented
+ * one specifically so that being throttled does not give back the enumeration
+ * the handlers withhold. This route was the exception.
+ *
+ * Nothing legitimate is lost. A real user only reaches this after signing in
+ * with their password, from a list of their OWN registered keys returned by
+ * /login -- so they cannot arrive here with an account that has none, and the
+ * message they would never see is not worth an oracle to everyone else.
+ */
+const NO_SECURITY_KEY_AVAILABLE: string =
+  "No security key is available for this account.";
 
 /*
  * How much a security key is asked to prove about the person holding it.
@@ -130,6 +170,111 @@ const explainVerificationFailure: VerifyWebAuthnResponseFunction = async (
   }
 };
 
+/*
+ * The relying party id, which is NOT the origin and must not be written as if
+ * it were.
+ *
+ * `expectedOrigin` is a full origin and MUST carry the port: a browser on
+ * https://oneuptime.example.com:8443 puts exactly that in its client data. The
+ * RP ID is a bare registrable domain and must NOT -- the spec defines it as a
+ * domain string, and a browser handed "oneuptime.example.com:8443" rejects the
+ * call outright with a SecurityError before any authenticator is asked
+ * anything. The two are built from the same HOST here, so they were the same
+ * string, and one of them was wrong.
+ *
+ * HOST is whatever the operator put in the environment (`Common/Server/EnvironmentConfig.ts`),
+ * and for a self-hosted instance not sitting on 80/443 that is routinely
+ * `host:port` -- which made WebAuthn unusable on those deployments rather than
+ * merely awkward. Nothing is invalidated by fixing it: on exactly the
+ * deployments this changes, the browser refused to create a credential at all,
+ * so there are none to invalidate. Where HOST carries no port, this is the
+ * identity function and no existing credential moves.
+ *
+ * `fromAuthority` rather than `fromString`: it is the one that understands
+ * bracketed IPv6 literals and userinfo instead of splitting on the first colon
+ * and turning "[::1]:8443" into a host of "[".
+ */
+type WebAuthnRelyingPartyIdFunction = () => string;
+
+const webAuthnRelyingPartyId: WebAuthnRelyingPartyIdFunction = (): string => {
+  return Hostname.fromAuthority(Host.toString()).hostname;
+};
+
+/*
+ * The transports a stored credential reported at registration, back out of the
+ * text column and into the shape `allowCredentials` wants.
+ *
+ * Spelled out locally rather than imported as the library's
+ * `AuthenticatorTransportFuture`, for the same reason the user-verification
+ * policy above is: the type has to hold when Common's jest config swaps the
+ * whole package for a stub.
+ *
+ * Deliberately forgiving, and it returns UNDEFINED rather than an empty array
+ * when it has nothing to say. Every credential registered before this change
+ * holds the literal "[]", and there is a difference between telling the
+ * browser "this key is reachable by no transport" and not telling it anything:
+ * the first is a hint that excludes every option, the second is what those
+ * credentials have always sent. An unreadable value costs the user a hint,
+ * never their sign-in.
+ *
+ * Filtering to the known set happens on READ, not on write, so a transport
+ * some future browser invents is still recorded faithfully in the column and
+ * only the hint drops it.
+ */
+type WebAuthnTransport =
+  | "ble"
+  | "cable"
+  | "hybrid"
+  | "internal"
+  | "nfc"
+  | "smart-card"
+  | "usb";
+
+const KNOWN_WEBAUTHN_TRANSPORTS: Array<string> = [
+  "ble",
+  "cable",
+  "hybrid",
+  "internal",
+  "nfc",
+  "smart-card",
+  "usb",
+];
+
+type ParseTransportsFunction = (
+  stored: string | undefined,
+) => Array<WebAuthnTransport> | undefined;
+
+const parseStoredTransports: ParseTransportsFunction = (
+  stored: string | undefined,
+): Array<WebAuthnTransport> | undefined => {
+  if (!stored) {
+    return undefined;
+  }
+
+  let parsed: unknown = undefined;
+
+  try {
+    parsed = JSON.parse(stored);
+  } catch {
+    return undefined;
+  }
+
+  if (!Array.isArray(parsed)) {
+    return undefined;
+  }
+
+  const transports: Array<WebAuthnTransport> = parsed.filter(
+    (transport: unknown) => {
+      return (
+        typeof transport === "string" &&
+        KNOWN_WEBAUTHN_TRANSPORTS.includes(transport)
+      );
+    },
+  ) as Array<WebAuthnTransport>;
+
+  return transports.length > 0 ? transports : undefined;
+};
+
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
@@ -165,6 +310,7 @@ export class Service extends DatabaseService<Model> {
       },
       select: {
         credentialId: true,
+        transports: true,
       },
       limit: LIMIT_PER_PROJECT,
       skip: 0,
@@ -175,7 +321,7 @@ export class Service extends DatabaseService<Model> {
 
     const options: any = await generateRegistrationOptions({
       rpName: "OneUptime",
-      rpID: Host.toString(),
+      rpID: webAuthnRelyingPartyId(),
       userID: new Uint8Array(Buffer.from(data.userId.toString())),
       userName: user.email.toString(),
       userDisplayName: user.name ? user.name.toString() : user.email.toString(),
@@ -185,9 +331,14 @@ export class Service extends DatabaseService<Model> {
           return cred.credentialId;
         })
         .map((cred: Model) => {
+          /* Same hint as allowCredentials carries; see the note there. */
+          const transports: Array<WebAuthnTransport> | undefined =
+            parseStoredTransports(cred.transports);
+
           return {
             id: cred.credentialId!,
             type: "public-key",
+            ...(transports ? { transports: transports } : {}),
           };
         }),
       authenticatorSelection: {
@@ -213,18 +364,10 @@ export class Service extends DatabaseService<Model> {
     }
 
     // Store the challenge server-side so verification uses a trusted value
-    await UserService.updateOneById({
-      id: data.userId,
-      data: {
-        webauthnChallenge: options.challenge,
-        webauthnChallengeExpiresAt: OneUptimeDate.addRemoveMinutes(
-          OneUptimeDate.getCurrentDate(),
-          WEBAUTHN_CHALLENGE_TTL_MINUTES,
-        ),
-      },
-      props: {
-        isRoot: true,
-      },
+    await this.storeChallenge({
+      userId: data.userId,
+      purpose: WebAuthnChallengePurpose.Registration,
+      challenge: options.challenge,
     });
 
     return {
@@ -244,9 +387,10 @@ export class Service extends DatabaseService<Model> {
     }
 
     // Retrieve the challenge from the server-side store
-    const storedChallenge: string = await this.getAndClearStoredChallenge(
-      data.props.userId,
-    );
+    const storedChallenge: string = await this.getAndClearStoredChallenge({
+      userId: data.props.userId,
+      purpose: WebAuthnChallengePurpose.Registration,
+    });
 
     const expectedOrigin: string = `${HttpProtocol}${Host.toString()}`;
 
@@ -255,7 +399,7 @@ export class Service extends DatabaseService<Model> {
         response: data.credential,
         expectedChallenge: storedChallenge,
         expectedOrigin: expectedOrigin,
-        expectedRPID: Host.toString(),
+        expectedRPID: webAuthnRelyingPartyId(),
         requireUserVerification: WEBAUTHN_REQUIRE_USER_VERIFICATION,
       });
     });
@@ -278,8 +422,40 @@ export class Service extends DatabaseService<Model> {
         publicKey: Buffer.from(registrationInfo.credential.publicKey).toString(
           "base64",
         ),
-        counter: "0",
-        transports: JSON.stringify([]),
+        /*
+         * From the authenticator, not hard-coded.
+         *
+         * The counter used to be written as "0" regardless. Most platform
+         * authenticators do report 0 -- a passkey synced between devices
+         * cannot keep a meaningful count -- but a discrete key that has been
+         * used elsewhere arrives with a real one, and pinning it to 0 threw
+         * that away. `verifyAuthenticationResponse` only compares counters
+         * when at least one side is above zero, so the discarded value was
+         * precisely the clone detection this credential was eligible for:
+         * a key registered at count 40 and a clone of it replaying count 12
+         * both looked fine against a stored 0.
+         *
+         * The trade is not free, and the tail is worth naming: an
+         * authenticator that reports the SAME counter at registration and at
+         * its first assertion now fails that comparison, where a stored 0
+         * would have waved it through. A spec-compliant key increments on
+         * every assertion, so this should not happen -- but if it does, the
+         * key is unusable and the way back in is a backup code (minted at
+         * enrolment, see UserWebAuthnAPI) followed by registering it again.
+         * The alternative is to keep discarding the counter and keep the
+         * clone detection permanently off, which is the worse default.
+         *
+         * Transports were likewise always "[]". They are the browser's hint
+         * about HOW to reach this key -- USB, NFC, the platform itself -- and
+         * with none recorded every sign-in prompt has to offer all of them.
+         */
+        counter:
+          typeof registrationInfo.credential.counter === "number"
+            ? registrationInfo.credential.counter.toString()
+            : "0",
+        transports: JSON.stringify(
+          registrationInfo.credential.transports || [],
+        ),
         isVerified: true,
         userId: data.props.userId,
       },
@@ -307,7 +483,7 @@ export class Service extends DatabaseService<Model> {
     });
 
     if (!user) {
-      throw new BadDataException("User not found");
+      throw new BadDataException(NO_SECURITY_KEY_AVAILABLE);
     }
 
     // Get user's WebAuthn credentials
@@ -318,6 +494,7 @@ export class Service extends DatabaseService<Model> {
       },
       select: {
         credentialId: true,
+        transports: true,
       },
       limit: LIMIT_PER_PROJECT,
       skip: 0,
@@ -327,15 +504,34 @@ export class Service extends DatabaseService<Model> {
     });
 
     if (credentials.length === 0) {
-      throw new BadDataException("No WebAuthn credentials found for this user");
+      throw new BadDataException(NO_SECURITY_KEY_AVAILABLE);
     }
 
     const options: any = await generateAuthenticationOptions({
-      rpID: Host.toString(),
+      rpID: webAuthnRelyingPartyId(),
       allowCredentials: credentials.map((cred: Model) => {
+        /*
+         * Recording transports at registration buys nothing unless they are
+         * handed back here: this is the only place the browser reads them.
+         * With the hint, a key that says "usb" prompts for a USB key rather
+         * than opening the whole carousel of ways a credential might be
+         * reachable. `generateAuthenticationOptions` copies unknown fields
+         * straight through onto the descriptor, and Login.tsx rewrites only
+         * `id`, so the array survives to navigator.credentials.get().
+         *
+         * SPREAD rather than `transports: undefined`, so a credential with no
+         * hint carries no `transports` member at all. The two are not the
+         * same to a browser -- an empty array is a hint that excludes every
+         * transport, and Chromium filters on the hint when it is present, so
+         * an empty one could hide a key that works perfectly well.
+         */
+        const transports: Array<WebAuthnTransport> | undefined =
+          parseStoredTransports(cred.transports);
+
         return {
           id: cred.credentialId!,
           type: "public-key",
+          ...(transports ? { transports: transports } : {}),
         };
       }),
       userVerification: WEBAUTHN_USER_VERIFICATION,
@@ -346,18 +542,10 @@ export class Service extends DatabaseService<Model> {
     // allowCredentials id is already base64url string
 
     // Store the challenge server-side so verification uses a trusted value
-    await UserService.updateOneById({
-      id: user.id!,
-      data: {
-        webauthnChallenge: options.challenge,
-        webauthnChallengeExpiresAt: OneUptimeDate.addRemoveMinutes(
-          OneUptimeDate.getCurrentDate(),
-          WEBAUTHN_CHALLENGE_TTL_MINUTES,
-        ),
-      },
-      props: {
-        isRoot: true,
-      },
+    await this.storeChallenge({
+      userId: user.id!,
+      purpose: WebAuthnChallengePurpose.Authentication,
+      challenge: options.challenge,
     });
 
     return {
@@ -373,9 +561,10 @@ export class Service extends DatabaseService<Model> {
     credential: any;
   }): Promise<User> {
     // Retrieve the challenge from the server-side store
-    const storedChallenge: string = await this.getAndClearStoredChallenge(
-      new ObjectID(data.userId),
-    );
+    const storedChallenge: string = await this.getAndClearStoredChallenge({
+      userId: new ObjectID(data.userId),
+      purpose: WebAuthnChallengePurpose.Authentication,
+    });
 
     const user: User | null = await UserService.findOneById({
       id: new ObjectID(data.userId),
@@ -421,7 +610,7 @@ export class Service extends DatabaseService<Model> {
         response: data.credential,
         expectedChallenge: storedChallenge,
         expectedOrigin: expectedOrigin,
-        expectedRPID: Host.toString(),
+        expectedRPID: webAuthnRelyingPartyId(),
         credential: {
           id: dbCredential.credentialId!,
           publicKey: Buffer.from(dbCredential.publicKey!, "base64"),
@@ -450,16 +639,94 @@ export class Service extends DatabaseService<Model> {
   }
 
   /**
-   * Retrieves the stored WebAuthn challenge for the given user,
+   * Writes a freshly issued challenge into the slot belonging to ONE flow.
+   *
+   * The purpose decides the columns, and the two sets never overlap, so a
+   * sign-in page asking for a challenge can no longer wipe out a registration
+   * the same user is halfway through in another tab.
+   *
+   * Written as two literal objects rather than computed column names: this is
+   * the code whose whole job is to keep the two flows apart, and a pair of
+   * string variables indexing into the row is precisely how they would find
+   * their way back together.
+   */
+  private async storeChallenge(data: {
+    userId: ObjectID;
+    purpose: WebAuthnChallengePurpose;
+    challenge: string;
+  }): Promise<void> {
+    const expiresAt: Date = OneUptimeDate.addRemoveMinutes(
+      OneUptimeDate.getCurrentDate(),
+      WEBAUTHN_CHALLENGE_TTL_MINUTES,
+    );
+
+    await UserService.updateOneById({
+      id: data.userId,
+      data:
+        data.purpose === WebAuthnChallengePurpose.Registration
+          ? {
+              webauthnRegistrationChallenge: data.challenge,
+              webauthnRegistrationChallengeExpiresAt: expiresAt,
+            }
+          : {
+              webauthnAuthenticationChallenge: data.challenge,
+              webauthnAuthenticationChallengeExpiresAt: expiresAt,
+            },
+      props: {
+        isRoot: true,
+      },
+    });
+  }
+
+  /**
+   * Empties one flow's slot. Used both when a challenge is spent and when it
+   * is found expired -- and it touches only the named flow, so clearing a
+   * dead sign-in challenge leaves a live registration one alone.
+   */
+  private async clearChallenge(data: {
+    userId: ObjectID;
+    purpose: WebAuthnChallengePurpose;
+  }): Promise<void> {
+    await UserService.updateOneById({
+      id: data.userId,
+      data:
+        data.purpose === WebAuthnChallengePurpose.Registration
+          ? {
+              webauthnRegistrationChallenge: null as any,
+              webauthnRegistrationChallengeExpiresAt: null as any,
+            }
+          : {
+              webauthnAuthenticationChallenge: null as any,
+              webauthnAuthenticationChallengeExpiresAt: null as any,
+            },
+      props: {
+        isRoot: true,
+      },
+    });
+  }
+
+  /**
+   * Retrieves the stored WebAuthn challenge for the given user and flow,
    * validates it has not expired, and clears it so it cannot be reused.
    */
-  private async getAndClearStoredChallenge(userId: ObjectID): Promise<string> {
+  private async getAndClearStoredChallenge(data: {
+    userId: ObjectID;
+    purpose: WebAuthnChallengePurpose;
+  }): Promise<string> {
+    const isRegistration: boolean =
+      data.purpose === WebAuthnChallengePurpose.Registration;
+
     const user: User | null = await UserService.findOneById({
-      id: userId,
-      select: {
-        webauthnChallenge: true,
-        webauthnChallengeExpiresAt: true,
-      },
+      id: data.userId,
+      select: isRegistration
+        ? {
+            webauthnRegistrationChallenge: true,
+            webauthnRegistrationChallengeExpiresAt: true,
+          }
+        : {
+            webauthnAuthenticationChallenge: true,
+            webauthnAuthenticationChallengeExpiresAt: true,
+          },
       props: {
         isRoot: true,
       },
@@ -469,29 +736,26 @@ export class Service extends DatabaseService<Model> {
       throw new BadDataException("User not found");
     }
 
-    if (!user.webauthnChallenge || !user.webauthnChallengeExpiresAt) {
+    const challenge: string | undefined = isRegistration
+      ? user.webauthnRegistrationChallenge
+      : user.webauthnAuthenticationChallenge;
+
+    const expiresAt: Date | undefined = isRegistration
+      ? user.webauthnRegistrationChallengeExpiresAt
+      : user.webauthnAuthenticationChallengeExpiresAt;
+
+    if (!challenge || !expiresAt) {
       throw new BadDataException(
         "No pending WebAuthn challenge found. Please initiate the WebAuthn flow again.",
       );
     }
 
     // Check expiry
-    if (
-      OneUptimeDate.isBefore(
-        user.webauthnChallengeExpiresAt,
-        OneUptimeDate.getCurrentDate(),
-      )
-    ) {
+    if (OneUptimeDate.isBefore(expiresAt, OneUptimeDate.getCurrentDate())) {
       // Clear the expired challenge
-      await UserService.updateOneById({
-        id: userId,
-        data: {
-          webauthnChallenge: null as any,
-          webauthnChallengeExpiresAt: null as any,
-        },
-        props: {
-          isRoot: true,
-        },
+      await this.clearChallenge({
+        userId: data.userId,
+        purpose: data.purpose,
       });
 
       throw new BadDataException(
@@ -499,18 +763,10 @@ export class Service extends DatabaseService<Model> {
       );
     }
 
-    const challenge: string = user.webauthnChallenge;
-
     // Clear the challenge immediately so it cannot be reused (one-time use)
-    await UserService.updateOneById({
-      id: userId,
-      data: {
-        webauthnChallenge: null as any,
-        webauthnChallengeExpiresAt: null as any,
-      },
-      props: {
-        isRoot: true,
-      },
+    await this.clearChallenge({
+      userId: data.userId,
+      purpose: data.purpose,
     });
 
     return challenge;

--- a/Common/Server/Services/UserWebAuthnService.ts
+++ b/Common/Server/Services/UserWebAuthnService.ts
@@ -471,7 +471,7 @@ export class Service extends DatabaseService<Model> {
   @CaptureSpan()
   public async generateAuthenticationOptions(data: {
     email: string;
-  }): Promise<{ options: any; challenge: string; userId: string }> {
+  }): Promise<{ options: any; challenge: string }> {
     const user: User | null = await UserService.findOneBy({
       query: { email: data.email },
       select: {
@@ -548,10 +548,25 @@ export class Service extends DatabaseService<Model> {
       challenge: options.challenge,
     });
 
+    /*
+     * The anonymous caller gets the ceremony and nothing else.
+     *
+     * This used to hand back `userId` too -- the account's real row id, to
+     * anybody who could name an email address with a key on it. Nothing ever
+     * read it: the browser posts the assertion to /verify-webauthn-auth along
+     * with the email and password again, and that route takes the user from
+     * the password it has just verified
+     * (App/FeatureSet/Identity/API/Authentication.ts), never from the body.
+     *
+     * So it was an identifier handed to strangers for free, on the one route
+     * that has just been made careful about what it tells them -- and it would
+     * have undone half of that: unifying the two refusals stops a caller
+     * learning whether an account exists, while a success that carries its
+     * internal id tells them rather more than that.
+     */
     return {
       options: options as any,
       challenge: options.challenge,
-      userId: user.id!.toString(),
     };
   }
 

--- a/Common/Server/Services/UserWebAuthnService.ts
+++ b/Common/Server/Services/UserWebAuthnService.ts
@@ -4,6 +4,7 @@ import DatabaseService from "./DatabaseService";
 import Model from "../../Models/DatabaseModels/UserWebAuthn";
 import UserService from "./UserService";
 import BadDataException from "../../Types/Exception/BadDataException";
+import Exception from "../../Types/Exception/Exception";
 import User from "../../Models/DatabaseModels/User";
 import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
@@ -19,6 +20,115 @@ import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCom
 import OneUptimeDate from "../../Types/Date";
 
 const WEBAUTHN_CHALLENGE_TTL_MINUTES: number = 5;
+
+/*
+ * How much a security key is asked to prove about the person holding it.
+ *
+ * "preferred" means: verify the user -- a fingerprint, a face, a PIN, a system
+ * password -- IF you can, and go ahead without it if you cannot. That second
+ * clause is the entire reason to choose the value over "required", and it is
+ * exercised constantly by ordinary hardware:
+ *
+ *   - a MacBook running folded shut on an external display ("clamshell") has
+ *     no reachable Touch ID sensor;
+ *   - a plain USB security key with no PIN set has nothing to verify with;
+ *   - Windows Hello is unavailable on a desktop with no camera or reader.
+ *
+ * In each case the browser returns a perfectly good credential with the UV bit
+ * in the authenticator data left CLEAR, exactly as we asked it to.
+ */
+type WebAuthnUserVerification = "required" | "preferred" | "discouraged";
+
+const WEBAUTHN_USER_VERIFICATION: WebAuthnUserVerification = "preferred";
+
+/*
+ * The other half of that policy, and the half that was missing.
+ *
+ * `verifyRegistrationResponse` and `verifyAuthenticationResponse` both default
+ * `requireUserVerification` to TRUE. Left unset, they therefore REJECT the
+ * very responses the options above told the authenticator were acceptable --
+ * so a user in clamshell mode got "User verification was required, but user
+ * could not be verified" thrown out of the library and rendered as an
+ * unexplained "Server Error" (issue #3652). Registration was where it was
+ * reported, but the identical default sits on the authentication call, so a
+ * key enrolled at a desk also failed to SIGN IN from the same laptop later.
+ *
+ * DERIVED from the requested policy rather than written as a bare `false` in
+ * two places, because the drift between what we asked for and what we then
+ * demanded IS the bug. Tying both to one constant means raising the policy to
+ * "required" cannot leave verification behind, and relaxing it cannot leave
+ * verification ahead. The comparison goes through a function taking the union
+ * type because TypeScript narrows a `const` to the literal it was initialised
+ * with and then rejects the comparison outright -- which would push this back
+ * to a hand-written `false` and reopen the drift.
+ *
+ * Relaxing this does not weaken the account. A security key is OneUptime's
+ * SECOND factor: the password has already been proven by the time any of this
+ * runs (see the verifyWebAuthn branch in
+ * App/FeatureSet/Identity/API/Authentication.ts), so user verification would
+ * be buying a second proof of the same person rather than a second factor.
+ * What it would cost is real -- every authenticator that cannot verify becomes
+ * unusable, and the user is locked out by hardware rather than by policy.
+ */
+type RequiresUserVerificationFunction = (
+  policy: WebAuthnUserVerification,
+) => boolean;
+
+const requiresUserVerification: RequiresUserVerificationFunction = (
+  policy: WebAuthnUserVerification,
+): boolean => {
+  return policy === "required";
+};
+
+const WEBAUTHN_REQUIRE_USER_VERIFICATION: boolean = requiresUserVerification(
+  WEBAUTHN_USER_VERIFICATION,
+);
+
+/*
+ * Everything @simplewebauthn/server refuses, it refuses by throwing a plain
+ * `Error` rather than one of our `Exception`s -- and the last-resort handler
+ * in Common/Server/Utils/StartServer.ts has no branch for a plain Error. It
+ * falls through to `res.status(500).send({ error: "Server Error" })`, which
+ * DISCARDS the message.
+ *
+ * That is the other half of what issue #3652 reported. The user saw an
+ * unexplained "Server Error"; the sentence that actually says what went wrong
+ * ("User verification was required, but user could not be verified") only ever
+ * reached the server log, which a hosted user cannot read at all and a
+ * self-hoster has to go looking for. Every WebAuthn failure looked identical
+ * from the browser: a misconfigured reverse proxy serving a different origin
+ * than HOST claims, a challenge that timed out while the user hunted for their
+ * key, and a genuinely bad credential were one indistinguishable 500.
+ *
+ * The messages are safe to show. They name the origin, the relying party id or
+ * the challenge THIS SERVER expected -- all of which the browser making the
+ * request already knows -- and for a self-hoster the origin mismatch is the
+ * single most useful thing the product can say.
+ *
+ * Exceptions we raised ourselves pass straight through, so the specific
+ * wording of the challenge errors below is not flattened into the generic one.
+ */
+type VerifyWebAuthnResponseFunction = (
+  verify: () => Promise<any>,
+) => Promise<any>;
+
+const explainVerificationFailure: VerifyWebAuthnResponseFunction = async (
+  verify: () => Promise<any>,
+): Promise<any> => {
+  try {
+    return await verify();
+  } catch (err) {
+    if (err instanceof Exception) {
+      throw err;
+    }
+
+    throw new BadDataException(
+      err instanceof Error && err.message
+        ? err.message
+        : "Could not verify this security key.",
+    );
+  }
+};
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -82,7 +192,7 @@ export class Service extends DatabaseService<Model> {
         }),
       authenticatorSelection: {
         residentKey: "discouraged",
-        userVerification: "preferred",
+        userVerification: WEBAUTHN_USER_VERIFICATION,
       },
     });
 
@@ -140,11 +250,14 @@ export class Service extends DatabaseService<Model> {
 
     const expectedOrigin: string = `${HttpProtocol}${Host.toString()}`;
 
-    const verification: any = await verifyRegistrationResponse({
-      response: data.credential,
-      expectedChallenge: storedChallenge,
-      expectedOrigin: expectedOrigin,
-      expectedRPID: Host.toString(),
+    const verification: any = await explainVerificationFailure(() => {
+      return verifyRegistrationResponse({
+        response: data.credential,
+        expectedChallenge: storedChallenge,
+        expectedOrigin: expectedOrigin,
+        expectedRPID: Host.toString(),
+        requireUserVerification: WEBAUTHN_REQUIRE_USER_VERIFICATION,
+      });
     });
 
     if (!verification.verified) {
@@ -225,7 +338,7 @@ export class Service extends DatabaseService<Model> {
           type: "public-key",
         };
       }),
-      userVerification: "preferred",
+      userVerification: WEBAUTHN_USER_VERIFICATION,
     });
 
     // Convert to JSON serializable format
@@ -303,16 +416,19 @@ export class Service extends DatabaseService<Model> {
 
     const expectedOrigin: string = `${HttpProtocol}${Host.toString()}`;
 
-    const verification: any = await verifyAuthenticationResponse({
-      response: data.credential,
-      expectedChallenge: storedChallenge,
-      expectedOrigin: expectedOrigin,
-      expectedRPID: Host.toString(),
-      credential: {
-        id: dbCredential.credentialId!,
-        publicKey: Buffer.from(dbCredential.publicKey!, "base64"),
-        counter: parseInt(dbCredential.counter!),
-      } as any,
+    const verification: any = await explainVerificationFailure(() => {
+      return verifyAuthenticationResponse({
+        response: data.credential,
+        expectedChallenge: storedChallenge,
+        expectedOrigin: expectedOrigin,
+        expectedRPID: Host.toString(),
+        credential: {
+          id: dbCredential.credentialId!,
+          publicKey: Buffer.from(dbCredential.publicKey!, "base64"),
+          counter: parseInt(dbCredential.counter!),
+        } as any,
+        requireUserVerification: WEBAUTHN_REQUIRE_USER_VERIFICATION,
+      });
     });
 
     if (!verification.verified) {

--- a/Common/Tests/Server/API/UserWebAuthnAuthenticationOptionsRoute.test.ts
+++ b/Common/Tests/Server/API/UserWebAuthnAuthenticationOptionsRoute.test.ts
@@ -1,0 +1,330 @@
+import UserWebAuthnAPI from "../../../Server/API/UserWebAuthnAPI";
+import UserMiddleware from "../../../Server/Middleware/UserAuthorization";
+import IdentityRateLimit, {
+  IdentityRateLimitBucket,
+} from "../../../Server/Middleware/IdentityRateLimit";
+import UserWebAuthnService from "../../../Server/Services/UserWebAuthnService";
+import Response from "../../../Server/Utils/Response";
+import {
+  NextFunction,
+  OneUptimeRequest,
+  OneUptimeResponse,
+} from "../../../Server/Utils/Express";
+import { mockRouter } from "./Helpers";
+import { getJestSpyOn } from "../../Spy";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "@jest/globals";
+
+/*
+ * ---------------------------------------------------------------------------
+ * POST /user-webauthn/generate-authentication-options -- the one route on this
+ * API that nobody is signed in for.
+ *
+ * It has to be anonymous. It is where the challenge a security key signs comes
+ * from, and it is needed BEFORE there is any assertion that could prove who is
+ * asking. But it was also unmetered, and those are different things: it takes
+ * an email address, and for that address it WRITES a challenge to the user's
+ * row. Unmetered, one request is one free database write against any address
+ * the caller cares to name, as fast as the process will answer.
+ *
+ * WHAT THIS FILE GUARDS
+ *
+ *   1. THE LIMITER IS ACTUALLY ON THE ROUTE. Asserted by identity against
+ *      `IdentityRateLimit.getMiddleware`, not by counting middlewares -- a
+ *      route that grew some other middleware would keep the count at one.
+ *
+ *   2. IT IS ON *THIS* ROUTE AND NOT THE OTHERS. The two registration routes
+ *      are already behind UserMiddleware and are not anonymous; putting a
+ *      limiter keyed on an email in front of them would meter a route whose
+ *      body carries no email at all, so every signed-in user would share one
+ *      bucket.
+ *
+ *   3. IT USES ITS OWN BUCKET. This route is the step immediately BEFORE
+ *      /verify-webauthn-auth, which spends the TwoFactor bucket. Sharing one
+ *      pool would mean every challenge a user asked for spent an attempt they
+ *      had not yet made -- and, worse, a user who had just exhausted the
+ *      shared budget failing at their key could not obtain a fresh challenge
+ *      to try again with. The step that exists to enable an attempt must not
+ *      be spendable by the attempts it enables. That is the same reasoning
+ *      that gives the backup-code route its own counter.
+ *
+ *   4. THE HANDLER STILL RUNS BEHIND IT. A limiter wired in front of a
+ *      handler that no longer works is not an improvement.
+ *
+ * WHAT IS MOCKED. `UserWebAuthnService.generateAuthenticationOptions` only, so
+ * nothing touches Postgres. `IdentityRateLimit` itself is NOT mocked: the
+ * assertions here are about which middleware is mounted and which budget it
+ * was given, both of which are answered without Redis. What the limiter DOES
+ * once it is running -- the two counters, the fail-closed 503 -- belongs to
+ * App/Tests/FeatureSet/Identity/IdentityRateLimit.test.ts and is not repeated.
+ * ---------------------------------------------------------------------------
+ */
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn(),
+    sendJsonArrayResponse: jest.fn(),
+    sendJsonObjectResponse: jest.fn(),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendErrorResponse: jest.fn(),
+    setNoCacheHeaders: jest.fn(),
+  };
+});
+
+const AUTHENTICATION_OPTIONS_ROUTE: string =
+  "/user-webauthn/generate-authentication-options";
+
+const REGISTRATION_OPTIONS_ROUTE: string =
+  "/user-webauthn/generate-registration-options";
+
+const VERIFY_REGISTRATION_ROUTE: string = "/user-webauthn/verify-registration";
+
+const OPTIONS_FROM_THE_SERVICE: {
+  options: unknown;
+  challenge: string;
+  userId: string;
+} = {
+  options: { rpId: "example.com", allowCredentials: [] },
+  challenge: "a-challenge",
+  userId: "44444444-4444-4444-8444-444444444444",
+};
+
+/*
+ * Captured at module load, before anything spies on it. The route stores the
+ * function `getMiddleware` RETURNED at construction time, so comparing against
+ * a spy installed later would compare against the wrong object.
+ */
+let mountedMiddleware: unknown = null;
+
+type CallRouteResult = {
+  thrownToNext: unknown;
+  nextCallCount: number;
+};
+
+type CallRouteFunction = (body?: unknown) => Promise<CallRouteResult>;
+
+const callRoute: CallRouteFunction = async (
+  body?: unknown,
+): Promise<CallRouteResult> => {
+  const req: OneUptimeRequest = {
+    params: {},
+    query: {},
+    body:
+      body === undefined ? { data: { email: "someone@example.com" } } : body,
+    headers: {},
+  } as unknown as OneUptimeRequest;
+
+  const res: OneUptimeResponse = {
+    send: jest.fn(),
+    json: jest.fn(),
+    setHeader: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+  } as unknown as OneUptimeResponse;
+
+  const next: jest.Mock = jest.fn();
+
+  await mockRouter
+    .match("post", AUTHENTICATION_OPTIONS_ROUTE)
+    .handlerFunction(req, res, next as unknown as NextFunction);
+
+  return {
+    thrownToNext: next.mock.calls[0] ? next.mock.calls[0][0] : undefined,
+    nextCallCount: next.mock.calls.length,
+  };
+};
+
+let generateSpy: jest.SpyInstance;
+
+beforeAll(() => {
+  mockRouter.routes.length = 0;
+
+  /*
+   * Record what `getMiddleware` hands back while the API class is being
+   * constructed, so the mounted function can be compared by identity.
+   */
+  const realGetMiddleware: typeof IdentityRateLimit.getMiddleware =
+    IdentityRateLimit.getMiddleware.bind(IdentityRateLimit);
+
+  const capture: jest.SpyInstance = getJestSpyOn(
+    IdentityRateLimit,
+    "getMiddleware",
+  );
+
+  capture.mockImplementation((bucket: unknown): unknown => {
+    const middleware: unknown = realGetMiddleware(
+      bucket as IdentityRateLimitBucket,
+    );
+    mountedMiddleware = middleware;
+    return middleware;
+  });
+
+  new UserWebAuthnAPI();
+
+  capture.mockRestore();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  generateSpy = getJestSpyOn(
+    UserWebAuthnService,
+    "generateAuthenticationOptions",
+  );
+  generateSpy.mockResolvedValue(OPTIONS_FROM_THE_SERVICE as never);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("POST /user-webauthn/generate-authentication-options", () => {
+  describe("the limiter in front of it", () => {
+    test("has one middleware, and it is the identity rate limiter", () => {
+      const route: { middlewares: Array<unknown> } = mockRouter.match(
+        "post",
+        AUTHENTICATION_OPTIONS_ROUTE,
+      );
+
+      expect(route.middlewares).toHaveLength(1);
+      expect(route.middlewares[0]).toBe(mountedMiddleware);
+    });
+
+    test("is not the user middleware", () => {
+      /*
+       * Stated explicitly because the obvious "fix" for an anonymous route is
+       * to authenticate it, and that would break every sign-in: the challenge
+       * has to be obtainable before the assertion that proves who is asking.
+       */
+      const route: { middlewares: Array<unknown> } = mockRouter.match(
+        "post",
+        AUTHENTICATION_OPTIONS_ROUTE,
+      );
+
+      expect(route.middlewares).not.toContain(UserMiddleware.getUserMiddleware);
+    });
+
+    test("spends its own budget, not the two-factor one", () => {
+      /*
+       * The budgets are separate objects, so identity is the assertion. If
+       * this route shared the TwoFactor bucket, a user would get five real
+       * sign-in attempts instead of ten -- each challenge spending an attempt
+       * they had not made yet -- and a user who had just spent the budget
+       * failing at their key could not get a fresh challenge to retry with.
+       */
+      expect(
+        IdentityRateLimit.getBucketConfig(
+          IdentityRateLimitBucket.WebAuthnChallenge,
+        ),
+      ).not.toBe(
+        IdentityRateLimit.getBucketConfig(IdentityRateLimitBucket.TwoFactor),
+      );
+    });
+
+    test("does not silently fall through to the login budget", () => {
+      /*
+       * `getBucketConfig` ends in an unguarded `return LOGIN_BUCKET`, so a
+       * bucket added to the enum without a matching branch gets the password
+       * budget and nothing anywhere complains. That is a one-line mistake
+       * with no other symptom.
+       */
+      expect(
+        IdentityRateLimit.getBucketConfig(
+          IdentityRateLimitBucket.WebAuthnChallenge,
+        ),
+      ).not.toBe(
+        IdentityRateLimit.getBucketConfig(IdentityRateLimitBucket.Login),
+      );
+    });
+
+    test("is more generous per account than the routes that check a credential", () => {
+      /*
+       * Nothing is being guessed here -- the route accepts no credential and
+       * can refuse nobody -- and abandoning a prompt is ordinary: a user who
+       * touches the wrong key, closes the dialog or reloads asks for another
+       * challenge each time. The per-address ceiling is what bounds the
+       * writes; the per-account number just must not be so tight that normal
+       * fumbling locks someone out of their own sign-in.
+       */
+      const challengeBudget: { perAccountLimit: number; perIpLimit: number } =
+        IdentityRateLimit.getBucketConfig(
+          IdentityRateLimitBucket.WebAuthnChallenge,
+        );
+
+      const twoFactorBudget: { perAccountLimit: number } =
+        IdentityRateLimit.getBucketConfig(IdentityRateLimitBucket.TwoFactor);
+
+      expect(challengeBudget.perAccountLimit).toBeGreaterThan(
+        twoFactorBudget.perAccountLimit,
+      );
+      expect(challengeBudget.perIpLimit).toBeGreaterThan(0);
+    });
+  });
+
+  describe("the routes that are NOT metered this way", () => {
+    test.each([
+      ["registration options", REGISTRATION_OPTIONS_ROUTE],
+      ["verify registration", VERIFY_REGISTRATION_ROUTE],
+    ])(
+      "%s stays behind the user middleware alone",
+      (_name: string, uri: string) => {
+        /*
+         * Both are authenticated, and neither carries an email in its body --
+         * so the limiter's account key would collapse to the same value for
+         * every caller and one user's enrolment attempts would throttle
+         * everybody's.
+         */
+        const route: { middlewares: Array<unknown> } = mockRouter.match(
+          "post",
+          uri,
+        );
+
+        expect(route.middlewares).toEqual([UserMiddleware.getUserMiddleware]);
+      },
+    );
+  });
+
+  describe("the handler behind the limiter", () => {
+    test("still answers with the options for the submitted email", async () => {
+      const result: CallRouteResult = await callRoute();
+
+      expect(result.nextCallCount).toBe(0);
+      expect(generateSpy).toHaveBeenCalledTimes(1);
+      expect((generateSpy.mock.calls[0]![0] as { email: string }).email).toBe(
+        "someone@example.com",
+      );
+      expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+    });
+
+    test("still refuses a request with no email", async () => {
+      const result: CallRouteResult = await callRoute({ data: {} });
+
+      expect(result.nextCallCount).toBe(1);
+      expect(result.thrownToNext).toBeInstanceOf(BadDataException);
+      expect(generateSpy).not.toHaveBeenCalled();
+    });
+
+    test("still refuses a request with no data at all", async () => {
+      const result: CallRouteResult = await callRoute({});
+
+      expect(result.nextCallCount).toBe(1);
+      expect(result.thrownToNext).toBeInstanceOf(BadDataException);
+      expect(generateSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Tests/Server/Services/UserWebAuthnUserVerification.test.ts
+++ b/Common/Tests/Server/Services/UserWebAuthnUserVerification.test.ts
@@ -1,0 +1,492 @@
+import UserWebAuthnService from "../../../Server/Services/UserWebAuthnService";
+import UserService from "../../../Server/Services/UserService";
+import User from "../../../Models/DatabaseModels/User";
+import UserWebAuthn from "../../../Models/DatabaseModels/UserWebAuthn";
+import Email from "../../../Types/Email";
+import ObjectID from "../../../Types/ObjectID";
+import OneUptimeDate from "../../../Types/Date";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import Exception from "../../../Types/Exception/Exception";
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+} from "@simplewebauthn/server";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * ---------------------------------------------------------------------------
+ * The user verification POLICY, held down at the seam where it was broken.
+ *
+ * Issue #3652: a passkey could not be registered from a MacBook running folded
+ * shut, because the policy lives in two places and they had drifted apart.
+ * `generateRegistrationOptions` told the authenticator that verifying the user
+ * was "preferred" -- go ahead without it if you cannot -- and then
+ * `verifyRegistrationResponse`, left on its own default of
+ * `requireUserVerification: true`, refused the response that invitation
+ * produced. The same default sits on `verifyAuthenticationResponse`, so the
+ * same account could not sign in from the same laptop either.
+ *
+ * WHAT THIS FILE IS FOR, AND WHAT IT DELIBERATELY IS NOT
+ *
+ * Common's jest config maps `@simplewebauthn/server` to a stub
+ * (Common/Tests/__mocks__/simplewebauthn.js). A stub has no library default,
+ * so nothing here can demonstrate the FAILURE -- a test of that written
+ * against the stub would have passed before the fix and after it, which is
+ * worse than no test. The demonstration lives in
+ * App/Tests/FeatureSet/Identity/WebAuthnUserVerification.test.ts, where the
+ * real v13 library verifies real ES256 assertions from an authenticator that
+ * leaves the UV bit clear.
+ *
+ * What belongs HERE is the invariant that made the failure possible in the
+ * first place, and which is invisible end-to-end: that the ASK and the CHECK
+ * are the same policy. Both are arguments this service passes to the library,
+ * so both can be read straight off the call, and the agreement between them
+ * asserted directly. That is the property a future edit will break -- someone
+ * tightening one call site without the other -- and it breaks here loudly,
+ * without waiting on the four-minute end-to-end suite.
+ *
+ * These assertions are written against `requireUserVerification` being
+ * PRESENT, not merely falsy. Omitting the argument is what the bug WAS, and
+ * `undefined` is indistinguishable from `false` under `toBeFalsy()`.
+ * ---------------------------------------------------------------------------
+ */
+
+const USER_ID: ObjectID = new ObjectID("7c1f2e3d-4a5b-4c6d-8e7f-081920304050");
+const USER_EMAIL: Email = new Email("policy.user@example.com");
+
+const CREDENTIAL_ID: string = "an-already-registered-credential";
+
+type AsMockFunction = (fn: unknown) => jest.Mock;
+
+const asMock: AsMockFunction = (fn: unknown): jest.Mock => {
+  return fn as unknown as jest.Mock;
+};
+
+type FirstArgumentFunction = (fn: unknown) => Record<string, unknown>;
+
+const firstArgument: FirstArgumentFunction = (
+  fn: unknown,
+): Record<string, unknown> => {
+  const call: Array<unknown> | undefined = asMock(fn).mock.calls[0];
+
+  if (!call) {
+    throw new Error(
+      "Expected the service to have called this library function",
+    );
+  }
+
+  return call[0] as Record<string, unknown>;
+};
+
+type BuildUserFunction = () => User;
+
+const buildUser: BuildUserFunction = (): User => {
+  const user: User = new User();
+  user.id = USER_ID;
+  user.email = USER_EMAIL;
+
+  /*
+   * A live, unexpired challenge, so verification gets past
+   * `getAndClearStoredChallenge` and reaches the library call under test. The
+   * value is whatever the stub issues.
+   */
+  user.webauthnChallenge = "mock-challenge";
+  user.webauthnChallengeExpiresAt = OneUptimeDate.addRemoveMinutes(
+    OneUptimeDate.getCurrentDate(),
+    5,
+  );
+
+  return user;
+};
+
+type BuildCredentialRowFunction = () => UserWebAuthn;
+
+const buildCredentialRow: BuildCredentialRowFunction = (): UserWebAuthn => {
+  const row: UserWebAuthn = new UserWebAuthn();
+  row.id = new ObjectID("0a0b0c0d-1e1f-4a2b-8c3d-4e5f60718293");
+  row.credentialId = CREDENTIAL_ID;
+  row.publicKey = Buffer.from("a public key").toString("base64");
+  row.counter = "0";
+  row.isVerified = true;
+  row.userId = USER_ID;
+
+  return row;
+};
+
+/* A credential body shaped the way navigator.credentials returns one. */
+const CREDENTIAL_FROM_THE_BROWSER: Record<string, unknown> = {
+  id: CREDENTIAL_ID,
+  rawId: CREDENTIAL_ID,
+  type: "public-key",
+  response: {
+    clientDataJSON: "client-data",
+    attestationObject: "attestation",
+    authenticatorData: "authenticator-data",
+    signature: "signature",
+  },
+  clientExtensionResults: {},
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  UserService.findOneById = jest.fn().mockResolvedValue(buildUser()) as never;
+  UserService.findOneBy = jest.fn().mockResolvedValue(buildUser()) as never;
+  UserService.updateOneById = jest.fn().mockResolvedValue(undefined) as never;
+
+  UserWebAuthnService.findBy = jest
+    .fn()
+    .mockResolvedValue([buildCredentialRow()]) as never;
+  UserWebAuthnService.findOneBy = jest
+    .fn()
+    .mockResolvedValue(buildCredentialRow()) as never;
+  UserWebAuthnService.create = jest.fn().mockResolvedValue({}) as never;
+  UserWebAuthnService.updateOneById = jest
+    .fn()
+    .mockResolvedValue(undefined) as never;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("UserWebAuthnService user verification policy", () => {
+  describe("registration", () => {
+    test("asks the authenticator for preferred user verification", async () => {
+      await UserWebAuthnService.generateRegistrationOptions({
+        userId: USER_ID,
+      });
+
+      const options: Record<string, unknown> = firstArgument(
+        generateRegistrationOptions,
+      );
+
+      const authenticatorSelection: Record<string, unknown> = options[
+        "authenticatorSelection"
+      ] as Record<string, unknown>;
+
+      expect(authenticatorSelection["userVerification"]).toBe("preferred");
+    });
+
+    test("tells the verifier explicitly not to require it", async () => {
+      /*
+       * The single line the bug was missing. Asserted on its PRESENCE as well
+       * as its value: leaving the property off is precisely what went wrong,
+       * and the library then supplies `true` on our behalf.
+       */
+      await UserWebAuthnService.verifyRegistration({
+        credential: CREDENTIAL_FROM_THE_BROWSER,
+        name: "MacBook Touch ID",
+        props: { userId: USER_ID },
+      });
+
+      const verification: Record<string, unknown> = firstArgument(
+        verifyRegistrationResponse,
+      );
+
+      expect(verification).toHaveProperty("requireUserVerification");
+      expect(verification["requireUserVerification"]).toBe(false);
+    });
+  });
+
+  describe("authentication", () => {
+    test("asks the authenticator for preferred user verification", async () => {
+      await UserWebAuthnService.generateAuthenticationOptions({
+        email: USER_EMAIL.toString(),
+      });
+
+      const options: Record<string, unknown> = firstArgument(
+        generateAuthenticationOptions,
+      );
+
+      expect(options["userVerification"]).toBe("preferred");
+    });
+
+    test("tells the verifier explicitly not to require it", async () => {
+      /*
+       * The half of the bug that was never reported, because registration
+       * failed first. It is the more dangerous half: the password has already
+       * been accepted by the time an assertion is checked, so a refusal here
+       * is a locked account rather than a failed setup.
+       */
+      await UserWebAuthnService.verifyAuthentication({
+        userId: USER_ID.toString(),
+        credential: CREDENTIAL_FROM_THE_BROWSER,
+      });
+
+      const verification: Record<string, unknown> = firstArgument(
+        verifyAuthenticationResponse,
+      );
+
+      expect(verification).toHaveProperty("requireUserVerification");
+      expect(verification["requireUserVerification"]).toBe(false);
+    });
+  });
+
+  describe("the ask and the check describe the same policy", () => {
+    /*
+     * THE INVARIANT, and the reason this file exists alongside the end-to-end
+     * test. Neither half is wrong on its own -- "preferred" is a legitimate
+     * ask and `requireUserVerification: true` is a legitimate check. The
+     * defect was the PAIR disagreeing, which no assertion on either half alone
+     * can catch.
+     *
+     * Stated as an equivalence rather than as two literals so that tightening
+     * the product's policy to "required" one day stays green here as long as
+     * BOTH sides move, and goes red the moment only one does.
+     */
+
+    type PolicyPair = {
+      requested: unknown;
+      required: unknown;
+    };
+
+    type AssertAgreementFunction = (pair: PolicyPair) => void;
+
+    const assertAgreement: AssertAgreementFunction = (
+      pair: PolicyPair,
+    ): void => {
+      expect(pair.requested).toEqual(expect.any(String));
+      expect(typeof pair.required).toBe("boolean");
+      expect(pair.required).toBe(pair.requested === "required");
+    };
+
+    test("on the registration flow", async () => {
+      await UserWebAuthnService.generateRegistrationOptions({
+        userId: USER_ID,
+      });
+
+      await UserWebAuthnService.verifyRegistration({
+        credential: CREDENTIAL_FROM_THE_BROWSER,
+        name: "MacBook Touch ID",
+        props: { userId: USER_ID },
+      });
+
+      const requested: Record<string, unknown> = firstArgument(
+        generateRegistrationOptions,
+      )["authenticatorSelection"] as Record<string, unknown>;
+
+      assertAgreement({
+        requested: requested["userVerification"],
+        required: firstArgument(verifyRegistrationResponse)[
+          "requireUserVerification"
+        ],
+      });
+    });
+
+    test("on the authentication flow", async () => {
+      await UserWebAuthnService.generateAuthenticationOptions({
+        email: USER_EMAIL.toString(),
+      });
+
+      await UserWebAuthnService.verifyAuthentication({
+        userId: USER_ID.toString(),
+        credential: CREDENTIAL_FROM_THE_BROWSER,
+      });
+
+      assertAgreement({
+        requested: firstArgument(generateAuthenticationOptions)[
+          "userVerification"
+        ],
+        required: firstArgument(verifyAuthenticationResponse)[
+          "requireUserVerification"
+        ],
+      });
+    });
+
+    test("and the two flows agree with each other", async () => {
+      /*
+       * Registration and authentication are separate call sites with separate
+       * arguments, and a key is enrolled by one and used by the other. A
+       * product that asked for "preferred" at enrolment and "required" at
+       * sign-in would let a user set up an authenticator they could then never
+       * sign in with -- the worst version of this bug, because it only
+       * surfaces later, on a different machine, after the password has been
+       * accepted.
+       */
+      await UserWebAuthnService.generateRegistrationOptions({
+        userId: USER_ID,
+      });
+
+      await UserWebAuthnService.generateAuthenticationOptions({
+        email: USER_EMAIL.toString(),
+      });
+
+      const registrationSelection: Record<string, unknown> = firstArgument(
+        generateRegistrationOptions,
+      )["authenticatorSelection"] as Record<string, unknown>;
+
+      expect(registrationSelection["userVerification"]).toBe(
+        firstArgument(generateAuthenticationOptions)["userVerification"],
+      );
+    });
+  });
+
+  describe("how a refusal from the library reaches the caller", () => {
+    /*
+     * The second half of the bug report -- "Get a 'Server Error' message" --
+     * and the reason the first half went undiagnosed. @simplewebauthn signals
+     * every refusal with a plain `Error`, and the last-resort handler in
+     * Common/Server/Utils/StartServer.ts has no branch for one: it answers
+     * `res.status(500).send({ error: "Server Error" })` and drops the message.
+     *
+     * Fast to assert here because the stub can be made to reject on demand;
+     * the end-to-end version, with the real library producing its own real
+     * messages, lives in
+     * App/Tests/FeatureSet/Identity/WebAuthnUserVerification.test.ts.
+     */
+
+    const LIBRARY_REFUSAL: Error = new Error(
+      'Unexpected registration response origin "https://evil.test", expected "https://oneuptime.example.com"',
+    );
+
+    test("a registration refusal becomes an Exception carrying the reason", async () => {
+      asMock(verifyRegistrationResponse).mockRejectedValueOnce(LIBRARY_REFUSAL);
+
+      let thrown: unknown = null;
+
+      try {
+        await UserWebAuthnService.verifyRegistration({
+          credential: CREDENTIAL_FROM_THE_BROWSER,
+          name: "MacBook Touch ID",
+          props: { userId: USER_ID },
+        });
+      } catch (error) {
+        thrown = error;
+      }
+
+      /*
+       * `instanceof Exception` is exactly what the handler branches on, so it
+       * is the property worth asserting -- not merely "it threw".
+       */
+      expect(thrown).toBeInstanceOf(BadDataException);
+      expect((thrown as Exception).message).toBe(LIBRARY_REFUSAL.message);
+    });
+
+    test("an authentication refusal does the same", async () => {
+      asMock(verifyAuthenticationResponse).mockRejectedValueOnce(
+        LIBRARY_REFUSAL,
+      );
+
+      let thrown: unknown = null;
+
+      try {
+        await UserWebAuthnService.verifyAuthentication({
+          userId: USER_ID.toString(),
+          credential: CREDENTIAL_FROM_THE_BROWSER,
+        });
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(BadDataException);
+      expect((thrown as Exception).message).toBe(LIBRARY_REFUSAL.message);
+    });
+
+    test("a refusal with nothing to say still says something", async () => {
+      /*
+       * Defensive, and cheap: an Error with an empty message would otherwise
+       * produce an empty-bodied 400, which reads to the user as a page that
+       * simply did nothing.
+       */
+      asMock(verifyRegistrationResponse).mockRejectedValueOnce(new Error(""));
+
+      await expect(
+        UserWebAuthnService.verifyRegistration({
+          credential: CREDENTIAL_FROM_THE_BROWSER,
+          name: "MacBook Touch ID",
+          props: { userId: USER_ID },
+        }),
+      ).rejects.toThrow(/could not verify this security key/i);
+    });
+
+    test("a response the library merely marks unverified is still refused", async () => {
+      /*
+       * The library has two ways of saying no -- throwing, and returning
+       * `verified: false` -- and the wrapper only touches the first. The
+       * second must keep reaching the caller as it always did, or a
+       * credential that failed verification would be saved.
+       */
+      asMock(verifyRegistrationResponse).mockResolvedValueOnce({
+        verified: false,
+      });
+
+      await expect(
+        UserWebAuthnService.verifyRegistration({
+          credential: CREDENTIAL_FROM_THE_BROWSER,
+          name: "MacBook Touch ID",
+          props: { userId: USER_ID },
+        }),
+      ).rejects.toThrow(/registration verification failed/i);
+
+      expect(UserWebAuthnService.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("what the policy does not touch", () => {
+    test("the challenge is still taken from the server, never from the caller", async () => {
+      /*
+       * Relaxing user verification removes one check, and this is the check it
+       * must not be confused with. The challenge is what makes a response
+       * fresh; it is read from the User row rather than from the request, and
+       * it is what the library is told to expect.
+       */
+      await UserWebAuthnService.verifyRegistration({
+        credential: {
+          ...CREDENTIAL_FROM_THE_BROWSER,
+          expectedChallenge: "a challenge the caller would like used",
+        },
+        name: "MacBook Touch ID",
+        props: { userId: USER_ID },
+      });
+
+      expect(
+        firstArgument(verifyRegistrationResponse)["expectedChallenge"],
+      ).toBe("mock-challenge");
+    });
+
+    test("the origin and relying party are still pinned", async () => {
+      /*
+       * Phishing resistance, which has nothing to do with user verification
+       * and everything to do with these two arguments being present at all.
+       */
+      await UserWebAuthnService.verifyAuthentication({
+        userId: USER_ID.toString(),
+        credential: CREDENTIAL_FROM_THE_BROWSER,
+      });
+
+      const verification: Record<string, unknown> = firstArgument(
+        verifyAuthenticationResponse,
+      );
+
+      expect(verification["expectedOrigin"]).toEqual(expect.any(String));
+      expect(verification["expectedRPID"]).toEqual(expect.any(String));
+    });
+
+    test("the challenge is still spent as it is read", async () => {
+      /*
+       * One-time use: the row is cleared during verification, so the same
+       * captured response cannot be replayed. Asserted here because it is the
+       * other write this code path makes to the User row, and a refactor of
+       * the policy constants sits close enough to it to disturb it.
+       */
+      await UserWebAuthnService.verifyRegistration({
+        credential: CREDENTIAL_FROM_THE_BROWSER,
+        name: "MacBook Touch ID",
+        props: { userId: USER_ID },
+      });
+
+      const clearing: Array<unknown> = asMock(
+        UserService.updateOneById,
+      ).mock.calls.map((call: Array<unknown>): unknown => {
+        return (call[0] as { data: Record<string, unknown> }).data[
+          "webauthnChallenge"
+        ];
+      });
+
+      expect(clearing).toContain(null);
+    });
+  });
+});

--- a/Common/Tests/Server/Services/UserWebAuthnUserVerification.test.ts
+++ b/Common/Tests/Server/Services/UserWebAuthnUserVerification.test.ts
@@ -88,15 +88,21 @@ const buildUser: BuildUserFunction = (): User => {
   user.email = USER_EMAIL;
 
   /*
-   * A live, unexpired challenge, so verification gets past
-   * `getAndClearStoredChallenge` and reaches the library call under test. The
-   * value is whatever the stub issues.
+   * A live, unexpired challenge in BOTH slots, so verification gets past
+   * `getAndClearStoredChallenge` whichever flow is under test and reaches the
+   * library call this file is actually about. The value is whatever the stub
+   * issues. That the slots are separate at all is exercised end to end in
+   * App/Tests/FeatureSet/Identity/WebAuthnUserVerification.test.ts.
    */
-  user.webauthnChallenge = "mock-challenge";
-  user.webauthnChallengeExpiresAt = OneUptimeDate.addRemoveMinutes(
+  const expiresAt: Date = OneUptimeDate.addRemoveMinutes(
     OneUptimeDate.getCurrentDate(),
     5,
   );
+
+  user.webauthnRegistrationChallenge = "mock-challenge";
+  user.webauthnRegistrationChallengeExpiresAt = expiresAt;
+  user.webauthnAuthenticationChallenge = "mock-challenge";
+  user.webauthnAuthenticationChallengeExpiresAt = expiresAt;
 
   return user;
 };
@@ -425,6 +431,174 @@ describe("UserWebAuthnService user verification policy", () => {
     });
   });
 
+  describe("which challenge slot each flow writes", () => {
+    /*
+     * The two flows land on the SAME User row -- registration keyed by the
+     * session's user, signing in keyed by an email address -- and they used to
+     * write the same pair of columns, so whichever went last destroyed the
+     * other's challenge.
+     *
+     * Asserted here at the column level because that is where the separation
+     * either exists or does not: a helper that computed its column names from
+     * a variable, or a refactor that reached for the wrong branch, would still
+     * pass an end-to-end test that only ever runs one flow at a time. The
+     * behavioural proof -- two live flows over one row -- is in
+     * App/Tests/FeatureSet/Identity/WebAuthnUserVerification.test.ts.
+     */
+
+    type WrittenKeysFunction = () => Array<Array<string>>;
+
+    const writtenKeys: WrittenKeysFunction = (): Array<Array<string>> => {
+      return asMock(UserService.updateOneById).mock.calls.map(
+        (call: Array<unknown>): Array<string> => {
+          return Object.keys(
+            (call[0] as { data: Record<string, unknown> }).data,
+          );
+        },
+      );
+    };
+
+    test("registering writes only the registration slot", async () => {
+      await UserWebAuthnService.generateRegistrationOptions({
+        userId: USER_ID,
+      });
+
+      for (const keys of writtenKeys()) {
+        expect(keys.sort()).toEqual([
+          "webauthnRegistrationChallenge",
+          "webauthnRegistrationChallengeExpiresAt",
+        ]);
+      }
+
+      expect(writtenKeys().length).toBeGreaterThan(0);
+    });
+
+    test("signing in writes only the authentication slot", async () => {
+      await UserWebAuthnService.generateAuthenticationOptions({
+        email: USER_EMAIL.toString(),
+      });
+
+      for (const keys of writtenKeys()) {
+        expect(keys.sort()).toEqual([
+          "webauthnAuthenticationChallenge",
+          "webauthnAuthenticationChallengeExpiresAt",
+        ]);
+      }
+
+      expect(writtenKeys().length).toBeGreaterThan(0);
+    });
+
+    test("clearing a spent registration challenge leaves the sign-in slot alone", async () => {
+      /*
+       * The clear is what actually did the damage. `getAndClearStoredChallenge`
+       * empties the slot it read, and with one shared slot that meant every
+       * completed ceremony wiped whatever the other flow had pending.
+       */
+      await UserWebAuthnService.verifyRegistration({
+        credential: CREDENTIAL_FROM_THE_BROWSER,
+        name: "MacBook Touch ID",
+        props: { userId: USER_ID },
+      });
+
+      const touched: Array<string> = writtenKeys().flat();
+
+      expect(touched).toContain("webauthnRegistrationChallenge");
+      expect(touched).not.toContain("webauthnAuthenticationChallenge");
+    });
+
+    test("clearing a spent sign-in challenge leaves the registration slot alone", async () => {
+      await UserWebAuthnService.verifyAuthentication({
+        userId: USER_ID.toString(),
+        credential: CREDENTIAL_FROM_THE_BROWSER,
+      });
+
+      const touched: Array<string> = writtenKeys().flat();
+
+      expect(touched).toContain("webauthnAuthenticationChallenge");
+      expect(touched).not.toContain("webauthnRegistrationChallenge");
+    });
+
+    test("each flow reads back only its own slot", async () => {
+      /*
+       * The read half of the same property. Selecting both slots would work
+       * today and quietly re-create the coupling the moment somebody picked
+       * the wrong one out of the row.
+       */
+      await UserWebAuthnService.verifyAuthentication({
+        userId: USER_ID.toString(),
+        credential: CREDENTIAL_FROM_THE_BROWSER,
+      });
+
+      const selected: Array<string> = asMock(
+        UserService.findOneById,
+      ).mock.calls.flatMap((call: Array<unknown>): Array<string> => {
+        const select: Record<string, unknown> | undefined = (
+          call[0] as { select?: Record<string, unknown> }
+        ).select;
+
+        return select ? Object.keys(select) : [];
+      });
+
+      expect(selected).toContain("webauthnAuthenticationChallenge");
+      expect(selected).not.toContain("webauthnRegistrationChallenge");
+    });
+  });
+
+  describe("what an anonymous caller learns about an account", () => {
+    /*
+     * generateAuthenticationOptions is reached by POSTing an email and nothing
+     * else, from anybody. Two distinguishable refusals made it an
+     * account-existence oracle plus a second one naming which accounts are
+     * protected by a security key -- on a surface whose other doors go out of
+     * their way not to say which half of a credential was wrong.
+     */
+
+    type RefusalForFunction = (setUp: () => void) => Promise<Exception>;
+
+    const refusalFor: RefusalForFunction = async (
+      setUp: () => void,
+    ): Promise<Exception> => {
+      setUp();
+
+      try {
+        await UserWebAuthnService.generateAuthenticationOptions({
+          email: USER_EMAIL.toString(),
+        });
+      } catch (error) {
+        return error as Exception;
+      }
+
+      throw new Error("Expected this to reject, and it resolved");
+    };
+
+    test("an unknown address and a known one without a key get the same answer", async () => {
+      const unknownAccount: Exception = await refusalFor((): void => {
+        UserService.findOneBy = jest.fn().mockResolvedValue(null) as never;
+      });
+
+      const noSecurityKey: Exception = await refusalFor((): void => {
+        UserService.findOneBy = jest
+          .fn()
+          .mockResolvedValue(buildUser()) as never;
+        UserWebAuthnService.findBy = jest.fn().mockResolvedValue([]) as never;
+      });
+
+      expect(unknownAccount.message).toBe(noSecurityKey.message);
+      expect(unknownAccount).toBeInstanceOf(BadDataException);
+      expect(noSecurityKey).toBeInstanceOf(BadDataException);
+    });
+
+    test("neither answer describes what was actually missing", async () => {
+      const unknownAccount: Exception = await refusalFor((): void => {
+        UserService.findOneBy = jest.fn().mockResolvedValue(null) as never;
+      });
+
+      expect(unknownAccount.message).not.toMatch(/user not found/i);
+      expect(unknownAccount.message).not.toMatch(/no webauthn credentials/i);
+      expect(unknownAccount.message).not.toContain(USER_EMAIL.toString());
+    });
+  });
+
   describe("what the policy does not touch", () => {
     test("the challenge is still taken from the server, never from the caller", async () => {
       /*
@@ -482,7 +656,7 @@ describe("UserWebAuthnService user verification policy", () => {
         UserService.updateOneById,
       ).mock.calls.map((call: Array<unknown>): unknown => {
         return (call[0] as { data: Record<string, unknown> }).data[
-          "webauthnChallenge"
+          "webauthnRegistrationChallenge"
         ];
       });
 

--- a/Common/Tests/Server/TestingUtils/SecurityKey.ts
+++ b/Common/Tests/Server/TestingUtils/SecurityKey.ts
@@ -1,0 +1,464 @@
+import crypto from "crypto";
+
+/*
+ * A stand-in for the security key -- or the platform authenticator built into
+ * the laptop -- that a user registers and then signs in with.
+ *
+ * Everything here is built from the WebAuthn and CTAP specifications using
+ * Node's own crypto primitives: the CBOR encoder below, the COSE key, the
+ * authenticator data byte layout and the ES256 signature. Nothing in this file
+ * imports `@simplewebauthn/server`, and that is the entire point. The server
+ * verifies with that library, so a test whose fixtures were also produced by
+ * it would prove only that the library agrees with itself -- and would have
+ * passed happily throughout issue #3652, while every user on a folded-shut
+ * MacBook was unable to register a passkey at all.
+ *
+ * The most useful knob in here is `performsUserVerification`. A real
+ * authenticator sets the UV bit in its authenticator data when it has actually
+ * checked who is holding it -- a fingerprint, a face, a PIN, a system password
+ * -- and leaves the bit CLEAR when it has no way to. Passing `false` models:
+ *
+ *   - a MacBook running folded shut on an external display ("clamshell"), the
+ *     configuration in the bug report, whose Touch ID sensor is unreachable;
+ *   - a plain USB security key with no PIN set;
+ *   - Windows Hello on a desktop with no camera and no reader.
+ *
+ * Every one of those responses is valid, and every one is what the server
+ * ASKED for by sending `userVerification: "preferred"`. Which is why the
+ * fixture has to be able to produce them.
+ */
+
+/*
+ * --------------------------------------------------------------------------
+ * CBOR, restricted to the handful of types a WebAuthn credential is made of.
+ *
+ * Attestation objects and COSE keys are CBOR, so producing an attestation the
+ * server can parse means encoding it. RFC 8949 is large; this covers unsigned
+ * integers, negative integers (COSE labels are negative), byte strings, text
+ * strings and maps, which is all of it that appears here.
+ * ------------------------------------------------------------------------
+ */
+
+export type CborValue = number | string | Buffer | Map<CborValue, CborValue>;
+
+type EncodeCborHeadFunction = (majorType: number, value: number) => Buffer;
+
+const encodeCborHead: EncodeCborHeadFunction = (
+  majorType: number,
+  value: number,
+): Buffer => {
+  const type: number = majorType << 5;
+
+  if (value < 24) {
+    return Buffer.from([type | value]);
+  }
+
+  if (value < 0x100) {
+    return Buffer.from([type | 24, value]);
+  }
+
+  if (value < 0x10000) {
+    const bytes: Buffer = Buffer.alloc(3);
+    bytes[0] = type | 25;
+    bytes.writeUInt16BE(value, 1);
+    return bytes;
+  }
+
+  const bytes: Buffer = Buffer.alloc(5);
+  bytes[0] = type | 26;
+  bytes.writeUInt32BE(value, 1);
+  return bytes;
+};
+
+export type EncodeCborFunction = (value: CborValue) => Buffer;
+
+export const encodeCbor: EncodeCborFunction = (value: CborValue): Buffer => {
+  if (typeof value === "number") {
+    /*
+     * Major type 0 is a non-negative integer; major type 1 is a negative one
+     * encoded as -1 - n, which is how COSE labels such as -2 (the x
+     * coordinate) travel.
+     */
+    return value >= 0
+      ? encodeCborHead(0, value)
+      : encodeCborHead(1, -value - 1);
+  }
+
+  if (typeof value === "string") {
+    return Buffer.concat([
+      encodeCborHead(3, Buffer.byteLength(value, "utf8")),
+      Buffer.from(value, "utf8"),
+    ]);
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return Buffer.concat([encodeCborHead(2, value.length), value]);
+  }
+
+  if (value instanceof Map) {
+    const parts: Array<Buffer> = [encodeCborHead(5, value.size)];
+
+    for (const [key, entry] of value.entries()) {
+      parts.push(encodeCbor(key));
+      parts.push(encodeCbor(entry));
+    }
+
+    return Buffer.concat(parts);
+  }
+
+  throw new Error(`Cannot CBOR encode ${typeof value}`);
+};
+
+/*
+ * --------------------------------------------------------------------------
+ * Encodings the browser uses on the wire.
+ * ------------------------------------------------------------------------
+ */
+
+export type ToBase64UrlFunction = (bytes: Buffer) => string;
+
+export const toBase64Url: ToBase64UrlFunction = (bytes: Buffer): string => {
+  return bytes.toString("base64url");
+};
+
+/*
+ * --------------------------------------------------------------------------
+ * Authenticator data.
+ *
+ * The flags byte is the whole reason this file exists, so it is spelled out
+ * rather than passed in as a number: UP is bit 0, UV is bit 2, BE and BS are
+ * bits 3 and 4, and AT -- attested credential data is appended -- is bit 6.
+ * ------------------------------------------------------------------------
+ */
+
+const FLAG_USER_PRESENT: number = 0x01;
+const FLAG_USER_VERIFIED: number = 0x04;
+const FLAG_BACKUP_ELIGIBLE: number = 0x08;
+const FLAG_BACKED_UP: number = 0x10;
+const FLAG_ATTESTED_CREDENTIAL_DATA: number = 0x40;
+
+/** The all-zero AAGUID a "none" attestation is required to report. */
+const ANONYMOUS_AAGUID: Buffer = Buffer.alloc(16, 0);
+
+export type SecurityKeyOptions = {
+  /** The relying party id the credential is scoped to, e.g. "example.com". */
+  rpId: string;
+
+  /** The origin the browser will put in client data, e.g. "https://example.com". */
+  origin: string;
+
+  /*
+   * Whether this authenticator can actually check who is holding it. `false`
+   * is the clamshell MacBook, the PIN-less USB key, the reader-less desktop.
+   */
+  performsUserVerification: boolean;
+
+  /*
+   * A synced passkey (iCloud Keychain, a password manager) reports itself as
+   * multi-device and backed up. A key soldered into one machine does not.
+   * Left off, the credential is a single-device one.
+   */
+  isMultiDevice?: boolean | undefined;
+
+  /*
+   * The signature counter the authenticator reports. Platform authenticators
+   * and passkeys generally report 0 forever; discrete keys increment.
+   */
+  signCount?: number | undefined;
+};
+
+/** A registration response, shaped exactly as the browser hands it over. */
+export type RegistrationResponse = {
+  id: string;
+  rawId: string;
+  response: {
+    clientDataJSON: string;
+    attestationObject: string;
+    transports: Array<string>;
+  };
+  type: string;
+  clientExtensionResults: Record<string, unknown>;
+};
+
+/** An authentication response, shaped exactly as the browser hands it over. */
+export type AuthenticationResponse = {
+  id: string;
+  rawId: string;
+  response: {
+    clientDataJSON: string;
+    authenticatorData: string;
+    signature: string;
+    userHandle: string | null;
+  };
+  type: string;
+  clientExtensionResults: Record<string, unknown>;
+};
+
+export type SecurityKey = {
+  /** The credential id, base64url, exactly as `credential.id` reaches the server. */
+  credentialId: string;
+
+  /** The COSE-encoded public key, base64, as the `UserWebAuthn` row stores it. */
+  publicKeyAsStored: string;
+
+  /** Whether this authenticator verifies its user -- what the UV bit will say. */
+  performsUserVerification: boolean;
+
+  /**
+   * navigator.credentials.create(). `challenge` is the base64url string the
+   * browser puts into client data, which is what the server compares against.
+   */
+  register: (data: { challenge: string }) => RegistrationResponse;
+
+  /** navigator.credentials.get(), signing with the key minted at registration. */
+  authenticate: (data: {
+    challenge: string;
+    signCount?: number | undefined;
+  }) => AuthenticationResponse;
+};
+
+type CreateSecurityKeyFunction = (options: SecurityKeyOptions) => SecurityKey;
+
+export const createSecurityKey: CreateSecurityKeyFunction = (
+  options: SecurityKeyOptions,
+): SecurityKey => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", {
+    namedCurve: "prime256v1",
+  });
+
+  const credentialIdBytes: Buffer = crypto.randomBytes(32);
+
+  /*
+   * COSE_Key for ES256 (RFC 8152): kty=EC2(2), alg=ES256(-7), crv=P-256(1),
+   * and the two 32-byte coordinates under the negative labels -2 and -3.
+   */
+  /*
+   * Typed locally rather than as `crypto.JsonWebKey`: App and Common compile
+   * against different @types/node, and the older of the two does not export
+   * that name. Only the two coordinates are needed here anyway.
+   */
+  const jwk: { x?: string | undefined; y?: string | undefined } =
+    publicKey.export({ format: "jwk" }) as {
+      x?: string | undefined;
+      y?: string | undefined;
+    };
+
+  const cosePublicKey: Buffer = encodeCbor(
+    new Map<CborValue, CborValue>([
+      [1, 2],
+      [3, -7],
+      [-1, 1],
+      [-2, Buffer.from(jwk.x as string, "base64url")],
+      [-3, Buffer.from(jwk.y as string, "base64url")],
+    ]),
+  );
+
+  const rpIdHash: Buffer = crypto
+    .createHash("sha256")
+    .update(options.rpId)
+    .digest();
+
+  type BuildFlagsFunction = (data: { attested: boolean }) => number;
+
+  const buildFlags: BuildFlagsFunction = (data: {
+    attested: boolean;
+  }): number => {
+    /*
+     * UP is always set: something touched the key. UV is set only when the
+     * authenticator could actually establish WHO touched it, which is the
+     * distinction this whole fixture exists to make.
+     */
+    let flags: number = FLAG_USER_PRESENT;
+
+    if (options.performsUserVerification) {
+      flags |= FLAG_USER_VERIFIED;
+    }
+
+    if (options.isMultiDevice) {
+      flags |= FLAG_BACKUP_ELIGIBLE | FLAG_BACKED_UP;
+    }
+
+    if (data.attested) {
+      flags |= FLAG_ATTESTED_CREDENTIAL_DATA;
+    }
+
+    return flags;
+  };
+
+  type BuildAuthenticatorDataFunction = (data: {
+    attested: boolean;
+    signCount: number;
+  }) => Buffer;
+
+  const buildAuthenticatorData: BuildAuthenticatorDataFunction = (data: {
+    attested: boolean;
+    signCount: number;
+  }): Buffer => {
+    const counter: Buffer = Buffer.alloc(4);
+    counter.writeUInt32BE(data.signCount, 0);
+
+    const header: Buffer = Buffer.concat([
+      rpIdHash,
+      Buffer.from([buildFlags({ attested: data.attested })]),
+      counter,
+    ]);
+
+    if (!data.attested) {
+      return header;
+    }
+
+    const credentialIdLength: Buffer = Buffer.alloc(2);
+    credentialIdLength.writeUInt16BE(credentialIdBytes.length, 0);
+
+    return Buffer.concat([
+      header,
+      ANONYMOUS_AAGUID,
+      credentialIdLength,
+      credentialIdBytes,
+      cosePublicKey,
+    ]);
+  };
+
+  type BuildClientDataFunction = (data: {
+    type: string;
+    challenge: string;
+  }) => Buffer;
+
+  const buildClientData: BuildClientDataFunction = (data: {
+    type: string;
+    challenge: string;
+  }): Buffer => {
+    return Buffer.from(
+      JSON.stringify({
+        type: data.type,
+        challenge: data.challenge,
+        origin: options.origin,
+        crossOrigin: false,
+      }),
+      "utf8",
+    );
+  };
+
+  const defaultSignCount: number = options.signCount ?? 0;
+
+  return {
+    credentialId: toBase64Url(credentialIdBytes),
+    publicKeyAsStored: cosePublicKey.toString("base64"),
+    performsUserVerification: options.performsUserVerification,
+
+    register: (data: { challenge: string }): RegistrationResponse => {
+      const authenticatorData: Buffer = buildAuthenticatorData({
+        attested: true,
+        signCount: defaultSignCount,
+      });
+
+      /*
+       * "none" attestation: the authenticator vouches for nothing beyond the
+       * key material, which is what the server asks for
+       * (attestationType: "none") and what every passkey returns.
+       */
+      const attestationObject: Buffer = encodeCbor(
+        new Map<CborValue, CborValue>([
+          ["fmt", "none"],
+          ["attStmt", new Map<CborValue, CborValue>()],
+          ["authData", authenticatorData],
+        ]),
+      );
+
+      return {
+        id: toBase64Url(credentialIdBytes),
+        rawId: toBase64Url(credentialIdBytes),
+        response: {
+          clientDataJSON: toBase64Url(
+            buildClientData({
+              type: "webauthn.create",
+              challenge: data.challenge,
+            }),
+          ),
+          attestationObject: toBase64Url(attestationObject),
+          transports: ["internal"],
+        },
+        type: "public-key",
+        clientExtensionResults: {},
+      };
+    },
+
+    authenticate: (data: {
+      challenge: string;
+      signCount?: number | undefined;
+    }): AuthenticationResponse => {
+      const authenticatorData: Buffer = buildAuthenticatorData({
+        attested: false,
+        signCount: data.signCount ?? defaultSignCount,
+      });
+
+      const clientData: Buffer = buildClientData({
+        type: "webauthn.get",
+        challenge: data.challenge,
+      });
+
+      /*
+       * The assertion signature covers the authenticator data concatenated
+       * with the SHA-256 of the client data -- so a fixture that got the
+       * flags byte wrong could not produce a signature the server accepts,
+       * and the UV bit under test is genuinely bound into the signature
+       * rather than being an assertion about a field nobody checks.
+       */
+      const signature: Buffer = crypto.sign(
+        "sha256",
+        Buffer.concat([
+          authenticatorData,
+          crypto.createHash("sha256").update(clientData).digest(),
+        ]),
+        privateKey,
+      );
+
+      return {
+        id: toBase64Url(credentialIdBytes),
+        rawId: toBase64Url(credentialIdBytes),
+        response: {
+          clientDataJSON: toBase64Url(clientData),
+          authenticatorData: toBase64Url(authenticatorData),
+          signature: toBase64Url(signature),
+          userHandle: null,
+        },
+        type: "public-key",
+        clientExtensionResults: {},
+      };
+    },
+  };
+};
+
+/*
+ * The two authenticators the bug is about, named so tests read as scenarios
+ * rather than as flag arithmetic.
+ */
+
+export type BuildSecurityKeyFunction = (options: {
+  rpId: string;
+  origin: string;
+}) => SecurityKey;
+
+/** A laptop at a desk, lid open: Touch ID is reachable, so UV is set. */
+export const securityKeyThatVerifiesTheUser: BuildSecurityKeyFunction =
+  (options: { rpId: string; origin: string }): SecurityKey => {
+    return createSecurityKey({
+      rpId: options.rpId,
+      origin: options.origin,
+      performsUserVerification: true,
+      isMultiDevice: true,
+    });
+  };
+
+/** The same laptop folded shut on an external display: UV is left clear. */
+export const securityKeyInClamshellMode: BuildSecurityKeyFunction = (options: {
+  rpId: string;
+  origin: string;
+}): SecurityKey => {
+  return createSecurityKey({
+    rpId: options.rpId,
+    origin: options.origin,
+    performsUserVerification: false,
+    isMultiDevice: true,
+  });
+};

--- a/Common/Tests/__mocks__/simplewebauthn.js
+++ b/Common/Tests/__mocks__/simplewebauthn.js
@@ -1,4 +1,26 @@
-// Mock for @simplewebauthn/server package
+/*
+ * Mock for the @simplewebauthn/server package, wired in through
+ * `moduleNameMapper` in Common/jest.config.json rather than through
+ * jest.mock(), so every Common test that reaches UserWebAuthnService gets it
+ * without asking.
+ *
+ * THE RETURN SHAPES MATTER. `registrationInfo.credential` is the v13 shape --
+ * v7 and earlier put `credentialID` / `credentialPublicKey` at the top of
+ * `registrationInfo`, and UserWebAuthnService reads the v13 one. A stub left
+ * on the old shape does not fail loudly; it hands the service `undefined` and
+ * the row is written with no credential id at all.
+ *
+ * WHAT THIS STUB CANNOT TELL YOU. It has no opinion about
+ * `requireUserVerification`, which is exactly the library default that caused
+ * issue #3652 -- so a test of that behaviour written against this stub would
+ * have passed before the fix and after it. The end-to-end test of that lives
+ * in App/Tests/FeatureSet/Identity/WebAuthnUserVerification.test.ts, where the
+ * REAL library runs; what belongs here is assertions about the arguments the
+ * service passes in.
+ */
+
+const MOCK_CREDENTIAL_ID = "mock-credential-id";
+
 module.exports = {
   generateRegistrationOptions: jest.fn().mockResolvedValue({
     challenge: "mock-challenge",
@@ -13,9 +35,14 @@ module.exports = {
   verifyRegistrationResponse: jest.fn().mockResolvedValue({
     verified: true,
     registrationInfo: {
-      credentialID: Buffer.from("mock-credential-id"),
-      credentialPublicKey: Buffer.from("mock-public-key"),
-      counter: 0,
+      credential: {
+        id: MOCK_CREDENTIAL_ID,
+        publicKey: Buffer.from("mock-public-key"),
+        counter: 0,
+        transports: ["internal"],
+      },
+      credentialDeviceType: "singleDevice",
+      credentialBackedUp: false,
     },
   }),
   generateAuthenticationOptions: jest.fn().mockResolvedValue({
@@ -29,6 +56,8 @@ module.exports = {
     verified: true,
     authenticationInfo: {
       newCounter: 1,
+      credentialID: MOCK_CREDENTIAL_ID,
+      userVerified: false,
     },
   }),
 };


### PR DESCRIPTION
Fixes #3652, plus four hardening fixes on the same surface that the investigation turned up.

## 1. The reported bug — passkey registration fails in clamshell mode

A MacBook running folded shut on an external display cannot reach its Touch ID sensor. Registering a passkey from one failed with a bare `Server Error`, and this in the log:

```
Error: User verification was required, but user could not be verified
    at verifyRegistrationResponse (.../verifyRegistrationResponse.js:122:15)
    at async Service.verifyRegistration (Common/Server/Services/UserWebAuthnService.ts:143:31)
```

I reproduced it against the real `@simplewebauthn/server` 13.2.2 rather than taking the report on trust.

**Cause.** The user-verification policy lived in two places and had drifted apart. `generateRegistrationOptions` asks for `userVerification: "preferred"`, which tells the authenticator that going ahead **without** verifying the user is acceptable — so the browser returns a perfectly valid credential with the UV bit clear, exactly as invited. Verification then called `verifyRegistrationResponse` without `requireUserVerification`, and the library defaults that to `true`. The server refused the very response its own options had asked for.

**The same defect breaks sign-in**, which nobody reported because nobody got that far. `verifyAuthenticationResponse` carries the identical default, so a key enrolled at a desk could not sign in from the same laptop later — and the password has already been accepted by then, so that is a locked account rather than a failed setup. A registration-only fix would have moved the lockout, not removed it.

Clamshell is not the only way in: a USB security key with no PIN, or Windows Hello on a desktop with no camera or reader, produce the same UV-clear response.

**Fix.** Both call sites derive their strictness from the one constant that states the policy. The drift between the ask and the check *is* the bug, so tying them together means raising the policy to `"required"` cannot leave verification behind, and relaxing it cannot leave verification ahead.

`"preferred"` stays. A security key is OneUptime's **second** factor, behind a password — demanding user verification buys a second proof of the same person while locking out every authenticator that has no reader, no camera and no PIN. Raising the options to `"required"` instead was considered and rejected: it turns the server error into a browser-side failure the clamshell user still cannot satisfy.

### The other half of the report: `Server Error`

The library signals every refusal by throwing a plain `Error`. The last-resort handler in `StartServer.ts` has no branch for one — it falls through to `res.status(500).send({ error: "Server Error" })` and **discards the message**. Every WebAuthn failure looked identical from the browser, which is why this needed a bug report rather than a glance at the screen. Library refusals now arrive as `BadDataException` carrying the library's own sentence, so a reverse proxy serving a different origin than `HOST` claims is diagnosable by the self-hoster who has to fix it. Exceptions raised by the service pass through unchanged.

## 2. The anonymous challenge route was unmetered, and answered too much

`POST /user-webauthn/generate-authentication-options` has to be anonymous — it is where the challenge a security key signs comes from, needed before any assertion exists to prove who is asking. But anonymous and unmetered are different things, and it was both: it takes an email address and, for that address, **writes** a challenge to the user's row, as fast as the process would answer.

It now sits behind `IdentityRateLimit` in **its own bucket**. Not the two-factor one — this route is the step immediately *before* `/verify-webauthn-auth`, so a shared pool would mean every challenge a user asked for spent an attempt they had not yet made, and a user who had just exhausted the budget failing at their key could not get a fresh challenge to retry with. The step that enables an attempt must not be spendable by the attempts it enables; that is the reasoning the recovery bucket already carries.

⚠️ It now fails closed with the rest of the identity surface, so a Redis outage refuses security-key sign-in one step earlier than before. Not a new lockout class — `/verify-webauthn-auth` already 503s in that state.

The same route answered `User not found` for an unregistered address and `No WebAuthn credentials found for this user` for one that exists without a key — an account-existence oracle plus a second one naming which accounts are protected by hardware, free to anyone who can send a POST. Every other door here already refuses to say that much. Both now give one answer; a real user only arrives here after their password, from a list of their own keys.

It was also returning the account's **real row id** in the success payload, so anyone who could name an email with a key on it got that id back — which would have undone half the change above, since a success carrying the internal id says rather more than "this account exists". Nothing ever read it: the browser posts the assertion to `/verify-webauthn-auth` with the email and password again, and that route takes the user from the password it has just verified, never from the body. The field is gone, and the test asserts the whole response key set rather than the absence of one field, because the next thing added to that return reaches anonymous callers too.

**What the limiter bounds but does not close** — stated here because the code now says it too. The write is not junk: it is the challenge the user's key is about to sign, in the single slot that holds it, so an overwrite landing between someone's generate and their verify makes the library reject an assertion that was correct. The account counter is keyed on the address the request came *from*, as it must be (a bare per-account counter is itself a lockout weapon), so an attacker with several source addresses gets the budget from each. Splitting the challenge slots stopped the two *flows* destroying each other; it does not stop two authentication requests for one account, which still share one slot. Closing that means the challenge ceasing to be a single overwritable row — a larger change, not attempted here.

## 3. Registration and signing in shared one challenge slot

Both wrote `User.webauthnChallenge`, and the reader **clears** what it reads — so whichever ceremony moved last destroyed the other's challenge. Registration is keyed by the session's user and signing in by an email address, but both land on the same row: a user adding a second key with a stale sign-in page open in another tab lost the registration they were halfway through, and got "No pending WebAuthn challenge found" for a key they were holding and touching. The anonymous route above made it reachable by strangers too.

Two named slots now. The old pair is **dropped** rather than kept as the sign-in one: a column whose name does not say which flow owns it is exactly how the two came to share it, and keeping it would leave a value written by a pre-deploy registration to be read afterwards as a sign-in challenge. Nothing durable is lost — these hold a single-use value with a five-minute TTL, so the worst case is a user mid-ceremony as the deploy lands being told to start again, which is what the message already says.

Migration: `1791800000000-SplitWebAuthnChallengeByPurpose`, generated (not hand-written) and registered in `SchemaMigrations/Index.ts`.

## 4. The relying party id carried HOST's port

`expectedOrigin` and `rpID` were built from the same `HOST` and are not the same string. The origin **must** carry the port — it is what the browser puts in its client data — and the RP ID **must not**, because the spec defines it as a domain and a browser handed `host:port` refuses the call outright.

Every shipped default is portless, so hosted OneUptime is untouched. But a port-carrying `HOST` is mandatory for any self-hosted instance not on 80/443, and on those WebAuthn did not work at all. Nothing is invalidated by fixing it: on exactly the deployments this changes, no credential could ever be created, and where `HOST` has no port it is the identity function.

## 5. The counter and transports were hard-coded

Registration wrote `counter: "0"` and `transports: "[]"` whatever the authenticator said. The library only compares counters when one side is above zero, so a discarded non-zero counter was exactly the clone detection that credential was eligible for.

Both now come from the response — which for transports means the browser has to send them, so the dashboard calls `getTransports()` defensively, and `allowCredentials` hands them back (the only place a browser reads them). Credentials registered before this send **no** transports member rather than an empty array: an empty hint excludes every transport, and Chromium filters on the hint when present.

The counter change has a tail, named in the code: an authenticator reporting the *same* counter at registration and at its first assertion now fails where a stored 0 waved it through. A spec-compliant key increments on every assertion; if one does not, the way back in is a backup code and re-registering. The alternative is leaving clone detection permanently off.

## Tests — 65 new

`Common/Tests/Server/TestingUtils/SecurityKey.ts` is a stand-in for a real authenticator, built from the WebAuthn and CTAP specs with Node crypto — CBOR encoder, COSE key, authenticator-data flags, real ES256 signatures. It imports nothing from `@simplewebauthn/server`, following the reasoning of the existing `AuthenticatorApp` fixture: a fixture produced by the library under test proves only that the library agrees with itself. Its `performsUserVerification` knob is the clamshell MacBook.

**`App/Tests/FeatureSet/Identity/WebAuthnUserVerification.test.ts` (39 tests)** runs the **real** v13 library end to end, with only Postgres stubbed. It lives in `App/Tests` because Common's jest config maps `@simplewebauthn/server` to a stub — and a stub has no library default to exhibit, so a test written there would have passed before this fix and after it.

**Every fix was verified to fail without it.** Reverting all five changes turns 19 tests red across the five areas — including, for #3652, the exact reported error on both registration and sign-in — while the safety-property tests (origin, relying party, challenge freshness, one-time use, private-key possession) pass either way. Removing one check must not quietly remove five.

The end-to-end suite carries the property no single-flow assertion can catch: two live ceremonies driven through the real service over one row, showing neither destroys the other. Plus the RP ID stripped while the origin keeps its port — asserted together, since a credential scoped to the bare domain has to verify against the ported origin.

**`Common/Tests/Server/Services/UserWebAuthnUserVerification.test.ts` (19 tests)** holds the column-level half — which slot each flow writes, reads and clears — and the invariant that is invisible end to end: that the ask and the check describe the same policy, read straight off the arguments handed to the library.

**`Common/Tests/Server/API/UserWebAuthnAuthenticationOptionsRoute.test.ts` (10 tests)** pins the limiter to the anonymous route by identity, keeps it off the two authenticated ones, and asserts the bucket is its own — the switch it hangs off ends in an unguarded `return LOGIN_BUCKET`, so a bucket added without a branch silently gets the password budget and nothing else would say so.

The shared `simplewebauthn` stub also returned the v7 `registrationInfo` shape while the service reads the v13 one; it would have handed a naive future test `undefined` instead of a credential id rather than failing loudly.

## Verification

- `npm run fix` and `npm run compile` clean in both `Common` and `App`.
- Full `App/Tests/FeatureSet/Identity` suite: **356 passed**. Common identity-adjacent suites: **133 passed**.
- Migration applied to a database carrying every registered migration, then a generate against the result: **"No changes in database schema were found"** — the same check CI's drift job runs.
