### PR TITLE
fix(discovery): apply a new auto-import rule to results already discovered

### DIFF
--- a/App/FeatureSet/BaseAPI/API/NetworkRuleRun.ts
+++ b/App/FeatureSet/BaseAPI/API/NetworkRuleRun.ts
@@ -55,10 +55,13 @@ import DatabaseBaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/Da
  * reaches any of it, and short of deleting and rediscovering every
  * device there was no way to close that gap — OneUptime/oneuptime#3191.
  * These endpoints apply one rule to the devices that already exist.
- * Auto-import rules have the same gap in time instead of space: the
- * worker only processes NEW scan results, so their Run Now applies one
- * rule to the completed scans already sitting in the project — and its
- * dryRun flag is the answer to "what would this rule import" BEFORE
+ * Auto-import rules have a narrower version of the same gap, in time
+ * instead of space: the worker only processes NEW scan results. Writing
+ * a rule now re-arms the project's results from the last 24 hours so
+ * the sweep applies it to them (issue #3487), which leaves this Run Now
+ * for what that deliberately will not touch — results older than that
+ * horizon, and a re-run over the whole project on demand. Its dryRun
+ * flag remains the answer to "what would this rule import" BEFORE
  * enabling it against live scans.
  *
  * All of these mutate network devices, so all demand the permission to

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/AutoImportRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/AutoImportRules.tsx
@@ -38,9 +38,21 @@ import {
 const networkDeviceAutoImportDocumentation: string = `
 ### How Auto Import Rules Work
 
-Auto Import Rules turn discovery scan results into Network Devices automatically — matching hosts are imported the moment a scan completes, with no manual "Review Results → Import" step. Site assignment, owner, and label rules then apply to the imported devices automatically.
+Auto Import Rules turn discovery scan results into Network Devices automatically — matching hosts are imported as a scan reports them, with no manual "Review Results → Import" step. Site assignment, owner, and label rules then apply to the imported devices automatically.
 
 An import rule can also select a **Network Device Monitor Template**. That opt-in completes the alerting pipeline: OneUptime creates an active monitor for each matching SNMP device, copies the template's criteria, interval, minimum probe agreement, custom fields and monitor labels, and then applies the normal Monitor Label and Owner Rules. Existing rules with no template remain inventory-only.
+
+### When Rules Run
+
+Rules have no schedule of their own because they do not need one — they run off scan results, and OneUptime checks for results to import every minute. A rule runs:
+
+- **As a scan reports hosts.** Every result a probe uploads is evaluated against the project's rules within about a minute, including the partial results a long sweep uploads while it is still running. A discovery scan with **Repeat this scan** turned on therefore imports newly discovered hosts on every rescan, with nobody pressing anything.
+- **When you create or change a rule.** Saving a rule re-offers the project's recent scan results to it, so a rule you write today applies to hosts discovered today — you do not have to run the scan again to see what the rule does.
+- **When you press Run Now**, described below.
+
+Results older than 24 hours are not imported automatically: an hours-old host list is the wrong thing to act on by surprise, so old results stay Run Now's job.
+
+Every host is checked against the project's inventory by IP address before anything is created. A host whose address already has a Network Device is skipped — repeating a scan, running a rule twice, and editing a rule all reconcile rather than duplicate.
 
 ### Match Criteria
 
@@ -70,7 +82,7 @@ An exclusion rule inverts the match: hosts it matches are **never** auto-importe
 
 ### Dry Run and Run Now
 
-Rules fire automatically when a discovery scan completes. **Run Now** applies a rule to completed scans already in the project, including backfilling a selected template monitor for an already-registered matching device. **Dry Run** performs the same reconciliation but writes nothing — it answers what would be imported and which monitors would be created before you trust the rule. It also works on a **disabled** rule. Device and monitor creation are idempotent, so running a rule more than once is safe.
+Rules run by themselves (see **When Rules Run** above); these two buttons are for doing it deliberately. **Run Now** applies a rule to every scan already in the project — including results older than the 24-hour horizon automatic imports stop at, and including backfilling a selected template monitor for an already-registered matching device. **Dry Run** performs the same reconciliation but writes nothing — it answers what would be imported and which monitors would be created before you trust the rule. It also works on a **disabled** rule. Device and monitor creation are idempotent, so running a rule more than once is safe.
 `;
 
 const NetworkDeviceAutoImportRulesPage: FunctionComponent<

--- a/App/FeatureSet/Docs/Content/en/monitor/network-device-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/network-device-monitor.md
@@ -410,13 +410,22 @@ Template](#oid-collection-templates) the devices it imports are given. A rule
 marked as an **exclusion** claims nothing and vetoes the others, which is how
 printers and phones are carved out of a broad subnet rule.
 
-Enabled rules run by themselves against each scan's results as they arrive —
-including the partial results a long sweep uploads while it is still running,
-so hosts are importable within a minute of being found rather than at the end
-of the range.
+Rules have no schedule of their own, and do not need one. Enabled rules run by
+themselves against each scan's results as they arrive — including the partial
+results a long sweep uploads while it is still running, so hosts are
+importable within a minute of being found rather than at the end of the range.
+Turn on **Repeat this scan** on a discovery scan and the pair becomes a
+standing arrangement: the scan re-sweeps its range on your interval, and every
+new host it finds is imported without anyone pressing anything.
 
-Two buttons on a rule reach the scans that are *already* in the project, which
-is what you want after writing or editing a rule:
+Saving a rule also applies it to the results the project *already* has. A rule
+you write or enable today reaches hosts discovered in the last 24 hours within
+about a minute, so a rule written after a one-shot scan is not left waiting for
+a scan that will never run again. Results older than that are left alone —
+importing an estate discovered last month is a decision, not a side effect of
+saving a rule — and the buttons below are how you make it.
+
+Two buttons on a rule reach *every* scan in the project, however old:
 
 - **Dry Run** evaluates every completed scan and reports what the rule would
   import and monitor. Nothing is written, so it is the safe way to answer "what

--- a/Common/Server/Services/NetworkDeviceAutoImportRuleEngineService.ts
+++ b/Common/Server/Services/NetworkDeviceAutoImportRuleEngineService.ts
@@ -52,13 +52,18 @@ import logger, { LogAttributes } from "../Utils/Logger";
  * then apply themselves through NetworkDeviceService.onCreateSuccess's
  * existing rule chain, exactly as they do for a manual import.
  *
- * Two entry points, mirroring the label-rule engine:
+ * Three entry points, the first two mirroring the label-rule engine:
  *
  *   - processCompletedScan: the automatic path, called by the
  *     NetworkDeviceDiscovery worker for each Completed scan whose
  *     autoImportProcessedAt marker is NULL.
  *   - applyRuleToCompletedScans: the manual "Run Now" (and its dry run),
  *     applying ONE rule to the project's existing completed scans.
+ *   - rearmRecentScansForRuleChange: called when a rule is written, it
+ *     imports nothing itself — it clears the marker on the project's recent
+ *     results so the automatic path above evaluates them against the rule
+ *     that just changed, instead of the operator having to press Run Now
+ *     (issue #3487).
  *
  * Everything here is idempotent by construction: a device exists per
  * (project, address), recurring scans re-report the same hosts every
@@ -119,6 +124,15 @@ export const MAX_MONITORS_PER_AUTO_IMPORT_RUN: number = 500;
 
 // Scans one manual "Run Now" will read, oldest results last.
 export const MAX_SCANS_PER_AUTO_IMPORT_RULE_RUN: number = 100;
+
+/*
+ * Scans one rule write re-arms — see rearmRecentScansForRuleChange. The same
+ * ceiling as a manual run's, because it feeds the same work: a project whose
+ * subnets are swept by more fresh scans than this has its newest results
+ * re-armed and the rest left to "Run Now", rather than a rule save turning
+ * into an unbounded burst of writes.
+ */
+export const MAX_SCANS_REARMED_PER_RULE_WRITE: number = 100;
 
 /*
  * How many monitor creates may fail IDENTICALLY, back to back with no success
@@ -427,6 +441,123 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
     });
 
     return result;
+  }
+
+  /*
+   * The third way stored results become importable, alongside a new upload
+   * and a manual "Run Now": the RULES changed.
+   *
+   * The sweep is driven entirely by the marker — it looks only at scans whose
+   * autoImportProcessedAt is NULL — so results the engine has already
+   * evaluated are, as far as the worker is concerned, finished with. That is
+   * right for results evaluated against the rules the project HAS, and wrong
+   * the moment somebody writes a new one: the rule an operator just authored
+   * has nothing left to apply to until a scan reports again. In a project
+   * whose scans are one-shot, that is never — so a brand-new rule appears to
+   * do nothing at all and the operator is left pressing Run Now by hand,
+   * which is what OneUptime issue #3487 reported as "auto import rules have
+   * no schedule".
+   *
+   * Clearing the marker on the project's recent results hands them back to
+   * the sweep, which applies the FULL rule set to them within a minute —
+   * same pass, same lock, same idempotency as any other tick. Nothing is
+   * imported here: this method writes one column and no devices, so a rule
+   * save stays a rule save and the minutes of paced import work stay in the
+   * worker where a crash is resumable.
+   *
+   * Bounded to results still inside the engine's own freshness horizon
+   * (MAX_RESULT_AGE_IN_HOURS), which preserves exactly the guarantee that
+   * stamping rule-less projects exists to give: a first rule can never
+   * mass-import an estate discovered months ago. Older results remain Run
+   * Now's business, where "import these old hosts" is a deliberate click.
+   *
+   * Returns how many scans were re-armed. It may throw — the callers are rule
+   * writes, and they catch and log rather than fail an operator's save over a
+   * re-arm that can be had again from the next scan result or from Run Now.
+   */
+  @CaptureSpan()
+  public async rearmRecentScansForRuleChange(data: {
+    projectId: ObjectID;
+  }): Promise<number> {
+    const scanStubs: Array<NetworkDeviceDiscoveryScan> =
+      await NetworkDeviceDiscoveryScanService.findBy({
+        query: {
+          projectId: data.projectId,
+          /*
+           * A scan that is still sweeping counts, for the reason its partial
+           * results are importable at all: those hosts have been found.
+           */
+          status: QueryHelper.any(DISCOVERY_SCAN_IMPORTABLE_STATUSES),
+          /*
+           * Only STAMPED scans need re-arming. One whose marker is already
+           * NULL is queued for the next tick as it stands, and clearing it
+           * again would be a write that changes nothing.
+           */
+          autoImportProcessedAt: QueryHelper.notNull(),
+          /*
+           * Fresh results only — the horizon processCompletedScan enforces
+           * anyway, applied here so a rule save does not re-arm scans the
+           * sweep would only retire again (one pointless write per scan, and
+           * a "too old to auto-import" warning per scan in the log).
+           * completedAt is NULL while a scan is still sweeping, and those
+           * results are the freshest the project has.
+           */
+          completedAt: QueryHelper.greaterThanEqualToOrNull(
+            OneUptimeDate.getSomeHoursAgo(MAX_RESULT_AGE_IN_HOURS),
+          ),
+        },
+        select: {
+          _id: true,
+        },
+        // Newest results first, so a capped re-arm keeps the ones that matter.
+        sort: {
+          completedAt: SortOrder.Descending,
+        },
+        limit: MAX_SCANS_REARMED_PER_RULE_WRITE,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+
+    for (const scanStub of scanStubs) {
+      /*
+       * The same hook-free single statement the ingest endpoint clears this
+       * marker with, and for the same reasons (see stampScan) — but
+       * deliberately WITHOUT refreshing updatedAt. On an In Progress scan
+       * that column is the "has this probe gone silent" clock the stale-scan
+       * reaper reads (Workers/Jobs/NetworkDeviceDiscovery/
+       * RequeueRecurringScans.ts); a rule save is not the probe saying
+       * something, and bumping it would postpone the rescue of a scan whose
+       * probe had already died.
+       *
+       * No compare-and-set, because the query above already excludes the row
+       * every racing writer is interested in: the sweep only ever reads scans
+       * whose marker is NULL, and these are the ones whose marker is set. The
+       * one interleaving left is ingest clearing the marker between the read
+       * and this write and a sweep consuming those new results — and that
+       * sweep loads its rules after the rule write that brought us here, so
+       * it applies them. Re-clearing behind it costs one more pass over
+       * results whose devices already exist.
+       */
+      await NetworkDeviceDiscoveryScanService.updateColumnsByIdWithoutHooks({
+        id: scanStub.id!,
+        // Cast: the model's JSON column makes DeepPartial recursion blow up.
+        data: {
+          autoImportProcessedAt: null,
+        } as unknown as QueryDeepPartialEntity<NetworkDeviceDiscoveryScan>,
+        skipUpdateDateColumn: true,
+      });
+    }
+
+    if (scanStubs.length > 0) {
+      logger.info(
+        `Auto-import: rules changed, so ${scanStubs.length} recent discovery scan result(s) were re-armed; the next sweep will apply the project's rules to them.`,
+        { projectId: data.projectId.toString() } as LogAttributes,
+      );
+    }
+
+    return scanStubs.length;
   }
 
   /*

--- a/Common/Server/Services/NetworkDeviceAutoImportRuleService.ts
+++ b/Common/Server/Services/NetworkDeviceAutoImportRuleService.ts
@@ -1,6 +1,7 @@
 import DatabaseService from "./DatabaseService";
 import MonitorTemplateService from "./MonitorTemplateService";
 import NetworkAlertPolicyService from "./NetworkAlertPolicyService";
+import NetworkDeviceAutoImportRuleEngineService from "./NetworkDeviceAutoImportRuleEngineService";
 import NetworkDeviceOidTemplateService from "./NetworkDeviceOidTemplateService";
 import Model from "../../Models/DatabaseModels/NetworkDeviceAutoImportRule";
 import Monitor from "../../Models/DatabaseModels/Monitor";
@@ -22,6 +23,8 @@ import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCom
 import DatabaseRequestType from "../Types/BaseDatabase/DatabaseRequestType";
 import TablePermission from "../Types/Database/Permissions/TablePermission";
 import NetworkDeviceMonitorTemplateUtil from "../../Utils/Monitor/NetworkDeviceMonitorTemplateUtil";
+import QueryHelper from "../Types/Database/QueryHelper";
+import logger, { LogAttributes } from "../Utils/Logger";
 
 /*
  * Write-time validation for auto-import rules, following the
@@ -58,6 +61,20 @@ function readOidTemplateId(data: Record<string, unknown>): ObjectID | null {
     OID_TEMPLATE_KEYS,
     "OID Collection Template",
   );
+}
+
+/*
+ * What onUpdateSuccess needs to know about an update it did not see the
+ * payload of: did this save change anything about WHICH hosts the rule
+ * claims, or what it does with them?
+ *
+ * Only the answer travels — not the rule's resulting state, which is read
+ * back from the row instead. A payload's `isEnabled` may arrive as the string
+ * "false" from a form post, and a rule mis-read as enabled would re-arm the
+ * project's scans on the very save that switched the rule off.
+ */
+interface AutoImportRuleUpdatePlan {
+  isRuleReachChanged: boolean;
 }
 
 export class Service extends DatabaseService<Model> {
@@ -134,6 +151,28 @@ export class Service extends DatabaseService<Model> {
     );
 
     /*
+     * Everything that can change what this rule imports, or what it creates
+     * for what it imports — the trigger for re-arming the project's recent
+     * scan results in onUpdateSuccess.
+     *
+     * `includePingOnlyHosts` is here even though it is not a "criteria
+     * change" above: it decides whether a whole class of discovered host is
+     * claimed, which is precisely reach. A rename or a description edit is
+     * not, and must not cost the project a sweep.
+     *
+     * The OID template is deliberately absent: it is copied onto devices as
+     * they are created and is not reconciled onto devices that already
+     * exist, so pointing a rule at a different one changes nothing about
+     * results already evaluated.
+     */
+    const plan: AutoImportRuleUpdatePlan = {
+      isRuleReachChanged:
+        isCriteriaChange ||
+        isMonitorProvisioningChange ||
+        dataKeys.includes("includePingOnlyHosts"),
+    };
+
+    /*
      * Validated before the early return and independently of the rest: an OID
      * Collection Template is the collect half of the rule, so pointing at one
      * is legitimate on its own and must not need a criteria or monitor change
@@ -154,7 +193,7 @@ export class Service extends DatabaseService<Model> {
     }
 
     if (!isCriteriaChange && !isMonitorProvisioningChange) {
-      return { updateBy, carryForward: null };
+      return { updateBy, carryForward: plan };
     }
 
     /*
@@ -253,7 +292,142 @@ export class Service extends DatabaseService<Model> {
       }
     }
 
-    return { updateBy, carryForward: null };
+    return { updateBy, carryForward: plan };
+  }
+
+  /*
+   * A rule that can import must not have to wait for the next scan to prove
+   * it — see rearmRecentScansForRuleChange on the engine, and issue #3487.
+   *
+   * The sweep only ever looks at results nothing has evaluated yet, so
+   * without this a rule written after a scan finished reaches nothing at all
+   * until that scan runs again — never, for the one-shot scans most projects
+   * start with — and the operator is left pressing "Run Now" by hand for
+   * work the product describes as automatic.
+   */
+  @CaptureSpan()
+  protected override async onCreateSuccess(
+    onCreate: OnCreate<Model>,
+    createdItem: Model,
+  ): Promise<Model> {
+    this.rearmRecentScansForRules([
+      /*
+       * projectId off the saved row, falling back to the tenant the write
+       * ran under: a create that named the project through the relation
+       * alone still has to reach the right scans.
+       */
+      {
+        projectId: createdItem.projectId || onCreate.createBy.props.tenantId,
+        isEnabled: createdItem.isEnabled,
+        isExclusion: createdItem.isExclusion,
+      },
+    ]);
+
+    return createdItem;
+  }
+
+  /*
+   * The same re-arm for an EDIT that changes what the rule claims: enabling a
+   * rule, widening its criteria, or attaching a monitor template to it all
+   * make the project's recent results answer differently than they did when
+   * the sweep last read them.
+   */
+  @CaptureSpan()
+  protected override async onUpdateSuccess(
+    onUpdate: OnUpdate<Model>,
+    updatedItemIds: Array<ObjectID>,
+  ): Promise<OnUpdate<Model>> {
+    const plan: AutoImportRuleUpdatePlan | null =
+      (onUpdate.carryForward as AutoImportRuleUpdatePlan | null) || null;
+
+    if (!plan?.isRuleReachChanged || updatedItemIds.length === 0) {
+      return onUpdate;
+    }
+
+    /*
+     * The rules as they stand now that the update has landed, read back
+     * rather than predicted from the payload — one update payload is shared
+     * by every row its query matched, and the toggles that decide whether a
+     * re-arm is worth anything arrive from a form as strings. See
+     * AutoImportRuleUpdatePlan.
+     */
+    const updatedRules: Array<Model> = await this.findBy({
+      query: {
+        _id: QueryHelper.any(updatedItemIds),
+      },
+      select: {
+        _id: true,
+        projectId: true,
+        isEnabled: true,
+        isExclusion: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    this.rearmRecentScansForRules(updatedRules);
+
+    return onUpdate;
+  }
+
+  /*
+   * Hand every affected project's recent scan results back to the auto-import
+   * sweep, once per project however many of its rules one write touched.
+   *
+   * Detached on purpose, in the shape NetworkDeviceService.onCreateSuccess
+   * uses for its own rule chain: the caller is a rule save, the operator is
+   * waiting on its response, and this is a query plus up to a hundred small
+   * writes. It must also never fail that save — a re-arm that could not run
+   * costs a delay until the next scan result (or one press of Run Now),
+   * which is not worth failing an otherwise valid edit over.
+   */
+  private rearmRecentScansForRules(
+    rules: Array<{
+      projectId?: ObjectID | undefined;
+      isEnabled?: boolean | undefined;
+      isExclusion?: boolean | undefined;
+    }>,
+  ): void {
+    const projectIds: Map<string, ObjectID> = new Map<string, ObjectID>();
+
+    for (const rule of rules) {
+      /*
+       * A disabled rule imports nothing, and an exclusion rule only vetoes
+       * what other rules claim — neither can newly take a host, so neither
+       * is worth a sweep of the project's results. isEnabled is checked
+       * against `false` rather than for truth because the column defaults to
+       * true: a create that never mentioned it is enabled.
+       *
+       * The mirror case — an exclusion rule switched off or deleted, which
+       * lifts a veto and so widens what the OTHER rules claim — is left to
+       * the next scan result or to Run Now. Re-arming needs a write that says
+       * "this now claims hosts", and lifting a veto says it only about rules
+       * this write never mentioned.
+       */
+      if (rule.isEnabled === false || rule.isExclusion) {
+        continue;
+      }
+
+      if (!rule.projectId) {
+        continue;
+      }
+
+      projectIds.set(rule.projectId.toString(), rule.projectId);
+    }
+
+    for (const projectId of projectIds.values()) {
+      NetworkDeviceAutoImportRuleEngineService.rearmRecentScansForRuleChange({
+        projectId: projectId,
+      }).catch((error: Error) => {
+        logger.error(
+          `Error re-arming discovery scan results after an auto-import rule was written: ${error}`,
+          { projectId: projectId.toString() } as LogAttributes,
+        );
+      });
+    }
   }
 
   /*

--- a/Common/Tests/Server/Services/AutoImportRuleRearmRecentScans.test.ts
+++ b/Common/Tests/Server/Services/AutoImportRuleRearmRecentScans.test.ts
@@ -1,0 +1,343 @@
+/*
+ * Contract under test — the THIRD way a discovery scan's stored results
+ * become importable, alongside a new upload and a manual "Run Now": the
+ * project's rules changed (OneUptime issue #3487).
+ *
+ * The auto-import sweep is driven entirely by the autoImportProcessedAt
+ * marker, so results it has already evaluated are finished with — which
+ * silently makes a NEW rule reach nothing at all until the next scan reports.
+ * In a project whose scans are one-shot that is never, and the operator is
+ * left pressing Run Now by hand for work the product calls automatic. Which
+ * is what the issue reported as "auto import rules have no schedule".
+ *
+ * rearmRecentScansForRuleChange closes that gap by clearing the marker, and
+ * every one of its boundaries fails silently if it drifts:
+ *
+ *   - WHICH scans: only this project's, only importable ones, only ones
+ *     already stamped, and only results still inside the freshness horizon
+ *     the automatic path itself enforces — re-arming an older scan would
+ *     merely have the sweep retire it again, one pointless write and one
+ *     warning per scan;
+ *   - HOW the marker is cleared: the hook-free single statement, and
+ *     WITHOUT refreshing updatedAt, which on an In Progress scan is the
+ *     "has this probe gone silent" clock the stale-scan reaper reads;
+ *   - WHAT ELSE it writes: nothing. It hands work to the worker rather than
+ *     importing inside a rule save.
+ *
+ * The collaborating singleton services are stubbed at the MODULE level
+ * before the engine is imported: their real files reach Postgres through
+ * DatabaseService (and PasswordHash, the local-only ts-jest compile
+ * failure), and nothing here should touch any of it.
+ */
+
+jest.mock("../../../Server/Services/NetworkDeviceService", () => {
+  return {
+    __esModule: true,
+    default: {
+      create: jest.fn(),
+      findBy: jest.fn(),
+      findOneBy: jest.fn(),
+      getDevicesByHostnames: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Services/NetworkDeviceDiscoveryScanService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: jest.fn(),
+      findBy: jest.fn(),
+      updateColumnsByIdWithoutHooks: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Services/NetworkDeviceAutoImportRuleService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: jest.fn(),
+      findBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Services/MonitorService", () => {
+  return {
+    __esModule: true,
+    default: {
+      create: jest.fn(),
+      findBy: jest.fn(),
+      findOneBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Services/MonitorTemplateService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Infrastructure/Semaphore", () => {
+  return {
+    __esModule: true,
+    default: {
+      lock: jest.fn(),
+      release: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      trace: jest.fn(),
+    },
+  };
+});
+
+import NetworkDeviceAutoImportRuleEngineService, {
+  MAX_RESULT_AGE_IN_HOURS,
+  MAX_SCANS_REARMED_PER_RULE_WRITE,
+} from "../../../Server/Services/NetworkDeviceAutoImportRuleEngineService";
+import NetworkDeviceDiscoveryScanService from "../../../Server/Services/NetworkDeviceDiscoveryScanService";
+import NetworkDeviceService from "../../../Server/Services/NetworkDeviceService";
+import logger from "../../../Server/Utils/Logger";
+import NetworkDeviceDiscoveryScan from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import ObjectID from "../../../Types/ObjectID";
+import OneUptimeDate from "../../../Types/Date";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+const scanFindByMock: jest.Mock =
+  NetworkDeviceDiscoveryScanService.findBy as unknown as jest.Mock;
+const scanUpdateMock: jest.Mock =
+  NetworkDeviceDiscoveryScanService.updateColumnsByIdWithoutHooks as unknown as jest.Mock;
+const deviceCreateMock: jest.Mock =
+  NetworkDeviceService.create as unknown as jest.Mock;
+const loggerInfoMock: jest.Mock = logger.info as unknown as jest.Mock;
+
+/*
+ * The SQL a QueryHelper filter generates. QueryHelper builds raw TypeORM
+ * FindOperators, so a test can only say what a filter MEANS by rendering it —
+ * "is not null" and "or is null" are the whole point of two of these, and an
+ * expect(...).toBeDefined() would pass for either of them and for their
+ * opposites.
+ */
+function sqlFor(filter: unknown): string {
+  const generator: (alias: string) => string = (
+    filter as { getSql: (alias: string) => string }
+  ).getSql;
+
+  return generator("column");
+}
+
+/*
+ * The values bound behind a raw filter — the status list of a
+ * QueryHelper.any(), or the cutoff date of a comparison.
+ */
+function parametersOf(filter: unknown): Array<unknown> {
+  const parameters: Record<string, unknown> = (
+    filter as { objectLiteralParameters?: Record<string, unknown> }
+  ).objectLiteralParameters!;
+
+  return Object.values(parameters);
+}
+
+function makeScanStub(id: string): NetworkDeviceDiscoveryScan {
+  return {
+    id: new ObjectID(id),
+    _id: id,
+  } as unknown as NetworkDeviceDiscoveryScan;
+}
+
+const SCAN_ONE: string = "33333333-3333-4333-8333-333333333333";
+const SCAN_TWO: string = "44444444-4444-4444-8444-444444444444";
+
+describe("NetworkDeviceAutoImportRuleEngineService.rearmRecentScansForRuleChange", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    scanFindByMock.mockResolvedValue([]);
+    scanUpdateMock.mockResolvedValue(undefined);
+  });
+
+  it("asks only for this project's stamped, importable, still-fresh scans", async () => {
+    const beforeCall: number = OneUptimeDate.getCurrentDate().getTime();
+
+    await NetworkDeviceAutoImportRuleEngineService.rearmRecentScansForRuleChange(
+      {
+        projectId: PROJECT_ID,
+      },
+    );
+
+    expect(scanFindByMock).toHaveBeenCalledTimes(1);
+
+    const findBy: {
+      query: Record<string, unknown>;
+      sort: Record<string, string>;
+      limit: number;
+      skip: number;
+      props: Record<string, boolean>;
+    } = scanFindByMock.mock.calls[0]![0];
+
+    expect(findBy.query["projectId"]).toEqual(PROJECT_ID);
+
+    /*
+     * A scan that is still SWEEPING counts as much as a finished one: its
+     * partial results are hosts the probe has already found, and waiting for
+     * the whole range is the delay issue #3599 was about.
+     */
+    expect(parametersOf(findBy.query["status"])[0]).toEqual([
+      "Completed",
+      "In Progress",
+    ]);
+
+    // Already-armed scans are queued as they stand; re-clearing changes nothing.
+    expect(sqlFor(findBy.query["autoImportProcessedAt"])).toContain(
+      "IS NOT NULL",
+    );
+
+    /*
+     * Fresh results only, and "still sweeping" (completedAt NULL) counts as
+     * the freshest of all.
+     */
+    const completedAtSql: string = sqlFor(findBy.query["completedAt"]);
+    expect(completedAtSql).toContain(">=");
+    expect(completedAtSql).toContain("IS NULL");
+
+    const cutoff: Date = parametersOf(findBy.query["completedAt"])[0] as Date;
+    const expectedCutoff: number =
+      beforeCall - MAX_RESULT_AGE_IN_HOURS * 60 * 60 * 1000;
+
+    // The engine's own horizon, not a second one that could drift from it.
+    expect(Math.abs(cutoff.getTime() - expectedCutoff)).toBeLessThan(10_000);
+
+    // Newest results first, so a capped re-arm keeps the ones that matter.
+    expect(findBy.sort["completedAt"]).toBe(SortOrder.Descending);
+    expect(findBy.limit).toBe(MAX_SCANS_REARMED_PER_RULE_WRITE);
+    expect(findBy.skip).toBe(0);
+    expect(findBy.props["isRoot"]).toBe(true);
+  });
+
+  it("clears the marker on every scan it found, without refreshing updatedAt", async () => {
+    scanFindByMock.mockResolvedValue([
+      makeScanStub(SCAN_ONE),
+      makeScanStub(SCAN_TWO),
+    ]);
+
+    const rearmed: number =
+      await NetworkDeviceAutoImportRuleEngineService.rearmRecentScansForRuleChange(
+        {
+          projectId: PROJECT_ID,
+        },
+      );
+
+    expect(rearmed).toBe(2);
+    expect(scanUpdateMock).toHaveBeenCalledTimes(2);
+
+    for (const scanId of [SCAN_ONE, SCAN_TWO]) {
+      const call: {
+        id: ObjectID;
+        data: Record<string, unknown>;
+        skipUpdateDateColumn?: boolean;
+      } = scanUpdateMock.mock.calls
+        .map((args: Array<unknown>) => {
+          return args[0] as {
+            id: ObjectID;
+            data: Record<string, unknown>;
+            skipUpdateDateColumn?: boolean;
+          };
+        })
+        .find((candidate: { id: ObjectID }): boolean => {
+          return candidate.id.toString() === scanId;
+        })!;
+
+      expect(call).toBeDefined();
+      expect(call.data["autoImportProcessedAt"]).toBeNull();
+
+      /*
+       * updatedAt is the stale-scan reaper's "the probe has gone silent"
+       * clock (Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans).
+       * A rule save is not the probe saying something, and bumping it would
+       * postpone the rescue of a scan whose probe had already died.
+       */
+      expect(call.skipUpdateDateColumn).toBe(true);
+    }
+  });
+
+  it("writes the marker and nothing else — no results, no counters, no devices", async () => {
+    scanFindByMock.mockResolvedValue([makeScanStub(SCAN_ONE)]);
+
+    await NetworkDeviceAutoImportRuleEngineService.rearmRecentScansForRuleChange(
+      {
+        projectId: PROJECT_ID,
+      },
+    );
+
+    const payload: Record<string, unknown> = scanUpdateMock.mock.calls[0]![0]
+      .data as Record<string, unknown>;
+
+    /*
+     * The importing itself belongs to the worker, where minutes of paced
+     * creates survive a restart. A rule save must stay a rule save.
+     */
+    expect(Object.keys(payload)).toEqual(["autoImportProcessedAt"]);
+    expect(deviceCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing when the project has no re-armable results", async () => {
+    scanFindByMock.mockResolvedValue([]);
+
+    const rearmed: number =
+      await NetworkDeviceAutoImportRuleEngineService.rearmRecentScansForRuleChange(
+        {
+          projectId: PROJECT_ID,
+        },
+      );
+
+    expect(rearmed).toBe(0);
+    expect(scanUpdateMock).not.toHaveBeenCalled();
+    // Nothing happened, so nothing is announced.
+    expect(loggerInfoMock).not.toHaveBeenCalled();
+  });
+
+  it("says how many results it re-armed", async () => {
+    scanFindByMock.mockResolvedValue([
+      makeScanStub(SCAN_ONE),
+      makeScanStub(SCAN_TWO),
+    ]);
+
+    await NetworkDeviceAutoImportRuleEngineService.rearmRecentScansForRuleChange(
+      {
+        projectId: PROJECT_ID,
+      },
+    );
+
+    expect(loggerInfoMock).toHaveBeenCalledTimes(1);
+    expect(String(loggerInfoMock.mock.calls[0]![0])).toContain("2 recent");
+  });
+
+  it("surfaces a database failure to its caller instead of half-re-arming in silence", async () => {
+    scanFindByMock.mockRejectedValue(new Error("connection terminated"));
+
+    await expect(
+      NetworkDeviceAutoImportRuleEngineService.rearmRecentScansForRuleChange({
+        projectId: PROJECT_ID,
+      }),
+    ).rejects.toThrow("connection terminated");
+  });
+});

--- a/Common/Tests/Server/Services/AutoImportRuleWriteRearmsScans.test.ts
+++ b/Common/Tests/Server/Services/AutoImportRuleWriteRearmsScans.test.ts
@@ -1,0 +1,381 @@
+/*
+ * Contract under test — writing an auto-import rule hands the project's
+ * recent discovery results back to the auto-import sweep (OneUptime issue
+ * #3487).
+ *
+ * The sweep only ever looks at results nothing has evaluated yet, so a rule
+ * written after a scan finished reaches nothing until that scan reports
+ * again — never, for the one-shot scans a project starts with. The operator
+ * then has a rule that visibly does nothing and a "Run Now" button they have
+ * to remember to press, which is the complaint the issue was filed as.
+ *
+ * What these tests pin is WHICH writes are worth a sweep, because both
+ * mistakes are quiet: too few and the rule goes on doing nothing, too many
+ * and every rename of a rule re-reads every recent scan in the project.
+ *
+ *   - a new enabled import rule re-arms; a disabled one and an exclusion one
+ *     do not, because neither can newly claim a host;
+ *   - an edit re-arms only when it changed what the rule CLAIMS (criteria,
+ *     ping-only hosts, the enable toggle, the monitor template) — never for
+ *     a rename;
+ *   - the decision is made from the rule as the DATABASE holds it after the
+ *     write, not from the payload, whose booleans arrive from a form as
+ *     strings;
+ *   - one re-arm per project however many rules a single update touched;
+ *   - and a re-arm that fails is logged, never raised: it must not fail an
+ *     otherwise valid rule save.
+ *
+ * The engine is stubbed at the MODULE level: the re-arm itself has its own
+ * suite (AutoImportRuleRearmRecentScans.test.ts), and the real module would
+ * pull the whole device/monitor write path — and Postgres with it — into a
+ * suite about hooks.
+ */
+
+jest.mock(
+  "../../../Server/Services/NetworkDeviceAutoImportRuleEngineService",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        rearmRecentScansForRuleChange: jest.fn(),
+      },
+    };
+  },
+);
+
+jest.mock("../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      trace: jest.fn(),
+    },
+  };
+});
+
+import NetworkDeviceAutoImportRuleService from "../../../Server/Services/NetworkDeviceAutoImportRuleService";
+import NetworkDeviceAutoImportRuleEngineService from "../../../Server/Services/NetworkDeviceAutoImportRuleEngineService";
+import MonitorTemplateService from "../../../Server/Services/MonitorTemplateService";
+import NetworkAlertPolicyService from "../../../Server/Services/NetworkAlertPolicyService";
+import logger from "../../../Server/Utils/Logger";
+import NetworkDeviceAutoImportRule from "../../../Models/DatabaseModels/NetworkDeviceAutoImportRule";
+import MonitorTemplate from "../../../Models/DatabaseModels/MonitorTemplate";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import { OnCreate, OnUpdate } from "../../../Server/Types/Database/Hooks";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import MonitorSteps from "../../../Types/Monitor/MonitorSteps";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const RULE_ID: ObjectID = new ObjectID("77777777-7777-4777-8777-777777777777");
+const OTHER_RULE_ID: ObjectID = new ObjectID(
+  "66666666-6666-4666-8666-666666666666",
+);
+const TEMPLATE_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+
+const rearmMock: jest.Mock =
+  NetworkDeviceAutoImportRuleEngineService.rearmRecentScansForRuleChange as unknown as jest.Mock;
+const loggerErrorMock: jest.Mock = logger.error as unknown as jest.Mock;
+
+function makeRule(
+  overrides: Partial<NetworkDeviceAutoImportRule> = {},
+): NetworkDeviceAutoImportRule {
+  const rule: NetworkDeviceAutoImportRule = new NetworkDeviceAutoImportRule();
+  rule.id = RULE_ID;
+  rule.projectId = PROJECT_ID;
+  rule.ipMatchTarget = "10.0.0.0/24";
+  rule.isEnabled = true;
+  Object.assign(rule, overrides);
+
+  return rule;
+}
+
+async function createSucceeds(
+  createdItem: NetworkDeviceAutoImportRule,
+  tenantId?: ObjectID,
+): Promise<void> {
+  const onCreate: OnCreate<NetworkDeviceAutoImportRule> = {
+    createBy: {
+      data: createdItem,
+      props: tenantId ? { tenantId: tenantId } : { isRoot: true },
+    } as CreateBy<NetworkDeviceAutoImportRule>,
+    carryForward: null,
+  };
+
+  await (NetworkDeviceAutoImportRuleService as any).onCreateSuccess(
+    onCreate,
+    createdItem,
+  );
+}
+
+/*
+ * One update, start to finish: onBeforeUpdate decides whether the save
+ * changed what the rule claims and carries that forward, and onUpdateSuccess
+ * acts on it. Running BOTH is the point — a plan that is computed and never
+ * carried, or carried and never read, is exactly the kind of break that
+ * leaves the feature silently doing nothing.
+ */
+async function updateSucceeds(data: {
+  payload: Record<string, unknown>;
+  rulesAfterUpdate: Array<NetworkDeviceAutoImportRule>;
+  updatedItemIds?: Array<ObjectID>;
+}): Promise<void> {
+  jest
+    .spyOn(NetworkDeviceAutoImportRuleService, "findBy")
+    .mockResolvedValue(data.rulesAfterUpdate);
+
+  const updateBy: UpdateBy<NetworkDeviceAutoImportRule> = {
+    query: { _id: RULE_ID.toString() },
+    data: data.payload,
+    props: { isRoot: true },
+  } as unknown as UpdateBy<NetworkDeviceAutoImportRule>;
+
+  const onUpdate: OnUpdate<NetworkDeviceAutoImportRule> = await (
+    NetworkDeviceAutoImportRuleService as any
+  ).onBeforeUpdate(updateBy);
+
+  await (NetworkDeviceAutoImportRuleService as any).onUpdateSuccess(
+    onUpdate,
+    data.updatedItemIds ||
+      data.rulesAfterUpdate.map((rule: NetworkDeviceAutoImportRule) => {
+        return rule.id!;
+      }),
+  );
+}
+
+// The project ids handed to the engine, in call order.
+function rearmedProjectIds(): Array<string> {
+  return rearmMock.mock.calls.map((args: Array<unknown>): string => {
+    return (args[0] as { projectId: ObjectID }).projectId.toString();
+  });
+}
+
+describe("Writing an auto-import rule re-arms the project's recent scan results", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    rearmMock.mockResolvedValue(0);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("on create", () => {
+    it("re-arms the project of a new enabled import rule", async () => {
+      await createSucceeds(makeRule());
+
+      expect(rearmedProjectIds()).toEqual([PROJECT_ID.toString()]);
+    });
+
+    /*
+     * The column defaults to true, so a create that never mentions it is an
+     * enabled rule — and the saved row a hook is handed need not carry every
+     * defaulted column.
+     */
+    it("re-arms when the create never mentioned the enable toggle", async () => {
+      const rule: NetworkDeviceAutoImportRule = makeRule();
+      delete rule.isEnabled;
+
+      await createSucceeds(rule);
+
+      expect(rearmMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-arm for a rule created disabled", async () => {
+      await createSucceeds(makeRule({ isEnabled: false }));
+
+      expect(rearmMock).not.toHaveBeenCalled();
+    });
+
+    /*
+     * An exclusion rule only vetoes what other rules claim. It can never
+     * take a host that was not already taken, so re-reading the project's
+     * scans on its account is work with no possible outcome.
+     */
+    it("does not re-arm for a new exclusion rule", async () => {
+      await createSucceeds(makeRule({ isExclusion: true }));
+
+      expect(rearmMock).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the tenant of the write when the row carries no projectId", async () => {
+      const rule: NetworkDeviceAutoImportRule = makeRule();
+      delete rule.projectId;
+
+      await createSucceeds(rule, OTHER_PROJECT_ID);
+
+      expect(rearmedProjectIds()).toEqual([OTHER_PROJECT_ID.toString()]);
+    });
+
+    it("returns the created rule and logs, rather than failing the save, when the re-arm fails", async () => {
+      rearmMock.mockRejectedValue(new Error("connection terminated"));
+
+      const rule: NetworkDeviceAutoImportRule = makeRule();
+
+      await expect(createSucceeds(rule)).resolves.toBeUndefined();
+
+      // The detached rejection is handled on the next tick.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(loggerErrorMock).toHaveBeenCalledTimes(1);
+      expect(String(loggerErrorMock.mock.calls[0]![0])).toContain(
+        "connection terminated",
+      );
+    });
+  });
+
+  describe("on update", () => {
+    it("re-arms when the rule's match criteria change", async () => {
+      await updateSucceeds({
+        payload: { ipMatchTarget: "10.0.0.0/8" },
+        rulesAfterUpdate: [makeRule({ ipMatchTarget: "10.0.0.0/8" })],
+      });
+
+      expect(rearmedProjectIds()).toEqual([PROJECT_ID.toString()]);
+    });
+
+    it("re-arms when a disabled rule is switched on", async () => {
+      await updateSucceeds({
+        payload: { isEnabled: true },
+        rulesAfterUpdate: [makeRule({ isEnabled: true })],
+      });
+
+      expect(rearmMock).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * Ping-only hosts are a whole class of discovered host the rule either
+     * claims or does not — reach, even though it is not one of the pattern
+     * criteria the validator groups together.
+     */
+    it("re-arms when the rule starts including ping-only hosts", async () => {
+      await updateSucceeds({
+        payload: { includePingOnlyHosts: true },
+        rulesAfterUpdate: [makeRule({ includePingOnlyHosts: true })],
+      });
+
+      expect(rearmMock).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * Attaching a template backfills a monitor onto devices this rule
+     * already imported, so the sweep has real work even though no new device
+     * will be created.
+     */
+    it("re-arms when a monitor template is attached", async () => {
+      const monitorTemplate: MonitorTemplate = new MonitorTemplate();
+      monitorTemplate.projectId = PROJECT_ID;
+      monitorTemplate.monitorType = MonitorType.NetworkDevice;
+      const step: MonitorStep = new MonitorStep();
+      step.data!.networkDeviceMonitor = {
+        networkDeviceId: ObjectID.generate().toString(),
+        monitorInterfaces: true,
+        oids: [],
+      };
+      monitorTemplate.monitorSteps = new MonitorSteps();
+      monitorTemplate.monitorSteps.data = {
+        monitorStepsInstanceArray: [step],
+      };
+
+      jest
+        .spyOn(MonitorTemplateService, "findOneById")
+        .mockResolvedValue(monitorTemplate);
+      jest.spyOn(NetworkAlertPolicyService, "findBy").mockResolvedValue([]);
+
+      await updateSucceeds({
+        payload: { monitorTemplateId: TEMPLATE_ID },
+        rulesAfterUpdate: [makeRule({ monitorTemplateId: TEMPLATE_ID })],
+      });
+
+      expect(rearmMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-arm when the save only renamed the rule", async () => {
+      const findBySpy: jest.SpyInstance = jest
+        .spyOn(NetworkDeviceAutoImportRuleService, "findBy")
+        .mockResolvedValue([makeRule()]);
+
+      await updateSucceeds({
+        payload: { name: "Access switches", description: "Ground floor" },
+        rulesAfterUpdate: [makeRule()],
+      });
+
+      expect(rearmMock).not.toHaveBeenCalled();
+      /*
+       * And it costs nothing: a cosmetic edit must not read the rules back
+       * either, or every rename in a big project pays for a query.
+       */
+      expect(findBySpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * The toggle a form posts is a string, and the rule the operator sees is
+     * the ROW. A save that switched the rule off must not re-arm on the
+     * strength of its own payload mentioning isEnabled.
+     */
+    it("does not re-arm when the rule ends up disabled", async () => {
+      await updateSucceeds({
+        payload: { isEnabled: false },
+        rulesAfterUpdate: [makeRule({ isEnabled: false })],
+      });
+
+      expect(rearmMock).not.toHaveBeenCalled();
+    });
+
+    it("does not re-arm when the rule ends up an exclusion rule", async () => {
+      await updateSucceeds({
+        payload: { isExclusion: true },
+        rulesAfterUpdate: [makeRule({ isExclusion: true })],
+      });
+
+      expect(rearmMock).not.toHaveBeenCalled();
+    });
+
+    it("re-arms each project once, however many of its rules one update matched", async () => {
+      await updateSucceeds({
+        payload: { ipMatchTarget: "10.0.0.0/8" },
+        rulesAfterUpdate: [
+          makeRule(),
+          makeRule({ id: OTHER_RULE_ID }),
+          makeRule({ id: OTHER_RULE_ID, projectId: OTHER_PROJECT_ID }),
+        ],
+        updatedItemIds: [RULE_ID, OTHER_RULE_ID],
+      });
+
+      expect(rearmedProjectIds()).toEqual([
+        PROJECT_ID.toString(),
+        OTHER_PROJECT_ID.toString(),
+      ]);
+    });
+
+    it("does nothing when the update matched no rows", async () => {
+      const findBySpy: jest.SpyInstance = jest
+        .spyOn(NetworkDeviceAutoImportRuleService, "findBy")
+        .mockResolvedValue([]);
+
+      await updateSucceeds({
+        payload: { ipMatchTarget: "10.0.0.0/8" },
+        rulesAfterUpdate: [],
+        updatedItemIds: [],
+      });
+
+      expect(rearmMock).not.toHaveBeenCalled();
+      // onBeforeUpdate's own validation read is the only one.
+      expect(findBySpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/Common/Tests/Server/Services/NetworkDeviceAutoImportRuleService.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceAutoImportRuleService.test.ts
@@ -1,3 +1,25 @@
+/*
+ * The service's create/update SUCCESS hooks hand the project's recent scan
+ * results back to the auto-import sweep through the engine (issue #3487).
+ * This suite is about the write-time validation that runs BEFORE those, so
+ * the engine is stubbed at the MODULE level: loading the real one would drag
+ * the whole device/monitor write path — and the Redis client its sweep lock
+ * reaches for — into a suite that never leaves memory. The re-arm itself is
+ * covered by AutoImportRuleWriteRearmsScans.test.ts and
+ * AutoImportRuleRearmRecentScans.test.ts.
+ */
+jest.mock(
+  "../../../Server/Services/NetworkDeviceAutoImportRuleEngineService",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        rearmRecentScansForRuleChange: jest.fn(),
+      },
+    };
+  },
+);
+
 import NetworkDeviceAutoImportRuleService from "../../../Server/Services/NetworkDeviceAutoImportRuleService";
 import MonitorTemplateService from "../../../Server/Services/MonitorTemplateService";
 import NetworkAlertPolicyService from "../../../Server/Services/NetworkAlertPolicyService";


### PR DESCRIPTION
Fixes #3487.

## What I found

The issue makes two claims. Taking them one at a time, against `master`:

**"Auto Import Rules only run via manual Run Now."** Not what the code does. `App/FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/ProcessAutoImportRules.ts` sweeps **every minute** for scans whose results have not been evaluated and hands each to the rule engine. The probe-ingest endpoint clears the scan's `autoImportProcessedAt` marker on every result upload — including the partial uploads a long sweep sends every 30 seconds — so a discovery scan with **Repeat this scan** turned on already imports newly discovered hosts on its own cadence with nobody pressing anything.

**"No automatic dedupe-by-IP check."** Also already there. Before creating anything, the engine primes the project's registered addresses from the hosts the scan actually found (`NetworkDeviceService.getDevicesByHostnames`) and skips hosts whose address already has a device (`hostsSkippedAlreadyRegistered`); provisioned monitors are deduped on the `(device, template)` provenance key, and a device an operator already monitors by hand is left alone.

**But the report is not wrong about the experience**, and there is a real gap underneath it. The sweep is driven entirely by the marker, and a scan whose results have been evaluated is stamped — including, deliberately, in a project that has *no import rules at all* (that stamp is what stops months of unprocessed results mass-importing the day someone writes their first rule). Consequences:

- the first rule a project ever writes has nothing left to apply to;
- a rule written after a one-shot scan waits for a rescan that will never happen.

Either way the rule visibly does nothing until somebody remembers **Run Now** — which is exactly what the issue describes, and why it reads as "these have no schedule". `App/FeatureSet/BaseAPI/API/NetworkRuleRun.ts` already named this gap in a comment and made Run Now the answer to it.

## What this changes

A rule write now hands the project's recent results back to the sweep.

`NetworkDeviceAutoImportRuleEngineService.rearmRecentScansForRuleChange` clears the marker on the project's importable scans that are still inside the engine's own 24-hour freshness horizon, and the next sweep applies the **full** rule set to them — same pass, same lock, same idempotency as any other tick. It imports nothing itself: it writes one column and no devices, so a rule save stays a rule save and the minutes of paced import work stay in the worker, where a crash is resumable.

The horizon is deliberate. It preserves exactly the guarantee the rule-less stamping exists to give — a first rule can never mass-import an estate discovered months ago — and leaves older results to Run Now, where "import these old hosts" is a click somebody made.

`NetworkDeviceAutoImportRuleService` triggers it from `onCreateSuccess` and `onUpdateSuccess`, for writes that can make the rules claim **more** than they did: a new enabled import rule, or an edit to the criteria, ping-only hosts, the enable toggle, or the monitor template (which backfills a monitor onto devices the rule already imported). A rename does not qualify. The decision is made from the rule as the database holds it after the write, not from a payload whose booleans arrive from a form as strings. The call is detached and its failure logged, so a re-arm can never fail an operator's save.

Net effect for the reporter: write a rule, and within about a minute it has claimed the hosts your recent scans already found — no Run Now. Turn on **Repeat this scan** and the arrangement is standing.

## What this deliberately does not add

The issue asks for a **"Repeat this rule" toggle + interval** mirroring Discovery Scans. I did not add one, because a rule's own timer cannot do the thing that is wanted: new hosts come from *scans*, so re-running a rule on a timer would re-read the same stored results over and over and import nothing new. The cadence that matters is the scan's, and that already exists. What was missing was the rule reaching results that already existed — which is what this PR adds. Happy to revisit if you would rather have the literal toggle.

Also left alone: an exclusion rule being switched off or deleted lifts a veto and so widens what the *other* rules claim. Re-arming keys off a write that says "this now claims hosts", and lifting a veto says that only about rules the write never mentioned. That case still waits for the next scan result or Run Now; the code says so where the decision is made.

## Tests

Two new suites, plus the engine mock the existing rule-service suite now needs:

- `Common/Tests/Server/Services/AutoImportRuleRearmRecentScans.test.ts` (6) — which scans the re-arm selects (this project, importable, already stamped, still inside `MAX_RESULT_AGE_IN_HOURS`, newest first, capped), that it clears the marker through the hook-free write **without** refreshing `updatedAt` (that column is the stale-scan reaper's "the probe has gone silent" clock), that it writes the marker and nothing else, and that a database failure surfaces rather than half-re-arming in silence.
- `Common/Tests/Server/Services/AutoImportRuleWriteRearmsScans.test.ts` (15) — which writes are worth a sweep and which are not: enabled/disabled/exclusion creates, criteria, ping-only, enable-toggle and monitor-template edits, a rename that must cost nothing, a payload the row contradicts, one re-arm per project across a multi-row update, and a failing re-arm that is logged instead of failing the save.

Run locally: `AutoImportRule*`, `NetworkDeviceAutoImportRule*`, `AutoImportScanCredentialSelect`, `NetworkDeviceOidTemplateService` (Common) and the `NetworkDeviceDiscovery` worker + `NetworkRuleRunAPI` suites (App) — 237 tests, all green. `tsc --noEmit` clean in both `Common` and `App`; eslint clean on the changed files.

## Docs

The Auto Import Rules page gains a **When Rules Run** section (results as they arrive, a rule write, Run Now — plus the 24-hour horizon and the by-IP skip), and `network-device-monitor.md` says the same and points at **Repeat this scan** for continuous discovery.
