### PR TITLE
fix(billing): require payment setup before pay-as-you-go usage

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Billing/BillingUsageStatus.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Billing/BillingUsageStatus.tsx
@@ -42,7 +42,9 @@ const BillingUsageStatus: FunctionComponent<ComponentProps> = (
           : !hasPaymentMethod
             ? [
                 {
-                  title: "Enable paid usage",
+                  title: props.isFreePlan
+                    ? "Enable paid usage"
+                    : "Add payment method",
                   icon: IconProp.Billing,
                   onClick: props.onAddPaymentMethod,
                   buttonStyle: ButtonStyleType.NORMAL,

--- a/App/FeatureSet/Dashboard/src/Components/Billing/BillingUsageStatus.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Billing/BillingUsageStatus.tsx
@@ -1,0 +1,75 @@
+import UsagePricingSummary from "./UsagePricingSummary";
+import IconProp from "Common/Types/Icon/IconProp";
+import Card from "Common/UI/Components/Card/Card";
+import { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  isFreePlan: boolean;
+  paymentMethodsCount: number | null;
+  onAddPaymentMethod: () => void;
+  onRetry: () => void;
+}
+
+const BillingUsageStatus: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const statusUnavailable: boolean = props.paymentMethodsCount === null;
+  const hasPaymentMethod: boolean = (props.paymentMethodsCount || 0) > 0;
+
+  const title: string = statusUnavailable
+    ? "Payment method status unavailable"
+    : hasPaymentMethod
+      ? props.isFreePlan
+        ? "Free plan + pay as you go"
+        : "Pay as you go enabled"
+      : props.isFreePlan
+        ? "Free plan — paid usage locked"
+        : "No payment method on file";
+
+  return (
+    <Card
+      title={title}
+      buttons={
+        statusUnavailable
+          ? [
+              {
+                title: "Retry payment method check",
+                icon: IconProp.Refresh,
+                onClick: props.onRetry,
+              },
+            ]
+          : !hasPaymentMethod
+            ? [
+                {
+                  title: "Enable paid usage",
+                  icon: IconProp.Billing,
+                  onClick: props.onAddPaymentMethod,
+                  buttonStyle: ButtonStyleType.NORMAL,
+                },
+              ]
+            : []
+      }
+    >
+      <div className="space-y-4" data-testid="billing-usage-status">
+        <p className="text-sm text-gray-700">
+          {statusUnavailable
+            ? "We could not check this project's payment methods. Retry to see whether paid usage is enabled."
+            : hasPaymentMethod
+              ? "A payment method is on file. Paid features are billed as you use them, separately from your subscription."
+              : props.isFreePlan
+                ? "No payment method is on file. Paid features require a payment method before they can create new usage charges. Your free features remain available."
+                : "Add a payment method before using paid features, including during a trial. Projects with an active invoice billing agreement can continue under that agreement."}
+        </p>
+        <p className="text-sm text-gray-700">
+          {props.isFreePlan
+            ? "Your Free subscription is $0. Adding a payment method enables paid usage and keeps you on the Free plan. Upgrade your plan separately if you need additional subscription features."
+            : "Adding a payment method does not change your subscription plan. Usage charges are separate from subscription charges."}
+        </p>
+        <UsagePricingSummary />
+      </div>
+    </Card>
+  );
+};
+
+export default BillingUsageStatus;

--- a/App/FeatureSet/Dashboard/src/Components/Billing/PaidUsageConsent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Billing/PaidUsageConsent.tsx
@@ -45,12 +45,13 @@ export default function PaidUsageConsent(props: Props): ReactElement {
         if (!projectId) {
           throw new Error("Project is unavailable");
         }
-        const response: HTTPResponse<JSONObject> = await BaseAPI.get<JSONObject>({
-          url: URL.fromString(APP_API_URL.toString()).addRoute(
-            "/billing/pay-as-you-go-status",
-          ),
-          headers: ModelAPI.getCommonHeaders(),
-        });
+        const response: HTTPResponse<JSONObject> =
+          await BaseAPI.get<JSONObject>({
+            url: URL.fromString(APP_API_URL.toString()).addRoute(
+              "/billing/pay-as-you-go-status",
+            ),
+            headers: ModelAPI.getCommonHeaders(),
+          });
         if (current) {
           setStatus({
             projectId,
@@ -83,7 +84,10 @@ export default function PaidUsageConsent(props: Props): ReactElement {
   return (
     <div className="space-y-3">
       {!allowed && (
-        <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-gray-700" role="status">
+        <div
+          className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-gray-700"
+          role="status"
+        >
           {state === "loading" && "Checking paid feature access…"}
           {state === "locked" &&
             "Add a payment method before using this paid feature. Free features remain available without a card."}

--- a/App/FeatureSet/Dashboard/src/Components/Billing/PaidUsageConsent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Billing/PaidUsageConsent.tsx
@@ -1,0 +1,130 @@
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import Route from "Common/Types/API/Route";
+import URL from "Common/Types/API/URL";
+import { JSONObject } from "Common/Types/JSON";
+import CheckboxElement from "Common/UI/Components/Checkbox/Checkbox";
+import Link from "Common/UI/Components/Link/Link";
+import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import { APP_API_URL, BILLING_ENABLED } from "Common/UI/Config";
+import BaseAPI from "Common/UI/Utils/API/API";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "Common/UI/Utils/Project";
+import React, { ReactElement, useEffect, useState } from "react";
+
+interface Props {
+  title: string;
+  description: string | ReactElement;
+  value?: boolean | undefined;
+  onChange?: ((value: boolean) => void) | undefined;
+  dataTestId: string;
+  error?: string | undefined;
+}
+
+/** Shared by single-resource forms and bulk monitor recommendations. */
+export default function PaidUsageConsent(props: Props): ReactElement {
+  const projectId: string | undefined =
+    ProjectUtil.getCurrentProjectId()?.toString();
+  const [status, setStatus] = useState<{
+    projectId: string | undefined;
+    state: "loading" | "allowed" | "locked" | "error";
+  }>({ projectId, state: "loading" });
+  const [attempt, setAttempt] = useState<number>(0);
+
+  useEffect(() => {
+    let current: boolean = true;
+    setStatus({ projectId, state: "loading" });
+
+    const loadStatus: () => Promise<void> = async (): Promise<void> => {
+      try {
+        if (!BILLING_ENABLED) {
+          if (current) {
+            setStatus({ projectId, state: "allowed" });
+          }
+          return;
+        }
+        if (!projectId) {
+          throw new Error("Project is unavailable");
+        }
+        const response: HTTPResponse<JSONObject> = await BaseAPI.get<JSONObject>({
+          url: URL.fromString(APP_API_URL.toString()).addRoute(
+            "/billing/pay-as-you-go-status",
+          ),
+          headers: ModelAPI.getCommonHeaders(),
+        });
+        if (current) {
+          setStatus({
+            projectId,
+            state: response.data["isAllowed"] === true ? "allowed" : "locked",
+          });
+        }
+      } catch {
+        if (current) {
+          setStatus({ projectId, state: "error" });
+        }
+      }
+    };
+
+    void loadStatus();
+    return (): void => {
+      current = false;
+    };
+  }, [projectId, attempt]);
+
+  const state: string =
+    status.projectId === projectId ? status.state : "loading";
+  const allowed: boolean = state === "allowed";
+
+  useEffect(() => {
+    if (!allowed && props.value) {
+      props.onChange?.(false);
+    }
+  }, [allowed, props.value, props.onChange]);
+
+  return (
+    <div className="space-y-3">
+      {!allowed && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-gray-700" role="status">
+          {state === "loading" && "Checking paid feature access…"}
+          {state === "locked" &&
+            "Add a payment method before using this paid feature. Free features remain available without a card."}
+          {state === "error" &&
+            "We could not check paid feature access. Try again before continuing."}
+          {state !== "loading" && (
+            <div className="mt-2 flex items-center gap-3">
+              {projectId && (
+                <Link
+                  className="font-medium underline"
+                  openInNewTab={true}
+                  to={new Route(`/dashboard/${projectId}/settings/billing`)}
+                >
+                  Set up billing
+                </Link>
+              )}
+              <Button
+                title="Check again"
+                buttonStyle={ButtonStyleType.OUTLINE}
+                onClick={(): void => {
+                  setAttempt(attempt + 1);
+                }}
+              />
+            </div>
+          )}
+        </div>
+      )}
+      <CheckboxElement
+        title={props.title}
+        ariaLabel={props.title}
+        description={props.description}
+        value={allowed && Boolean(props.value)}
+        disabled={!allowed}
+        error={props.error}
+        dataTestId={props.dataTestId}
+        onChange={(value: boolean): void => {
+          if (allowed) {
+            props.onChange?.(value);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo.tsx
@@ -301,8 +301,9 @@ const TelemetryPayAsYouGoModalNotice: FunctionComponent = (): ReactElement => {
       title="Telemetry is a pay as you go feature"
     >
       <p className="text-sm text-gray-700">
-        Your project is on the Free plan, which does not bundle any telemetry.
-        A payment method is required before you can create a key or send paid telemetry. Data sent with this ingestion key is billed as you use it.{" "}
+        Your project is on the Free plan, which does not bundle any telemetry. A
+        payment method is required before you can create a key or send paid
+        telemetry. Data sent with this ingestion key is billed as you use it.{" "}
         {TELEMETRY_RATES_SENTENCE}{" "}
         <Link
           className="underline"
@@ -356,15 +357,24 @@ export function getTelemetryPayAsYouGoFormFields(): Array<
       doNotShowWhenEditing: true,
       spanFullRow: true,
       fieldType: FormFieldSchemaType.CustomComponent,
-      getCustomElement: (values: FormValues<TelemetryIngestionKey>, props: CustomElementProps): ReactElement => {
-        return <PaidUsageConsent
-          title="I agree to these usage charges"
-          description={TELEMETRY_RATES_SENTENCE}
-          value={(values as Record<string, unknown>)[TELEMETRY_CONSENT_FIELD_KEY] === true}
-          onChange={props.onChange}
-          error={props.error}
-          dataTestId="telemetry-pay-as-you-go-consent"
-        />;
+      getCustomElement: (
+        values: FormValues<TelemetryIngestionKey>,
+        props: CustomElementProps,
+      ): ReactElement => {
+        return (
+          <PaidUsageConsent
+            title="I agree to these usage charges"
+            description={TELEMETRY_RATES_SENTENCE}
+            value={
+              (values as Record<string, unknown>)[
+                TELEMETRY_CONSENT_FIELD_KEY
+              ] === true
+            }
+            onChange={props.onChange}
+            error={props.error}
+            dataTestId="telemetry-pay-as-you-go-consent"
+          />
+        );
       },
       title: "I understand telemetry sent with this key is billed as I use it",
       description: TELEMETRY_RATES_SENTENCE,
@@ -498,15 +508,23 @@ export function getMonitorPayAsYouGoFormFields(data: {
       stepId: data.stepId,
       spanFullRow: true,
       fieldType: FormFieldSchemaType.CustomComponent,
-      getCustomElement: (values: FormValues<Monitor>, props: CustomElementProps): ReactElement => {
-        return <PaidUsageConsent
-          title="I agree to these usage charges"
-          description={`${ACTIVE_MONITOR_PRICE_SENTENCE}. Manual monitors remain free.`}
-          value={(values as Record<string, unknown>)[MONITOR_CONSENT_FIELD_KEY] === true}
-          onChange={props.onChange}
-          error={props.error}
-          dataTestId="monitor-pay-as-you-go-consent"
-        />;
+      getCustomElement: (
+        values: FormValues<Monitor>,
+        props: CustomElementProps,
+      ): ReactElement => {
+        return (
+          <PaidUsageConsent
+            title="I agree to these usage charges"
+            description={`${ACTIVE_MONITOR_PRICE_SENTENCE}. Manual monitors remain free.`}
+            value={
+              (values as Record<string, unknown>)[MONITOR_CONSENT_FIELD_KEY] ===
+              true
+            }
+            onChange={props.onChange}
+            error={props.error}
+            dataTestId="monitor-pay-as-you-go-consent"
+          />
+        );
       },
       title: `I understand this monitor is billed at ${ACTIVE_MONITOR_PRICE_TEXT} per month`,
       description: `Your project is on the Free plan. Every monitor type except ${MonitorType.Manual} is an active monitor, billed at ${ACTIVE_MONITOR_PRICE_SENTENCE}. Pick ${MonitorType.Manual} if you do not want to be billed for this monitor.`,

--- a/App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo.tsx
@@ -19,7 +19,8 @@ import AlertBanner, {
 } from "Common/UI/Components/AlertBanner/AlertBanner";
 import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import Card from "Common/UI/Components/Card/Card";
-import CheckboxElement from "Common/UI/Components/Checkbox/Checkbox";
+import PaidUsageConsent from "./PaidUsageConsent";
+import { CustomElementProps } from "Common/UI/Components/Forms/Types/Field";
 import Icon, { SizeProp, ThickProp } from "Common/UI/Components/Icon/Icon";
 import Link from "Common/UI/Components/Link/Link";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
@@ -32,9 +33,9 @@ import React, { FunctionComponent, ReactElement } from "react";
  *
  * Telemetry ingest and active monitors are metered: nothing about them is
  * included in the Free plan, so a user who creates an ingestion key or a
- * non-Manual monitor starts a charge. The server bills for it either way -
- * these components exist so the first the user hears of it is not the
- * invoice. Everything here renders only when billing is on AND the project is
+ * non-Manual monitor requires billing setup. The server enforces payment
+ * eligibility, and these components explain prices and require acknowledgement
+ * before a user can start paid usage. Everything here renders only when billing is on AND the project is
  * on Free (see isProjectOnFreePlan, which fails closed).
  */
 
@@ -251,7 +252,7 @@ export const TelemetryPayAsYouGoCard: FunctionComponent = (): ReactElement => {
       priceCaption={`per GB ingested (${TELEMETRY_PRICE_RETENTION_IN_DAYS} day retention)`}
       summary={`Telemetry is available on the Free plan, but it is not bundled into it. Data you send with an ingestion key is billed as you use it. ${TELEMETRY_RATES_SENTENCE}`}
       points={[
-        "No commitment - you are only charged for what you ingest.",
+        "A payment method is required before you can send paid telemetry.",
         "Stop sending data, or delete the key, and the charge stops.",
         "Longer retention costs proportionally more per GB.",
       ]}
@@ -281,6 +282,7 @@ export const MonitorPayAsYouGoCard: FunctionComponent = (): ReactElement => {
       summary={`Your project is on the Free plan. Every monitor type except ${MonitorType.Manual} is an active monitor and is billed at ${ACTIVE_MONITOR_PRICE_SENTENCE}.`}
       points={[
         `${MonitorType.Manual} monitors are always free, and unlimited.`,
+        "Add a payment method before creating an active monitor.",
         "No commitment - delete a monitor and the charge stops.",
         "Telemetry based monitors are billed as active monitors on top of the telemetry they read.",
       ]}
@@ -300,7 +302,7 @@ const TelemetryPayAsYouGoModalNotice: FunctionComponent = (): ReactElement => {
     >
       <p className="text-sm text-gray-700">
         Your project is on the Free plan, which does not bundle any telemetry.
-        Data sent with this ingestion key is billed as you use it.{" "}
+        A payment method is required before you can create a key or send paid telemetry. Data sent with this ingestion key is billed as you use it.{" "}
         {TELEMETRY_RATES_SENTENCE}{" "}
         <Link
           className="underline"
@@ -353,7 +355,17 @@ export function getTelemetryPayAsYouGoFormFields(): Array<
       showEvenIfPermissionDoesNotExist: true,
       doNotShowWhenEditing: true,
       spanFullRow: true,
-      fieldType: FormFieldSchemaType.Checkbox,
+      fieldType: FormFieldSchemaType.CustomComponent,
+      getCustomElement: (values: FormValues<TelemetryIngestionKey>, props: CustomElementProps): ReactElement => {
+        return <PaidUsageConsent
+          title="I agree to these usage charges"
+          description={TELEMETRY_RATES_SENTENCE}
+          value={(values as Record<string, unknown>)[TELEMETRY_CONSENT_FIELD_KEY] === true}
+          onChange={props.onChange}
+          error={props.error}
+          dataTestId="telemetry-pay-as-you-go-consent"
+        />;
+      },
       title: "I understand telemetry sent with this key is billed as I use it",
       description: TELEMETRY_RATES_SENTENCE,
       dataTestId: "telemetry-pay-as-you-go-consent",
@@ -439,7 +451,7 @@ export const MonitorBatchPayAsYouGoConsent: FunctionComponent<
       className="rounded-lg border border-amber-200 bg-amber-50 p-4"
       data-testid="monitor-batch-pay-as-you-go-notice"
     >
-      <CheckboxElement
+      <PaidUsageConsent
         title={`I understand these monitors are billed at ${ACTIVE_MONITOR_PRICE_TEXT} per month each`}
         description={
           <span>
@@ -485,7 +497,17 @@ export function getMonitorPayAsYouGoFormFields(data: {
       showEvenIfPermissionDoesNotExist: true,
       stepId: data.stepId,
       spanFullRow: true,
-      fieldType: FormFieldSchemaType.Checkbox,
+      fieldType: FormFieldSchemaType.CustomComponent,
+      getCustomElement: (values: FormValues<Monitor>, props: CustomElementProps): ReactElement => {
+        return <PaidUsageConsent
+          title="I agree to these usage charges"
+          description={`${ACTIVE_MONITOR_PRICE_SENTENCE}. Manual monitors remain free.`}
+          value={(values as Record<string, unknown>)[MONITOR_CONSENT_FIELD_KEY] === true}
+          onChange={props.onChange}
+          error={props.error}
+          dataTestId="monitor-pay-as-you-go-consent"
+        />;
+      },
       title: `I understand this monitor is billed at ${ACTIVE_MONITOR_PRICE_TEXT} per month`,
       description: `Your project is on the Free plan. Every monitor type except ${MonitorType.Manual} is an active monitor, billed at ${ACTIVE_MONITOR_PRICE_SENTENCE}. Pick ${MonitorType.Manual} if you do not want to be billed for this monitor.`,
       dataTestId: "monitor-pay-as-you-go-consent",

--- a/App/FeatureSet/Dashboard/src/Components/Billing/UsagePricingSummary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Billing/UsagePricingSummary.tsx
@@ -1,0 +1,48 @@
+import {
+  ACTIVE_MONITOR_PRICE_IN_USD_PER_MONTH,
+  PRICING_PAGE_URL,
+  SESSION_REPLAY_PRICE_IN_USD_PER_GB,
+  TELEMETRY_PRICE_IN_USD_PER_GB,
+  TELEMETRY_PRICE_RETENTION_IN_DAYS,
+  formatPriceInUSD,
+} from "Common/Types/Billing/PayAsYouGoPricing";
+import URL from "Common/Types/API/URL";
+import Link from "Common/UI/Components/Link/Link";
+import React, { ReactElement } from "react";
+
+const UsagePricingSummary: () => ReactElement = (): ReactElement => {
+  return (
+    <div className="space-y-2 text-sm text-gray-700">
+      <ul className="list-disc space-y-1 pl-5">
+        <li>
+          Active monitors:{" "}
+          {formatPriceInUSD(ACTIVE_MONITOR_PRICE_IN_USD_PER_MONTH)} per monitor
+          per month. Manual monitors are free.
+        </li>
+        <li>
+          Logs, traces, metrics, profiles and security events:{" "}
+          {formatPriceInUSD(TELEMETRY_PRICE_IN_USD_PER_GB)} per GB ingested.
+        </li>
+        <li>
+          Session replay: {formatPriceInUSD(SESSION_REPLAY_PRICE_IN_USD_PER_GB)}{" "}
+          per GB. These telemetry rates include{" "}
+          {TELEMETRY_PRICE_RETENTION_IN_DAYS} day retention; longer retention
+          costs more.
+        </li>
+      </ul>
+      <p>
+        Other paid features have their own rates. Review the{" "}
+        <Link
+          to={URL.fromString(PRICING_PAGE_URL)}
+          openInNewTab={true}
+          className="text-indigo-600 underline"
+        >
+          full pricing
+        </Link>{" "}
+        before enabling them.
+      </p>
+    </div>
+  );
+};
+
+export default UsagePricingSummary;

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/Billing.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/Billing.tsx
@@ -3,6 +3,7 @@ import PageMap from "../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import PageComponentProps from "../PageComponentProps";
 import CheckoutForm from "./BillingPaymentMethodForm";
+import BillingUsageStatus from "../../Components/Billing/BillingUsageStatus";
 import { Elements } from "@stripe/react-stripe-js";
 import { Stripe } from "@stripe/stripe-js";
 /*
@@ -96,13 +97,17 @@ const Settings: FunctionComponent<ComponentProps> = (
 
   const [balance, setBalance] = useState<number>(0);
 
-  const [paymentMethodsCount, setPaymentMethodsCount] = useState<number>(0);
+  const [paymentMethodsCount, setPaymentMethodsCount] = useState<number | null>(
+    null,
+  );
+  const [paymentMethodsRefresh, setPaymentMethodsRefresh] = useState<number>(0);
   const [showNoPaymentMethodModal, setShowNoPaymentMethodModal] =
     useState<boolean>(false);
 
   const [currentPlanId, setCurrentPlanId] = useState<string | null>(null);
 
-  const formRef: any = useRef<any>(null);
+  const formRef: React.RefObject<HTMLButtonElement> =
+    useRef<HTMLButtonElement>(null);
 
   const currentProjectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
   const projectCrudRoute: Route | null = new Project().getCrudApiPath();
@@ -131,7 +136,7 @@ const Settings: FunctionComponent<ComponentProps> = (
           });
         setPaymentMethodsCount(result.count);
       } catch {
-        setPaymentMethodsCount(0);
+        setPaymentMethodsCount(null);
       }
     };
 
@@ -341,6 +346,9 @@ const Settings: FunctionComponent<ComponentProps> = (
   const fetchSetupIntent: PromiseVoidFunction = async (): Promise<void> => {
     try {
       setIsModalLoading(true);
+      setIsModalSubmitButtonLoading(false);
+      setModalError(null);
+      setSetupIntent("");
 
       const response: HTTPResponse<JSONObject> = await BaseAPI.post<JSONObject>(
         {
@@ -386,14 +394,31 @@ const Settings: FunctionComponent<ComponentProps> = (
 
       {!isLoading && !error ? (
         <div>
+          {BILLING_ENABLED && !reseller ? (
+            <BillingUsageStatus
+              isFreePlan={Boolean(
+                currentPlanId &&
+                  SubscriptionPlan.isFreePlan(currentPlanId, getAllEnvVars()),
+              )}
+              paymentMethodsCount={paymentMethodsCount}
+              onAddPaymentMethod={async () => {
+                setShowPaymentMethodModal(true);
+                await fetchSetupIntent();
+              }}
+              onRetry={fetchPaymentMethodsCount}
+            />
+          ) : (
+            <></>
+          )}
           {!reseller && (
             <CardModelDetail<Project>
               name="Plan Details"
               cardProps={{
                 title: "Current Plan",
-                description: "Here is the plan this project is subscribed to.",
+                description:
+                  "Your subscription plan controls included features. Pay as you go usage is billed separately.",
               }}
-              isEditable={true}
+              isEditable={paymentMethodsCount !== null}
               editButtonText={"Change Plan"}
               onBeforeEdit={() => {
                 if (paymentMethodsCount === 0) {
@@ -434,14 +459,16 @@ const Settings: FunctionComponent<ComponentProps> = (
                       isSubscriptionPlanYearly &&
                       plan.getYearlySubscriptionAmountInUSD() === 0
                     ) {
-                      description = "This plan is free, forever. ";
+                      description =
+                        "$0 subscription. Paid features are billed separately when pay as you go is enabled.";
                     }
 
                     if (
                       !isSubscriptionPlanYearly &&
                       plan.getMonthlySubscriptionAmountInUSD() === 0
                     ) {
-                      description = "This plan is free, forever. ";
+                      description =
+                        "$0 subscription. Paid features are billed separately when pay as you go is enabled.";
                     }
 
                     return {
@@ -512,14 +539,16 @@ const Settings: FunctionComponent<ComponentProps> = (
                         isYearlyPlan &&
                         plan.getYearlySubscriptionAmountInUSD() === 0
                       ) {
-                        description = "This plan is free, forever. ";
+                        description =
+                          "$0 subscription. Paid features are billed separately when pay as you go is enabled.";
                       }
 
                       if (
                         !isYearlyPlan &&
                         plan.getMonthlySubscriptionAmountInUSD() === 0
                       ) {
-                        description = "This plan is free, forever. ";
+                        description =
+                          "$0 subscription. Paid features are billed separately when pay as you go is enabled.";
                       }
 
                       return (
@@ -644,6 +673,8 @@ const Settings: FunctionComponent<ComponentProps> = (
             isEditable={false}
             isCreateable={false}
             isViewable={false}
+            refreshToggle={paymentMethodsRefresh.toString()}
+            onItemDeleted={fetchPaymentMethodsCount}
             name="Settings > Billing > Add Payment Method"
             cardProps={{
               buttons: [
@@ -659,7 +690,7 @@ const Settings: FunctionComponent<ComponentProps> = (
               ],
               title: "Payment Methods",
               description:
-                "Here is a list of payment methods attached to this project.",
+                "Adding a payment method enables paid usage. It does not upgrade your subscription plan.",
             }}
             noItemsMessage={"No payment methods found."}
             query={{
@@ -716,7 +747,7 @@ const Settings: FunctionComponent<ComponentProps> = (
             <ConfirmModal
               title={`Add a Payment Method`}
               description={
-                "You need to add a payment method before you can change your plan. Please add a payment method to continue."
+                "You need a payment method before changing your subscription plan. Adding one also enables pay as you go usage at the published rates. You will review these charges before saving your payment method."
               }
               submitButtonText={"Add Payment Method"}
               onSubmit={async () => {
@@ -736,19 +767,24 @@ const Settings: FunctionComponent<ComponentProps> = (
             <Modal
               title={`Add Payment Method`}
               onSubmit={async () => {
+                if (!formRef.current) {
+                  return;
+                }
+                setModalError(null);
                 setIsModalSubmitButtonLoading(true);
                 formRef.current.click();
               }}
               isLoading={isModalSubmitButtonLoading}
+              disableSubmitButton={isModalLoading || !setupIntent || !stripe}
               onClose={() => {
                 setShowPaymentMethodModal(false);
               }}
-              submitButtonText={`Save`}
+              submitButtonText={`Save payment method and enable paid usage`}
               error={modalError || ""}
               isBodyLoading={isModalLoading}
               submitButtonType={ButtonType.Submit}
             >
-              {setupIntent && !modalError && stripe ? (
+              {setupIntent && stripe ? (
                 <Elements
                   stripe={stripe}
                   options={{
@@ -777,6 +813,10 @@ const Settings: FunctionComponent<ComponentProps> = (
                     onSuccess={async () => {
                       setIsModalSubmitButtonLoading(false);
                       await fetchPaymentMethodsCount();
+                      setPaymentMethodsRefresh((value: number) => {
+                        return value + 1;
+                      });
+                      setShowPaymentMethodModal(false);
                     }}
                     onError={(errorMessage: string) => {
                       setModalError(errorMessage);

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/BillingPaymentMethodForm.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/BillingPaymentMethodForm.tsx
@@ -1,76 +1,113 @@
+import UsagePricingSummary from "../../Components/Billing/UsagePricingSummary";
 import {
   PaymentElement,
   useElements,
   useStripe,
 } from "@stripe/react-stripe-js";
+import CheckboxElement from "Common/UI/Components/Checkbox/Checkbox";
 import Navigation from "Common/UI/Utils/Navigation";
-import React, { FunctionComponent, ReactElement, Ref } from "react";
+import React, {
+  FormEvent,
+  FunctionComponent,
+  ReactElement,
+  Ref,
+  useRef,
+  useState,
+} from "react";
 
 export interface ComponentProps {
   onError: (error: string) => void;
   onSuccess: () => void;
-  formRef: Ref<any>;
+  formRef: Ref<HTMLButtonElement>;
 }
+
+export const PAYMENT_METHOD_CONSENT_LABEL: string =
+  "I understand that adding a payment method enables paid usage, billed at the published rates in addition to any subscription charges.";
+
+export const PAYMENT_METHOD_CONSENT_ERROR: string =
+  "Please confirm you understand the usage charges before adding a payment method.";
 
 const CheckoutForm: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const stripe: any = useStripe();
-  const elements: any = useElements();
+  const stripe: ReturnType<typeof useStripe> = useStripe();
+  const elements: ReturnType<typeof useElements> = useElements();
+  const [hasAcknowledgedCharges, setHasAcknowledgedCharges] =
+    useState<boolean>(false);
+  const isSubmitting: React.MutableRefObject<boolean> = useRef<boolean>(false);
 
-  type SubmitFormFunction = (event: Event) => Promise<void>;
-
-  const submitForm: SubmitFormFunction = async (
-    event: Event,
+  const submitForm: (
+    event: FormEvent<HTMLFormElement>,
+  ) => Promise<void> = async (
+    event: FormEvent<HTMLFormElement>,
   ): Promise<void> => {
     event.preventDefault();
-    /*
-     * We don't want to let default form submission happen here,
-     * which would refresh the page.
-     */
-    event.preventDefault();
 
-    if (!stripe || !elements) {
-      /*
-       * Stripe.js has not yet loaded.
-       * Make sure to disable form submission until Stripe.js has loaded.
-       */
+    if (isSubmitting.current) {
       return;
     }
 
-    const { error } = await stripe.confirmSetup({
-      //`Elements` instance that was used to create the Payment Element
-      elements,
-      confirmParams: {
-        return_url: Navigation.getCurrentURL().removeQueryString().toString(),
-      },
-    });
+    if (!hasAcknowledgedCharges) {
+      props.onError(PAYMENT_METHOD_CONSENT_ERROR);
+      return;
+    }
 
-    if (error) {
-      /*
-       * This point will only be reached if there is an immediate error when
-       * confirming the payment. Show error to your customer (for example, payment
-       * details incomplete)
-       */
-
+    if (!stripe || !elements) {
       props.onError(
-        error.message?.toString() ||
-          "Unknown error with your payemnt provider.",
+        "The payment form is still loading. Please try again in a moment.",
       );
-    } else {
-      /*
-       * Your customer will be redirected to your `return_url`. For some payment
-       * methods like iDEAL, your customer will be redirected to an indeterminate
-       * site first to authorize the payment, then redirected to the `return_url`.
-       */
-      props.onSuccess();
+      return;
+    }
+
+    isSubmitting.current = true;
+
+    try {
+      const { error } = await stripe.confirmSetup({
+        elements,
+        confirmParams: {
+          return_url: Navigation.getCurrentURL().removeQueryString().toString(),
+        },
+      });
+
+      if (error) {
+        props.onError(
+          error.message ||
+            "Unable to save your payment method. Please try again.",
+        );
+      } else {
+        props.onSuccess();
+      }
+    } catch {
+      props.onError("Unable to save your payment method. Please try again.");
+    } finally {
+      isSubmitting.current = false;
     }
   };
 
   return (
-    <div ref={props.formRef} onClick={submitForm as any}>
+    <form onSubmit={submitForm} className="space-y-5">
+      <div className="space-y-3 rounded-lg border border-indigo-100 bg-indigo-50 p-4">
+        <p className="text-sm font-medium text-gray-900">
+          Adding a payment method enables paid usage for this project. Your
+          subscription plan stays the same.
+        </p>
+        <UsagePricingSummary />
+        <CheckboxElement
+          title={PAYMENT_METHOD_CONSENT_LABEL}
+          ariaLabel={PAYMENT_METHOD_CONSENT_LABEL}
+          value={hasAcknowledgedCharges}
+          onChange={setHasAcknowledgedCharges}
+          dataTestId="payment-method-usage-consent"
+        />
+      </div>
       <PaymentElement />
-    </div>
+      <button
+        ref={props.formRef}
+        type="submit"
+        hidden={true}
+        aria-label="Save payment method"
+      />
+    </form>
   );
 };
 

--- a/App/FeatureSet/Telemetry/GrpcServer.ts
+++ b/App/FeatureSet/Telemetry/GrpcServer.ts
@@ -3,6 +3,7 @@ import * as protoLoader from "@grpc/proto-loader";
 import path from "path";
 import logger from "Common/Server/Utils/Logger";
 import ObjectID from "Common/Types/ObjectID";
+import PaymentRequiredException from "Common/Types/Exception/PaymentRequiredException";
 import ProductType from "Common/Types/MeteredPlan/ProductType";
 import TelemetryIngestionKeyService from "Common/Server/Services/TelemetryIngestionKeyService";
 import TelemetryIngestionKeyGuard, {
@@ -168,7 +169,7 @@ export function buildTelemetryRequest(
   return req as TelemetryRequest;
 }
 
-async function handleExport(
+export async function handleExport(
   call: GrpcCall,
   callback: GrpcCallback,
   productType: ProductType,
@@ -205,6 +206,17 @@ async function handleExport(
 
     callback(null, {});
   } catch (err) {
+    if (err instanceof PaymentRequiredException) {
+      callback({
+        name: "PaymentRequiredException",
+        message: err.message,
+        code: grpc.status.PERMISSION_DENIED,
+        details: err.message,
+        metadata: new grpc.Metadata(),
+      });
+      return;
+    }
+
     logger.error(`gRPC ${productType} export error:`, { service: "telemetry" });
     logger.error(err, { service: "telemetry" });
     // Return success to avoid OTel SDK retries

--- a/App/FeatureSet/Telemetry/MqttServer.ts
+++ b/App/FeatureSet/Telemetry/MqttServer.ts
@@ -15,6 +15,8 @@ import logger from "Common/Server/Utils/Logger";
 import ObjectID from "Common/Types/ObjectID";
 import ProductType from "Common/Types/MeteredPlan/ProductType";
 import TelemetryIngestionKeyService from "Common/Server/Services/TelemetryIngestionKeyService";
+import PayAsYouGoBillingService from "Common/Server/Services/PayAsYouGoBillingService";
+import PaymentRequiredException from "Common/Types/Exception/PaymentRequiredException";
 import TelemetryIngestionKeyGuard, {
   TelemetryIngestionKeyRefusal,
 } from "Common/Server/Utils/Telemetry/TelemetryIngestionKeyGuard";
@@ -183,6 +185,10 @@ async function resolveAuthContext(
         return null;
       }
 
+      await PayAsYouGoBillingService.requirePayAsYouGo(
+        new ObjectID(context.projectId),
+      );
+
       return {
         projectId: new ObjectID(context.projectId),
         device: {
@@ -326,6 +332,10 @@ async function handleAuthorizePublish(
     return;
   }
 
+  // A connected session can outlive its project's payment setup, including
+  // device credentials that do not use a project ingestion key.
+  await PayAsYouGoBillingService.requirePayAsYouGo(projectId);
+
   const payload: Buffer = Buffer.isBuffer(packet.payload)
     ? packet.payload
     : Buffer.from(packet.payload || "", "utf8");
@@ -455,6 +465,18 @@ function createMqttBroker(): Aedes {
         done(null, true);
       })
       .catch((err: unknown) => {
+        if (err instanceof PaymentRequiredException) {
+          logger.warn(err.message, { service: "telemetry" });
+          done(
+            makeAuthenticateError(
+              err.message,
+              CONNACK_BAD_USERNAME_OR_PASSWORD,
+            ),
+            false,
+          );
+          return;
+        }
+
         logger.error("MQTT: error while authenticating client:", {
           service: "telemetry",
         });

--- a/App/FeatureSet/Telemetry/MqttServer.ts
+++ b/App/FeatureSet/Telemetry/MqttServer.ts
@@ -332,8 +332,10 @@ async function handleAuthorizePublish(
     return;
   }
 
-  // A connected session can outlive its project's payment setup, including
-  // device credentials that do not use a project ingestion key.
+  /*
+   * A connected session can outlive its project's payment setup, including
+   * device credentials that do not use a project ingestion key.
+   */
   await PayAsYouGoBillingService.requirePayAsYouGo(projectId);
 
   const payload: Buffer = Buffer.isBuffer(packet.payload)

--- a/App/Tests/Telemetry/GrpcMqttIngestionKeyRefusal.test.ts
+++ b/App/Tests/Telemetry/GrpcMqttIngestionKeyRefusal.test.ts
@@ -16,6 +16,14 @@ import logger from "Common/Server/Utils/Logger";
 import { authenticateRequest } from "../../FeatureSet/Telemetry/GrpcServer";
 import { startMqttServer } from "../../FeatureSet/Telemetry/MqttServer";
 
+// Billing admission is exercised independently by TelemetryPayAsYouGoBilling.
+jest.mock("Common/Server/Services/PayAsYouGoBillingService", () => {
+  return {
+    __esModule: true,
+    default: { requirePayAsYouGo: jest.fn().mockResolvedValue(undefined) },
+  };
+});
+
 /*
  * THE INVARIANT
  * =============

--- a/App/Tests/Telemetry/GrpcServerAuthCache.test.ts
+++ b/App/Tests/Telemetry/GrpcServerAuthCache.test.ts
@@ -13,6 +13,14 @@ import TelemetryIngestionKey from "Common/Models/DatabaseModels/TelemetryIngesti
 import logger from "Common/Server/Utils/Logger";
 import { authenticateRequest } from "../../FeatureSet/Telemetry/GrpcServer";
 
+// Payment eligibility is covered by the billing admission suites.
+jest.mock("Common/Server/Services/PayAsYouGoBillingService", () => {
+  return {
+    __esModule: true,
+    default: { requirePayAsYouGo: jest.fn().mockResolvedValue(undefined) },
+  };
+});
+
 /*
  * This suite proves the END-TO-END property behind the gRPC auth change:
  * repeated authenticateRequest calls for the same token reach the

--- a/App/Tests/Telemetry/TelemetryPayAsYouGoBilling.test.ts
+++ b/App/Tests/Telemetry/TelemetryPayAsYouGoBilling.test.ts
@@ -1,0 +1,327 @@
+import { beforeAll, beforeEach, describe, expect, test } from "@jest/globals";
+import * as grpc from "@grpc/grpc-js";
+import { Client, PublishPacket, AuthenticateError } from "aedes";
+import ObjectID from "Common/Types/ObjectID";
+import ProductType from "Common/Types/MeteredPlan/ProductType";
+import PaymentRequiredException from "Common/Types/Exception/PaymentRequiredException";
+import TelemetryIngestionKeyType from "Common/Types/Telemetry/TelemetryIngestionKeyType";
+import TelemetryIngestionKeyService from "Common/Server/Services/TelemetryIngestionKeyService";
+import PayAsYouGoBillingService from "Common/Server/Services/PayAsYouGoBillingService";
+import IoTDeviceCredentialService from "Common/Server/Services/IoTDeviceCredentialService";
+import { handleExport } from "../../FeatureSet/Telemetry/GrpcServer";
+import { startMqttServer } from "../../FeatureSet/Telemetry/MqttServer";
+import MetricsQueueService from "../../FeatureSet/Telemetry/Services/Queue/MetricsQueueService";
+
+jest.mock("Common/Server/Infrastructure/Queue", () => {
+  return {
+    __esModule: true,
+    default: { addJob: jest.fn() },
+    QueueName: {
+      Workflow: "Workflow",
+      Worker: "Worker",
+      Telemetry: "Telemetry",
+      Runbook: "Runbook",
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/TelemetryIngestionKeyService", () => {
+  return {
+    __esModule: true,
+    default: { getPolicyFromSecretKey: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Services/PayAsYouGoBillingService", () => {
+  return {
+    __esModule: true,
+    default: { requirePayAsYouGo: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Services/IoTDeviceCredentialService", () => {
+  return {
+    __esModule: true,
+    default: { getCredentialContext: jest.fn(), markConnected: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Middleware/TelemetryIngestionDisabled", () => {
+  return {
+    __esModule: true,
+    default: {
+      isDisabled: (): boolean => {
+        return false;
+      },
+    },
+  };
+});
+
+jest.mock(
+  "../../FeatureSet/Telemetry/Services/Queue/MetricsQueueService",
+  () => {
+    return { __esModule: true, default: { addMetricIngestJob: jest.fn() } };
+  },
+);
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../FeatureSet/Telemetry/Config", () => {
+  return {
+    MQTT_INGEST_ENABLED: true,
+    MQTT_INGEST_PORT: 1883,
+    MQTT_WEBSOCKET_PATH: "/mqtt",
+  };
+});
+
+jest.mock("aedes", () => {
+  const broker: Record<string, unknown> = { on: jest.fn() };
+  return {
+    __esModule: true,
+    createBroker: (): Record<string, unknown> => {
+      return broker;
+    },
+    __broker: broker,
+  };
+});
+
+jest.mock("net", () => {
+  return {
+    ...(jest.requireActual("net") as Record<string, unknown>),
+    createServer: (): Record<string, unknown> => {
+      return { on: jest.fn(), listen: jest.fn() };
+    },
+  };
+});
+
+type MockFn = jest.Mock;
+const projectId: ObjectID = ObjectID.generate();
+const paymentError: PaymentRequiredException = new PaymentRequiredException(
+  "Add a payment method in Project Settings > Billing before sending telemetry.",
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (PayAsYouGoBillingService.requirePayAsYouGo as MockFn).mockResolvedValue(
+    undefined,
+  );
+  (IoTDeviceCredentialService.getCredentialContext as MockFn).mockResolvedValue(
+    null,
+  );
+  (IoTDeviceCredentialService.markConnected as MockFn).mockResolvedValue(
+    undefined,
+  );
+  (MetricsQueueService.addMetricIngestJob as MockFn).mockResolvedValue(
+    undefined,
+  );
+  (
+    TelemetryIngestionKeyService.getPolicyFromSecretKey as MockFn
+  ).mockResolvedValue({
+    ingestionKeyId: ObjectID.generate(),
+    projectId,
+    keyType: TelemetryIngestionKeyType.Server,
+    allowedOrigins: [],
+    pinnedServiceName: null,
+    isEnabled: true,
+    expiresAt: null,
+    requestsPerMinuteLimit: null,
+  });
+});
+
+describe("gRPC payment refusal", () => {
+  test.each([
+    ProductType.Logs,
+    ProductType.Metrics,
+    ProductType.Traces,
+    ProductType.Profiles,
+  ])(
+    "returns a useful nonretryable refusal without queueing %s",
+    async (productType: ProductType) => {
+      (
+        TelemetryIngestionKeyService.getPolicyFromSecretKey as MockFn
+      ).mockRejectedValue(paymentError);
+      const metadata: grpc.Metadata = new grpc.Metadata();
+      metadata.set("x-oneuptime-token", ObjectID.generate().toString());
+      const callback: MockFn = jest.fn();
+      const queue: MockFn = jest.fn();
+      await handleExport(
+        { request: {}, metadata },
+        callback,
+        productType,
+        queue,
+      );
+      expect(queue).not.toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: grpc.status.PERMISSION_DENIED,
+          details: paymentError.message,
+        }),
+      );
+    },
+  );
+
+  test("continues to queue an authorized project", async () => {
+    const metadata: grpc.Metadata = new grpc.Metadata();
+    metadata.set("x-oneuptime-token", ObjectID.generate().toString());
+    const callback: MockFn = jest.fn();
+    const queue: MockFn = jest.fn().mockResolvedValue(undefined);
+    await handleExport(
+      { request: {}, metadata },
+      callback,
+      ProductType.Logs,
+      queue,
+    );
+    expect(queue).toHaveBeenCalledWith(expect.objectContaining({ projectId }));
+    expect(callback).toHaveBeenCalledWith(null, {});
+  });
+});
+
+interface TestBroker {
+  authenticate: (
+    client: Client,
+    username: string | undefined,
+    password: Buffer,
+    done: (error: AuthenticateError | null, success: boolean | null) => void,
+  ) => void;
+  authorizePublish: (
+    client: Client | null,
+    packet: PublishPacket,
+    callback: (error?: Error | null) => void,
+  ) => void;
+}
+let broker: TestBroker;
+
+beforeAll(() => {
+  startMqttServer();
+  broker = (jest.requireMock("aedes") as { __broker: TestBroker }).__broker;
+});
+
+function client(): Client {
+  return { id: "sensor", closed: false, close: jest.fn() } as unknown as Client;
+}
+
+function connect(
+  target: Client,
+  username: string | undefined = undefined,
+  secret: string = ObjectID.generate().toString(),
+): Promise<{ error: AuthenticateError | null; success: boolean | null }> {
+  return new Promise(
+    (
+      resolve: (result: {
+        error: AuthenticateError | null;
+        success: boolean | null;
+      }) => void,
+    ): void => {
+      broker.authenticate(
+        target,
+        username,
+        Buffer.from(secret),
+        (error: AuthenticateError | null, success: boolean | null): void => {
+          resolve({ error, success });
+        },
+      );
+    },
+  );
+}
+
+function publish(target: Client): Promise<Error | null | undefined> {
+  const packet: PublishPacket = {
+    cmd: "publish",
+    qos: 0,
+    dup: false,
+    retain: false,
+    topic: "oneuptime/fleet/sensor/telemetry",
+    payload: Buffer.from(JSON.stringify({ metrics: { temperature: 21 } })),
+  } as PublishPacket;
+  return new Promise(
+    (resolve: (error: Error | null | undefined) => void): void => {
+      broker.authorizePublish(target, packet, resolve);
+    },
+  );
+}
+
+describe("MQTT payment admission", () => {
+  test("refuses a project key when the shared resolver requires payment", async () => {
+    (
+      TelemetryIngestionKeyService.getPolicyFromSecretKey as MockFn
+    ).mockRejectedValue(paymentError);
+    const result: { error: AuthenticateError | null; success: boolean | null } =
+      await connect(client());
+    expect(result.success).toBe(false);
+    expect(result.error?.returnCode).toBe(4);
+    expect(result.error?.message).toBe(paymentError.message);
+    expect(MetricsQueueService.addMetricIngestJob).not.toHaveBeenCalled();
+  });
+
+  test("checks payment setup for device credentials without a project key", async () => {
+    const credentialId: string = ObjectID.generate().toString();
+    const secretKey: string = ObjectID.generate().toString();
+    (
+      IoTDeviceCredentialService.getCredentialContext as MockFn
+    ).mockResolvedValue({
+      credentialId,
+      secretKey,
+      projectId: projectId.toString(),
+      iotFleetId: ObjectID.generate().toString(),
+      fleetName: "fleet",
+      externalId: "sensor",
+    });
+    (PayAsYouGoBillingService.requirePayAsYouGo as MockFn).mockRejectedValue(
+      paymentError,
+    );
+    const result: { error: AuthenticateError | null; success: boolean | null } =
+      await connect(client(), credentialId, secretKey);
+    expect(result.success).toBe(false);
+    expect(result.error?.returnCode).toBe(4);
+    expect(PayAsYouGoBillingService.requirePayAsYouGo).toHaveBeenCalledWith(
+      projectId,
+    );
+    expect(IoTDeviceCredentialService.markConnected).not.toHaveBeenCalled();
+  });
+
+  test("rechecks billing for an already-connected project before queueing each publish", async () => {
+    const target: Client = client();
+    expect((await connect(target)).success).toBe(true);
+    await expect(publish(target)).resolves.toBeNull();
+    expect(MetricsQueueService.addMetricIngestJob).toHaveBeenCalledTimes(1);
+    (PayAsYouGoBillingService.requirePayAsYouGo as MockFn).mockRejectedValue(
+      paymentError,
+    );
+    await expect(publish(target)).resolves.toBe(paymentError);
+    expect(PayAsYouGoBillingService.requirePayAsYouGo).toHaveBeenCalledTimes(2);
+    expect(MetricsQueueService.addMetricIngestJob).toHaveBeenCalledTimes(1);
+  });
+
+  test("also rechecks billing on a connected device credential session", async () => {
+    const target: Client = client();
+    const credentialId: string = ObjectID.generate().toString();
+    const secretKey: string = ObjectID.generate().toString();
+    (
+      IoTDeviceCredentialService.getCredentialContext as MockFn
+    ).mockResolvedValue({
+      credentialId,
+      secretKey,
+      projectId: projectId.toString(),
+      iotFleetId: ObjectID.generate().toString(),
+      fleetName: "fleet",
+      externalId: "sensor",
+    });
+    expect((await connect(target, credentialId, secretKey)).success).toBe(true);
+    (PayAsYouGoBillingService.requirePayAsYouGo as MockFn).mockRejectedValue(
+      paymentError,
+    );
+    await expect(publish(target)).resolves.toBe(paymentError);
+    expect(MetricsQueueService.addMetricIngestJob).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Server/API/BillingAPI.ts
+++ b/Common/Server/API/BillingAPI.ts
@@ -2,6 +2,7 @@ import { BillingWebhookSecret, IsBillingEnabled } from "../EnvironmentConfig";
 import Stripe from "stripe";
 import UserMiddleware from "../Middleware/UserAuthorization";
 import BillingService from "../Services/BillingService";
+import PayAsYouGoBillingService from "../Services/PayAsYouGoBillingService";
 import ProjectService from "../Services/ProjectService";
 import Express, {
   ExpressRequest,
@@ -117,6 +118,35 @@ export default class BillingAPI {
             `[Invoice Email] Stripe webhook error: ${err}`,
             getLogAttributesFromRequest(req as OneUptimeRequest),
           );
+          next(err);
+        }
+      },
+    );
+
+    this.router.get(
+      `/billing/pay-as-you-go-status`,
+      UserMiddleware.getUserMiddleware,
+      async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+        try {
+          const projectId: ObjectID | null = this.getTenantId(req);
+          if (!projectId) {
+            throw new BadDataException("Project ID is required");
+          }
+
+          // Members need the feature gate, but never card or invoice details.
+          const permissions: Array<UserPermission> =
+            await this.getPermissionsForTenant(req);
+          if (
+            permissions.length === 0 &&
+            !(req as OneUptimeRequest).userAuthorization?.isMasterAdmin
+          ) {
+            throw new BadDataException("You do not have access to this project");
+          }
+
+          return Response.sendJsonObjectResponse(req, res, {
+            isAllowed: await PayAsYouGoBillingService.canUsePayAsYouGo(projectId),
+          });
+        } catch (err) {
           next(err);
         }
       },

--- a/Common/Server/API/BillingAPI.ts
+++ b/Common/Server/API/BillingAPI.ts
@@ -140,11 +140,14 @@ export default class BillingAPI {
             permissions.length === 0 &&
             !(req as OneUptimeRequest).userAuthorization?.isMasterAdmin
           ) {
-            throw new BadDataException("You do not have access to this project");
+            throw new BadDataException(
+              "You do not have access to this project",
+            );
           }
 
           return Response.sendJsonObjectResponse(req, res, {
-            isAllowed: await PayAsYouGoBillingService.canUsePayAsYouGo(projectId),
+            isAllowed:
+              await PayAsYouGoBillingService.canUsePayAsYouGo(projectId),
           });
         } catch (err) {
           next(err);

--- a/Common/Server/Services/BillingService.ts
+++ b/Common/Server/Services/BillingService.ts
@@ -26,6 +26,7 @@ import ObjectID from "../../Types/ObjectID";
 import Sleep from "../../Types/Sleep";
 import Stripe from "stripe";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import PayAsYouGoBillingService from "./PayAsYouGoBillingService";
 
 export type SubscriptionItem = Stripe.SubscriptionItem;
 
@@ -44,6 +45,9 @@ export interface PaymentMethod {
  * instead of a raw payment-provider failure.
  */
 export const MAX_TRIAL_LENGTH_IN_DAYS: number = 730;
+
+export const METERED_BILLING_START_METADATA_KEY: string =
+  "oneuptime_pay_as_you_go_started_at";
 
 /*
  * How long to wait before trying a cancel again, per retry.
@@ -574,6 +578,12 @@ export class BillingService extends BaseService {
     }
 
     // check if this pricing exists
+
+    if (quantity > 0) {
+      await PayAsYouGoBillingService.requireMeteredSubscriptionPayment(
+        subscription,
+      );
+    }
 
     const pricingExists: boolean = subscription.items.data.some(
       (item: SubscriptionItem) => {
@@ -1272,6 +1282,43 @@ export class BillingService extends BaseService {
     }
 
     return false;
+  }
+
+  /**
+   * Old usage must not become a debt when a customer adds their first card.
+   * Establish a durable boundary at the first authorized billing pass. For
+   * existing customers without the marker this deliberately forgives older
+   * unreported telemetry. Never derive consent from subscription creation:
+   * signup creates a subscription even when no payment method exists.
+   */
+  public async getMeteredBillingStartDate(customerId: string): Promise<Date> {
+    if (!this.isBillingEnabled()) {
+      throw new BadDataException(Errors.BillingService.BILLING_NOT_ENABLED);
+    }
+
+    const customer: Stripe.Customer | Stripe.DeletedCustomer =
+      await this.stripe.customers.retrieve(customerId);
+    if (customer.deleted) {
+      throw new BadDataException(Errors.BillingService.CUSTOMER_NOT_FOUND);
+    }
+
+    const storedValue: string | undefined =
+      customer.metadata[METERED_BILLING_START_METADATA_KEY];
+    const storedDate: Date | undefined = storedValue
+      ? new Date(storedValue)
+      : undefined;
+
+    if (storedDate && Number.isFinite(storedDate.getTime())) {
+      return storedDate;
+    }
+
+    const startsAt: Date = OneUptimeDate.getCurrentDate();
+    await this.stripe.customers.update(customerId, {
+      metadata: {
+        [METERED_BILLING_START_METADATA_KEY]: startsAt.toISOString(),
+      },
+    });
+    return startsAt;
   }
 
   @CaptureSpan()

--- a/Common/Server/Services/MonitorService.ts
+++ b/Common/Server/Services/MonitorService.ts
@@ -1391,7 +1391,10 @@ export class Service extends DatabaseService<Model> {
         createBy.props.tenantId,
       );
 
-      if (currentPlan.isSubscriptionUnpaid) {
+      if (
+        currentPlan.isSubscriptionUnpaid &&
+        createBy.data.monitorType !== MonitorType.Manual
+      ) {
         throw new BadDataException(
           "Your subscription is unpaid. Please update your payment method and pay all the outstanding invoices to add more monitors.",
         );

--- a/Common/Server/Services/MonitorService.ts
+++ b/Common/Server/Services/MonitorService.ts
@@ -31,6 +31,7 @@ import ServerException from "../../Types/Exception/ServerException";
 import Sleep from "../../Types/Sleep";
 import ProbeService from "./ProbeService";
 import ProjectService, { CurrentPlan } from "./ProjectService";
+import PayAsYouGoBillingService from "./PayAsYouGoBillingService";
 import TeamMemberService from "./TeamMemberService";
 import URL from "../../Types/API/URL";
 import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
@@ -763,6 +764,46 @@ export class Service extends DatabaseService<Model> {
       });
     }
 
+    if (
+      IsBillingEnabled &&
+      ((updateBy.data.monitorType &&
+        updateBy.data.monitorType !== MonitorType.Manual) ||
+        updateBy.data.disableActiveMonitoring === false)
+    ) {
+      const monitors: Array<Model> = await this.findBy({
+        query:
+          !updateBy.props.isRoot && updateBy.props.tenantId
+            ? { ...updateBy.query, projectId: updateBy.props.tenantId }
+            : updateBy.query,
+        select: { projectId: true, monitorType: true },
+        limit: updateBy.limit,
+        skip: updateBy.skip,
+        props: { isRoot: true, ignoreHooks: true },
+      });
+      const checkedProjects: Set<string> = new Set<string>();
+
+      for (const monitor of monitors) {
+        const monitorType: MonitorType | undefined =
+          (updateBy.data.monitorType as MonitorType | undefined) ||
+          monitor.monitorType;
+
+        if (monitorType === MonitorType.Manual) {
+          continue;
+        }
+
+        if (!monitor.projectId) {
+          throw new BadDataException(
+            "ProjectId required to enable monitoring.",
+          );
+        }
+
+        if (!checkedProjects.has(monitor.projectId.toString())) {
+          await PayAsYouGoBillingService.requirePayAsYouGo(monitor.projectId);
+          checkedProjects.add(monitor.projectId.toString());
+        }
+      }
+    }
+
     return { updateBy, carryForward: null };
   }
 
@@ -1340,6 +1381,12 @@ export class Service extends DatabaseService<Model> {
     }
 
     if (IsBillingEnabled && createBy.props.tenantId) {
+      if (createBy.data.monitorType !== MonitorType.Manual) {
+        await PayAsYouGoBillingService.requirePayAsYouGo(
+          createBy.props.tenantId,
+        );
+      }
+
       const currentPlan: CurrentPlan = await ProjectService.getCurrentPlan(
         createBy.props.tenantId,
       );

--- a/Common/Server/Services/PayAsYouGoBillingService.ts
+++ b/Common/Server/Services/PayAsYouGoBillingService.ts
@@ -89,8 +89,10 @@ export class Service {
       project.paymentProviderCustomerId,
     );
 
-    // Daily aggregates cannot separate pre-card and post-card usage. Forgive
-    // the partial authorization day and begin with the next complete UTC day.
+    /*
+     * Daily aggregates cannot separate pre-card and post-card usage. Forgive
+     * the partial authorization day and begin with the next complete UTC day.
+     */
     return new Date(
       Date.UTC(
         authorizedAt.getUTCFullYear(),
@@ -142,17 +144,20 @@ export class Service {
     }
 
     if (project.resellerId && project.resellerPlanId) {
-      // The redeemed license is bound to the project and reseller. Its
-      // original plan can differ after an authenticated reseller tier change.
-      const redeemedLicense: PromoCode | null = await PromoCodeService.findOneBy({
-        query: {
-          projectId: projectId,
-          resellerId: project.resellerId,
-          isPromoCodeUsed: true,
-        },
-        select: { _id: true },
-        props: { isRoot: true, ignoreHooks: true },
-      });
+      /*
+       * The redeemed license is bound to the project and reseller. Its
+       * original plan can differ after an authenticated reseller tier change.
+       */
+      const redeemedLicense: PromoCode | null =
+        await PromoCodeService.findOneBy({
+          query: {
+            projectId: projectId,
+            resellerId: project.resellerId,
+            isPromoCodeUsed: true,
+          },
+          select: { _id: true },
+          props: { isRoot: true, ignoreHooks: true },
+        });
       if (redeemedLicense) {
         return "reseller";
       }

--- a/Common/Server/Services/PayAsYouGoBillingService.ts
+++ b/Common/Server/Services/PayAsYouGoBillingService.ts
@@ -1,0 +1,205 @@
+import Project from "../../Models/DatabaseModels/Project";
+import PromoCode from "../../Models/DatabaseModels/PromoCode";
+import SubscriptionPlan, {
+  PlanType,
+} from "../../Types/Billing/SubscriptionPlan";
+import PaymentRequiredException from "../../Types/Exception/PaymentRequiredException";
+import ObjectID from "../../Types/ObjectID";
+import { getAllEnvVars } from "../EnvironmentConfig";
+import InMemoryTTLCache from "../Infrastructure/InMemoryTTLCache";
+import BillingService from "./BillingService";
+import ProjectService from "./ProjectService";
+import PromoCodeService from "./PromoCodeService";
+import Stripe from "stripe";
+
+export const PAY_AS_YOU_GO_PAYMENT_REQUIRED_MESSAGE: string =
+  "Add a payment method in Project Settings > Billing before using paid monitoring or telemetry. These features have usage charges even on the Free plan. Manual monitors remain free.";
+
+type PaymentAuthorization = "payment-method" | "invoice" | "reseller";
+
+export class Service {
+  private authorizedProjects: InMemoryTTLCache<PaymentAuthorization> =
+    new InMemoryTTLCache(10_000);
+
+  /**
+   * A subscription created during signup is not permission to incur charges.
+   * Require a payment method, or a real invoice/reseller billing agreement.
+   * Short positive caching keeps the telemetry admission path affordable;
+   * rejected checks are never cached so adding a card works immediately.
+   */
+  public async canUsePayAsYouGo(
+    projectId: ObjectID,
+    options?: { useCache?: boolean },
+  ): Promise<boolean> {
+    if (!BillingService.isBillingEnabled()) {
+      return true;
+    }
+
+    const cacheKey: string = projectId.toString();
+    if (options?.useCache !== false && this.authorizedProjects.get(cacheKey)) {
+      return true;
+    }
+
+    const authorization: PaymentAuthorization | null =
+      await this.checkPaymentAuthorization(projectId);
+    if (authorization) {
+      this.authorizedProjects.set(cacheKey, authorization, 60_000);
+    } else {
+      this.authorizedProjects.delete(cacheKey);
+    }
+    return Boolean(authorization);
+  }
+
+  public async requirePayAsYouGo(projectId: ObjectID): Promise<void> {
+    if (!(await this.canUsePayAsYouGo(projectId))) {
+      throw new PaymentRequiredException(
+        PAY_AS_YOU_GO_PAYMENT_REQUIRED_MESSAGE,
+      );
+    }
+  }
+
+  public async getTelemetryBillingStartDate(
+    projectId: ObjectID,
+  ): Promise<Date | undefined> {
+    await this.requirePayAsYouGo(projectId);
+    if (!BillingService.isBillingEnabled()) {
+      return undefined;
+    }
+
+    const authorization: PaymentAuthorization | undefined =
+      this.authorizedProjects.get(projectId.toString());
+    if (authorization === "invoice" || authorization === "reseller") {
+      return undefined;
+    }
+
+    const project: Project | null = await ProjectService.findOneById({
+      id: projectId,
+      select: {
+        paymentProviderCustomerId: true,
+      },
+      props: { isRoot: true, ignoreHooks: true },
+    });
+    if (!project?.paymentProviderCustomerId) {
+      throw new PaymentRequiredException(
+        PAY_AS_YOU_GO_PAYMENT_REQUIRED_MESSAGE,
+      );
+    }
+
+    const authorizedAt: Date = await BillingService.getMeteredBillingStartDate(
+      project.paymentProviderCustomerId,
+    );
+
+    // Daily aggregates cannot separate pre-card and post-card usage. Forgive
+    // the partial authorization day and begin with the next complete UTC day.
+    return new Date(
+      Date.UTC(
+        authorizedAt.getUTCFullYear(),
+        authorizedAt.getUTCMonth(),
+        authorizedAt.getUTCDate() + 1,
+      ),
+    );
+  }
+
+  public async requireMeteredSubscriptionPayment(
+    subscription: Stripe.Subscription,
+  ): Promise<void> {
+    const customerId: string =
+      typeof subscription.customer === "string"
+        ? subscription.customer
+        : subscription.customer.id;
+    const project: Project | null = await ProjectService.findOneBy({
+      query: { paymentProviderCustomerId: customerId },
+      select: { _id: true },
+      props: { isRoot: true, ignoreHooks: true },
+    });
+    if (
+      !project?.id ||
+      !(await this.canUsePayAsYouGo(project.id, { useCache: false }))
+    ) {
+      throw new PaymentRequiredException(
+        PAY_AS_YOU_GO_PAYMENT_REQUIRED_MESSAGE,
+      );
+    }
+  }
+
+  private async checkPaymentAuthorization(
+    projectId: ObjectID,
+  ): Promise<PaymentAuthorization | null> {
+    const project: Project | null = await ProjectService.findOneById({
+      id: projectId,
+      select: {
+        paymentProviderPlanId: true,
+        paymentProviderCustomerId: true,
+        paymentProviderSubscriptionId: true,
+        resellerId: true,
+        resellerPlanId: true,
+      },
+      props: { isRoot: true, ignoreHooks: true },
+    });
+
+    if (!project) {
+      return null;
+    }
+
+    if (project.resellerId && project.resellerPlanId) {
+      // The redeemed license is bound to the project and reseller. Its
+      // original plan can differ after an authenticated reseller tier change.
+      const redeemedLicense: PromoCode | null = await PromoCodeService.findOneBy({
+        query: {
+          projectId: projectId,
+          resellerId: project.resellerId,
+          isPromoCodeUsed: true,
+        },
+        select: { _id: true },
+        props: { isRoot: true, ignoreHooks: true },
+      });
+      if (redeemedLicense) {
+        return "reseller";
+      }
+    }
+
+    if (!project.paymentProviderPlanId || !project.paymentProviderCustomerId) {
+      return null;
+    }
+
+    const plan: SubscriptionPlan | undefined =
+      SubscriptionPlan.getSubscriptionPlanById(
+        project.paymentProviderPlanId,
+        getAllEnvVars(),
+      );
+
+    if (!plan) {
+      return null;
+    }
+
+    if (
+      plan.getName() !== PlanType.Free &&
+      project.paymentProviderSubscriptionId
+    ) {
+      const subscription: Stripe.Subscription =
+        await BillingService.getSubscription(
+          project.paymentProviderSubscriptionId,
+        );
+      const customerId: string =
+        typeof subscription.customer === "string"
+          ? subscription.customer
+          : subscription.customer.id;
+
+      if (
+        customerId === project.paymentProviderCustomerId &&
+        subscription.collection_method === "send_invoice" &&
+        subscription.status === "active"
+      ) {
+        return "invoice";
+      }
+    }
+
+    return (await BillingService.hasPaymentMethods(
+      project.paymentProviderCustomerId,
+    ))
+      ? "payment-method"
+      : null;
+  }
+}
+
+export default new Service();

--- a/Common/Server/Services/TelemetryIngestionKeyService.ts
+++ b/Common/Server/Services/TelemetryIngestionKeyService.ts
@@ -4,6 +4,8 @@ import Query from "../Types/Database/Query";
 import UpdateBy from "../Types/Database/UpdateBy";
 import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
 import DatabaseService from "./DatabaseService";
+import PayAsYouGoBillingService from "./PayAsYouGoBillingService";
+import { IsBillingEnabled } from "../EnvironmentConfig";
 import ObjectID from "../../Types/ObjectID";
 import OneUptimeDate from "../../Types/Date";
 import Model from "../../Models/DatabaseModels/TelemetryIngestionKey";
@@ -189,6 +191,19 @@ export class Service extends DatabaseService<Model> {
       data["expiresAt"] = this.validateExpiresAt(data["expiresAt"]);
     }
 
+    if (IsBillingEnabled) {
+      const projectId: ObjectID | undefined =
+        createBy.props.tenantId || createBy.data.projectId;
+
+      if (!projectId) {
+        throw new BadDataException(
+          "ProjectId required to create a telemetry ingestion key.",
+        );
+      }
+
+      await PayAsYouGoBillingService.requirePayAsYouGo(projectId);
+    }
+
     return { createBy, carryForward: null };
   }
 
@@ -252,9 +267,8 @@ export class Service extends DatabaseService<Model> {
       /*
        * Only an EMPTY new list needs to know what kind of keys are being
        * updated, so the extra read is paid for only then. A non-empty list is
-       * valid on both key types, and the overwhelmingly common update (rename,
-       * toggle isEnabled, set an expiry) does not touch allowedOrigins at all
-       * and therefore reads nothing extra.
+       * valid on both key types. Renaming, disabling, or setting an expiry
+       * does not need this lookup; re-enabling has a separate billing check.
        */
       if (allowedOrigins.length === 0) {
         await this.assertNoBrowserKeyIsBeingUpdated(updateBy);
@@ -279,6 +293,33 @@ export class Service extends DatabaseService<Model> {
       data["expiresAt"] = this.validateExpiresAt(data["expiresAt"]);
     }
 
+    if (IsBillingEnabled && data["isEnabled"] === true) {
+      const keys: Array<Model> = await this.findBy({
+        query:
+          !updateBy.props.isRoot && updateBy.props.tenantId
+            ? { ...updateBy.query, projectId: updateBy.props.tenantId }
+            : updateBy.query,
+        select: { projectId: true },
+        limit: updateBy.limit,
+        skip: updateBy.skip,
+        props: { isRoot: true, ignoreHooks: true },
+      });
+      const checkedProjects: Set<string> = new Set<string>();
+
+      for (const key of keys) {
+        if (!key.projectId) {
+          throw new BadDataException(
+            "ProjectId required to enable a telemetry ingestion key.",
+          );
+        }
+
+        if (!checkedProjects.has(key.projectId.toString())) {
+          await PayAsYouGoBillingService.requirePayAsYouGo(key.projectId);
+          checkedProjects.add(key.projectId.toString());
+        }
+      }
+    }
+
     /*
      * Same reasoning as onBeforeDelete. The cached policy now carries the kill
      * switch, the expiry, the origin allowlist and the rate limit, so almost
@@ -296,9 +337,9 @@ export class Service extends DatabaseService<Model> {
    * Postgres. Returns null for unknown or malformed tokens (also cached, for a
    * shorter TTL).
    *
-   * A returned policy is NOT a decision: a disabled or expired key still
-   * resolves. Enforcement belongs to the caller, which knows which ingest
-   * surface it is and can therefore say *why* a request was refused.
+   * A disabled or expired key still resolves so the caller can explain that
+   * refusal. An otherwise usable key requires payment setup here, so every
+   * transport and validation endpoint shares the same billing admission rule.
    */
   @CaptureSpan()
   public async getPolicyFromSecretKey(
@@ -316,7 +357,9 @@ export class Service extends DatabaseService<Model> {
     const cached: CachedIngestionKeyPolicy | null | undefined =
       this.policyCache.get(cacheKey);
     if (cached !== undefined) {
-      return cached === null ? null : this.hydratePolicy(cached);
+      return cached === null
+        ? null
+        : this.requireBillingForPolicy(this.hydratePolicy(cached));
     }
 
     let secretKeyObjectId: ObjectID;
@@ -358,14 +401,28 @@ export class Service extends DatabaseService<Model> {
     );
 
     this.policyCache.set(cacheKey, snapshot, POSITIVE_TTL_MS);
-    return this.hydratePolicy(snapshot);
+    return this.requireBillingForPolicy(this.hydratePolicy(snapshot));
+  }
+
+  private async requireBillingForPolicy(
+    policy: TelemetryIngestionKeyPolicy,
+  ): Promise<TelemetryIngestionKeyPolicy> {
+    if (
+      policy.isEnabled &&
+      (!policy.expiresAt || policy.expiresAt.getTime() > Date.now())
+    ) {
+      // Check even on key-cache hits. Billing eligibility has its own bounded
+      // cache, and must not remain enabled for the lifetime of a live key.
+      await PayAsYouGoBillingService.requirePayAsYouGo(policy.projectId);
+    }
+
+    return policy;
   }
 
   /**
    * Resolve an ingestion token to its projectId.
    *
-   * Unchanged in signature and in meaning: it is a LOOKUP, and it answers
-   * "which project owns this token" for any token that exists. It deliberately
+   * Shares billing admission with getPolicyFromSecretKey. It deliberately
    * does NOT enforce the kill switch or the expiry.
    *
    * That restraint is the point. Several callers (gRPC, MQTT, session replay,

--- a/Common/Server/Services/TelemetryIngestionKeyService.ts
+++ b/Common/Server/Services/TelemetryIngestionKeyService.ts
@@ -411,8 +411,10 @@ export class Service extends DatabaseService<Model> {
       policy.isEnabled &&
       (!policy.expiresAt || policy.expiresAt.getTime() > Date.now())
     ) {
-      // Check even on key-cache hits. Billing eligibility has its own bounded
-      // cache, and must not remain enabled for the lifetime of a live key.
+      /*
+       * Check even on key-cache hits. Billing eligibility has its own bounded
+       * cache, and must not remain enabled for the lifetime of a live key.
+       */
       await PayAsYouGoBillingService.requirePayAsYouGo(policy.projectId);
     }
 

--- a/Common/Server/Services/TelemetryUsageBillingService.ts
+++ b/Common/Server/Services/TelemetryUsageBillingService.ts
@@ -52,6 +52,8 @@ import {
   IsBillingEnabled,
 } from "../EnvironmentConfig";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import QueryHelper from "../Types/Database/QueryHelper";
+import PayAsYouGoBillingService from "./PayAsYouGoBillingService";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -71,6 +73,7 @@ export class Service extends DatabaseService<Model> {
         projectId: data.projectId,
         productType: data.productType,
         isReportedToBillingProvider: false,
+        totalCostInUSD: QueryHelper.greaterThan(0),
       },
       skip: 0,
       limit: LIMIT_MAX, /// because a project can have MANY telemetry services.
@@ -84,6 +87,31 @@ export class Service extends DatabaseService<Model> {
     });
   }
 
+  public async waiveUnreportedUsageBilling(data: {
+    projectId: ObjectID;
+    productType: ProductType;
+    before?: Date;
+  }): Promise<void> {
+    let updated: number;
+    do {
+      updated = await this.updateBy({
+        query: {
+          projectId: data.projectId,
+          productType: data.productType,
+          isReportedToBillingProvider: false,
+          totalCostInUSD: QueryHelper.greaterThan(0),
+          ...(data.before
+            ? { createdAt: QueryHelper.lessThan(data.before) }
+            : {}),
+        },
+        data: { totalCostInUSD: new Decimal(0) },
+        skip: 0,
+        limit: LIMIT_MAX,
+        props: { isRoot: true, ignoreHooks: true },
+      });
+    } while (updated === LIMIT_MAX);
+  }
+
   @CaptureSpan()
   public async stageTelemetryUsageForProject(data: {
     projectId: ObjectID;
@@ -94,9 +122,30 @@ export class Service extends DatabaseService<Model> {
       return;
     }
 
+    if (
+      !(await PayAsYouGoBillingService.canUsePayAsYouGo(data.projectId, {
+        useCache: false,
+      }))
+    ) {
+      await this.waiveUnreportedUsageBilling(data);
+      return;
+    }
+
     const usageDate: Date = data.usageDate
       ? OneUptimeDate.fromString(data.usageDate)
       : OneUptimeDate.addRemoveDays(OneUptimeDate.getCurrentDate(), -1);
+
+    const billingStartsAt: Date | undefined =
+      await PayAsYouGoBillingService.getTelemetryBillingStartDate(
+        data.projectId,
+      );
+    if (
+      billingStartsAt &&
+      OneUptimeDate.getStartOfDay(usageDate, "UTC").getTime() <
+        billingStartsAt.getTime()
+    ) {
+      return;
+    }
 
     const averageRowSizeInBytes: number = this.getAverageRowSizeForProduct(
       data.productType,
@@ -138,9 +187,9 @@ export class Service extends DatabaseService<Model> {
       return;
     }
 
-    const usageDayString: string = OneUptimeDate.getDateString(usageDate);
-    const startOfDay: Date = OneUptimeDate.getStartOfDay(usageDate);
-    const endOfDay: Date = OneUptimeDate.getEndOfDay(usageDate);
+    const usageDayString: string = this.getUsageDayString(usageDate);
+    const startOfDay: Date = OneUptimeDate.getStartOfDay(usageDate, "UTC");
+    const endOfDay: Date = OneUptimeDate.getEndOfDay(usageDate, "UTC");
 
     /*
      * Enumerate usage from ClickHouse by (primaryEntityId, primaryEntityType) in a
@@ -580,7 +629,7 @@ export class Service extends DatabaseService<Model> {
       ? OneUptimeDate.fromString(data.usageDate)
       : OneUptimeDate.getCurrentDate();
 
-    const usageDayString: string = OneUptimeDate.getDateString(usageDate);
+    const usageDayString: string = this.getUsageDayString(usageDate);
 
     const totalCostOfThisOperationInUSD: number =
       serverMeteredPlan.getTotalCostInUSD({
@@ -660,6 +709,14 @@ export class Service extends DatabaseService<Model> {
         },
       });
     }
+  }
+
+  private getUsageDayString(usageDate: Date): string {
+    return OneUptimeDate.getDateAsCustomFormattedStringInTimezone({
+      date: usageDate,
+      timezone: "UTC",
+      format: "MMM DD, YYYY",
+    });
   }
 
   private getAverageRowSizeForProduct(productType: ProductType): number {

--- a/Common/Server/Types/Billing/MeteredPlan/ActiveMonitoringMeteredPlan.ts
+++ b/Common/Server/Types/Billing/MeteredPlan/ActiveMonitoringMeteredPlan.ts
@@ -9,6 +9,7 @@ import ObjectID from "../../../../Types/ObjectID";
 import PositiveNumber from "../../../../Types/PositiveNumber";
 import Project from "../../../../Models/DatabaseModels/Project";
 import CaptureSpan from "../../../Utils/Telemetry/CaptureSpan";
+import PayAsYouGoBillingService from "../../../Services/PayAsYouGoBillingService";
 
 export default class ActiveMonitoringMeteredPlan extends ServerMeteredPlan {
   @CaptureSpan()
@@ -43,6 +44,14 @@ export default class ActiveMonitoringMeteredPlan extends ServerMeteredPlan {
         isRoot: true,
       },
     });
+
+    if (
+      !(await PayAsYouGoBillingService.canUsePayAsYouGo(projectId, {
+        useCache: false,
+      }))
+    ) {
+      return;
+    }
 
     // update this count in project as well.
     const project: Project | null = await ProjectService.findOneById({

--- a/Common/Server/Types/Billing/MeteredPlan/TelemetryMeteredPlan.ts
+++ b/Common/Server/Types/Billing/MeteredPlan/TelemetryMeteredPlan.ts
@@ -8,6 +8,7 @@ import ObjectID from "../../../../Types/ObjectID";
 import Project from "../../../../Models/DatabaseModels/Project";
 import TelemetryUsageBilling from "../../../../Models/DatabaseModels/TelemetryUsageBilling";
 import CaptureSpan from "../../../Utils/Telemetry/CaptureSpan";
+import PayAsYouGoBillingService from "../../../Services/PayAsYouGoBillingService";
 
 export default class TelemetryMeteredPlan extends ServerMeteredPlan {
   private _productType!: ProductType;
@@ -54,7 +55,27 @@ export default class TelemetryMeteredPlan extends ServerMeteredPlan {
       meteredPlanSubscriptionId?: string | undefined;
     },
   ): Promise<void> {
-    // get all unreported logs
+    if (
+      !(await PayAsYouGoBillingService.canUsePayAsYouGo(projectId, {
+        useCache: false,
+      }))
+    ) {
+      await TelemetryUsageBillingService.waiveUnreportedUsageBilling({
+        projectId: projectId,
+        productType: this.productType,
+      });
+      return;
+    }
+
+    const billingStartsAt: Date | undefined =
+      await PayAsYouGoBillingService.getTelemetryBillingStartDate(projectId);
+    if (billingStartsAt) {
+      await TelemetryUsageBillingService.waiveUnreportedUsageBilling({
+        projectId: projectId,
+        productType: this.productType,
+        before: billingStartsAt,
+      });
+    }
 
     await TelemetryUsageBillingService.stageTelemetryUsageForProject({
       projectId: projectId,

--- a/Common/Tests/App/Dashboard/BillingPaidUsageFlow.test.tsx
+++ b/Common/Tests/App/Dashboard/BillingPaidUsageFlow.test.tsx
@@ -1,0 +1,346 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React, { ReactElement, ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import Billing from "../../../../App/FeatureSet/Dashboard/src/Pages/Settings/Billing";
+import {
+  PAYMENT_METHOD_CONSENT_ERROR,
+  PAYMENT_METHOD_CONSENT_LABEL,
+} from "../../../../App/FeatureSet/Dashboard/src/Pages/Settings/BillingPaymentMethodForm";
+import ProjectUtil from "../../../UI/Utils/Project";
+import Navigation from "../../../UI/Utils/Navigation";
+import SubscriptionPlan from "../../../Types/Billing/SubscriptionPlan";
+import BillingPaymentMethod from "../../../Models/DatabaseModels/BillingPaymentMethod";
+import ObjectID from "../../../Types/ObjectID";
+import Route from "../../../Types/API/Route";
+import URL from "../../../Types/API/URL";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import { getJestSpyOn } from "../../Spy";
+
+const getListMock: MockFunction = getJestMockFunction();
+const getItemMock: MockFunction = getJestMockFunction();
+const postMock: MockFunction = getJestMockFunction();
+const confirmSetupMock: MockFunction = getJestMockFunction();
+let billingEnabled: boolean = true;
+const projectId: ObjectID = ObjectID.generate();
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<unknown>) => {
+        return getListMock(...args);
+      },
+      getItem: (...args: Array<unknown>) => {
+        return getItemMock(...args);
+      },
+      getCommonHeaders: () => {
+        return {};
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      get: async () => {
+        return { data: { balance: 0 } };
+      },
+      post: (...args: Array<unknown>) => {
+        return postMock(...args);
+      },
+      getFriendlyMessage: (error: Error) => {
+        return error.message;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Analytics", () => {
+  return {
+    __esModule: true,
+    default: { capture: () => {}, captureRevenueEvent: () => {} },
+  };
+});
+
+jest.mock("../../../UI/Config", () => {
+  const config: Record<string, unknown> = {
+    ...jest.requireActual("../../../UI/Config"),
+  };
+  Object.defineProperty(config, "BILLING_ENABLED", {
+    get: () => {
+      return billingEnabled;
+    },
+  });
+  return config;
+});
+
+jest.mock(
+  "@stripe/stripe-js/pure",
+  () => {
+    return {
+      loadStripe: async () => {
+        return {};
+      },
+    };
+  },
+  { virtual: true },
+);
+
+jest.mock(
+  "@stripe/react-stripe-js",
+  () => {
+    return {
+      Elements: (props: { children: ReactNode }) => {
+        return <>{props.children}</>;
+      },
+      PaymentElement: () => {
+        return <div>Payment details</div>;
+      },
+      useStripe: () => {
+        return { confirmSetup: confirmSetupMock };
+      },
+      useElements: () => {
+        return {};
+      },
+    };
+  },
+  { virtual: true },
+);
+
+// Keep the billing page, its usage card and its real checkout form together;
+// unrelated model editors and the external provider are test boundaries.
+jest.mock("../../../UI/Components/ModelDetail/CardModelDetail", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return null;
+    },
+  };
+});
+
+jest.mock("../../../UI/Components/ModelTable/ModelTable", () => {
+  return {
+    __esModule: true,
+    default: (props: {
+      onItemDeleted: () => void;
+      refreshToggle: string;
+      cardProps: { buttons: Array<{ title: string; onClick: () => void }> };
+    }) => {
+      return (
+        <div
+          data-testid="payment-methods-table"
+          data-refresh={props.refreshToggle}
+        >
+          <button onClick={props.onItemDeleted}>Remove payment method</button>
+          {props.cardProps.buttons.map(
+            (button: { title: string; onClick: () => void }) => {
+              return (
+                <button key={button.title} onClick={button.onClick}>
+                  {button.title}
+                </button>
+              );
+            },
+          )}
+        </div>
+      );
+    },
+  };
+});
+
+jest.mock("../../../UI/Components/Modal/Modal", () => {
+  return {
+    __esModule: true,
+    default: (props: {
+      children: ReactNode;
+      error: string;
+      submitButtonText: string;
+      onSubmit: () => void;
+      onClose: () => void;
+      disableSubmitButton: boolean;
+      isLoading: boolean;
+    }): ReactElement => {
+      return (
+        <section role="dialog">
+          {props.error ? <p role="alert">{props.error}</p> : <></>}
+          {props.children}
+          <button
+            onClick={props.onSubmit}
+            disabled={props.disableSubmitButton || props.isLoading}
+          >
+            {props.submitButtonText}
+          </button>
+          <button onClick={props.onClose}>Close payment form</button>
+        </section>
+      );
+    },
+  };
+});
+
+function renderBilling(): void {
+  render(
+    <Billing
+      pageRoute={new Route("/settings/billing")}
+      currentProject={null}
+      hasPaymentMethod={false}
+    />,
+  );
+}
+
+describe("Billing page paid usage flow", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    billingEnabled = true;
+    getListMock.mockReset().mockResolvedValue({ data: [], count: 0 });
+    getItemMock
+      .mockReset()
+      .mockResolvedValue({ paymentProviderPlanId: "free-plan" });
+    postMock
+      .mockReset()
+      .mockResolvedValue({ data: { setupIntent: "test-secret" } });
+    confirmSetupMock.mockReset().mockResolvedValue({});
+    getJestSpyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(projectId);
+    getJestSpyOn(SubscriptionPlan, "isFreePlan").mockReturnValue(true);
+    getJestSpyOn(SubscriptionPlan, "getSubscriptionPlans").mockReturnValue([]);
+    getJestSpyOn(Navigation, "getCurrentURL").mockReturnValue(
+      URL.fromString("https://example.com/dashboard/project/settings/billing"),
+    );
+  });
+
+  it("loads payment status only for the current project", async () => {
+    renderBilling();
+    await screen.findByRole("heading", {
+      name: "Free plan — paid usage locked",
+    });
+    expect(getListMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelType: BillingPaymentMethod,
+        query: { projectId },
+        select: { _id: true },
+        limit: 1,
+      }),
+    );
+  });
+
+  it("keeps a failed payment lookup unknown and lets the user retry", async () => {
+    getListMock
+      .mockRejectedValueOnce(new Error("Payment methods unavailable"))
+      .mockResolvedValueOnce({ data: [], count: 1 });
+    renderBilling();
+    await screen.findByRole("heading", {
+      name: "Payment method status unavailable",
+    });
+    expect(
+      screen.queryByText("Free plan — paid usage locked"),
+    ).not.toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Retry payment method check" }),
+    );
+    await screen.findByRole("heading", { name: "Free plan + pay as you go" });
+  });
+
+  it("refreshes paid usage status when the last payment method is deleted", async () => {
+    getListMock
+      .mockResolvedValueOnce({ data: [], count: 1 })
+      .mockResolvedValueOnce({ data: [], count: 0 });
+    renderBilling();
+    await screen.findByRole("heading", { name: "Free plan + pay as you go" });
+    await userEvent.click(
+      screen.getByRole("button", { name: "Remove payment method" }),
+    );
+    await screen.findByRole("heading", {
+      name: "Free plan — paid usage locked",
+    });
+    expect(getListMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the form visible after missing consent and refreshes both status and card list after saving", async () => {
+    getListMock
+      .mockResolvedValueOnce({ data: [], count: 0 })
+      .mockResolvedValueOnce({ data: [], count: 1 });
+    renderBilling();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Enable paid usage" }),
+    );
+    const save: HTMLElement = await screen.findByRole("button", {
+      name: "Save payment method and enable paid usage",
+    });
+    await waitFor(() => {
+      expect(save).not.toBeDisabled();
+    });
+    await userEvent.click(save);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      PAYMENT_METHOD_CONSENT_ERROR,
+    );
+    expect(
+      screen.getByRole("checkbox", { name: PAYMENT_METHOD_CONSENT_LABEL }),
+    ).toBeInTheDocument();
+    expect(confirmSetupMock).not.toHaveBeenCalled();
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: PAYMENT_METHOD_CONSENT_LABEL }),
+    );
+    await userEvent.click(save);
+    await screen.findByRole("heading", { name: "Free plan + pay as you go" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.getByTestId("payment-methods-table")).toHaveAttribute(
+      "data-refresh",
+      "1",
+    );
+    expect(confirmSetupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears a prior setup error and requests new consent when the payment modal is reopened", async () => {
+    postMock
+      .mockRejectedValueOnce(new Error("Payment provider unavailable"))
+      .mockResolvedValueOnce({ data: { setupIntent: "second-secret" } });
+    renderBilling();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Enable paid usage" }),
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Payment provider unavailable",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Close payment form" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Enable paid usage" }),
+    );
+    expect(
+      await screen.findByRole("checkbox", {
+        name: PAYMENT_METHOD_CONSENT_LABEL,
+      }),
+    ).not.toBeChecked();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(postMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not show cloud usage status on a self-hosted installation with billing disabled", async () => {
+    billingEnabled = false;
+    renderBilling();
+    await screen.findByTestId("payment-methods-table");
+    expect(
+      screen.queryByTestId("billing-usage-status"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("preserves the reseller billing experience", async () => {
+    getItemMock.mockResolvedValueOnce({
+      paymentProviderPlanId: "free-plan",
+      reseller: {
+        name: "Example reseller",
+        description: "Your account contact",
+      },
+    });
+    renderBilling();
+    await screen.findByRole("heading", {
+      name: "You have purchased this plan from Example reseller",
+    });
+    expect(
+      screen.queryByTestId("billing-usage-status"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/Common/Tests/App/Dashboard/BillingPaidUsageFlow.test.tsx
+++ b/Common/Tests/App/Dashboard/BillingPaidUsageFlow.test.tsx
@@ -111,8 +111,10 @@ jest.mock(
   { virtual: true },
 );
 
-// Keep the billing page, its usage card and its real checkout form together;
-// unrelated model editors and the external provider are test boundaries.
+/*
+ * Keep the billing page, its usage card and its real checkout form together;
+ * unrelated model editors and the external provider are test boundaries.
+ */
 jest.mock("../../../UI/Components/ModelDetail/CardModelDetail", () => {
   return {
     __esModule: true,

--- a/Common/Tests/App/Dashboard/BillingPaymentMethodConsent.test.tsx
+++ b/Common/Tests/App/Dashboard/BillingPaymentMethodConsent.test.tsx
@@ -1,0 +1,232 @@
+import "@testing-library/jest-dom";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import CheckoutForm, {
+  PAYMENT_METHOD_CONSENT_ERROR,
+  PAYMENT_METHOD_CONSENT_LABEL,
+} from "../../../../App/FeatureSet/Dashboard/src/Pages/Settings/BillingPaymentMethodForm";
+import Navigation from "../../../UI/Utils/Navigation";
+import URL from "../../../Types/API/URL";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import { getJestSpyOn } from "../../Spy";
+
+const confirmSetupMock: MockFunction = getJestMockFunction();
+let stripeReady: boolean = true;
+let elementsReady: boolean = true;
+const mockElements: object = {};
+
+jest.mock(
+  "@stripe/react-stripe-js",
+  () => {
+    return {
+      PaymentElement: () => {
+        return <div data-testid="stripe-payment-element">Payment details</div>;
+      },
+      useStripe: () => {
+        return stripeReady ? { confirmSetup: confirmSetupMock } : null;
+      },
+      useElements: () => {
+        return elementsReady ? mockElements : null;
+      },
+    };
+  },
+  { virtual: true },
+);
+
+function renderForm(): {
+  onError: MockFunction;
+  onSuccess: MockFunction;
+  submit: () => void;
+  unmount: () => void;
+} {
+  const onError: MockFunction = getJestMockFunction();
+  const onSuccess: MockFunction = getJestMockFunction();
+  const formRef: React.RefObject<HTMLButtonElement> =
+    React.createRef<HTMLButtonElement>();
+  const { unmount } = render(
+    <CheckoutForm formRef={formRef} onError={onError} onSuccess={onSuccess} />,
+  );
+  return {
+    onError,
+    onSuccess,
+    submit: () => {
+      fireEvent.click(formRef.current!);
+    },
+    unmount,
+  };
+}
+
+describe("Adding a payment method requires acknowledgement of paid usage", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    confirmSetupMock.mockReset().mockResolvedValue({});
+    stripeReady = true;
+    elementsReady = true;
+    getJestSpyOn(Navigation, "getCurrentURL").mockReturnValue(
+      URL.fromString(
+        "https://example.com/dashboard/project/settings/billing?setup_intent=old",
+      ),
+    );
+  });
+
+  it("shows rates and an unchecked acknowledgement before saving a card", () => {
+    const { submit, onError } = renderForm();
+    expect(
+      screen.getByText(/Your subscription plan stays the same/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Active monitors:/)).toHaveTextContent(
+      "$1 per monitor per month",
+    );
+    expect(screen.getByText(/Logs, traces, metrics/)).toHaveTextContent(
+      "$0.10 per GB ingested",
+    );
+    expect(screen.getByText(/Session replay:/)).toHaveTextContent("$2 per GB");
+    expect(
+      screen.getByRole("checkbox", { name: PAYMENT_METHOD_CONSENT_LABEL }),
+    ).not.toBeChecked();
+    submit();
+    expect(onError).toHaveBeenCalledWith(PAYMENT_METHOD_CONSENT_ERROR);
+    expect(confirmSetupMock).not.toHaveBeenCalled();
+  });
+
+  it("does not start setup when the acknowledgement or payment details are clicked", async () => {
+    renderForm();
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: PAYMENT_METHOD_CONSENT_LABEL }),
+    );
+    await userEvent.click(screen.getByTestId("stripe-payment-element"));
+    expect(confirmSetupMock).not.toHaveBeenCalled();
+  });
+
+  it("saves only after acknowledgement and returns to the clean billing URL", async () => {
+    const { submit, onSuccess, onError } = renderForm();
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: PAYMENT_METHOD_CONSENT_LABEL }),
+    );
+    submit();
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+    expect(confirmSetupMock).toHaveBeenCalledWith({
+      elements: mockElements,
+      confirmParams: {
+        return_url: "https://example.com/dashboard/project/settings/billing",
+      },
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("blocks submission again if acknowledgement is withdrawn", async () => {
+    const { submit, onError } = renderForm();
+    const checkbox: HTMLElement = screen.getByRole("checkbox", {
+      name: PAYMENT_METHOD_CONSENT_LABEL,
+    });
+    await userEvent.click(checkbox);
+    await userEvent.click(checkbox);
+    submit();
+    expect(onError).toHaveBeenCalledWith(PAYMENT_METHOD_CONSENT_ERROR);
+    expect(confirmSetupMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["stripe", "elements"])(
+    "reports an unavailable %s provider instead of leaving the save button loading",
+    async (provider: string) => {
+      stripeReady = provider !== "stripe";
+      elementsReady = provider !== "elements";
+      const { submit, onError } = renderForm();
+      await userEvent.click(
+        screen.getByRole("checkbox", { name: PAYMENT_METHOD_CONSENT_LABEL }),
+      );
+      submit();
+      expect(onError).toHaveBeenCalledWith(
+        "The payment form is still loading. Please try again in a moment.",
+      );
+      expect(confirmSetupMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps acknowledgement after a provider error and supports retry", async () => {
+    confirmSetupMock
+      .mockResolvedValueOnce({ error: { message: "Your card was declined." } })
+      .mockResolvedValueOnce({});
+    const { submit, onSuccess, onError } = renderForm();
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: PAYMENT_METHOD_CONSENT_LABEL }),
+    );
+    submit();
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith("Your card was declined.");
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("checkbox", { name: PAYMENT_METHOD_CONSENT_LABEL }),
+    ).toBeChecked();
+    submit();
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+    expect(confirmSetupMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("recovers from an unexpected provider failure without an unhandled rejection", async () => {
+    confirmSetupMock.mockRejectedValueOnce(new Error("Network error"));
+    const { submit, onError, onSuccess } = renderForm();
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: PAYMENT_METHOD_CONSENT_LABEL }),
+    );
+    submit();
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(
+        "Unable to save your payment method. Please try again.",
+      );
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+    submit();
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("suppresses duplicate submissions while setup is in progress", async () => {
+    let resolveSetup: ((result: object) => void) | undefined;
+    confirmSetupMock.mockImplementationOnce(() => {
+      return new Promise<object>((resolve: (result: object) => void) => {
+        resolveSetup = resolve;
+      });
+    });
+    const { submit, onSuccess } = renderForm();
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: PAYMENT_METHOD_CONSENT_LABEL }),
+    );
+    submit();
+    submit();
+    expect(confirmSetupMock).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveSetup!({});
+    });
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts with fresh acknowledgement when the add-card form is reopened", async () => {
+    const first: ReturnType<typeof renderForm> = renderForm();
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: PAYMENT_METHOD_CONSENT_LABEL }),
+    );
+    first.unmount();
+    const second: ReturnType<typeof renderForm> = renderForm();
+    expect(
+      screen.getByRole("checkbox", { name: PAYMENT_METHOD_CONSENT_LABEL }),
+    ).not.toBeChecked();
+    second.submit();
+    expect(second.onError).toHaveBeenCalledWith(PAYMENT_METHOD_CONSENT_ERROR);
+    expect(confirmSetupMock).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/App/Dashboard/BillingPaymentMethodConsent.test.tsx
+++ b/Common/Tests/App/Dashboard/BillingPaymentMethodConsent.test.tsx
@@ -21,7 +21,7 @@ import { getJestSpyOn } from "../../Spy";
 const confirmSetupMock: MockFunction = getJestMockFunction();
 let stripeReady: boolean = true;
 let elementsReady: boolean = true;
-const mockElements: object = {};
+const mockElements: Record<string, unknown> = {};
 
 jest.mock(
   "@stripe/react-stripe-js",
@@ -196,11 +196,13 @@ describe("Adding a payment method requires acknowledgement of paid usage", () =>
   });
 
   it("suppresses duplicate submissions while setup is in progress", async () => {
-    let resolveSetup: ((result: object) => void) | undefined;
+    let resolveSetup: ((result: Record<string, unknown>) => void) | undefined;
     confirmSetupMock.mockImplementationOnce(() => {
-      return new Promise<object>((resolve: (result: object) => void) => {
-        resolveSetup = resolve;
-      });
+      return new Promise<Record<string, unknown>>(
+        (resolve: (result: Record<string, unknown>) => void) => {
+          resolveSetup = resolve;
+        },
+      );
     });
     const { submit, onSuccess } = renderForm();
     await userEvent.click(

--- a/Common/Tests/App/Dashboard/BillingUsageStatus.test.tsx
+++ b/Common/Tests/App/Dashboard/BillingUsageStatus.test.tsx
@@ -1,0 +1,172 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, expect, it } from "@jest/globals";
+import BillingUsageStatus from "../../../../App/FeatureSet/Dashboard/src/Components/Billing/BillingUsageStatus";
+import {
+  ACTIVE_MONITOR_PRICE_IN_USD_PER_MONTH,
+  PRICING_PAGE_URL,
+  SESSION_REPLAY_PRICE_IN_USD_PER_GB,
+  TELEMETRY_PRICE_IN_USD_PER_GB,
+  formatPriceInUSD,
+} from "../../../Types/Billing/PayAsYouGoPricing";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+function renderStatus(data: {
+  paymentMethodsCount: number | null;
+  isFreePlan?: boolean;
+}): { onAddPaymentMethod: MockFunction; onRetry: MockFunction } {
+  const onAddPaymentMethod: MockFunction = getJestMockFunction();
+  const onRetry: MockFunction = getJestMockFunction();
+  render(
+    <BillingUsageStatus
+      isFreePlan={data.isFreePlan ?? true}
+      paymentMethodsCount={data.paymentMethodsCount}
+      onAddPaymentMethod={onAddPaymentMethod}
+      onRetry={onRetry}
+    />,
+  );
+  return { onAddPaymentMethod, onRetry };
+}
+
+describe("Billing usage status", () => {
+  it("explains that a Free project without a payment method cannot run paid features", async () => {
+    const { onAddPaymentMethod } = renderStatus({ paymentMethodsCount: 0 });
+    expect(
+      screen.getByRole("heading", { name: "Free plan — paid usage locked" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Your free features remain available/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Your Free subscription is \$0/)).toHaveTextContent(
+      "Upgrade your plan separately",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Enable paid usage" }),
+    );
+    expect(onAddPaymentMethod).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([1, 2])(
+    "labels Free plus paid usage when %i payment methods are present",
+    (paymentMethodsCount: number) => {
+      renderStatus({ paymentMethodsCount });
+      expect(
+        screen.getByRole("heading", { name: "Free plan + pay as you go" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Paid features are billed as you use them, separately from your subscription/,
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Enable paid usage" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/keeps you on the Free plan/),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it("shows published rates, replay's separate price and a pricing link", () => {
+    renderStatus({ paymentMethodsCount: 0 });
+    expect(screen.getByText(/Active monitors:/)).toHaveTextContent(
+      `${formatPriceInUSD(ACTIVE_MONITOR_PRICE_IN_USD_PER_MONTH)} per monitor per month`,
+    );
+    expect(screen.getByText(/Logs, traces, metrics/)).toHaveTextContent(
+      `${formatPriceInUSD(TELEMETRY_PRICE_IN_USD_PER_GB)} per GB ingested`,
+    );
+    expect(screen.getByText(/Session replay:/)).toHaveTextContent(
+      `${formatPriceInUSD(SESSION_REPLAY_PRICE_IN_USD_PER_GB)} per GB`,
+    );
+    expect(screen.getByRole("link", { name: "full pricing" })).toHaveAttribute(
+      "href",
+      PRICING_PAGE_URL,
+    );
+    expect(screen.getByRole("link", { name: "full pricing" })).toHaveAttribute(
+      "target",
+      "_blank",
+    );
+  });
+
+  it("does not report payment lookup failure as zero payment methods", async () => {
+    const { onRetry, onAddPaymentMethod } = renderStatus({
+      paymentMethodsCount: null,
+    });
+    expect(
+      screen.getByRole("heading", {
+        name: "Payment method status unavailable",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Free plan — paid usage locked"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Free plan + pay as you go"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Enable paid usage" }),
+    ).not.toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Retry payment method check" }),
+    );
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onAddPaymentMethod).not.toHaveBeenCalled();
+  });
+
+  it("does not claim a paid invoice contract without a card is locked", () => {
+    renderStatus({ paymentMethodsCount: 0, isFreePlan: false });
+    expect(
+      screen.getByRole("heading", { name: "No payment method on file" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/active invoice billing agreement can continue/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/paid usage locked/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Your Free subscription/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("distinguishes subscription charges from paid usage on paid plans", () => {
+    renderStatus({ paymentMethodsCount: 1, isFreePlan: false });
+    expect(
+      screen.getByRole("heading", { name: "Pay as you go enabled" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Usage charges are separate from subscription charges/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Your Free subscription/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("updates from enabled to locked when the last payment method is removed", () => {
+    const { rerender } = render(
+      <BillingUsageStatus
+        isFreePlan={true}
+        paymentMethodsCount={1}
+        onAddPaymentMethod={() => {}}
+        onRetry={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { name: "Free plan + pay as you go" }),
+    ).toBeInTheDocument();
+    rerender(
+      <BillingUsageStatus
+        isFreePlan={true}
+        paymentMethodsCount={0}
+        onAddPaymentMethod={() => {}}
+        onRetry={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { name: "Free plan — paid usage locked" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Enable paid usage" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/Common/Tests/App/Dashboard/BillingUsageStatus.test.tsx
+++ b/Common/Tests/App/Dashboard/BillingUsageStatus.test.tsx
@@ -115,8 +115,11 @@ describe("Billing usage status", () => {
     expect(onAddPaymentMethod).not.toHaveBeenCalled();
   });
 
-  it("does not claim a paid invoice contract without a card is locked", () => {
-    renderStatus({ paymentMethodsCount: 0, isFreePlan: false });
+  it("does not claim a paid invoice contract without a card is locked", async () => {
+    const { onAddPaymentMethod } = renderStatus({
+      paymentMethodsCount: 0,
+      isFreePlan: false,
+    });
     expect(
       screen.getByRole("heading", { name: "No payment method on file" }),
     ).toBeInTheDocument();
@@ -127,6 +130,13 @@ describe("Billing usage status", () => {
     expect(
       screen.queryByText(/Your Free subscription/),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Enable paid usage" }),
+    ).not.toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add payment method" }),
+    );
+    expect(onAddPaymentMethod).toHaveBeenCalledTimes(1);
   });
 
   it("distinguishes subscription charges from paid usage on paid plans", () => {

--- a/Common/Tests/App/Dashboard/PaidUsageConsent.test.tsx
+++ b/Common/Tests/App/Dashboard/PaidUsageConsent.test.tsx
@@ -1,7 +1,13 @@
 import "@testing-library/jest-dom";
 import React from "react";
 import userEvent from "@testing-library/user-event";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import PaidUsageConsent from "../../../../App/FeatureSet/Dashboard/src/Components/Billing/PaidUsageConsent";
 import BaseAPI from "../../../UI/Utils/API/API";
 import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
@@ -54,14 +60,18 @@ describe("PaidUsageConsent", () => {
   });
 
   it("explains locked features and lets the user recheck after billing setup", async () => {
-    jest.spyOn(BaseAPI, "get")
+    jest
+      .spyOn(BaseAPI, "get")
       .mockResolvedValueOnce({ data: { isAllowed: false } } as any)
       .mockResolvedValueOnce({ data: { isAllowed: true } } as any);
     renderConsent();
     await screen.findByText(/Add a payment method before/);
     expect(screen.getByTestId("consent")).toBeDisabled();
-    expect(screen.getByRole("link", { name: "Set up billing" })).toHaveAttribute(
-      "href", `/dashboard/${projectId.toString()}/settings/billing`,
+    expect(
+      screen.getByRole("link", { name: "Set up billing" }),
+    ).toHaveAttribute(
+      "href",
+      `/dashboard/${projectId.toString()}/settings/billing`,
     );
     await userEvent.click(screen.getByTestId("consent"));
     expect(onChange).not.toHaveBeenCalled();
@@ -73,7 +83,8 @@ describe("PaidUsageConsent", () => {
   });
 
   it("keeps consent locked on network failure and supports retry", async () => {
-    jest.spyOn(BaseAPI, "get")
+    jest
+      .spyOn(BaseAPI, "get")
       .mockRejectedValueOnce(new Error("Unavailable"))
       .mockResolvedValueOnce({ data: { isAllowed: true } } as any);
     renderConsent();
@@ -86,7 +97,9 @@ describe("PaidUsageConsent", () => {
   });
 
   it("does not accept an absent or nonboolean authorization value", async () => {
-    jest.spyOn(BaseAPI, "get").mockResolvedValue({ data: { isAllowed: "true" } } as any);
+    jest
+      .spyOn(BaseAPI, "get")
+      .mockResolvedValue({ data: { isAllowed: "true" } } as any);
     renderConsent();
     await screen.findByText(/Add a payment method before/);
     expect(screen.getByTestId("consent")).toBeDisabled();
@@ -94,7 +107,8 @@ describe("PaidUsageConsent", () => {
 
   it("does not use a stale project response after the selected project changes", async () => {
     let resolveOld: (value: any) => void = (): void => {};
-    jest.spyOn(BaseAPI, "get")
+    jest
+      .spyOn(BaseAPI, "get")
       .mockImplementationOnce(() => {
         return new Promise<any>((done: (value: any) => void) => {
           resolveOld = done;
@@ -102,8 +116,16 @@ describe("PaidUsageConsent", () => {
       })
       .mockResolvedValueOnce({ data: { isAllowed: false } } as any);
     const view: ReturnType<typeof render> = renderConsent();
-    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(ObjectID.generate());
-    view.rerender(<PaidUsageConsent title="I agree" description="Paid usage" dataTestId="consent" />);
+    jest
+      .spyOn(ProjectUtil, "getCurrentProjectId")
+      .mockReturnValue(ObjectID.generate());
+    view.rerender(
+      <PaidUsageConsent
+        title="I agree"
+        description="Paid usage"
+        dataTestId="consent"
+      />,
+    );
     await screen.findByText(/Add a payment method before/);
     await act(async () => {
       resolveOld({ data: { isAllowed: true } });
@@ -112,24 +134,44 @@ describe("PaidUsageConsent", () => {
   });
 
   it("does not reload eligibility when a form recreates its callback", async () => {
-    const getStatus: jest.SpyInstance = jest.spyOn(BaseAPI, "get")
+    const getStatus: jest.SpyInstance = jest
+      .spyOn(BaseAPI, "get")
       .mockResolvedValue({ data: { isAllowed: true } } as any);
     const view: ReturnType<typeof render> = renderConsent();
     await waitFor(() => {
       expect(screen.getByTestId("consent")).toBeEnabled();
     });
-    view.rerender(<PaidUsageConsent title="I agree" description="Paid usage" dataTestId="consent" onChange={(): void => {}} />);
+    view.rerender(
+      <PaidUsageConsent
+        title="I agree"
+        description="Paid usage"
+        dataTestId="consent"
+        onChange={(): void => {}}
+      />,
+    );
     expect(getStatus).toHaveBeenCalledTimes(1);
   });
 
   it("clears an earlier acknowledgement when changing projects", async () => {
-    jest.spyOn(BaseAPI, "get").mockResolvedValue({ data: { isAllowed: true } } as any);
+    jest
+      .spyOn(BaseAPI, "get")
+      .mockResolvedValue({ data: { isAllowed: true } } as any);
     const view: ReturnType<typeof render> = renderConsent();
     await waitFor(() => {
       expect(screen.getByTestId("consent")).toBeEnabled();
     });
-    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(ObjectID.generate());
-    view.rerender(<PaidUsageConsent title="I agree" description="Paid usage" dataTestId="consent" value={true} onChange={onChange} />);
+    jest
+      .spyOn(ProjectUtil, "getCurrentProjectId")
+      .mockReturnValue(ObjectID.generate());
+    view.rerender(
+      <PaidUsageConsent
+        title="I agree"
+        description="Paid usage"
+        dataTestId="consent"
+        value={true}
+        onChange={onChange}
+      />,
+    );
     expect(onChange).toHaveBeenCalledWith(false);
     await waitFor(() => {
       expect(screen.getByTestId("consent")).toBeEnabled();

--- a/Common/Tests/App/Dashboard/PaidUsageConsent.test.tsx
+++ b/Common/Tests/App/Dashboard/PaidUsageConsent.test.tsx
@@ -1,0 +1,138 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import PaidUsageConsent from "../../../../App/FeatureSet/Dashboard/src/Components/Billing/PaidUsageConsent";
+import BaseAPI from "../../../UI/Utils/API/API";
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "../../../UI/Utils/Project";
+import ObjectID from "../../../Types/ObjectID";
+
+jest.mock("../../../UI/Config", () => {
+  return { ...jest.requireActual("../../../UI/Config"), BILLING_ENABLED: true };
+});
+
+describe("PaidUsageConsent", () => {
+  const onChange: jest.Mock = jest.fn();
+  const projectId: ObjectID = ObjectID.generate();
+
+  const renderConsent: () => ReturnType<typeof render> = () => {
+    return render(
+      <PaidUsageConsent
+        title="I agree to usage charges"
+        description="$1 per active monitor per month"
+        dataTestId="consent"
+        onChange={onChange}
+      />,
+    );
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    onChange.mockClear();
+    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(projectId);
+    jest.spyOn(ModelAPI, "getCommonHeaders").mockReturnValue({});
+  });
+
+  it("keeps consent disabled until the authoritative status returns", async () => {
+    let resolve: (value: any) => void = (): void => {};
+    jest.spyOn(BaseAPI, "get").mockImplementation(() => {
+      return new Promise<any>((done: (value: any) => void) => {
+        resolve = done;
+      });
+    });
+    renderConsent();
+    expect(screen.getByTestId("consent")).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent("Checking");
+    await act(async () => {
+      resolve({ data: { isAllowed: true } });
+    });
+    expect(screen.getByTestId("consent")).toBeEnabled();
+    expect(screen.getByTestId("consent")).not.toBeChecked();
+    fireEvent.click(screen.getByTestId("consent"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("explains locked features and lets the user recheck after billing setup", async () => {
+    jest.spyOn(BaseAPI, "get")
+      .mockResolvedValueOnce({ data: { isAllowed: false } } as any)
+      .mockResolvedValueOnce({ data: { isAllowed: true } } as any);
+    renderConsent();
+    await screen.findByText(/Add a payment method before/);
+    expect(screen.getByTestId("consent")).toBeDisabled();
+    expect(screen.getByRole("link", { name: "Set up billing" })).toHaveAttribute(
+      "href", `/dashboard/${projectId.toString()}/settings/billing`,
+    );
+    await userEvent.click(screen.getByTestId("consent"));
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("consent")).toBeEnabled();
+    });
+    expect(screen.getByTestId("consent")).not.toBeChecked();
+  });
+
+  it("keeps consent locked on network failure and supports retry", async () => {
+    jest.spyOn(BaseAPI, "get")
+      .mockRejectedValueOnce(new Error("Unavailable"))
+      .mockResolvedValueOnce({ data: { isAllowed: true } } as any);
+    renderConsent();
+    await screen.findByText(/We could not check paid feature access/);
+    expect(screen.getByTestId("consent")).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("consent")).toBeEnabled();
+    });
+  });
+
+  it("does not accept an absent or nonboolean authorization value", async () => {
+    jest.spyOn(BaseAPI, "get").mockResolvedValue({ data: { isAllowed: "true" } } as any);
+    renderConsent();
+    await screen.findByText(/Add a payment method before/);
+    expect(screen.getByTestId("consent")).toBeDisabled();
+  });
+
+  it("does not use a stale project response after the selected project changes", async () => {
+    let resolveOld: (value: any) => void = (): void => {};
+    jest.spyOn(BaseAPI, "get")
+      .mockImplementationOnce(() => {
+        return new Promise<any>((done: (value: any) => void) => {
+          resolveOld = done;
+        });
+      })
+      .mockResolvedValueOnce({ data: { isAllowed: false } } as any);
+    const view: ReturnType<typeof render> = renderConsent();
+    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(ObjectID.generate());
+    view.rerender(<PaidUsageConsent title="I agree" description="Paid usage" dataTestId="consent" />);
+    await screen.findByText(/Add a payment method before/);
+    await act(async () => {
+      resolveOld({ data: { isAllowed: true } });
+    });
+    expect(screen.getByTestId("consent")).toBeDisabled();
+  });
+
+  it("does not reload eligibility when a form recreates its callback", async () => {
+    const getStatus: jest.SpyInstance = jest.spyOn(BaseAPI, "get")
+      .mockResolvedValue({ data: { isAllowed: true } } as any);
+    const view: ReturnType<typeof render> = renderConsent();
+    await waitFor(() => {
+      expect(screen.getByTestId("consent")).toBeEnabled();
+    });
+    view.rerender(<PaidUsageConsent title="I agree" description="Paid usage" dataTestId="consent" onChange={(): void => {}} />);
+    expect(getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears an earlier acknowledgement when changing projects", async () => {
+    jest.spyOn(BaseAPI, "get").mockResolvedValue({ data: { isAllowed: true } } as any);
+    const view: ReturnType<typeof render> = renderConsent();
+    await waitFor(() => {
+      expect(screen.getByTestId("consent")).toBeEnabled();
+    });
+    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(ObjectID.generate());
+    view.rerender(<PaidUsageConsent title="I agree" description="Paid usage" dataTestId="consent" value={true} onChange={onChange} />);
+    expect(onChange).toHaveBeenCalledWith(false);
+    await waitFor(() => {
+      expect(screen.getByTestId("consent")).toBeEnabled();
+    });
+  });
+});

--- a/Common/Tests/App/Dashboard/PayAsYouGoConsentGate.test.tsx
+++ b/Common/Tests/App/Dashboard/PayAsYouGoConsentGate.test.tsx
@@ -14,6 +14,15 @@ import FormFieldSchemaType from "../../../UI/Components/Forms/Types/FormFieldSch
 import ProjectUtil from "../../../UI/Utils/Project";
 import getJestMockFunction, { MockFunction } from "../../MockType";
 import { getJestSpyOn } from "../../Spy";
+import ModelForm, { FormType } from "../../../UI/Components/Forms/ModelForm";
+import {
+  MONITOR_CONSENT_ERROR,
+  MONITOR_CONSENT_FIELD_KEY,
+  TELEMETRY_CONSENT_ERROR,
+  TELEMETRY_CONSENT_FIELD_KEY,
+  getMonitorPayAsYouGoFormFields,
+  getTelemetryPayAsYouGoFormFields,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo";
 
 /*
  * The consent checkbox is the whole point of the change: on the Free plan a
@@ -116,16 +125,6 @@ jest.mock("../../../UI/Config", () => {
   return mocked;
 });
 
-// Imported after the mocks above.
-import ModelForm, { FormType } from "../../../UI/Components/Forms/ModelForm";
-import {
-  MONITOR_CONSENT_ERROR,
-  MONITOR_CONSENT_FIELD_KEY,
-  TELEMETRY_CONSENT_ERROR,
-  TELEMETRY_CONSENT_FIELD_KEY,
-  getMonitorPayAsYouGoFormFields,
-  getTelemetryPayAsYouGoFormFields,
-} from "../../../../App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo";
 
 /*
  * These render real forms that validate on every keystroke, so give the waits

--- a/Common/Tests/App/Dashboard/PayAsYouGoConsentGate.test.tsx
+++ b/Common/Tests/App/Dashboard/PayAsYouGoConsentGate.test.tsx
@@ -1,3 +1,5 @@
+import BaseAPI from "../../../UI/Utils/API/API";
+import ObjectID from "../../../Types/ObjectID";
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -33,6 +35,7 @@ jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
       getItem: (...args: Array<any>) => {
         return getItemMock(...args);
       },
+      getCommonHeaders: () => { return {}; },
       createOrUpdate: (...args: Array<any>) => {
         return createOrUpdateMock(...args);
       },
@@ -186,6 +189,8 @@ const renderMonitorForm: RenderMonitorFormFunction = (
 describe("Pay as you go consent gate", () => {
   beforeEach(() => {
     jest.restoreAllMocks();
+    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(ObjectID.generate());
+    jest.spyOn(BaseAPI, "get").mockResolvedValue({ data: { isAllowed: true } } as any);
     config.billingEnabled = true;
     createOrUpdateMock.mockReset();
     getItemMock.mockReset();

--- a/Common/Tests/App/Dashboard/PayAsYouGoConsentGate.test.tsx
+++ b/Common/Tests/App/Dashboard/PayAsYouGoConsentGate.test.tsx
@@ -44,7 +44,9 @@ jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
       getItem: (...args: Array<any>) => {
         return getItemMock(...args);
       },
-      getCommonHeaders: () => { return {}; },
+      getCommonHeaders: () => {
+        return {};
+      },
       createOrUpdate: (...args: Array<any>) => {
         return createOrUpdateMock(...args);
       },
@@ -125,7 +127,6 @@ jest.mock("../../../UI/Config", () => {
   return mocked;
 });
 
-
 /*
  * These render real forms that validate on every keystroke, so give the waits
  * room to survive a loaded CI box.
@@ -188,8 +189,12 @@ const renderMonitorForm: RenderMonitorFormFunction = (
 describe("Pay as you go consent gate", () => {
   beforeEach(() => {
     jest.restoreAllMocks();
-    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(ObjectID.generate());
-    jest.spyOn(BaseAPI, "get").mockResolvedValue({ data: { isAllowed: true } } as any);
+    jest
+      .spyOn(ProjectUtil, "getCurrentProjectId")
+      .mockReturnValue(ObjectID.generate());
+    jest
+      .spyOn(BaseAPI, "get")
+      .mockResolvedValue({ data: { isAllowed: true } } as any);
     config.billingEnabled = true;
     createOrUpdateMock.mockReset();
     getItemMock.mockReset();

--- a/Common/Tests/App/Dashboard/PayAsYouGoNotices.test.tsx
+++ b/Common/Tests/App/Dashboard/PayAsYouGoNotices.test.tsx
@@ -71,7 +71,6 @@ jest.mock("../../../UI/Config", () => {
   return mocked;
 });
 
-
 type SetPlanFunction = (plan: PlanType | null) => void;
 
 const setPlan: SetPlanFunction = (plan: PlanType | null): void => {
@@ -81,9 +80,13 @@ const setPlan: SetPlanFunction = (plan: PlanType | null): void => {
 describe("Pay as you go notices", () => {
   beforeEach(() => {
     jest.restoreAllMocks();
-    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(ObjectID.generate());
+    jest
+      .spyOn(ProjectUtil, "getCurrentProjectId")
+      .mockReturnValue(ObjectID.generate());
     jest.spyOn(ModelAPI, "getCommonHeaders").mockReturnValue({});
-    jest.spyOn(BaseAPI, "get").mockResolvedValue({ data: { isAllowed: true } } as any);
+    jest
+      .spyOn(BaseAPI, "get")
+      .mockResolvedValue({ data: { isAllowed: true } } as any);
     config.billingEnabled = true;
     setPlan(PlanType.Free);
   });

--- a/Common/Tests/App/Dashboard/PayAsYouGoNotices.test.tsx
+++ b/Common/Tests/App/Dashboard/PayAsYouGoNotices.test.tsx
@@ -1,3 +1,6 @@
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
+import BaseAPI from "../../../UI/Utils/API/API";
+import ObjectID from "../../../Types/ObjectID";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -79,6 +82,9 @@ const setPlan: SetPlanFunction = (plan: PlanType | null): void => {
 describe("Pay as you go notices", () => {
   beforeEach(() => {
     jest.restoreAllMocks();
+    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(ObjectID.generate());
+    jest.spyOn(ModelAPI, "getCommonHeaders").mockReturnValue({});
+    jest.spyOn(BaseAPI, "get").mockResolvedValue({ data: { isAllowed: true } } as any);
     config.billingEnabled = true;
     setPlan(PlanType.Free);
   });
@@ -267,7 +273,7 @@ describe("Pay as you go notices", () => {
 
       expect(fields).toHaveLength(2);
       expect(fields[0]?.fieldType).toBe(FormFieldSchemaType.CustomComponent);
-      expect(fields[1]?.fieldType).toBe(FormFieldSchemaType.Checkbox);
+      expect(fields[1]?.fieldType).toBe(FormFieldSchemaType.CustomComponent);
     });
 
     it("renders the modal notice with the rate and a pricing link", () => {
@@ -382,7 +388,7 @@ describe("Pay as you go notices", () => {
       );
 
       expect(fields).toHaveLength(1);
-      expect(fields[0]?.fieldType).toBe(FormFieldSchemaType.Checkbox);
+      expect(fields[0]?.fieldType).toBe(FormFieldSchemaType.CustomComponent);
       expect(fields[0]?.stepId).toBe("monitor-info");
       expect(fields[0]?.overrideField).toEqual({
         [MONITOR_CONSENT_FIELD_KEY]: true,

--- a/Common/Tests/App/Dashboard/PayAsYouGoNotices.test.tsx
+++ b/Common/Tests/App/Dashboard/PayAsYouGoNotices.test.tsx
@@ -16,6 +16,24 @@ import { ModelField } from "../../../UI/Components/Forms/ModelForm";
 import ProjectUtil from "../../../UI/Utils/Project";
 import getJestMockFunction, { MockFunction } from "../../MockType";
 import { getJestSpyOn } from "../../Spy";
+import {
+  ACTIVE_MONITOR_PRICE_TEXT,
+  MONITOR_CONSENT_ERROR,
+  MONITOR_CONSENT_FIELD_KEY,
+  MonitorBatchPayAsYouGoConsent,
+  MonitorPayAsYouGoCard,
+  SESSION_REPLAY_PRICE_PER_GB_TEXT,
+  TELEMETRY_CONSENT_ERROR,
+  TELEMETRY_CONSENT_FIELD_KEY,
+  TELEMETRY_PRICE_PER_GB_TEXT,
+  TelemetryPayAsYouGoCard,
+  getMonitorBatchPriceSentence,
+  getMonitorPayAsYouGoFormFields,
+  getTelemetryPayAsYouGoFormFields,
+  isMonitorBatchConsentRequired,
+  validateMonitorConsent,
+  validateTelemetryConsent,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo";
 
 /*
  * The pay-as-you-go notices are the only warning a Free plan user gets before
@@ -53,25 +71,6 @@ jest.mock("../../../UI/Config", () => {
   return mocked;
 });
 
-// Imported after the mock so the components read the switchable flag.
-import {
-  ACTIVE_MONITOR_PRICE_TEXT,
-  MONITOR_CONSENT_ERROR,
-  MONITOR_CONSENT_FIELD_KEY,
-  MonitorBatchPayAsYouGoConsent,
-  MonitorPayAsYouGoCard,
-  SESSION_REPLAY_PRICE_PER_GB_TEXT,
-  TELEMETRY_CONSENT_ERROR,
-  TELEMETRY_CONSENT_FIELD_KEY,
-  TELEMETRY_PRICE_PER_GB_TEXT,
-  TelemetryPayAsYouGoCard,
-  getMonitorBatchPriceSentence,
-  getMonitorPayAsYouGoFormFields,
-  getTelemetryPayAsYouGoFormFields,
-  isMonitorBatchConsentRequired,
-  validateMonitorConsent,
-  validateTelemetryConsent,
-} from "../../../../App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo";
 
 type SetPlanFunction = (plan: PlanType | null) => void;
 

--- a/Common/Tests/Server/API/BillingPayAsYouGoStatus.test.ts
+++ b/Common/Tests/Server/API/BillingPayAsYouGoStatus.test.ts
@@ -1,6 +1,10 @@
 import BillingAPI from "../../../Server/API/BillingAPI";
 import PayAsYouGoBillingService from "../../../Server/Services/PayAsYouGoBillingService";
-import { NextFunction, OneUptimeRequest, OneUptimeResponse } from "../../../Server/Utils/Express";
+import {
+  NextFunction,
+  OneUptimeRequest,
+  OneUptimeResponse,
+} from "../../../Server/Utils/Express";
 import Response from "../../../Server/Utils/Response";
 import ObjectID from "../../../Types/ObjectID";
 import Permission, { UserPermission } from "../../../Types/Permission";
@@ -19,7 +23,11 @@ jest.mock("../../../Server/Middleware/UserAuthorization", () => {
   return { __esModule: true, default: { getUserMiddleware: jest.fn() } };
 });
 jest.mock("../../../Server/Utils/Express", () => {
-  return { getRouter: () => { return mockRouter; } };
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
 });
 jest.mock("../../../Server/Services/PayAsYouGoBillingService", () => {
   return { __esModule: true, default: { canUsePayAsYouGo: jest.fn() } };
@@ -35,7 +43,8 @@ describe("GET /billing/pay-as-you-go-status", () => {
   let next: NextFunction;
 
   const requestStatus: () => Promise<void> = async (): Promise<void> => {
-    await mockRouter.match("get", "/billing/pay-as-you-go-status")
+    await mockRouter
+      .match("get", "/billing/pay-as-you-go-status")
       .handlerFunction(req, res, next);
   };
 
@@ -45,38 +54,61 @@ describe("GET /billing/pay-as-you-go-status", () => {
     req = { tenantId: projectId } as OneUptimeRequest;
     res = {} as OneUptimeResponse;
     next = jest.fn();
-    jest.spyOn(BillingAPI.prototype, "getPermissionsForTenant").mockResolvedValue([
-      { permission: Permission.ProjectMember } as UserPermission,
-    ]);
+    jest
+      .spyOn(BillingAPI.prototype, "getPermissionsForTenant")
+      .mockResolvedValue([
+        { permission: Permission.ProjectMember } as UserPermission,
+      ]);
   });
 
-  afterEach(() => { jest.restoreAllMocks(); });
-
-  it.each([true, false])("returns only the feature eligibility (%s) to a project member", async (isAllowed: boolean) => {
-    jest.mocked(PayAsYouGoBillingService.canUsePayAsYouGo).mockResolvedValue(isAllowed);
-    await requestStatus();
-    expect(PayAsYouGoBillingService.canUsePayAsYouGo).toHaveBeenCalledWith(projectId);
-    expect(Response.sendJsonObjectResponse).toHaveBeenCalledWith(req, res, { isAllowed });
-    expect(next).not.toHaveBeenCalled();
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
+
+  it.each([true, false])(
+    "returns only the feature eligibility (%s) to a project member",
+    async (isAllowed: boolean) => {
+      jest
+        .mocked(PayAsYouGoBillingService.canUsePayAsYouGo)
+        .mockResolvedValue(isAllowed);
+      await requestStatus();
+      expect(PayAsYouGoBillingService.canUsePayAsYouGo).toHaveBeenCalledWith(
+        projectId,
+      );
+      expect(Response.sendJsonObjectResponse).toHaveBeenCalledWith(req, res, {
+        isAllowed,
+      });
+      expect(next).not.toHaveBeenCalled();
+    },
+  );
 
   it("requires a selected project", async () => {
     req = {} as OneUptimeRequest;
     await requestStatus();
-    expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: "Project ID is required" }));
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Project ID is required" }),
+    );
     expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
   });
 
   it("requires project membership", async () => {
-    jest.spyOn(BillingAPI.prototype, "getPermissionsForTenant").mockResolvedValue([]);
+    jest
+      .spyOn(BillingAPI.prototype, "getPermissionsForTenant")
+      .mockResolvedValue([]);
     await requestStatus();
-    expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: "You do not have access to this project" }));
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "You do not have access to this project",
+      }),
+    );
     expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
   });
 
   it("propagates provider failures instead of incorrectly granting access", async () => {
     const error: Error = new Error("Billing unavailable");
-    jest.mocked(PayAsYouGoBillingService.canUsePayAsYouGo).mockRejectedValue(error);
+    jest
+      .mocked(PayAsYouGoBillingService.canUsePayAsYouGo)
+      .mockRejectedValue(error);
     await requestStatus();
     expect(next).toHaveBeenCalledWith(error);
     expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();

--- a/Common/Tests/Server/API/BillingPayAsYouGoStatus.test.ts
+++ b/Common/Tests/Server/API/BillingPayAsYouGoStatus.test.ts
@@ -1,0 +1,84 @@
+import BillingAPI from "../../../Server/API/BillingAPI";
+import PayAsYouGoBillingService from "../../../Server/Services/PayAsYouGoBillingService";
+import { NextFunction, OneUptimeRequest, OneUptimeResponse } from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import ObjectID from "../../../Types/ObjectID";
+import Permission, { UserPermission } from "../../../Types/Permission";
+import { mockRouter } from "./Helpers";
+
+jest.mock("../../../Server/Services/BillingService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../Server/Services/ProjectService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../Server/API/CommonAPI", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../Server/Middleware/UserAuthorization", () => {
+  return { __esModule: true, default: { getUserMiddleware: jest.fn() } };
+});
+jest.mock("../../../Server/Utils/Express", () => {
+  return { getRouter: () => { return mockRouter; } };
+});
+jest.mock("../../../Server/Services/PayAsYouGoBillingService", () => {
+  return { __esModule: true, default: { canUsePayAsYouGo: jest.fn() } };
+});
+jest.mock("../../../Server/Utils/Response", () => {
+  return { __esModule: true, default: { sendJsonObjectResponse: jest.fn() } };
+});
+
+describe("GET /billing/pay-as-you-go-status", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  let req: OneUptimeRequest;
+  let res: OneUptimeResponse;
+  let next: NextFunction;
+
+  const requestStatus: () => Promise<void> = async (): Promise<void> => {
+    await mockRouter.match("get", "/billing/pay-as-you-go-status")
+      .handlerFunction(req, res, next);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    new BillingAPI();
+    req = { tenantId: projectId } as OneUptimeRequest;
+    res = {} as OneUptimeResponse;
+    next = jest.fn();
+    jest.spyOn(BillingAPI.prototype, "getPermissionsForTenant").mockResolvedValue([
+      { permission: Permission.ProjectMember } as UserPermission,
+    ]);
+  });
+
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  it.each([true, false])("returns only the feature eligibility (%s) to a project member", async (isAllowed: boolean) => {
+    jest.mocked(PayAsYouGoBillingService.canUsePayAsYouGo).mockResolvedValue(isAllowed);
+    await requestStatus();
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).toHaveBeenCalledWith(projectId);
+    expect(Response.sendJsonObjectResponse).toHaveBeenCalledWith(req, res, { isAllowed });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("requires a selected project", async () => {
+    req = {} as OneUptimeRequest;
+    await requestStatus();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: "Project ID is required" }));
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
+  });
+
+  it("requires project membership", async () => {
+    jest.spyOn(BillingAPI.prototype, "getPermissionsForTenant").mockResolvedValue([]);
+    await requestStatus();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: "You do not have access to this project" }));
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
+  });
+
+  it("propagates provider failures instead of incorrectly granting access", async () => {
+    const error: Error = new Error("Billing unavailable");
+    jest.mocked(PayAsYouGoBillingService.canUsePayAsYouGo).mockRejectedValue(error);
+    await requestStatus();
+    expect(next).toHaveBeenCalledWith(error);
+    expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Services/BillingService.test.ts
+++ b/Common/Tests/Server/Services/BillingService.test.ts
@@ -747,6 +747,15 @@ describe("BillingService", () => {
     describe("addOrUpdateMeteredPricingOnSubscription", () => {
       const quantity: number = 10;
 
+      beforeEach(async () => {
+        const { default: paymentAuthorization } = await import(
+          "../../../Server/Services/PayAsYouGoBillingService"
+        );
+        jest
+          .spyOn(paymentAuthorization, "requireMeteredSubscriptionPayment")
+          .mockResolvedValue(undefined);
+      });
+
       it("should throw if billing is not enabled", async () => {
         billingService = await mockIsBillingEnabled(false);
 

--- a/Common/Tests/Server/Services/BillingService.test.ts
+++ b/Common/Tests/Server/Services/BillingService.test.ts
@@ -39,6 +39,17 @@ import SubscriptionPlan from "../../../Types/Billing/SubscriptionPlan";
 import SubscriptionStatus from "../../../Types/Billing/SubscriptionStatus";
 import OneUptimeDate from "../../../Types/Date";
 
+jest.mock("../../../Server/Services/PayAsYouGoBillingService", () => {
+  return {
+    __esModule: true,
+    default: {
+      requireMeteredSubscriptionPayment: jest.fn(async (): Promise<void> => {
+        return;
+      }),
+    },
+  };
+});
+
 describe("BillingService", () => {
   let billingService: BillingService;
   const customer: CustomerData = getCustomerData();
@@ -746,15 +757,6 @@ describe("BillingService", () => {
 
     describe("addOrUpdateMeteredPricingOnSubscription", () => {
       const quantity: number = 10;
-
-      beforeEach(async () => {
-        const { default: paymentAuthorization } = await import(
-          "../../../Server/Services/PayAsYouGoBillingService"
-        );
-        jest
-          .spyOn(paymentAuthorization, "requireMeteredSubscriptionPayment")
-          .mockResolvedValue(undefined);
-      });
 
       it("should throw if billing is not enabled", async () => {
         billingService = await mockIsBillingEnabled(false);

--- a/Common/Tests/Server/Services/BillingServiceMeteredPaymentAuthorization.test.ts
+++ b/Common/Tests/Server/Services/BillingServiceMeteredPaymentAuthorization.test.ts
@@ -9,12 +9,24 @@ import OneUptimeDate from "../../../Types/Date";
 import { getJestSpyOn } from "../../Spy";
 import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
 
-jest.mock("../../../Server/Services/ProjectService", () => ({ __esModule: true, default: {} }));
-jest.mock("../../../Server/Services/MailService", () => ({ __esModule: true, default: {} }));
-jest.mock("../../../Server/Services/PayAsYouGoBillingService", () => ({
-  __esModule: true,
-  default: { requireMeteredSubscriptionPayment: jest.fn() },
-}));
+jest.mock("../../../Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: {},
+  };
+});
+jest.mock("../../../Server/Services/MailService", () => {
+  return {
+    __esModule: true,
+    default: {},
+  };
+});
+jest.mock("../../../Server/Services/PayAsYouGoBillingService", () => {
+  return {
+    __esModule: true,
+    default: { requireMeteredSubscriptionPayment: jest.fn() },
+  };
+});
 const ActiveMonitoringMeteredPlan: ServerMeteredPlan = new ServerMeteredPlan();
 
 describe("BillingService metered payment authorization", () => {

--- a/Common/Tests/Server/Services/BillingServiceMeteredPaymentAuthorization.test.ts
+++ b/Common/Tests/Server/Services/BillingServiceMeteredPaymentAuthorization.test.ts
@@ -1,0 +1,163 @@
+import {
+  BillingService,
+  METERED_BILLING_START_METADATA_KEY,
+} from "../../../Server/Services/BillingService";
+import PayAsYouGoBillingService from "../../../Server/Services/PayAsYouGoBillingService";
+import ServerMeteredPlan from "../../../Server/Types/Billing/MeteredPlan/ServerMeteredPlan";
+import PaymentRequiredException from "../../../Types/Exception/PaymentRequiredException";
+import OneUptimeDate from "../../../Types/Date";
+import { getJestSpyOn } from "../../Spy";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+jest.mock("../../../Server/Services/ProjectService", () => ({ __esModule: true, default: {} }));
+jest.mock("../../../Server/Services/MailService", () => ({ __esModule: true, default: {} }));
+jest.mock("../../../Server/Services/PayAsYouGoBillingService", () => ({
+  __esModule: true,
+  default: { requireMeteredSubscriptionPayment: jest.fn() },
+}));
+const ActiveMonitoringMeteredPlan: ServerMeteredPlan = new ServerMeteredPlan();
+
+describe("BillingService metered payment authorization", () => {
+  let service: BillingService;
+  let retrieveCustomer: jest.Mock;
+  let updateCustomer: jest.Mock;
+  let createItem: jest.Mock;
+  let createUsage: jest.Mock;
+  let requirePayment: jest.SpyInstance;
+
+  beforeEach(() => {
+    service = new BillingService();
+    retrieveCustomer = jest.fn().mockResolvedValue({ metadata: {} });
+    updateCustomer = jest.fn().mockResolvedValue({});
+    createItem = jest.fn().mockResolvedValue({ id: "item_new" });
+    createUsage = jest.fn().mockResolvedValue({});
+    (service as unknown as { stripe: unknown }).stripe = {
+      customers: { retrieve: retrieveCustomer, update: updateCustomer },
+      subscriptionItems: { create: createItem, createUsageRecord: createUsage },
+    };
+    getJestSpyOn(service, "isBillingEnabled").mockReturnValue(true);
+    getJestSpyOn(ActiveMonitoringMeteredPlan, "hasPriceId").mockReturnValue(
+      true,
+    );
+    getJestSpyOn(ActiveMonitoringMeteredPlan, "getPriceId").mockReturnValue(
+      "price_monitor",
+    );
+    getJestSpyOn(service, "getSubscription").mockResolvedValue({
+      id: "sub_metered",
+      customer: "cus_project",
+      items: {
+        data: [{ id: "item_existing", price: { id: "price_monitor" } }],
+      },
+    });
+    requirePayment = getJestSpyOn(
+      PayAsYouGoBillingService,
+      "requireMeteredSubscriptionPayment",
+    ).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([true, false])(
+    "prevents any Stripe usage write without payment authorization (existing price: %s)",
+    async (existingPrice: boolean) => {
+      if (!existingPrice) {
+        getJestSpyOn(service, "getSubscription").mockResolvedValue({
+          id: "sub_metered",
+          customer: "cus_project",
+          items: { data: [] },
+        });
+      }
+      requirePayment.mockRejectedValue(
+        new PaymentRequiredException("Add a payment method"),
+      );
+      await expect(
+        service.addOrUpdateMeteredPricingOnSubscription(
+          "sub_metered",
+          ActiveMonitoringMeteredPlan,
+          1,
+        ),
+      ).rejects.toBeInstanceOf(PaymentRequiredException);
+      expect(createItem).not.toHaveBeenCalled();
+      expect(createUsage).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reports authorized usage to the existing subscription item", async () => {
+    await service.addOrUpdateMeteredPricingOnSubscription(
+      "sub_metered",
+      ActiveMonitoringMeteredPlan,
+      3,
+    );
+    expect(requirePayment).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: "cus_project" }),
+    );
+    expect(createUsage).toHaveBeenCalledWith("item_existing", { quantity: 3 });
+  });
+
+  it("allows zero usage without demanding a card", async () => {
+    await service.addOrUpdateMeteredPricingOnSubscription(
+      "sub_metered",
+      ActiveMonitoringMeteredPlan,
+      0,
+    );
+    expect(requirePayment).not.toHaveBeenCalled();
+    expect(createUsage).toHaveBeenCalledWith("item_existing", { quantity: 0 });
+  });
+
+  it("preserves a durable authorization boundary across worker restarts", async () => {
+    retrieveCustomer.mockResolvedValue({
+      metadata: {
+        [METERED_BILLING_START_METADATA_KEY]: "2026-09-08T15:04:03.000Z",
+      },
+    });
+    await expect(
+      service.getMeteredBillingStartDate("cus_project"),
+    ).resolves.toEqual(new Date("2026-09-08T15:04:03Z"));
+    expect(updateCustomer).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, "invalid-date"])(
+    "initializes a conservative boundary for missing or invalid metadata (%s)",
+    async (stored: string | undefined) => {
+      const now: Date = new Date("2026-09-08T15:04:03Z");
+      getJestSpyOn(OneUptimeDate, "getCurrentDate").mockReturnValue(now);
+      retrieveCustomer.mockResolvedValue({
+        metadata: {
+          other_customer_metadata: "preserve",
+          [METERED_BILLING_START_METADATA_KEY]: stored,
+        },
+      });
+      await expect(
+        service.getMeteredBillingStartDate("cus_project"),
+      ).resolves.toEqual(now);
+      expect(updateCustomer).toHaveBeenCalledWith("cus_project", {
+        metadata: { [METERED_BILLING_START_METADATA_KEY]: now.toISOString() },
+      });
+    },
+  );
+
+  it("does not authorize staging when durable marker persistence fails", async () => {
+    updateCustomer.mockRejectedValue(new Error("Stripe unavailable"));
+    await expect(
+      service.getMeteredBillingStartDate("cus_project"),
+    ).rejects.toThrow("Stripe unavailable");
+  });
+
+  it("rejects a deleted billing customer without writing metadata", async () => {
+    retrieveCustomer.mockResolvedValue({ deleted: true });
+    await expect(
+      service.getMeteredBillingStartDate("cus_project"),
+    ).rejects.toThrow();
+    expect(updateCustomer).not.toHaveBeenCalled();
+  });
+
+  it("does not access Stripe when billing is disabled", async () => {
+    getJestSpyOn(service, "isBillingEnabled").mockReturnValue(false);
+    await expect(
+      service.getMeteredBillingStartDate("cus_project"),
+    ).rejects.toThrow();
+    expect(retrieveCustomer).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Services/BillingServiceMeteredPaymentAuthorization.test.ts
+++ b/Common/Tests/Server/Services/BillingServiceMeteredPaymentAuthorization.test.ts
@@ -26,6 +26,7 @@ describe("BillingService metered payment authorization", () => {
   let requirePayment: jest.SpyInstance;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     service = new BillingService();
     retrieveCustomer = jest.fn().mockResolvedValue({ metadata: {} });
     updateCustomer = jest.fn().mockResolvedValue({});

--- a/Common/Tests/Server/Services/MonitorPayAsYouGoBilling.test.ts
+++ b/Common/Tests/Server/Services/MonitorPayAsYouGoBilling.test.ts
@@ -112,6 +112,22 @@ describe("monitor creation payment admission", () => {
     expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
   });
 
+  test.each([PlanType.Free, PlanType.Growth])(
+    "keeps free Manual monitors available when the %s subscription is unpaid",
+    async (plan: PlanType) => {
+      jest.spyOn(ProjectService, "getCurrentPlan").mockResolvedValue({
+        plan,
+        isSubscriptionUnpaid: true,
+      });
+
+      await expect(
+        hooks.onBeforeCreate(createInput(MonitorType.Manual)),
+      ).resolves.toBeDefined();
+      expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
+      expect(MonitorService.countBy).not.toHaveBeenCalled();
+    },
+  );
+
   test("checks the creating tenant even when the payload names another project", async () => {
     const input: CreateBy<Monitor> = createInput(MonitorType.Website);
     input.data.projectId = otherProjectId;

--- a/Common/Tests/Server/Services/MonitorPayAsYouGoBilling.test.ts
+++ b/Common/Tests/Server/Services/MonitorPayAsYouGoBilling.test.ts
@@ -1,0 +1,263 @@
+import MonitorService from "../../../Server/Services/MonitorService";
+import MonitorStatusService from "../../../Server/Services/MonitorStatusService";
+import ProjectService from "../../../Server/Services/ProjectService";
+import PayAsYouGoBillingService from "../../../Server/Services/PayAsYouGoBillingService";
+import MonitorStepsProjectValidator from "../../../Server/Utils/Monitor/MonitorStepsProjectValidator";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorStatus from "../../../Models/DatabaseModels/MonitorStatus";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import { PlanType } from "../../../Types/Billing/SubscriptionPlan";
+import PaymentRequiredException from "../../../Types/Exception/PaymentRequiredException";
+import * as EnvironmentConfig from "../../../Server/EnvironmentConfig";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+jest.mock("../../../Server/EnvironmentConfig", () => {
+  return {
+    __esModule: true,
+    ...(jest.requireActual(
+      "../../../Server/EnvironmentConfig",
+    ) as typeof EnvironmentConfig),
+    IsBillingEnabled: true,
+  };
+});
+
+type MonitorHooks = {
+  onBeforeCreate: (input: CreateBy<Monitor>) => Promise<unknown>;
+  onBeforeUpdate: (input: UpdateBy<Monitor>) => Promise<unknown>;
+};
+const hooks: MonitorHooks = MonitorService as unknown as MonitorHooks;
+const projectId: ObjectID = ObjectID.generate();
+const otherProjectId: ObjectID = ObjectID.generate();
+
+function createInput(monitorType: MonitorType): CreateBy<Monitor> {
+  const monitor: Monitor = new Monitor();
+  monitor.monitorType = monitorType;
+  return { data: monitor, props: { isRoot: true, tenantId: projectId } };
+}
+
+function updateInput(data: UpdateBy<Monitor>["data"]): UpdateBy<Monitor> {
+  return {
+    data,
+    query: { _id: ObjectID.generate().toString() },
+    props: { isRoot: true },
+    limit: 10,
+    skip: 0,
+  };
+}
+
+function storedMonitor(project: ObjectID, monitorType: MonitorType): Monitor {
+  return Object.assign(new Monitor(), { projectId: project, monitorType });
+}
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  (EnvironmentConfig as { IsBillingEnabled: boolean }).IsBillingEnabled = true;
+  jest
+    .spyOn(PayAsYouGoBillingService, "canUsePayAsYouGo")
+    .mockResolvedValue(false);
+  jest.spyOn(ProjectService, "getCurrentPlan").mockResolvedValue({
+    plan: PlanType.Free,
+    isSubscriptionUnpaid: false,
+  });
+  jest
+    .spyOn(MonitorService, "countBy")
+    .mockResolvedValue(new PositiveNumber(0));
+  jest
+    .spyOn(MonitorStepsProjectValidator, "validateMonitorStepsBelongToProject")
+    .mockResolvedValue(undefined);
+  jest
+    .spyOn(MonitorService, "validateDependencyConfiguration")
+    .mockResolvedValue(undefined);
+  const status: MonitorStatus = new MonitorStatus();
+  status.id = ObjectID.generate();
+  jest.spyOn(MonitorStatusService, "findOneBy").mockResolvedValue(status);
+  jest.spyOn(MonitorService, "findBy").mockResolvedValue([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("monitor creation payment admission", () => {
+  test.each(
+    Object.values(MonitorType).filter((type: MonitorType) => {
+      return type !== MonitorType.Manual;
+    }),
+  )(
+    "requires payment setup before creating %s on a Free project",
+    async (monitorType: MonitorType) => {
+      await expect(
+        hooks.onBeforeCreate(createInput(monitorType)),
+      ).rejects.toBeInstanceOf(PaymentRequiredException);
+      expect(MonitorStatusService.findOneBy).not.toHaveBeenCalled();
+      expect(MonitorService.countBy).not.toHaveBeenCalled();
+    },
+  );
+
+  test("keeps Manual monitors available without payment setup", async () => {
+    await expect(
+      hooks.onBeforeCreate(createInput(MonitorType.Manual)),
+    ).resolves.toBeDefined();
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
+  });
+
+  test("checks the creating tenant even when the payload names another project", async () => {
+    const input: CreateBy<Monitor> = createInput(MonitorType.Website);
+    input.data.projectId = otherProjectId;
+    await expect(hooks.onBeforeCreate(input)).rejects.toBeInstanceOf(
+      PaymentRequiredException,
+    );
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).toHaveBeenCalledWith(
+      projectId,
+    );
+  });
+
+  test("admits an authorized Free project and retains its monitor count limit", async () => {
+    jest
+      .spyOn(PayAsYouGoBillingService, "canUsePayAsYouGo")
+      .mockResolvedValue(true);
+    await expect(
+      hooks.onBeforeCreate(createInput(MonitorType.Website)),
+    ).resolves.toBeDefined();
+    expect(MonitorService.countBy).toHaveBeenCalledTimes(1);
+    jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValue(
+        new PositiveNumber(
+          EnvironmentConfig.AllowedActiveMonitorCountInFreePlan,
+        ),
+      );
+    await expect(
+      hooks.onBeforeCreate(createInput(MonitorType.Website)),
+    ).rejects.toThrow("maximum allowed monitor limit");
+  });
+
+  test("retains the existing unpaid subscription refusal after payment admission", async () => {
+    jest
+      .spyOn(PayAsYouGoBillingService, "canUsePayAsYouGo")
+      .mockResolvedValue(true);
+    jest
+      .spyOn(ProjectService, "getCurrentPlan")
+      .mockResolvedValue({ plan: PlanType.Growth, isSubscriptionUnpaid: true });
+    await expect(
+      hooks.onBeforeCreate(createInput(MonitorType.Website)),
+    ).rejects.toThrow("subscription is unpaid");
+  });
+
+  test("preserves active monitors on installations with billing disabled", async () => {
+    (EnvironmentConfig as { IsBillingEnabled: boolean }).IsBillingEnabled =
+      false;
+    await expect(
+      hooks.onBeforeCreate(createInput(MonitorType.Website)),
+    ).resolves.toBeDefined();
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
+    expect(ProjectService.getCurrentPlan).not.toHaveBeenCalled();
+  });
+});
+
+describe("monitor update payment admission", () => {
+  test("requires payment to re-enable an existing active monitor", async () => {
+    jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([storedMonitor(projectId, MonitorType.Website)]);
+    await expect(
+      hooks.onBeforeUpdate(updateInput({ disableActiveMonitoring: false })),
+    ).rejects.toBeInstanceOf(PaymentRequiredException);
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).toHaveBeenCalledWith(
+      projectId,
+    );
+  });
+
+  test("guards internal Manual-to-active changes using the stored project", async () => {
+    jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([storedMonitor(otherProjectId, MonitorType.Manual)]);
+    const input: UpdateBy<Monitor> = updateInput({
+      monitorType: MonitorType.API,
+    });
+    input.props.tenantId = projectId;
+    await expect(hooks.onBeforeUpdate(input)).rejects.toBeInstanceOf(
+      PaymentRequiredException,
+    );
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).toHaveBeenCalledWith(
+      otherProjectId,
+    );
+  });
+
+  test("scopes non-root update lookups to their tenant", async () => {
+    const input: UpdateBy<Monitor> = updateInput({
+      disableActiveMonitoring: false,
+    });
+    input.props = { tenantId: projectId };
+    await hooks.onBeforeUpdate(input);
+    expect(MonitorService.findBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: { ...input.query, projectId },
+        limit: input.limit,
+        skip: input.skip,
+      }),
+    );
+  });
+
+  test("checks every distinct project in an internal bulk update", async () => {
+    jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([
+        storedMonitor(projectId, MonitorType.Website),
+        storedMonitor(projectId, MonitorType.API),
+        storedMonitor(otherProjectId, MonitorType.Website),
+      ]);
+    jest
+      .spyOn(PayAsYouGoBillingService, "canUsePayAsYouGo")
+      .mockImplementation(async (id: ObjectID): Promise<boolean> => {
+        return id.toString() === projectId.toString();
+      });
+    await expect(
+      hooks.onBeforeUpdate(updateInput({ disableActiveMonitoring: false })),
+    ).rejects.toBeInstanceOf(PaymentRequiredException);
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).toHaveBeenCalledTimes(2);
+  });
+
+  test("allows re-enabling Manual monitors without payment setup", async () => {
+    jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([storedMonitor(projectId, MonitorType.Manual)]);
+    await expect(
+      hooks.onBeforeUpdate(updateInput({ disableActiveMonitoring: false })),
+    ).resolves.toBeDefined();
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    { disableActiveMonitoring: true },
+    { name: "Renamed monitor" },
+    { monitorType: MonitorType.Manual },
+  ])(
+    "allows nonbillable updates %j without consulting billing",
+    async (data: UpdateBy<Monitor>["data"]) => {
+      await expect(
+        hooks.onBeforeUpdate(updateInput(data)),
+      ).resolves.toBeDefined();
+      expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
+      expect(MonitorService.findBy).not.toHaveBeenCalled();
+    },
+  );
+
+  test("does not block self-hosted re-enabling or load billing records", async () => {
+    (EnvironmentConfig as { IsBillingEnabled: boolean }).IsBillingEnabled =
+      false;
+    await hooks.onBeforeUpdate(updateInput({ disableActiveMonitoring: false }));
+    expect(MonitorService.findBy).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Services/PayAsYouGoBillingService.test.ts
+++ b/Common/Tests/Server/Services/PayAsYouGoBillingService.test.ts
@@ -16,18 +16,29 @@ import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
 const PROJECT_ID: ObjectID = ObjectID.generate();
 const OTHER_PROJECT_ID: ObjectID = ObjectID.generate();
 
-jest.mock("../../../Server/Services/BillingService", () => ({
-  __esModule: true,
-  default: { isBillingEnabled: jest.fn(), hasPaymentMethods: jest.fn(), getSubscription: jest.fn(), getMeteredBillingStartDate: jest.fn() },
-}));
-jest.mock("../../../Server/Services/ProjectService", () => ({
-  __esModule: true,
-  default: { findOneById: jest.fn(), findOneBy: jest.fn() },
-}));
-jest.mock("../../../Server/Services/PromoCodeService", () => ({
-  __esModule: true,
-  default: { findOneBy: jest.fn() },
-}));
+jest.mock("../../../Server/Services/BillingService", () => {
+  return {
+    __esModule: true,
+    default: {
+      isBillingEnabled: jest.fn(),
+      hasPaymentMethods: jest.fn(),
+      getSubscription: jest.fn(),
+      getMeteredBillingStartDate: jest.fn(),
+    },
+  };
+});
+jest.mock("../../../Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: { findOneById: jest.fn(), findOneBy: jest.fn() },
+  };
+});
+jest.mock("../../../Server/Services/PromoCodeService", () => {
+  return {
+    __esModule: true,
+    default: { findOneBy: jest.fn() },
+  };
+});
 
 describe("PayAsYouGoBillingService", () => {
   let service: Service;
@@ -170,15 +181,21 @@ describe("PayAsYouGoBillingService", () => {
   it("preserves explicit reseller billing agreements", async () => {
     project.resellerId = ObjectID.generate();
     project.resellerPlanId = ObjectID.generate();
-    project.paymentProviderCustomerId = undefined;
-    getJestSpyOn(PromoCodeService, "findOneBy").mockResolvedValue(new PromoCode());
+    delete project.paymentProviderCustomerId;
+    getJestSpyOn(PromoCodeService, "findOneBy").mockResolvedValue(
+      new PromoCode(),
+    );
     await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(true);
     expect(hasPaymentMethods).not.toHaveBeenCalled();
-    expect(PromoCodeService.findOneBy).toHaveBeenCalledWith(expect.objectContaining({ query: {
-      projectId: PROJECT_ID,
-      resellerId: project.resellerId,
-      isPromoCodeUsed: true,
-    } }));
+    expect(PromoCodeService.findOneBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: {
+          projectId: PROJECT_ID,
+          resellerId: project.resellerId,
+          isPromoCodeUsed: true,
+        },
+      }),
+    );
   });
 
   it("requires a redeemed license bound to this project before granting a reseller exemption", async () => {
@@ -217,9 +234,18 @@ describe("PayAsYouGoBillingService", () => {
     });
 
     it("preserves already authorized invoice history without a new cutoff", async () => {
-      getSubscription.mockResolvedValue({ customer: "cus_project", status: "active", collection_method: "send_invoice" });
-      const start: jest.SpyInstance = getJestSpyOn(BillingService, "getMeteredBillingStartDate");
-      await expect(service.getTelemetryBillingStartDate(PROJECT_ID)).resolves.toBeUndefined();
+      getSubscription.mockResolvedValue({
+        customer: "cus_project",
+        status: "active",
+        collection_method: "send_invoice",
+      });
+      const start: jest.SpyInstance = getJestSpyOn(
+        BillingService,
+        "getMeteredBillingStartDate",
+      );
+      await expect(
+        service.getTelemetryBillingStartDate(PROJECT_ID),
+      ).resolves.toBeUndefined();
       expect(start).not.toHaveBeenCalled();
     });
 
@@ -283,7 +309,9 @@ describe("PayAsYouGoBillingService", () => {
   it("leaves self-hosted and reseller telemetry without a Stripe cutoff", async () => {
     project.resellerId = ObjectID.generate();
     project.resellerPlanId = ObjectID.generate();
-    getJestSpyOn(PromoCodeService, "findOneBy").mockResolvedValue(new PromoCode());
+    getJestSpyOn(PromoCodeService, "findOneBy").mockResolvedValue(
+      new PromoCode(),
+    );
     const start: jest.SpyInstance = getJestSpyOn(
       BillingService,
       "getMeteredBillingStartDate",
@@ -301,17 +329,34 @@ describe("PayAsYouGoBillingService", () => {
   it("resolves the project from the Stripe customer before authorizing a direct metered write", async () => {
     const owner: Project = new Project();
     owner.id = PROJECT_ID;
-    const findOwner: jest.SpyInstance = getJestSpyOn(ProjectService, "findOneBy").mockResolvedValue(owner);
-    const subscription: Stripe.Subscription = { customer: { id: "cus_project" } } as Stripe.Subscription;
-    await expect(service.requireMeteredSubscriptionPayment(subscription)).rejects.toBeInstanceOf(PaymentRequiredException);
-    expect(findOwner).toHaveBeenCalledWith(expect.objectContaining({ query: { paymentProviderCustomerId: "cus_project" } }));
+    const findOwner: jest.SpyInstance = getJestSpyOn(
+      ProjectService,
+      "findOneBy",
+    ).mockResolvedValue(owner);
+    const subscription: Stripe.Subscription = {
+      customer: { id: "cus_project" },
+    } as Stripe.Subscription;
+    await expect(
+      service.requireMeteredSubscriptionPayment(subscription),
+    ).rejects.toBeInstanceOf(PaymentRequiredException);
+    expect(findOwner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: { paymentProviderCustomerId: "cus_project" },
+      }),
+    );
     hasPaymentMethods.mockResolvedValue(true);
-    await expect(service.requireMeteredSubscriptionPayment(subscription)).resolves.toBeUndefined();
+    await expect(
+      service.requireMeteredSubscriptionPayment(subscription),
+    ).resolves.toBeUndefined();
   });
 
   it("rejects a direct metered write for an unrecognized billing customer", async () => {
     getJestSpyOn(ProjectService, "findOneBy").mockResolvedValue(null);
-    await expect(service.requireMeteredSubscriptionPayment({ customer: "cus_unknown" } as Stripe.Subscription)).rejects.toBeInstanceOf(PaymentRequiredException);
+    await expect(
+      service.requireMeteredSubscriptionPayment({
+        customer: "cus_unknown",
+      } as Stripe.Subscription),
+    ).rejects.toBeInstanceOf(PaymentRequiredException);
     expect(hasPaymentMethods).not.toHaveBeenCalled();
   });
 });

--- a/Common/Tests/Server/Services/PayAsYouGoBillingService.test.ts
+++ b/Common/Tests/Server/Services/PayAsYouGoBillingService.test.ts
@@ -38,6 +38,7 @@ describe("PayAsYouGoBillingService", () => {
   let getPlan: jest.SpyInstance;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     service = new Service();
     project = Object.assign(new Project(), {
       paymentProviderPlanId: "free",

--- a/Common/Tests/Server/Services/PayAsYouGoBillingService.test.ts
+++ b/Common/Tests/Server/Services/PayAsYouGoBillingService.test.ts
@@ -1,0 +1,316 @@
+import { Service } from "../../../Server/Services/PayAsYouGoBillingService";
+import BillingService from "../../../Server/Services/BillingService";
+import ProjectService from "../../../Server/Services/ProjectService";
+import PromoCodeService from "../../../Server/Services/PromoCodeService";
+import Project from "../../../Models/DatabaseModels/Project";
+import PromoCode from "../../../Models/DatabaseModels/PromoCode";
+import SubscriptionPlan, {
+  PlanType,
+} from "../../../Types/Billing/SubscriptionPlan";
+import PaymentRequiredException from "../../../Types/Exception/PaymentRequiredException";
+import ObjectID from "../../../Types/ObjectID";
+import Stripe from "stripe";
+import { getJestSpyOn } from "../../Spy";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const OTHER_PROJECT_ID: ObjectID = ObjectID.generate();
+
+jest.mock("../../../Server/Services/BillingService", () => ({
+  __esModule: true,
+  default: { isBillingEnabled: jest.fn(), hasPaymentMethods: jest.fn(), getSubscription: jest.fn(), getMeteredBillingStartDate: jest.fn() },
+}));
+jest.mock("../../../Server/Services/ProjectService", () => ({
+  __esModule: true,
+  default: { findOneById: jest.fn(), findOneBy: jest.fn() },
+}));
+jest.mock("../../../Server/Services/PromoCodeService", () => ({
+  __esModule: true,
+  default: { findOneBy: jest.fn() },
+}));
+
+describe("PayAsYouGoBillingService", () => {
+  let service: Service;
+  let project: Project;
+  let findProject: jest.SpyInstance;
+  let hasPaymentMethods: jest.SpyInstance;
+  let getSubscription: jest.SpyInstance;
+  let getPlan: jest.SpyInstance;
+
+  beforeEach(() => {
+    service = new Service();
+    project = Object.assign(new Project(), {
+      paymentProviderPlanId: "free",
+      paymentProviderCustomerId: "cus_project",
+      paymentProviderSubscriptionId: "sub_project",
+    });
+    findProject = getJestSpyOn(ProjectService, "findOneById").mockResolvedValue(
+      project,
+    );
+    hasPaymentMethods = getJestSpyOn(
+      BillingService,
+      "hasPaymentMethods",
+    ).mockResolvedValue(false);
+    getJestSpyOn(BillingService, "isBillingEnabled").mockReturnValue(true);
+    getJestSpyOn(PromoCodeService, "findOneBy").mockResolvedValue(null);
+    getPlan = getJestSpyOn(
+      SubscriptionPlan,
+      "getSubscriptionPlanById",
+    ).mockReturnValue(
+      new SubscriptionPlan("free", "free_yearly", PlanType.Free, 0, 0, 0, 0),
+    );
+    getSubscription = getJestSpyOn(
+      BillingService,
+      "getSubscription",
+    ).mockResolvedValue({
+      customer: "cus_project",
+      status: "active",
+      collection_method: "charge_automatically",
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("allows self-hosted use without consulting projects or payment providers", async () => {
+    getJestSpyOn(BillingService, "isBillingEnabled").mockReturnValue(false);
+    await expect(
+      service.requirePayAsYouGo(PROJECT_ID),
+    ).resolves.toBeUndefined();
+    expect(findProject).not.toHaveBeenCalled();
+    expect(hasPaymentMethods).not.toHaveBeenCalled();
+  });
+
+  it("rejects a Free account with a signup subscription but no card", async () => {
+    await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+    await expect(service.requirePayAsYouGo(PROJECT_ID)).rejects.toBeInstanceOf(
+      PaymentRequiredException,
+    );
+    await expect(service.requirePayAsYouGo(PROJECT_ID)).rejects.toThrow(
+      "Project Settings > Billing",
+    );
+    expect(getSubscription).not.toHaveBeenCalled();
+    expect(findProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: PROJECT_ID,
+        props: { isRoot: true, ignoreHooks: true },
+      }),
+    );
+  });
+
+  it("allows a Free project after a payment method has been added", async () => {
+    hasPaymentMethods.mockResolvedValue(true);
+    await expect(
+      service.requirePayAsYouGo(PROJECT_ID),
+    ).resolves.toBeUndefined();
+    expect(hasPaymentMethods).toHaveBeenCalledWith("cus_project");
+  });
+
+  it("does not cache a rejection, so adding a payment method takes effect immediately", async () => {
+    await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+    hasPaymentMethods.mockResolvedValue(true);
+    await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(true);
+    expect(hasPaymentMethods).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches positive admission checks for at most sixty seconds", async () => {
+    const now: jest.SpyInstance = getJestSpyOn(Date, "now").mockReturnValue(
+      100_000,
+    );
+    hasPaymentMethods.mockResolvedValue(true);
+    await service.canUsePayAsYouGo(PROJECT_ID);
+    await service.canUsePayAsYouGo(PROJECT_ID);
+    expect(findProject).toHaveBeenCalledTimes(1);
+    now.mockReturnValue(160_001);
+    hasPaymentMethods.mockResolvedValue(false);
+    await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+    expect(findProject).toHaveBeenCalledTimes(2);
+  });
+
+  it("never shares cached eligibility between projects", async () => {
+    hasPaymentMethods.mockResolvedValueOnce(true).mockResolvedValue(false);
+    await service.canUsePayAsYouGo(PROJECT_ID);
+    await expect(service.canUsePayAsYouGo(OTHER_PROJECT_ID)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("fresh billing checks bypass and invalidate positive admission cache", async () => {
+    hasPaymentMethods.mockResolvedValueOnce(true).mockResolvedValue(false);
+    await service.canUsePayAsYouGo(PROJECT_ID);
+    await expect(
+      service.canUsePayAsYouGo(PROJECT_ID, { useCache: false }),
+    ).resolves.toBe(false);
+    await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+    expect(hasPaymentMethods).toHaveBeenCalledTimes(3);
+  });
+
+  it.each(["paymentProviderPlanId", "paymentProviderCustomerId"])(
+    "denies incomplete onboarding without %s",
+    async (field: string) => {
+      (project as unknown as Record<string, unknown>)[field] = undefined;
+      await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+      expect(hasPaymentMethods).not.toHaveBeenCalled();
+    },
+  );
+
+  it("denies a missing project", async () => {
+    findProject.mockResolvedValue(null);
+    await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+  });
+
+  it("denies an unrecognized plan even when the caller has a card", async () => {
+    getPlan.mockReturnValue(undefined);
+    hasPaymentMethods.mockResolvedValue(true);
+    await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+  });
+
+  it("preserves explicit reseller billing agreements", async () => {
+    project.resellerId = ObjectID.generate();
+    project.resellerPlanId = ObjectID.generate();
+    project.paymentProviderCustomerId = undefined;
+    getJestSpyOn(PromoCodeService, "findOneBy").mockResolvedValue(new PromoCode());
+    await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(true);
+    expect(hasPaymentMethods).not.toHaveBeenCalled();
+    expect(PromoCodeService.findOneBy).toHaveBeenCalledWith(expect.objectContaining({ query: {
+      projectId: PROJECT_ID,
+      resellerId: project.resellerId,
+      isPromoCodeUsed: true,
+    } }));
+  });
+
+  it("requires a redeemed license bound to this project before granting a reseller exemption", async () => {
+    project.resellerId = ObjectID.generate();
+    project.resellerPlanId = ObjectID.generate();
+    await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+  });
+
+  it("does not treat an incomplete reseller reference as payment authorization", async () => {
+    project.resellerId = ObjectID.generate();
+    await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+  });
+
+  describe("paid subscriptions without a stored payment method", () => {
+    beforeEach(() => {
+      getPlan.mockReturnValue(
+        new SubscriptionPlan(
+          "growth",
+          "growth_yearly",
+          PlanType.Growth,
+          20,
+          200,
+          1,
+          14,
+        ),
+      );
+    });
+
+    it("permits a verified active invoice agreement", async () => {
+      getSubscription.mockResolvedValue({
+        customer: { id: "cus_project" },
+        status: "active",
+        collection_method: "send_invoice",
+      });
+      await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(true);
+    });
+
+    it("preserves already authorized invoice history without a new cutoff", async () => {
+      getSubscription.mockResolvedValue({ customer: "cus_project", status: "active", collection_method: "send_invoice" });
+      const start: jest.SpyInstance = getJestSpyOn(BillingService, "getMeteredBillingStartDate");
+      await expect(service.getTelemetryBillingStartDate(PROJECT_ID)).resolves.toBeUndefined();
+      expect(start).not.toHaveBeenCalled();
+    });
+
+    it.each(["trialing", "unpaid", "canceled", "past_due", "incomplete"])(
+      "does not interpret a %s subscription as a paid invoice contract",
+      async (status: string) => {
+        getSubscription.mockResolvedValue({
+          customer: "cus_project",
+          status,
+          collection_method: "send_invoice",
+        });
+        await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+      },
+    );
+
+    it("denies automatic collection without a card", async () => {
+      await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+    });
+
+    it("does not accept another customer's invoice contract", async () => {
+      getSubscription.mockResolvedValue({
+        customer: "cus_other",
+        status: "active",
+        collection_method: "send_invoice",
+      });
+      await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+    });
+  });
+
+  it("propagates provider failures rather than granting usage or treating debt as waived", async () => {
+    hasPaymentMethods.mockRejectedValue(
+      new Error("Payment provider unavailable"),
+    );
+    await expect(service.canUsePayAsYouGo(PROJECT_ID)).rejects.toThrow(
+      "Payment provider unavailable",
+    );
+  });
+
+  it("starts telemetry on the next complete UTC day after durable authorization", async () => {
+    hasPaymentMethods.mockResolvedValue(true);
+    getJestSpyOn(
+      BillingService,
+      "getMeteredBillingStartDate",
+    ).mockResolvedValue(new Date("2026-09-08T23:59:00Z"));
+    await expect(
+      service.getTelemetryBillingStartDate(PROJECT_ID),
+    ).resolves.toEqual(new Date("2026-09-09T00:00:00Z"));
+  });
+
+  it("does not create a billing start marker before a card is added", async () => {
+    const start: jest.SpyInstance = getJestSpyOn(
+      BillingService,
+      "getMeteredBillingStartDate",
+    );
+    await expect(
+      service.getTelemetryBillingStartDate(PROJECT_ID),
+    ).rejects.toBeInstanceOf(PaymentRequiredException);
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("leaves self-hosted and reseller telemetry without a Stripe cutoff", async () => {
+    project.resellerId = ObjectID.generate();
+    project.resellerPlanId = ObjectID.generate();
+    getJestSpyOn(PromoCodeService, "findOneBy").mockResolvedValue(new PromoCode());
+    const start: jest.SpyInstance = getJestSpyOn(
+      BillingService,
+      "getMeteredBillingStartDate",
+    );
+    await expect(
+      service.getTelemetryBillingStartDate(PROJECT_ID),
+    ).resolves.toBeUndefined();
+    getJestSpyOn(BillingService, "isBillingEnabled").mockReturnValue(false);
+    await expect(
+      service.getTelemetryBillingStartDate(PROJECT_ID),
+    ).resolves.toBeUndefined();
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("resolves the project from the Stripe customer before authorizing a direct metered write", async () => {
+    const owner: Project = new Project();
+    owner.id = PROJECT_ID;
+    const findOwner: jest.SpyInstance = getJestSpyOn(ProjectService, "findOneBy").mockResolvedValue(owner);
+    const subscription: Stripe.Subscription = { customer: { id: "cus_project" } } as Stripe.Subscription;
+    await expect(service.requireMeteredSubscriptionPayment(subscription)).rejects.toBeInstanceOf(PaymentRequiredException);
+    expect(findOwner).toHaveBeenCalledWith(expect.objectContaining({ query: { paymentProviderCustomerId: "cus_project" } }));
+    hasPaymentMethods.mockResolvedValue(true);
+    await expect(service.requireMeteredSubscriptionPayment(subscription)).resolves.toBeUndefined();
+  });
+
+  it("rejects a direct metered write for an unrecognized billing customer", async () => {
+    getJestSpyOn(ProjectService, "findOneBy").mockResolvedValue(null);
+    await expect(service.requireMeteredSubscriptionPayment({ customer: "cus_unknown" } as Stripe.Subscription)).rejects.toBeInstanceOf(PaymentRequiredException);
+    expect(hasPaymentMethods).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Services/TelemetryIngestionKeyPolicyResolution.test.ts
+++ b/Common/Tests/Server/Services/TelemetryIngestionKeyPolicyResolution.test.ts
@@ -5,6 +5,14 @@ import TelemetryIngestionKeyPolicy from "../../../Types/Telemetry/TelemetryInges
 import TelemetryIngestionKeyType from "../../../Types/Telemetry/TelemetryIngestionKeyType";
 import TelemetryIngestionKeyService from "../../../Server/Services/TelemetryIngestionKeyService";
 
+// Payment eligibility is covered by the billing admission suites.
+jest.mock("../../../Server/Services/PayAsYouGoBillingService", () => {
+  return {
+    __esModule: true,
+    default: { requirePayAsYouGo: jest.fn().mockResolvedValue(undefined) },
+  };
+});
+
 /*
  * Every TelemetryIngestionKey in every installation that exists today was
  * written before this feature's seven columns did, so it reads back with all

--- a/Common/Tests/Server/Services/TelemetryIngestionKeyValidation.test.ts
+++ b/Common/Tests/Server/Services/TelemetryIngestionKeyValidation.test.ts
@@ -17,6 +17,18 @@ import TelemetryIngestionKeyType from "../../../Types/Telemetry/TelemetryIngesti
 import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 
+// Payment eligibility is covered by the billing admission suites.
+jest.mock("../../../Server/Services/PayAsYouGoBillingService", () => {
+  return {
+    __esModule: true,
+    default: {
+      requirePayAsYouGo: jest
+        .fn<() => Promise<void>>()
+        .mockResolvedValue(undefined),
+    },
+  };
+});
+
 /*
  * WHAT THIS FILE IS DEFENDING
  *
@@ -51,8 +63,9 @@ import { beforeEach, describe, expect, jest, test } from "@jest/globals";
  *      "you may not empty this list" guard.
  *   3. COST. The guard that refuses an empty allowlist has to read the rows
  *      the update matches. That read must happen ONLY when the patch actually
- *      empties the list - the common update (rename, toggle isEnabled, set an
- *      expiry) must not start paying a query for a rule it cannot break.
+ *      empties the list. Renaming, disabling, or setting an expiry must not
+ *      start paying a query for a rule they cannot break. Re-enabling has its
+ *      own billing check, covered by TelemetryPayAsYouGoBilling.test.ts.
  *
  * Nothing here touches Postgres or Redis: the hooks are invoked directly on a
  * fresh service instance whose findBy/findOneBy are stubbed.
@@ -130,7 +143,7 @@ function buildService(): Harness {
 function createByModel(payload: Record<string, unknown>): CreateBy<Model> {
   return {
     data: Object.assign(new Model(), payload) as Model,
-    props: { isRoot: true },
+    props: { isRoot: true, tenantId: PROJECT_ID },
   };
 }
 
@@ -141,7 +154,7 @@ function createByModel(payload: Record<string, unknown>): CreateBy<Model> {
 function createByBag(payload: Record<string, unknown>): CreateBy<Model> {
   return {
     data: payload as unknown as Model,
-    props: { isRoot: true },
+    props: { isRoot: true, tenantId: PROJECT_ID },
   };
 }
 

--- a/Common/Tests/Server/Services/TelemetryPayAsYouGoBilling.test.ts
+++ b/Common/Tests/Server/Services/TelemetryPayAsYouGoBilling.test.ts
@@ -1,0 +1,332 @@
+import TelemetryIngestionKeyService, {
+  Service,
+} from "../../../Server/Services/TelemetryIngestionKeyService";
+import PayAsYouGoBillingService from "../../../Server/Services/PayAsYouGoBillingService";
+import TelemetryIngest, {
+  TelemetryRequest,
+} from "../../../Server/Middleware/TelemetryIngest";
+import TelemetryIngestionKey from "../../../Models/DatabaseModels/TelemetryIngestionKey";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import TelemetryIngestSurface from "../../../Types/Telemetry/TelemetryIngestSurface";
+import TelemetryIngestionKeyType from "../../../Types/Telemetry/TelemetryIngestionKeyType";
+import PaymentRequiredException from "../../../Types/Exception/PaymentRequiredException";
+import ObjectID from "../../../Types/ObjectID";
+import * as EnvironmentConfig from "../../../Server/EnvironmentConfig";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+jest.mock("../../../Server/EnvironmentConfig", () => {
+  return {
+    __esModule: true,
+    ...(jest.requireActual(
+      "../../../Server/EnvironmentConfig",
+    ) as typeof EnvironmentConfig),
+    IsBillingEnabled: true,
+  };
+});
+
+type KeyHooks = {
+  onBeforeCreate: (input: CreateBy<TelemetryIngestionKey>) => Promise<unknown>;
+  onBeforeUpdate: (input: UpdateBy<TelemetryIngestionKey>) => Promise<unknown>;
+};
+let service: Service;
+let hooks: KeyHooks;
+const projectId: ObjectID = ObjectID.generate();
+const otherProjectId: ObjectID = ObjectID.generate();
+
+function key(project: ObjectID = projectId): TelemetryIngestionKey {
+  return Object.assign(new TelemetryIngestionKey(), {
+    id: ObjectID.generate(),
+    projectId: project,
+    secretKey: ObjectID.generate(),
+    isEnabled: true,
+    keyType: TelemetryIngestionKeyType.Server,
+  });
+}
+
+function createInput(): CreateBy<TelemetryIngestionKey> {
+  return { data: key(), props: { tenantId: projectId } };
+}
+
+function updateInput(
+  data: UpdateBy<TelemetryIngestionKey>["data"],
+): UpdateBy<TelemetryIngestionKey> {
+  return {
+    data,
+    query: { _id: ObjectID.generate().toString() },
+    props: { isRoot: true },
+    limit: 10,
+    skip: 0,
+  };
+}
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  (EnvironmentConfig as { IsBillingEnabled: boolean }).IsBillingEnabled = true;
+  service = new Service();
+  hooks = service as unknown as KeyHooks;
+  jest
+    .spyOn(PayAsYouGoBillingService, "canUsePayAsYouGo")
+    .mockResolvedValue(false);
+  jest.spyOn(service, "findBy").mockResolvedValue([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("telemetry key creation and enablement payment admission", () => {
+  test.each(Object.values(TelemetryIngestionKeyType))(
+    "requires payment setup to create a %s key",
+    async (keyType: TelemetryIngestionKeyType) => {
+      const input: CreateBy<TelemetryIngestionKey> = createInput();
+      input.data.keyType = keyType;
+      input.data.allowedOrigins = ["https://example.com"];
+      await expect(hooks.onBeforeCreate(input)).rejects.toBeInstanceOf(
+        PaymentRequiredException,
+      );
+    },
+  );
+
+  test("also guards legacy create requests without a key type", async () => {
+    const input: CreateBy<TelemetryIngestionKey> = createInput();
+    delete input.data.keyType;
+    await expect(hooks.onBeforeCreate(input)).rejects.toThrow(
+      "Project Settings > Billing",
+    );
+  });
+
+  test("checks the authenticated tenant instead of the payload project", async () => {
+    const input: CreateBy<TelemetryIngestionKey> = createInput();
+    input.data.projectId = otherProjectId;
+    await expect(hooks.onBeforeCreate(input)).rejects.toBeInstanceOf(
+      PaymentRequiredException,
+    );
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).toHaveBeenCalledWith(
+      projectId,
+    );
+  });
+
+  test("uses the project on an internal create without a request tenant", async () => {
+    const input: CreateBy<TelemetryIngestionKey> = createInput();
+    input.props = { isRoot: true };
+    await expect(hooks.onBeforeCreate(input)).rejects.toBeInstanceOf(
+      PaymentRequiredException,
+    );
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).toHaveBeenCalledWith(
+      projectId,
+    );
+  });
+
+  test("does not admit a billed create without a project", async () => {
+    await expect(
+      hooks.onBeforeCreate({
+        data: new TelemetryIngestionKey(),
+        props: { isRoot: true },
+      }),
+    ).rejects.toThrow("ProjectId required");
+  });
+
+  test("allows key creation when payment setup is authorized", async () => {
+    jest
+      .spyOn(PayAsYouGoBillingService, "canUsePayAsYouGo")
+      .mockResolvedValue(true);
+    await expect(hooks.onBeforeCreate(createInput())).resolves.toBeDefined();
+  });
+
+  test("preserves self-hosted key creation without consulting billing", async () => {
+    (EnvironmentConfig as { IsBillingEnabled: boolean }).IsBillingEnabled =
+      false;
+    await expect(hooks.onBeforeCreate(createInput())).resolves.toBeDefined();
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
+  });
+
+  test("guards re-enabling an existing key using its stored project", async () => {
+    jest.spyOn(service, "findBy").mockResolvedValue([key(otherProjectId)]);
+    const input: UpdateBy<TelemetryIngestionKey> = updateInput({
+      isEnabled: true,
+    });
+    input.props.tenantId = projectId;
+    await expect(hooks.onBeforeUpdate(input)).rejects.toBeInstanceOf(
+      PaymentRequiredException,
+    );
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).toHaveBeenCalledWith(
+      otherProjectId,
+    );
+  });
+
+  test("checks every distinct project of a bulk enable operation", async () => {
+    jest
+      .spyOn(service, "findBy")
+      .mockResolvedValue([key(), key(), key(otherProjectId)]);
+    jest
+      .spyOn(PayAsYouGoBillingService, "canUsePayAsYouGo")
+      .mockImplementation(async (id: ObjectID): Promise<boolean> => {
+        return id.toString() === projectId.toString();
+      });
+    await expect(
+      hooks.onBeforeUpdate(updateInput({ isEnabled: true })),
+    ).rejects.toBeInstanceOf(PaymentRequiredException);
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).toHaveBeenCalledTimes(2);
+  });
+
+  test("scopes a non-root enable lookup to the request tenant", async () => {
+    const input: UpdateBy<TelemetryIngestionKey> = updateInput({
+      isEnabled: true,
+    });
+    input.props = { tenantId: projectId };
+    await hooks.onBeforeUpdate(input);
+    expect(service.findBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: { ...input.query, projectId },
+        limit: input.limit,
+        skip: input.skip,
+      }),
+    );
+  });
+
+  test.each([{ isEnabled: false }, { name: "Renamed key" }])(
+    "allows a nonbillable update %j without payment setup",
+    async (data: UpdateBy<TelemetryIngestionKey>["data"]) => {
+      await expect(
+        hooks.onBeforeUpdate(updateInput(data)),
+      ).resolves.toBeDefined();
+      expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
+      expect(service.findBy).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe("existing key payment admission", () => {
+  test("rejects existing enabled keys before returning their policy or project", async () => {
+    const existingKey: TelemetryIngestionKey = key();
+    jest.spyOn(service, "findOneBy").mockResolvedValue(existingKey);
+    await expect(
+      service.getPolicyFromSecretKey(existingKey.secretKey!.toString()),
+    ).rejects.toBeInstanceOf(PaymentRequiredException);
+    await expect(
+      service.getProjectIdFromSecretKey(existingKey.secretKey!.toString()),
+    ).rejects.toBeInstanceOf(PaymentRequiredException);
+  });
+
+  test("checks cached keys again so removing payment setup cannot leave an admitted key indefinitely", async () => {
+    const existingKey: TelemetryIngestionKey = key();
+    jest.spyOn(service, "findOneBy").mockResolvedValue(existingKey);
+    jest
+      .spyOn(PayAsYouGoBillingService, "canUsePayAsYouGo")
+      .mockResolvedValue(true);
+    await expect(
+      service.getPolicyFromSecretKey(existingKey.secretKey!.toString()),
+    ).resolves.toMatchObject({ projectId });
+    jest
+      .spyOn(PayAsYouGoBillingService, "canUsePayAsYouGo")
+      .mockResolvedValue(false);
+    await expect(
+      service.getPolicyFromSecretKey(existingKey.secretKey!.toString()),
+    ).rejects.toBeInstanceOf(PaymentRequiredException);
+    expect(service.findOneBy).toHaveBeenCalledTimes(1);
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).toHaveBeenCalledTimes(2);
+  });
+
+  test("starts accepting an existing key after payment setup succeeds", async () => {
+    const existingKey: TelemetryIngestionKey = key();
+    jest.spyOn(service, "findOneBy").mockResolvedValue(existingKey);
+    await expect(
+      service.getPolicyFromSecretKey(existingKey.secretKey!.toString()),
+    ).rejects.toBeInstanceOf(PaymentRequiredException);
+    jest
+      .spyOn(PayAsYouGoBillingService, "canUsePayAsYouGo")
+      .mockResolvedValue(true);
+    await expect(
+      service.getPolicyFromSecretKey(existingKey.secretKey!.toString()),
+    ).resolves.toMatchObject({ projectId });
+    expect(service.findOneBy).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([{ isEnabled: false }, { expiresAt: new Date(0) }])(
+    "retains diagnostic policy resolution for unusable keys %j",
+    async (state: Partial<TelemetryIngestionKey>) => {
+      const existingKey: TelemetryIngestionKey = Object.assign(key(), state);
+      jest.spyOn(service, "findOneBy").mockResolvedValue(existingKey);
+      await expect(
+        service.getPolicyFromSecretKey(existingKey.secretKey!.toString()),
+      ).resolves.toMatchObject({ projectId });
+      expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
+    },
+  );
+
+  test("does not consult billing when no key resolves", async () => {
+    jest.spyOn(service, "findOneBy").mockResolvedValue(null);
+    await expect(
+      service.getPolicyFromSecretKey(ObjectID.generate().toString()),
+    ).resolves.toBeNull();
+    expect(PayAsYouGoBillingService.canUsePayAsYouGo).not.toHaveBeenCalled();
+  });
+});
+
+describe("HTTP telemetry admission integrates key resolution and billing", () => {
+  test.each(Object.values(TelemetryIngestSurface))(
+    "prevents existing no-card keys reaching the %s handler",
+    async (surface: TelemetryIngestSurface) => {
+      const existingKey: TelemetryIngestionKey = key();
+      jest
+        .spyOn(TelemetryIngestionKeyService, "findOneBy")
+        .mockResolvedValue(existingKey);
+      jest
+        .spyOn(TelemetryIngestionKeyService, "markUsed")
+        .mockResolvedValue(undefined);
+      const request: ExpressRequest = {
+        headers: { "x-oneuptime-token": existingKey.secretKey!.toString() },
+      } as unknown as ExpressRequest;
+      const next: NextFunction = jest.fn() as unknown as NextFunction;
+      await TelemetryIngest.forSurface(surface)(
+        request,
+        {} as ExpressResponse,
+        next as NextFunction,
+      );
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.any(PaymentRequiredException));
+      expect((request as TelemetryRequest).projectId).toBeUndefined();
+      expect(TelemetryIngestionKeyService.markUsed).not.toHaveBeenCalled();
+    },
+  );
+
+  test("continues to the handler after payment setup with the stored key project", async () => {
+    const existingKey: TelemetryIngestionKey = key(otherProjectId);
+    jest
+      .spyOn(TelemetryIngestionKeyService, "findOneBy")
+      .mockResolvedValue(existingKey);
+    jest
+      .spyOn(TelemetryIngestionKeyService, "markUsed")
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(PayAsYouGoBillingService, "canUsePayAsYouGo")
+      .mockResolvedValue(true);
+    const request: ExpressRequest = {
+      headers: { "x-oneuptime-token": existingKey.secretKey!.toString() },
+    } as unknown as ExpressRequest;
+    const next: NextFunction = jest.fn() as unknown as NextFunction;
+    await TelemetryIngest.isAuthorizedServiceMiddleware(
+      request,
+      {} as ExpressResponse,
+      next as NextFunction,
+    );
+    expect(next).toHaveBeenCalledWith();
+    expect((request as TelemetryRequest).projectId.toString()).toBe(
+      otherProjectId.toString(),
+    );
+    expect(TelemetryIngestionKeyService.markUsed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/Server/Types/Billing/PayAsYouGoMeteredAuthorization.test.ts
+++ b/Common/Tests/Server/Types/Billing/PayAsYouGoMeteredAuthorization.test.ts
@@ -25,26 +25,85 @@ jest.mock("../../../../Server/EnvironmentConfig", () => {
   };
 });
 
-jest.mock("../../../../Server/Services/PayAsYouGoBillingService", () => ({ __esModule: true, default: { canUsePayAsYouGo: jest.fn(), getTelemetryBillingStartDate: jest.fn() } }));
-jest.mock("../../../../Server/Services/BillingService", () => ({ __esModule: true, default: { addOrUpdateMeteredPricingOnSubscription: jest.fn(), getMeteredPlanPriceId: jest.fn(), hasMeteredPlanPriceId: jest.fn() } }));
-jest.mock("../../../../Server/Services/ProjectService", () => ({ __esModule: true, default: { findOneById: jest.fn(), updateOneById: jest.fn() } }));
-jest.mock("../../../../Server/Services/MonitorService", () => ({ __esModule: true, default: { countBy: jest.fn() } }));
-jest.mock("../../../../Server/Services/LogService", () => ({ __esModule: true, default: { groupTelemetryUsageByService: jest.fn() } }));
-jest.mock("../../../../Server/Services/ServiceService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/SpanService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/SecurityEventService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/MetricService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/ExceptionInstanceService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/ProfileService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/RumSessionService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/ProfileSampleService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/HostService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/DockerHostService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/PodmanHostService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/KubernetesClusterService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/ProxmoxClusterService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/CephClusterService", () => ({ __esModule: true, default: {  } }));
-jest.mock("../../../../Server/Services/IoTFleetService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/PayAsYouGoBillingService", () => {
+  return {
+    __esModule: true,
+    default: {
+      canUsePayAsYouGo: jest.fn(),
+      getTelemetryBillingStartDate: jest.fn(),
+    },
+  };
+});
+jest.mock("../../../../Server/Services/BillingService", () => {
+  return {
+    __esModule: true,
+    default: {
+      addOrUpdateMeteredPricingOnSubscription: jest.fn(),
+      getMeteredPlanPriceId: jest.fn(),
+      hasMeteredPlanPriceId: jest.fn(),
+    },
+  };
+});
+jest.mock("../../../../Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: { findOneById: jest.fn(), updateOneById: jest.fn() },
+  };
+});
+jest.mock("../../../../Server/Services/MonitorService", () => {
+  return { __esModule: true, default: { countBy: jest.fn() } };
+});
+jest.mock("../../../../Server/Services/LogService", () => {
+  return {
+    __esModule: true,
+    default: { groupTelemetryUsageByService: jest.fn() },
+  };
+});
+jest.mock("../../../../Server/Services/ServiceService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/SpanService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/SecurityEventService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/MetricService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/ExceptionInstanceService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/ProfileService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/RumSessionService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/ProfileSampleService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/HostService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/DockerHostService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/PodmanHostService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/KubernetesClusterService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/ProxmoxClusterService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/CephClusterService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../../Server/Services/IoTFleetService", () => {
+  return { __esModule: true, default: {} };
+});
 
 const PROJECT_ID: ObjectID = ObjectID.generate();
 const CUTOFF: Date = new Date("2026-09-09T00:00:00Z");
@@ -273,21 +332,56 @@ describe("metered billing payment protection", () => {
     it("uses the same UTC day key for staging and writes across timezone changes and retries", async () => {
       const resourceId: ObjectID = ObjectID.generate();
       const stored: Array<TelemetryUsageBilling> = [];
-      aggregation.mockResolvedValue([{ primaryEntityId: resourceId.toString(), primaryEntityType: ServiceType.OpenTelemetry, rowCount: 1, estimatedBytes: 1024 }]);
-      getJestSpyOn(TelemetryUsageBillingService, "buildTelemetryRetentionMap").mockResolvedValue(new Map());
-      getJestSpyOn(TelemetryUsageBillingService, "getProjectDefaultRetentionInDays").mockResolvedValue(15);
-      getJestSpyOn(TelemetryUsageBillingService, "findBy").mockImplementation(async (args: any): Promise<Array<TelemetryUsageBilling>> => {
-        return stored.filter((row: TelemetryUsageBilling) => { return row.day === args.query.day; });
+      aggregation.mockResolvedValue([
+        {
+          primaryEntityId: resourceId.toString(),
+          primaryEntityType: ServiceType.OpenTelemetry,
+          rowCount: 1,
+          estimatedBytes: 1024,
+        },
+      ]);
+      getJestSpyOn(
+        TelemetryUsageBillingService,
+        "buildTelemetryRetentionMap",
+      ).mockResolvedValue(new Map());
+      getJestSpyOn(
+        TelemetryUsageBillingService,
+        "getProjectDefaultRetentionInDays",
+      ).mockResolvedValue(15);
+      getJestSpyOn(TelemetryUsageBillingService, "findBy").mockImplementation(
+        async (args: any): Promise<Array<TelemetryUsageBilling>> => {
+          return stored.filter((row: TelemetryUsageBilling) => {
+            return row.day === args.query.day;
+          });
+        },
+      );
+      getJestSpyOn(TelemetryUsageBillingService, "findOneBy").mockResolvedValue(
+        null,
+      );
+      const create: jest.SpyInstance = getJestSpyOn(
+        TelemetryUsageBillingService,
+        "create",
+      ).mockImplementation(
+        async (args: any): Promise<TelemetryUsageBilling> => {
+          stored.push(args.data as TelemetryUsageBilling);
+          return args.data as TelemetryUsageBilling;
+        },
+      );
+      const timezone: jest.SpyInstance = getJestSpyOn(
+        OneUptimeDate,
+        "getCurrentTimezone",
+      ).mockReturnValue("America/Los_Angeles");
+      await TelemetryUsageBillingService.stageTelemetryUsageForProject({
+        projectId: PROJECT_ID,
+        productType: ProductType.Logs,
+        usageDate: new Date("2026-09-09T00:30:00Z"),
       });
-      getJestSpyOn(TelemetryUsageBillingService, "findOneBy").mockResolvedValue(null);
-      const create: jest.SpyInstance = getJestSpyOn(TelemetryUsageBillingService, "create").mockImplementation(async (args: any): Promise<TelemetryUsageBilling> => {
-        stored.push(args.data as TelemetryUsageBilling);
-        return args.data as TelemetryUsageBilling;
-      });
-      const timezone: jest.SpyInstance = getJestSpyOn(OneUptimeDate, "getCurrentTimezone").mockReturnValue("America/Los_Angeles");
-      await TelemetryUsageBillingService.stageTelemetryUsageForProject({ projectId: PROJECT_ID, productType: ProductType.Logs, usageDate: new Date("2026-09-09T00:30:00Z") });
       timezone.mockReturnValue("Asia/Tokyo");
-      await TelemetryUsageBillingService.stageTelemetryUsageForProject({ projectId: PROJECT_ID, productType: ProductType.Logs, usageDate: new Date("2026-09-09T23:30:00Z") });
+      await TelemetryUsageBillingService.stageTelemetryUsageForProject({
+        projectId: PROJECT_ID,
+        productType: ProductType.Logs,
+        usageDate: new Date("2026-09-09T23:30:00Z"),
+      });
       expect(stored[0]?.day).toBe("Sep 09, 2026");
       expect(create).toHaveBeenCalledTimes(1);
       for (const call of aggregation.mock.calls) {

--- a/Common/Tests/Server/Types/Billing/PayAsYouGoMeteredAuthorization.test.ts
+++ b/Common/Tests/Server/Types/Billing/PayAsYouGoMeteredAuthorization.test.ts
@@ -1,0 +1,323 @@
+import "../../../../Server/Types/Billing/MeteredPlan/AllMeteredPlans";
+import ActiveMonitoringMeteredPlan from "../../../../Server/Types/Billing/MeteredPlan/ActiveMonitoringMeteredPlan";
+import TelemetryMeteredPlan from "../../../../Server/Types/Billing/MeteredPlan/TelemetryMeteredPlan";
+import PayAsYouGoBillingService from "../../../../Server/Services/PayAsYouGoBillingService";
+import BillingService from "../../../../Server/Services/BillingService";
+import MonitorService from "../../../../Server/Services/MonitorService";
+import ProjectService from "../../../../Server/Services/ProjectService";
+import TelemetryUsageBillingService from "../../../../Server/Services/TelemetryUsageBillingService";
+import LogService from "../../../../Server/Services/LogService";
+import Project from "../../../../Models/DatabaseModels/Project";
+import TelemetryUsageBilling from "../../../../Models/DatabaseModels/TelemetryUsageBilling";
+import Decimal from "../../../../Types/Decimal";
+import ObjectID from "../../../../Types/ObjectID";
+import ProductType from "../../../../Types/MeteredPlan/ProductType";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import OneUptimeDate from "../../../../Types/Date";
+import ServiceType from "../../../../Types/Telemetry/ServiceType";
+import { getJestSpyOn } from "../../../Spy";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+jest.mock("../../../../Server/EnvironmentConfig", () => {
+  return {
+    ...jest.requireActual("../../../../Server/EnvironmentConfig"),
+    IsBillingEnabled: true,
+  };
+});
+
+jest.mock("../../../../Server/Services/PayAsYouGoBillingService", () => ({ __esModule: true, default: { canUsePayAsYouGo: jest.fn(), getTelemetryBillingStartDate: jest.fn() } }));
+jest.mock("../../../../Server/Services/BillingService", () => ({ __esModule: true, default: { addOrUpdateMeteredPricingOnSubscription: jest.fn(), getMeteredPlanPriceId: jest.fn(), hasMeteredPlanPriceId: jest.fn() } }));
+jest.mock("../../../../Server/Services/ProjectService", () => ({ __esModule: true, default: { findOneById: jest.fn(), updateOneById: jest.fn() } }));
+jest.mock("../../../../Server/Services/MonitorService", () => ({ __esModule: true, default: { countBy: jest.fn() } }));
+jest.mock("../../../../Server/Services/LogService", () => ({ __esModule: true, default: { groupTelemetryUsageByService: jest.fn() } }));
+jest.mock("../../../../Server/Services/ServiceService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/SpanService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/SecurityEventService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/MetricService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/ExceptionInstanceService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/ProfileService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/RumSessionService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/ProfileSampleService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/HostService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/DockerHostService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/PodmanHostService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/KubernetesClusterService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/ProxmoxClusterService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/CephClusterService", () => ({ __esModule: true, default: {  } }));
+jest.mock("../../../../Server/Services/IoTFleetService", () => ({ __esModule: true, default: {  } }));
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const CUTOFF: Date = new Date("2026-09-09T00:00:00Z");
+
+describe("metered billing payment protection", () => {
+  let canUse: jest.SpyInstance;
+  let report: jest.SpyInstance;
+
+  beforeEach(() => {
+    canUse = getJestSpyOn(
+      PayAsYouGoBillingService,
+      "canUsePayAsYouGo",
+    ).mockResolvedValue(true);
+    getJestSpyOn(
+      PayAsYouGoBillingService,
+      "getTelemetryBillingStartDate",
+    ).mockResolvedValue(CUTOFF);
+    report = getJestSpyOn(
+      BillingService,
+      "addOrUpdateMeteredPricingOnSubscription",
+    ).mockResolvedValue(undefined);
+    getJestSpyOn(ProjectService, "findOneById").mockResolvedValue(
+      Object.assign(new Project(), {
+        paymentProviderMeteredSubscriptionId: "sub_metered",
+        paymentProviderPlanId: "free",
+      }),
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("active monitors", () => {
+    beforeEach(() => {
+      getJestSpyOn(MonitorService, "countBy").mockResolvedValue(
+        new PositiveNumber(3),
+      );
+      getJestSpyOn(ProjectService, "updateOneById").mockResolvedValue(1);
+    });
+
+    it("updates visible monitor counts without charging a no-card project", async () => {
+      canUse.mockResolvedValue(false);
+      await new ActiveMonitoringMeteredPlan().reportQuantityToBillingProvider(
+        PROJECT_ID,
+      );
+      expect(ProjectService.updateOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: PROJECT_ID,
+          data: { currentActiveMonitorsCount: 3 },
+        }),
+      );
+      expect(canUse).toHaveBeenCalledWith(PROJECT_ID, { useCache: false });
+      expect(report).not.toHaveBeenCalled();
+    });
+
+    it("reports authorized monitors and honors a replacement subscription", async () => {
+      const plan: ActiveMonitoringMeteredPlan =
+        new ActiveMonitoringMeteredPlan();
+      await plan.reportQuantityToBillingProvider(PROJECT_ID, {
+        meteredPlanSubscriptionId: "sub_replacement",
+      });
+      expect(report).toHaveBeenCalledWith("sub_replacement", plan, 3);
+    });
+  });
+
+  describe("telemetry reports", () => {
+    let stage: jest.SpyInstance;
+    let waive: jest.SpyInstance;
+    let readUsage: jest.SpyInstance;
+    let markReported: jest.SpyInstance;
+    let plan: TelemetryMeteredPlan;
+
+    beforeEach(() => {
+      stage = getJestSpyOn(
+        TelemetryUsageBillingService,
+        "stageTelemetryUsageForProject",
+      ).mockResolvedValue(undefined);
+      waive = getJestSpyOn(
+        TelemetryUsageBillingService,
+        "waiveUnreportedUsageBilling",
+      ).mockResolvedValue(undefined);
+      readUsage = getJestSpyOn(
+        TelemetryUsageBillingService,
+        "getUnreportedUsageBilling",
+      ).mockResolvedValue([
+        Object.assign(new TelemetryUsageBilling(), {
+          id: ObjectID.generate(),
+          totalCostInUSD: new Decimal(1.25),
+        }),
+      ]);
+      markReported = getJestSpyOn(
+        TelemetryUsageBillingService,
+        "updateOneById",
+      ).mockResolvedValue(1);
+      plan = new TelemetryMeteredPlan({
+        productType: ProductType.Logs,
+        unitCostInUSD: 0.1,
+      });
+    });
+
+    it.each([
+      ProductType.Logs,
+      ProductType.Metrics,
+      ProductType.Traces,
+      ProductType.Profiles,
+      ProductType.SessionReplay,
+      ProductType.SecurityEvents,
+    ])(
+      "waives unapproved %s debt and does not stage or report it",
+      async (productType: ProductType) => {
+        canUse.mockResolvedValue(false);
+        plan.productType = productType;
+        await plan.reportQuantityToBillingProvider(PROJECT_ID);
+        expect(waive).toHaveBeenCalledWith({
+          projectId: PROJECT_ID,
+          productType,
+        });
+        expect(stage).not.toHaveBeenCalled();
+        expect(readUsage).not.toHaveBeenCalled();
+        expect(report).not.toHaveBeenCalled();
+        expect(markReported).not.toHaveBeenCalled();
+      },
+    );
+
+    it("waives historical costs before reporting only authorized usage", async () => {
+      await plan.reportQuantityToBillingProvider(PROJECT_ID);
+      expect(waive).toHaveBeenCalledWith({
+        projectId: PROJECT_ID,
+        productType: ProductType.Logs,
+        before: CUTOFF,
+      });
+      expect(waive.mock.invocationCallOrder[0]).toBeLessThan(
+        stage.mock.invocationCallOrder[0]!,
+      );
+      expect(report).toHaveBeenCalledWith("sub_metered", plan, 125);
+      expect(markReported).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves prior usage for invoice and reseller contracts without a cutoff", async () => {
+      getJestSpyOn(
+        PayAsYouGoBillingService,
+        "getTelemetryBillingStartDate",
+      ).mockResolvedValue(undefined);
+      await plan.reportQuantityToBillingProvider(PROJECT_ID);
+      expect(waive).not.toHaveBeenCalled();
+      expect(report).toHaveBeenCalled();
+    });
+
+    it("does not waive debt or stage usage during a payment-provider outage", async () => {
+      canUse.mockRejectedValue(new Error("Provider unavailable"));
+      await expect(
+        plan.reportQuantityToBillingProvider(PROJECT_ID),
+      ).rejects.toThrow("Provider unavailable");
+      expect(waive).not.toHaveBeenCalled();
+      expect(stage).not.toHaveBeenCalled();
+    });
+
+    it("does not mark usage reported if the final billing guard refuses it", async () => {
+      report.mockRejectedValue(new Error("Payment method was removed"));
+      await expect(
+        plan.reportQuantityToBillingProvider(PROJECT_ID),
+      ).rejects.toThrow("Payment method was removed");
+      expect(markReported).not.toHaveBeenCalled();
+    });
+
+    it("retains the minimum reporting threshold after authorization", async () => {
+      readUsage.mockResolvedValue([
+        Object.assign(new TelemetryUsageBilling(), {
+          totalCostInUSD: new Decimal(0.99),
+        }),
+      ]);
+      await plan.reportQuantityToBillingProvider(PROJECT_ID);
+      expect(report).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("daily staging", () => {
+    let aggregation: jest.SpyInstance;
+
+    beforeEach(() => {
+      aggregation = getJestSpyOn(
+        LogService,
+        "groupTelemetryUsageByService",
+      ).mockResolvedValue([]);
+    });
+
+    it("blocks direct staging for no-card projects", async () => {
+      canUse.mockResolvedValue(false);
+      const waive: jest.SpyInstance = getJestSpyOn(
+        TelemetryUsageBillingService,
+        "waiveUnreportedUsageBilling",
+      ).mockResolvedValue(undefined);
+      await TelemetryUsageBillingService.stageTelemetryUsageForProject({
+        projectId: PROJECT_ID,
+        productType: ProductType.Logs,
+      });
+      expect(waive).toHaveBeenCalled();
+      expect(aggregation).not.toHaveBeenCalled();
+    });
+
+    it.each(["2026-09-07T12:00:00Z", "2026-09-08T23:59:59Z"])(
+      "never backfills usage from before authorization or its partial day (%s)",
+      async (usageDate: string) => {
+        await TelemetryUsageBillingService.stageTelemetryUsageForProject({
+          projectId: PROJECT_ID,
+          productType: ProductType.Logs,
+          usageDate: new Date(usageDate),
+        });
+        expect(aggregation).not.toHaveBeenCalled();
+      },
+    );
+
+    it("stages the first complete authorized UTC day", async () => {
+      await TelemetryUsageBillingService.stageTelemetryUsageForProject({
+        projectId: PROJECT_ID,
+        productType: ProductType.Logs,
+        usageDate: CUTOFF,
+      });
+      expect(aggregation).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: PROJECT_ID, startDate: CUTOFF }),
+      );
+    });
+
+    it("uses the same UTC day key for staging and writes across timezone changes and retries", async () => {
+      const resourceId: ObjectID = ObjectID.generate();
+      const stored: Array<TelemetryUsageBilling> = [];
+      aggregation.mockResolvedValue([{ primaryEntityId: resourceId.toString(), primaryEntityType: ServiceType.OpenTelemetry, rowCount: 1, estimatedBytes: 1024 }]);
+      getJestSpyOn(TelemetryUsageBillingService, "buildTelemetryRetentionMap").mockResolvedValue(new Map());
+      getJestSpyOn(TelemetryUsageBillingService, "getProjectDefaultRetentionInDays").mockResolvedValue(15);
+      getJestSpyOn(TelemetryUsageBillingService, "findBy").mockImplementation(async (args: any): Promise<Array<TelemetryUsageBilling>> => {
+        return stored.filter((row: TelemetryUsageBilling) => { return row.day === args.query.day; });
+      });
+      getJestSpyOn(TelemetryUsageBillingService, "findOneBy").mockResolvedValue(null);
+      const create: jest.SpyInstance = getJestSpyOn(TelemetryUsageBillingService, "create").mockImplementation(async (args: any): Promise<TelemetryUsageBilling> => {
+        stored.push(args.data as TelemetryUsageBilling);
+        return args.data as TelemetryUsageBilling;
+      });
+      const timezone: jest.SpyInstance = getJestSpyOn(OneUptimeDate, "getCurrentTimezone").mockReturnValue("America/Los_Angeles");
+      await TelemetryUsageBillingService.stageTelemetryUsageForProject({ projectId: PROJECT_ID, productType: ProductType.Logs, usageDate: new Date("2026-09-09T00:30:00Z") });
+      timezone.mockReturnValue("Asia/Tokyo");
+      await TelemetryUsageBillingService.stageTelemetryUsageForProject({ projectId: PROJECT_ID, productType: ProductType.Logs, usageDate: new Date("2026-09-09T23:30:00Z") });
+      expect(stored[0]?.day).toBe("Sep 09, 2026");
+      expect(create).toHaveBeenCalledTimes(1);
+      for (const call of aggregation.mock.calls) {
+        expect(call[0].startDate).toEqual(CUTOFF);
+        expect(call[0].endDate).toEqual(new Date("2026-09-09T23:59:59.999Z"));
+      }
+    });
+  });
+
+  describe("waiving unapproved usage", () => {
+    it("preserves recorded volume and invoice history while zeroing every unreported positive cost", async () => {
+      const update: jest.SpyInstance = getJestSpyOn(
+        TelemetryUsageBillingService,
+        "updateBy",
+      )
+        .mockResolvedValueOnce(10000)
+        .mockResolvedValueOnce(3);
+      await TelemetryUsageBillingService.waiveUnreportedUsageBilling({
+        projectId: PROJECT_ID,
+        productType: ProductType.Logs,
+        before: CUTOFF,
+      });
+      expect(update).toHaveBeenCalledTimes(2);
+      const args: any = update.mock.calls[0]![0];
+      expect(args.query.projectId).toEqual(PROJECT_ID);
+      expect(args.query.isReportedToBillingProvider).toBe(false);
+      expect(args.query.createdAt).toBeDefined();
+      expect(args.query.totalCostInUSD).toBeDefined();
+      expect(Object.keys(args.data)).toEqual(["totalCostInUSD"]);
+      expect(args.data.totalCostInUSD.value).toBe(0);
+      expect(args.skip).toBe(0);
+    });
+  });
+});

--- a/Common/Tests/Server/Types/Billing/PayAsYouGoMeteredAuthorization.test.ts
+++ b/Common/Tests/Server/Types/Billing/PayAsYouGoMeteredAuthorization.test.ts
@@ -54,6 +54,7 @@ describe("metered billing payment protection", () => {
   let report: jest.SpyInstance;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     canUse = getJestSpyOn(
       PayAsYouGoBillingService,
       "canUsePayAsYouGo",

--- a/Common/Typings/Index.d.ts
+++ b/Common/Typings/Index.d.ts
@@ -13,3 +13,66 @@ declare module "*.gif";
  * supplies the behaviour at runtime.
  */
 declare module "i18next-browser-languagedetector";
+
+/*
+ * Billing's Common tests import Dashboard pages and provide virtual Stripe
+ * mocks. Stripe's browser packages are installed only by Dashboard, so the
+ * Common-only CI job needs declarations for the browser API those tests use.
+ * Keep these contracts narrow rather than declaring the packages as `any`.
+ * Dashboard's tsconfig does not include this file: production compilation
+ * continues to check against the packages' complete upstream declarations.
+ */
+declare module "@stripe/stripe-js" {
+  export interface StripeError {
+    message?: string;
+  }
+
+  export type StripeElements = Record<string, unknown>;
+
+  export interface PaymentIntentResult {
+    error?: StripeError;
+  }
+
+  export interface Stripe {
+    confirmSetup(options: {
+      elements: StripeElements;
+      confirmParams: { return_url: string };
+    }): Promise<{ error?: StripeError }>;
+    confirmCardPayment(
+      clientSecret: string,
+      options: { payment_method: string },
+    ): Promise<PaymentIntentResult>;
+  }
+
+  export interface StripeElementsOptions {
+    clientSecret?: string;
+    appearance?: {
+      theme?: "stripe" | "night" | "flat";
+      variables?: Record<string, string>;
+    };
+  }
+
+  export function loadStripe(publishableKey: string): Promise<Stripe | null>;
+}
+
+declare module "@stripe/react-stripe-js" {
+  import {
+    Stripe,
+    StripeElements,
+    StripeElementsOptions,
+  } from "@stripe/stripe-js";
+  import { FunctionComponent, ReactNode } from "react";
+
+  export const Elements: FunctionComponent<{
+    stripe: Stripe | PromiseLike<Stripe | null> | null;
+    options?: StripeElementsOptions;
+    children?: ReactNode;
+  }>;
+  export const PaymentElement: FunctionComponent;
+  export function useStripe(): Stripe | null;
+  export function useElements(): StripeElements | null;
+}
+
+declare module "@stripe/stripe-js/pure" {
+  export { loadStripe } from "@stripe/stripe-js";
+}


### PR DESCRIPTION
### Title of this pull request?

Require payment setup before pay-as-you-go usage

### Small Description?

A Free project can currently create active monitors and send telemetry without a payment method, while that usage can still produce an invoice. This change requires payment setup before creating or re-enabling paid resources, admitting telemetry, or reporting positive metered usage.

- Share payment eligibility across monitor and ingestion-key services, HTTP, gRPC, MQTT, and the final metered billing boundary. Preserve Manual monitors (including projects with an older unpaid metered invoice), billing-disabled installations, redeemed reseller licenses, and active paid invoice agreements.
- Show when paid usage is locked, provide billing setup and retry actions, and require explicit acknowledgement of published usage prices before saving a card or starting paid features. Distinguish the $0 Free subscription from pay-as-you-go usage.
- Prevent pre-authorization telemetry from becoming a later bill. Use a durable billing start marker and consistent UTC staging boundaries and day keys.

**Rollout:** Existing monitors keep running. Card-billed customers without the new Stripe customer metadata marker receive a one-time waiver of older unreported telemetry, including the partial authorization day. Active paid invoice agreements and redeemed reseller licenses are exempt from that cutoff. This does not cancel already-reported usage or invoices, or change fixed subscription trial billing. Telemetry admission eligibility can be cached for up to 60 seconds; positive metered reporting always checks fresh eligibility.

### Validation

- Passed: 390 relevant tests across payment eligibility, metered billing, monitors, ingestion keys, HTTP/gRPC/MQTT transport behavior, billing UI, and existing pricing/consent forms.
- `npm run compile` passed in Common, App, and Dashboard on the final revision.
- Type checking passed for all changed test files. Billing test suites also pass with Dashboard’s Stripe packages hidden to reproduce the Common-only CI dependency setup.
- The repository-wide `npm run fix` was attempted and stopped after 32 minutes under heavy local memory pressure. The same ESLint fixer passed on all 35 changed files. Full lint runs in CI.
- GitHub is rerunning the complete test and lint workflows on the final commit.

Full live-app testing was blocked: Docker is unavailable and the configured development host returns HTTP 502. A separate Chrome preview confirmed the locked paid-feature state using the actual UI components and simulated billing.

### Pull Request Checklist:

- [ ] All CI jobs pass before requesting review.
- [x] Local lint check completed for changed files.
- [x] Added focused unit, service, transport, and UI integration regression tests.

### Related Issue?

Customer billing experience feedback; no linked public issue.

### Screenshots

[View the three Chrome screenshots](https://github.com/OneUptime/oneuptime/pull/3656#issuecomment-5584964599) showing paid usage locked, payment setup acknowledgment, and paid usage enabled. These use actual app components with simulated billing and Stripe data.
