### PR TITLE
fix(test): stop the license validation test expiring seven days after it was written

### DIFF
--- a/Common/Tests/Server/API/EnterpriseLicenseReportUserCount.test.ts
+++ b/Common/Tests/Server/API/EnterpriseLicenseReportUserCount.test.ts
@@ -1503,6 +1503,17 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/validate", () => {
           return [];
         },
       );
+    /*
+     * Relative to now, like every other date in this file: the legacy usage
+     * fallback only trusts userCountUpdatedAt while it is inside the
+     * InstanceUsageFreshnessInDays window, so a fixed date silently stops
+     * being fresh and the echoed count collapses to 0.
+     */
+    const userCountUpdatedAt: Date = OneUptimeDate.addRemoveDays(
+      OneUptimeDate.getCurrentDate(),
+      -1,
+    );
+
     EnterpriseLicenseService.findOneById = jest
       .fn()
       .mockImplementation(async (): Promise<EnterpriseLicense> => {
@@ -1510,7 +1521,7 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/validate", () => {
         events.push("license");
         return makeLicense({
           currentUserCount: 17,
-          userCountUpdatedAt: new Date("2026-09-01T12:00:00.000Z"),
+          userCountUpdatedAt,
         });
       });
 
@@ -1523,7 +1534,7 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/validate", () => {
     expect(getResponseBody()).toEqual(
       expect.objectContaining({
         currentUserCount: 17,
-        userCountUpdatedAt: "2026-09-01T12:00:00.000Z",
+        userCountUpdatedAt: userCountUpdatedAt.toISOString(),
       }),
     );
     expect(


### PR DESCRIPTION
`test (6/8)` is failing on master. It is not a regression from any recent change — the test expired on a timer.

## What happens

`EnterpriseLicenseReportUserCount`'s test *"serializes registration and re-reads usage inside the aggregation lock"* pinned its fixture to the literal `2026-09-01T12:00:00.000Z`. Every other date in that file is built from `OneUptimeDate.getCurrentDate()`.

That timestamp is load-bearing, not decorative. The test mocks `EnterpriseLicenseInstanceService.findBy` to return no instances, so `hasActiveReportedInstanceUsage` is false and the response falls through to the legacy usage path in `EnterpriseLicenseAPI` — which only trusts `license.userCountUpdatedAt` while `isTimestampWithinUsageWindow` holds, i.e. `InstanceUsageFreshnessInDays`, seven days.

The fixture crossed that boundary at **2026-09-08T12:00:00Z**. After it, the instance is inactive, the legacy fallback declines the stored value, and the echoed `currentUserCount` collapses from `17` to `0`:

```
- ObjectContaining {
-   "currentUserCount": 17,
+   "currentUserCount": 0,
+   "instances": Array [],
```

So the test began failing with no change to itself or to the code under test. I confirmed it fails on a pristine `origin/master` worktree.

## The fix

Build the timestamp a day back from now, the way the rest of the file does, so it stays inside the window permanently.

The test still pins what it was written to pin — it is not asserted away. Setting the fixture 30 days back reproduces the original failure, so the freshness path is still genuinely exercised. All 50 tests in the file pass; `tsc --noEmit` and eslint are clean.

## Worth a follow-up

Other suites hold hardcoded absolute dates with no fake clock — `SloUtil` (69), `AIInvestigationAPI` (28), `UptimeUtil` (22) among them. Most look harmless, since an absolute date is only a hazard where it meets a now-relative window, as it did here. I deliberately did not audit them in this PR.