### PR TITLE
fix(dashboard): stop a clicked widget covering the auto-refresh picker

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/Index.tsx
@@ -24,6 +24,9 @@ import useDashboardGridDnd, {
   GRID_ITEM_TRANSITION,
   ResizeDirection,
 } from "Common/UI/Utils/UseDashboardGridDnd";
+import DashboardStackingLayers, {
+  DASHBOARD_CANVAS_ISOLATION,
+} from "Common/UI/Utils/DashboardStackingLayers";
 import RangeStartAndEndDateTime from "Common/Types/Time/RangeStartAndEndDateTime";
 import MetricType from "Common/Models/DatabaseModels/MetricType";
 import DashboardVariable from "Common/Types/Dashboard/DashboardVariable";
@@ -251,7 +254,10 @@ const DashboardCanvas: FunctionComponent<ComponentProps> = (
             rect.top * cellSizeInPx
           }px)`,
           transition: isActive ? "none" : GRID_ITEM_TRANSITION,
-          zIndex: isSelected && !isActive ? 20 : undefined,
+          zIndex:
+            isSelected && !isActive
+              ? DashboardStackingLayers.canvasSelectedComponent
+              : undefined,
         }}
       >
         <DashboardBaseComponentElement
@@ -328,7 +334,7 @@ const DashboardCanvas: FunctionComponent<ComponentProps> = (
             borderRadius: "12px",
             border: "2px dashed rgba(59, 130, 246, 0.55)",
             background: "rgba(59, 130, 246, 0.08)",
-            zIndex: 5,
+            zIndex: DashboardStackingLayers.canvasPlaceholder,
             pointerEvents: "none",
           }}
         >
@@ -376,6 +382,14 @@ const DashboardCanvas: FunctionComponent<ComponentProps> = (
           }}
           style={{
             position: "relative",
+            /*
+             * Widgets live in their own layer stack. Without this the raise a
+             * selected or dragged tile asks for is measured against the whole
+             * page, and it wins - that is issue #3660, where a clicked tile
+             * covered the toolbar's auto-refresh menu. See
+             * Common/UI/Utils/DashboardStackingLayers.
+             */
+            isolation: DASHBOARD_CANVAS_ISOLATION,
             width: "100%",
             height: `${containerHeightInPx}px`,
             borderRadius: "12px",

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardToolbar.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardToolbar.tsx
@@ -26,6 +26,7 @@ import DashboardVariableSelector from "./DashboardVariableSelector";
 import DashboardVariablesModal from "./DashboardVariablesModal";
 import Icon from "Common/UI/Components/Icon/Icon";
 import AddWidgetModal from "./AddWidgetModal";
+import DashboardStackingLayers from "Common/UI/Utils/DashboardStackingLayers";
 
 export interface ComponentProps {
   onEditClick: () => void;
@@ -256,7 +257,16 @@ const AutoRefreshDropdown: FunctionComponent<AutoRefreshDropdownProps> = (
 
       {/* Dropdown */}
       {isOpen && (
-        <div className="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-lg bg-white shadow-xl ring-1 ring-gray-200 focus:outline-none py-1">
+        <div
+          className="absolute right-0 mt-2 w-56 origin-top-right rounded-lg bg-white shadow-xl ring-1 ring-gray-200 focus:outline-none py-1"
+          /*
+           * Issue #3660: this used to be `z-10`, which lost to a clicked
+           * widget's raise and left the picker opening behind the board. The
+           * canvas can no longer compete for the page's layers at all, and
+           * this puts the menu on the same layer as every other toolbar menu.
+           */
+          style={{ zIndex: DashboardStackingLayers.toolbarPopup }}
+        >
           {Object.values(AutoRefreshInterval).map(
             (interval: AutoRefreshInterval) => {
               const isSelected: boolean =

--- a/App/Tests/Dashboard/DashboardCanvasLayering.test.ts
+++ b/App/Tests/Dashboard/DashboardCanvasLayering.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import DashboardStackingLayers, {
+  DASHBOARD_CANVAS_ISOLATION,
+} from "Common/UI/Utils/DashboardStackingLayers";
+
+/*
+ * Issue #3660: clicking a dashboard tile once made it paint over the
+ * toolbar's auto-refresh menu, so opening the picker showed a blank white
+ * rectangle where the options should be.
+ *
+ * The canvas raises a selected tile to a layer of its own so the tile's ring
+ * and resize handles clear the neighbours they overhang. That raise was
+ * correct; what was missing was a boundary. The positioner the tiles live in
+ * is `position: relative` with `z-index: auto`, which creates no stacking
+ * context, and neither does anything above it up to the document - so the
+ * board's "above my neighbours" and the toolbar's "above the toolbar card"
+ * were resolved against each other in the ROOT stacking context, and the
+ * bigger number won.
+ *
+ * The fix is a boundary plus one scale: the positioner isolates, and every
+ * layer either side of it is read from Common/UI/Utils/DashboardStackingLayers
+ * instead of written inline in each file.
+ *
+ * None of that is expressible as a type. This suite runs in a plain Node
+ * environment (App/jest.config.json sets testEnvironment "node"), and even
+ * under jsdom no stylesheet is loaded - Tailwind arrives through the Play CDN
+ * at runtime - so getComputedStyle can never resolve a `z-*` or `isolate`
+ * class. The relationship is therefore pinned against the sources, the same
+ * way MapChromeHeaderLayering pins issue #3373 and NetworkTopologyPanelLayering
+ * pins the detail-panel ladder from #3134.
+ *
+ * The behaviour behind these pins is exercised against a real rendered DOM in
+ * Common/Tests/App/Dashboard/DashboardToolbarPopupLayering.test.tsx, and the
+ * arithmetic alone in Common/Tests/UI/Utils/DashboardStackingLayers.test.ts.
+ */
+
+const REPO_ROOT: string = path.join(__dirname, "..", "..", "..");
+
+/*
+ * Comments are stripped before anything is matched. Each of these files
+ * explains this bug in prose directly above the code that fixes it, quoting
+ * the very identifiers and z-index values the assertions look for, so a
+ * matcher that read the commentary would find its anchor in the explanation
+ * every time.
+ */
+function readSource(...relativeParts: Array<string>): string {
+  return fs
+    .readFileSync(path.join(REPO_ROOT, ...relativeParts), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/.*$/gm, " ");
+}
+
+const CANVAS: string = readSource(
+  "App",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Components",
+  "Dashboard",
+  "Canvas",
+  "Index.tsx",
+);
+
+const TOOLBAR: string = readSource(
+  "App",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Components",
+  "Dashboard",
+  "Toolbar",
+  "DashboardToolbar.tsx",
+);
+
+const SHELL: string = readSource(
+  "App",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Components",
+  "Dashboard",
+  "DashboardView.tsx",
+);
+
+const GRID_DND: string = readSource(
+  "Common",
+  "UI",
+  "Utils",
+  "UseDashboardGridDnd.ts",
+);
+
+const PUBLIC_PAGE: string = readSource(
+  "App",
+  "FeatureSet",
+  "PublicDashboard",
+  "src",
+  "Pages",
+  "DashboardView",
+  "DashboardViewPage.tsx",
+);
+
+const PUBLIC_CANVAS: string = readSource(
+  "App",
+  "FeatureSet",
+  "PublicDashboard",
+  "src",
+  "Components",
+  "DashboardCanvas.tsx",
+);
+
+/*
+ * Throws rather than returning null: an anchor that silently stopped matching
+ * would turn every assertion below it into a no-op, which is the one failure
+ * mode a source-pinned test cannot afford.
+ */
+function anchor(source: string, pattern: RegExp, what: string): string {
+  const match: RegExpMatchArray | null = source.match(pattern);
+
+  if (!match || match[1] === undefined) {
+    throw new Error(
+      `Cannot find ${what} any more - the anchor this test reads it with no longer matches. Re-point the anchor, and check that the layering contract from issue #3660 still holds before you do.`,
+    );
+  }
+
+  return match[1];
+}
+
+/**
+ * The style object of the canvas positioner - the box tiles are absolutely
+ * placed inside, and the only box in the tree that is allowed to isolate.
+ */
+function positionerStyle(): string {
+  return anchor(
+    CANVAS,
+    /ref=\{positionerRef\}[\s\S]{0,600}?style=\{\{([\s\S]*?)\}\}\s*>/,
+    "the canvas positioner's style object",
+  );
+}
+
+/** The style object the toolbar's auto-refresh panel carries. */
+function autoRefreshPanelStyle(): string {
+  return anchor(
+    TOOLBAR,
+    /className="absolute right-0 mt-2 w-56 origin-top-right[^"]*"\s*style=\{\{([^}]*)\}\}/,
+    "the auto-refresh menu's panel",
+  );
+}
+
+/** Tailwind's z-N utilities, which jsdom can never resolve. */
+function tailwindZIndexesIn(source: string): Array<number> {
+  return Array.from(source.matchAll(/(?<![\w-])z-(\d+)(?![\w-])/g)).map(
+    (match: RegExpMatchArray): number => {
+      return Number(match[1]);
+    },
+  );
+}
+
+/*
+ * Layers the app puts over its pages, read out of the components that own
+ * them rather than written down here, so renumbering any of them moves these
+ * assertions with it.
+ */
+const PAGE_CHROME: Array<{ name: string; zIndex: number }> = [
+  {
+    name: "the shell's sticky header",
+    zIndex: Number(
+      anchor(
+        readSource(
+          "Common",
+          "UI",
+          "Components",
+          "MasterPage",
+          "MasterPage.tsx",
+        ),
+        /makeTopSectionUnstick \? "" : "sticky top-0 z-(\d+)"/,
+        "the shell's sticky top section",
+      ),
+    ),
+  },
+  {
+    name: "SideOver",
+    zIndex: Number(
+      anchor(
+        readSource("Common", "UI", "Components", "SideOver", "SideOver.tsx"),
+        /className="relative z-(\d+)"/,
+        "SideOver's root",
+      ),
+    ),
+  },
+  {
+    name: "the AI chat panel",
+    zIndex: Number(
+      anchor(
+        readSource(
+          "App",
+          "FeatureSet",
+          "Dashboard",
+          "src",
+          "Components",
+          "AIChat",
+          "AIChatPanel.tsx",
+        ),
+        /className="relative z-(\d+)" role="dialog"/,
+        "the AI chat panel's root",
+      ),
+    ),
+  },
+  {
+    name: "Modal",
+    zIndex: Number(
+      anchor(
+        readSource("Common", "UI", "Components", "Modal", "Modal.tsx"),
+        /<div className="relative z-(\d+)">/,
+        "Modal's root",
+      ),
+    ),
+  },
+];
+
+describe("the dashboard canvas cannot paint over the page (issue #3660)", () => {
+  describe("the positioner", () => {
+    test("creates a stacking context", () => {
+      expect(positionerStyle()).toContain(
+        "isolation: DASHBOARD_CANVAS_ISOLATION",
+      );
+      expect(DASHBOARD_CANVAS_ISOLATION).toBe("isolate");
+    });
+
+    test("is also the positioning parent its tiles anchor to", () => {
+      /*
+       * Isolating alone would scope the z-indexes but leave the absolutely
+       * positioned tiles resolving their offsets against some ancestor
+       * further up, which is how they would escape the canvas box.
+       */
+      expect(positionerStyle()).toContain('position: "relative"');
+    });
+
+    test("claims no z-index of its own", () => {
+      /*
+       * An isolated box that also carried a z-index would re-enter the
+       * competition it was added to leave, and the whole board would outrank
+       * the toolbar again in one piece instead of one tile at a time.
+       */
+      expect(positionerStyle()).not.toMatch(/zIndex/);
+    });
+
+    test("is the only box in the canvas that isolates", () => {
+      /*
+       * The tempting bigger version of this fix is to isolate the wrapper
+       * above it. That also traps ComponentSettingsModal, which the canvas
+       * renders OUTSIDE the positioner precisely so it can keep the Modal
+       * layer: trapped, its z-50 becomes canvas-local and the AI chat panel
+       * paints over the open settings dialog.
+       *
+       * Isolate the box that holds the tiles, never the box that holds the
+       * canvas.
+       */
+      expect(CANVAS.match(/isolation/g)).toHaveLength(1);
+      expect(SHELL).not.toMatch(/isolation/);
+      expect(SHELL).not.toMatch(/(?<![\w-])isolate(?![\w-])/);
+    });
+  });
+
+  describe("every layer the board hands out", () => {
+    test("comes from the shared scale, not from a number written in place", () => {
+      /*
+       * The bug was two files each deciding a layer on its own and never
+       * finding out they disagreed. A bare number here is that situation
+       * restored.
+       */
+      const inlineNumbers: Array<string> = Array.from(
+        CANVAS.matchAll(/zIndex:\s*(-?\d+)/g),
+      ).map((match: RegExpMatchArray): string => {
+        return match[0];
+      });
+
+      expect(inlineNumbers).toEqual([]);
+      expect(CANVAS).toContain(
+        "DashboardStackingLayers.canvasSelectedComponent",
+      );
+      expect(CANVAS).toContain("DashboardStackingLayers.canvasPlaceholder");
+    });
+
+    test("including the one the drag code sets imperatively", () => {
+      expect(GRID_DND).not.toMatch(/style\.zIndex\s*=\s*"\d+"/);
+      expect(GRID_DND).toContain(
+        "DashboardStackingLayers.canvasDraggingComponent",
+      );
+    });
+
+    test("still raises the selected tile, rather than giving the raise up", () => {
+      /*
+       * The other way to make the report go away is to stop raising the tile
+       * at all, which puts its selection ring and its resize handles back
+       * under the neighbouring cards they overhang.
+       */
+      expect(CANVAS).toMatch(
+        /zIndex:\s*isSelected && !isActive\s*\?\s*DashboardStackingLayers\.canvasSelectedComponent/,
+      );
+    });
+  });
+
+  describe("the toolbar's auto-refresh menu", () => {
+    test("takes its layer from the shared scale", () => {
+      expect(autoRefreshPanelStyle()).toContain(
+        "zIndex: DashboardStackingLayers.toolbarPopup",
+      );
+    });
+
+    test("no longer carries a Tailwind layer class jsdom cannot see", () => {
+      /*
+       * The panel used to be `z-10`. Keeping a class alongside the style
+       * would leave two answers to the same question, and the class is the
+       * one no test can read.
+       */
+      const panel: string = anchor(
+        TOOLBAR,
+        /className="(absolute right-0 mt-2 w-56 origin-top-right[^"]*)"/,
+        "the auto-refresh menu's class list",
+      );
+
+      expect(tailwindZIndexesIn(panel)).toEqual([]);
+    });
+  });
+
+  describe("why the isolation is load-bearing", () => {
+    /*
+     * These are the assertions that stop #3660 being "fixed" by renumbering
+     * and deleting the boundary. Each names a layer of app chrome the board's
+     * own numbers would outrank in a shared stacking context.
+     */
+    for (const chrome of PAGE_CHROME) {
+      test(`a widget mid-drag would otherwise outrank ${chrome.name}`, () => {
+        expect(chrome.zIndex).toBeGreaterThan(0);
+        expect(DashboardStackingLayers.canvasDraggingComponent).toBeGreaterThan(
+          chrome.zIndex,
+        );
+      });
+    }
+
+    test("and a merely selected widget would outrank the sticky header", () => {
+      const header: number = PAGE_CHROME[0]!.zIndex;
+
+      expect(
+        DashboardStackingLayers.canvasSelectedComponent,
+      ).toBeGreaterThanOrEqual(header);
+    });
+  });
+
+  describe("the public dashboard", () => {
+    test("mounts the same canvas, so it is covered by the same boundary", () => {
+      /*
+       * The precondition for everything else in this block. Fork the public
+       * canvas and the isolation quietly stops covering that surface.
+       */
+      expect(PUBLIC_CANVAS).toContain(
+        '"../../../Dashboard/src/Components/Dashboard/Canvas/Index"',
+      );
+    });
+
+    test("never raises a tile in the first place", () => {
+      /*
+       * Its immunity lives in these props, not in the canvas - which is why
+       * it is pinned here rather than inferred from the canvas file.
+       */
+      expect(PUBLIC_PAGE).toMatch(/selectedComponentId=\{null\}/);
+      expect(PUBLIC_PAGE).toMatch(/isEditMode=\{false\}/);
+    });
+
+    test("opens its own auto-refresh picker through the shared menu", () => {
+      /*
+       * It uses MoreMenu, which is why it never reproduced the report.
+       * Copying the hand-rolled panel back over here would bring the bug with
+       * it - now on a surface with no edit mode to notice it.
+       */
+      expect(PUBLIC_PAGE).toContain("MoreMenu");
+      expect(PUBLIC_PAGE).not.toContain("AutoRefreshDropdown");
+    });
+  });
+});

--- a/Common/Tests/App/Dashboard/DashboardToolbarPopupLayering.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardToolbarPopupLayering.test.tsx
@@ -1,0 +1,566 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { ObjectType } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import TimeRange from "../../../Types/Time/TimeRange";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import DashboardMode from "../../../Types/Dashboard/DashboardMode";
+import DashboardViewConfig, {
+  AutoRefreshInterval,
+} from "../../../Types/Dashboard/DashboardViewConfig";
+import DashboardBaseComponent from "../../../Types/Dashboard/DashboardComponents/DashboardBaseComponent";
+import DashboardTextComponentUtil from "../../../Utils/Dashboard/Components/DashboardTextComponent";
+import DefaultDashboardSize from "../../../Types/Dashboard/DashboardSize";
+import DashboardStackingLayers from "../../../UI/Utils/DashboardStackingLayers";
+
+/*
+ * github.com/OneUptime/oneuptime/issues/3660.
+ *
+ * "Click the topmost tile once, then open the auto-refresh picker: it is
+ * hidden behind the tile. Click a tile further down and the picker appears as
+ * intended."
+ *
+ * The click is the whole story. Clicking a widget selects it - in VIEW mode
+ * too, where selection has no other visible effect at all - and the canvas
+ * raised the selected tile's wrapper to z-index 20 so its ring and resize
+ * handles clear its neighbours. But the wrapper's only positioned ancestors
+ * were `position: relative` with `z-index: auto`, which creates no stacking
+ * context, so that 20 was resolved in the ROOT stacking context, against the
+ * toolbar menu's 10. Clicking a tile further down did not fix the layering;
+ * it just moved the raised box out from under the menu.
+ *
+ * What is asserted here is the relationship, not the numbers: the menu is
+ * painted after the selected tile, in a real DOM shaped exactly as the
+ * dashboard shell shapes it. `paintsAbove` below implements CSS 2.1
+ * Appendix E over the rendered tree, so the assertion fails the moment the
+ * canvas stops isolating - and the last test in this file proves that by
+ * taking the isolation away and watching the bug come back.
+ *
+ * jsdom has no stylesheet (Tailwind arrives via the Play CDN at runtime), so
+ * only INLINE style is computable here. Every property this file reads -
+ * isolation, position, z-index, transform - is inline in the components under
+ * test, which is why the fix is written as inline style rather than as a
+ * Tailwind class. The Tailwind-class side of the same contract is pinned
+ * against the sources in App/Tests/Dashboard/DashboardCanvasLayering.test.ts.
+ */
+
+/*
+ * The one mock. DashboardBaseComponent is the fan-out to ~60 widget
+ * implementations and none of them are under test; the tile WRAPPER, which is
+ * where the bug lives, stays real. The stub keeps the two things the wrapper's
+ * behaviour depends on: it forwards the click that selects, and it carries a
+ * transform, because the real card always sets `transform: scale(1)` and that
+ * makes the card a stacking context of its own.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent",
+  () => {
+    const reactModule: typeof React = jest.requireActual(
+      "react",
+    ) as typeof React;
+
+    return {
+      __esModule: true,
+      default: (props: {
+        componentId: { toString: () => string };
+        onClick: () => void;
+      }) => {
+        return reactModule.createElement("div", {
+          "data-testid": `widget-${props.componentId.toString()}`,
+          style: { transform: "scale(1)" },
+          onClick: () => {
+            props.onClick();
+          },
+        });
+      },
+    };
+  },
+);
+
+import DashboardCanvas from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/Index";
+import DashboardToolbar from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardToolbar";
+
+// ── a model of CSS painting order ──────────────────────────────────────
+
+/*
+ * Which properties open a stacking context. Only the ones reachable in jsdom
+ * are listed - a class-driven one would read as absent here AND is absent from
+ * the real chain this file models, so leaving it out changes no answer.
+ */
+function createsStackingContext(element: HTMLElement): boolean {
+  if (element === element.ownerDocument.documentElement) {
+    return true;
+  }
+
+  const style: CSSStyleDeclaration = window.getComputedStyle(element);
+
+  if (style.isolation === "isolate") {
+    return true;
+  }
+
+  if (style.position === "fixed" || style.position === "sticky") {
+    return true;
+  }
+
+  if (
+    (style.position === "relative" || style.position === "absolute") &&
+    style.zIndex !== "" &&
+    style.zIndex !== "auto"
+  ) {
+    return true;
+  }
+
+  if (style.transform !== "" && style.transform !== "none") {
+    return true;
+  }
+
+  if (style.filter !== "" && style.filter !== "none") {
+    return true;
+  }
+
+  if (style.opacity !== "" && Number(style.opacity) < 1) {
+    return true;
+  }
+
+  if (style.mixBlendMode !== "" && style.mixBlendMode !== "normal") {
+    return true;
+  }
+
+  return false;
+}
+
+/** The nearest ancestor that boxes `element` into a stacking context. */
+function stackingContextOf(element: HTMLElement): HTMLElement {
+  let node: HTMLElement | null = element.parentElement;
+
+  while (node) {
+    if (createsStackingContext(node)) {
+      return node;
+    }
+
+    node = node.parentElement;
+  }
+
+  return element.ownerDocument.documentElement;
+}
+
+/** Root-first list of the stacking contexts `element` sits inside. */
+function stackingContextChain(element: HTMLElement): Array<HTMLElement> {
+  const chain: Array<HTMLElement> = [];
+  let context: HTMLElement = stackingContextOf(element);
+
+  for (;;) {
+    chain.unshift(context);
+
+    if (context === element.ownerDocument.documentElement) {
+      return chain;
+    }
+
+    context = stackingContextOf(context);
+  }
+}
+
+/*
+ * The ancestor-or-self of `element` that competes directly inside `context`.
+ * Everything below it is painted with it, atomically, wherever it lands.
+ */
+function participantIn(
+  element: HTMLElement,
+  context: HTMLElement,
+): HTMLElement {
+  let node: HTMLElement = element;
+
+  while (stackingContextOf(node) !== context) {
+    const parent: HTMLElement | null = node.parentElement;
+
+    if (!parent) {
+      throw new Error(
+        "participantIn was given an element that does not live inside the context it was asked about.",
+      );
+    }
+
+    node = parent;
+  }
+
+  return node;
+}
+
+/*
+ * The stack level a box competes at inside its own context. `auto` and `0` are
+ * the same level (CSS 2.1 Appendix E paints them together in tree order), and
+ * an element that opens a stacking context for some other reason - a transform,
+ * say - joins them there.
+ *
+ * A browser would ignore a z-index on a static box; this deliberately does
+ * not, because jsdom cannot see class-driven `position`. The toolbar panel is
+ * positioned by Tailwind's `absolute` and carries only its z-index inline, so
+ * requiring positioned-ness here would silently read the real, load-bearing
+ * layer of the element under test as zero. Erring the other way costs nothing:
+ * a z-index that a browser would ignore is a mistake this file should surface,
+ * not quietly agree with.
+ */
+function stackLevelOf(element: HTMLElement): number {
+  const zIndex: string = window.getComputedStyle(element).zIndex;
+
+  if (zIndex === "" || zIndex === "auto") {
+    return 0;
+  }
+
+  return Number(zIndex);
+}
+
+/**
+ * True when `a` is painted after - and so over - `b`, per CSS 2.1 Appendix E.
+ *
+ * Both boxes are reduced to whichever ancestor competes inside their deepest
+ * shared stacking context, since a stacking context is painted atomically. The
+ * winner is the higher stack level, or, at equal levels, the one later in the
+ * document.
+ */
+function paintsAbove(a: HTMLElement, b: HTMLElement): boolean {
+  const chainA: Array<HTMLElement> = stackingContextChain(a);
+  const chainB: Array<HTMLElement> = stackingContextChain(b);
+
+  let shared: HTMLElement = a.ownerDocument.documentElement;
+
+  for (
+    let depth: number = 0;
+    depth < Math.min(chainA.length, chainB.length);
+    depth++
+  ) {
+    if (chainA[depth] !== chainB[depth]) {
+      break;
+    }
+
+    shared = chainA[depth]!;
+  }
+
+  const boxA: HTMLElement = participantIn(a, shared);
+  const boxB: HTMLElement = participantIn(b, shared);
+
+  if (boxA === boxB) {
+    throw new Error(
+      "paintsAbove was asked to order two boxes that are painted as one. Give it elements that really do compete.",
+    );
+  }
+
+  const levelA: number = stackLevelOf(boxA);
+  const levelB: number = stackLevelOf(boxB);
+
+  if (levelA !== levelB) {
+    return levelA > levelB;
+  }
+
+  return Boolean(
+    boxB.compareDocumentPosition(boxA) & Node.DOCUMENT_POSITION_FOLLOWING,
+  );
+}
+
+// ── the board under test ───────────────────────────────────────────────
+
+const TOP_TILE_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const LOWER_TILE_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+function makeTile(componentId: ObjectID, top: number): DashboardBaseComponent {
+  return {
+    ...DashboardTextComponentUtil.getDefaultComponent(),
+    componentId,
+    topInDashboardUnits: top,
+    leftInDashboardUnits: 0,
+  };
+}
+
+const VIEW_CONFIG: DashboardViewConfig = {
+  _type: ObjectType.DashboardViewConfig,
+  components: [makeTile(TOP_TILE_ID, 0), makeTile(LOWER_TILE_ID, 3)],
+  heightInDashboardUnits: DefaultDashboardSize.heightInDashboardUnits,
+};
+
+const RANGE: RangeStartAndEndDateTime = {
+  range: TimeRange.PAST_ONE_HOUR,
+  startAndEndDate: new InBetween<Date>(
+    new Date("2026-09-08T10:00:00.000Z"),
+    new Date("2026-09-08T11:00:00.000Z"),
+  ),
+};
+
+function noop(): void {
+  return undefined;
+}
+
+/*
+ * The dashboard shell's own shape: the toolbar and the canvas as siblings
+ * under one plain wrapper, exactly as
+ * App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx renders
+ * them. Neither wrapper carries a stacking context, and that is the point -
+ * the fix must not depend on one appearing above the canvas.
+ */
+const DashboardShell: React.FunctionComponent = (): React.ReactElement => {
+  const [selectedComponentId, setSelectedComponentId] =
+    React.useState<ObjectID | null>(null);
+
+  return (
+    <div className="min-h-screen">
+      <DashboardToolbar
+        dashboardMode={DashboardMode.View}
+        dashboardName="Monitor Dashboard"
+        dashboardViewConfig={VIEW_CONFIG}
+        isSaving={false}
+        canEditDashboard={true}
+        startAndEndDate={RANGE}
+        onStartAndEndDateChange={noop}
+        autoRefreshInterval={AutoRefreshInterval.OFF}
+        onAutoRefreshIntervalChange={noop}
+        onEditClick={noop}
+        onSaveClick={noop}
+        onCancelEditClick={noop}
+        onFullScreenClick={noop}
+        onAddComponentClick={noop}
+      />
+      <div className="px-1 pb-4 mx-3 mb-4 rounded-2xl border border-gray-200/60">
+        <DashboardCanvas
+          dashboardViewConfig={VIEW_CONFIG}
+          onDashboardViewConfigChange={noop}
+          isEditMode={false}
+          currentTotalDashboardWidthInPx={1200}
+          selectedComponentId={selectedComponentId}
+          onComponentSelected={(componentId: ObjectID) => {
+            setSelectedComponentId(componentId);
+          }}
+          onComponentUnselected={() => {
+            setSelectedComponentId(null);
+          }}
+          metrics={{ metricTypes: [], telemetryAttributes: [] }}
+          dashboardStartAndEndDate={RANGE}
+        />
+      </div>
+    </div>
+  );
+};
+
+function tileWrapperOf(componentId: ObjectID): HTMLElement {
+  const wrapper: HTMLElement | null = document.getElementById(
+    `dashboard-component-${componentId.toString()}`,
+  );
+
+  if (!wrapper) {
+    throw new Error(
+      `The canvas no longer renders a tile wrapper with id dashboard-component-${componentId.toString()}. Re-point this test at whatever now carries the tile's z-index.`,
+    );
+  }
+
+  return wrapper;
+}
+
+function positionerElement(): HTMLElement {
+  const positioner: HTMLElement | null =
+    tileWrapperOf(TOP_TILE_ID).parentElement;
+
+  if (!positioner) {
+    throw new Error("The tile wrapper is no longer inside a positioner.");
+  }
+
+  return positioner;
+}
+
+function selectTile(componentId: ObjectID): void {
+  fireEvent.click(screen.getByTestId(`widget-${componentId.toString()}`));
+}
+
+/*
+ * Opens the picker and hands back its panel. The panel is found as "the
+ * wrapper's child that is not the trigger" rather than by text, so a reworded
+ * interval label cannot silently turn these assertions into no-ops - and the
+ * option count is checked, so a panel that rendered empty would fail loudly
+ * instead of passing a layering test about nothing.
+ */
+function openAutoRefreshMenu(): HTMLElement {
+  const trigger: HTMLElement = screen.getByTitle("Auto-refresh settings");
+
+  fireEvent.click(trigger);
+
+  const wrapper: HTMLElement | null = trigger.parentElement;
+
+  if (!wrapper) {
+    throw new Error("The auto-refresh trigger is no longer inside a wrapper.");
+  }
+
+  const panel: HTMLElement | undefined = Array.from(wrapper.children).find(
+    (child: Element): boolean => {
+      return child !== trigger;
+    },
+  ) as HTMLElement | undefined;
+
+  if (!panel) {
+    throw new Error(
+      "Clicking the auto-refresh trigger no longer opens a panel next to it.",
+    );
+  }
+
+  expect(panel.querySelectorAll("button")).toHaveLength(
+    Object.values(AutoRefreshInterval).length,
+  );
+
+  return panel;
+}
+
+beforeEach(() => {
+  render(<DashboardShell />);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("the auto-refresh picker opens above the board (issue #3660)", () => {
+  test("the reported gesture: click the topmost tile, then open the picker", () => {
+    selectTile(TOP_TILE_ID);
+
+    const tile: HTMLElement = tileWrapperOf(TOP_TILE_ID);
+    const panel: HTMLElement = openAutoRefreshMenu();
+
+    /* The tile really is raised - this is not passing because nothing happened. */
+    expect(tile.style.zIndex).toBe(
+      String(DashboardStackingLayers.canvasSelectedComponent),
+    );
+
+    expect(paintsAbove(panel, tile)).toBe(true);
+  });
+
+  test("and with no tile clicked at all, which always worked", () => {
+    const tile: HTMLElement = tileWrapperOf(TOP_TILE_ID);
+    const panel: HTMLElement = openAutoRefreshMenu();
+
+    expect(tile.style.zIndex).toBe("");
+    expect(paintsAbove(panel, tile)).toBe(true);
+  });
+
+  test("clicking a tile further down does not put the first one back on top", () => {
+    /*
+     * The report's workaround. Both tiles are checked, because the bug was
+     * never about which tile was clicked - only about which one happened to
+     * sit under the menu.
+     */
+    selectTile(LOWER_TILE_ID);
+
+    const panel: HTMLElement = openAutoRefreshMenu();
+
+    expect(paintsAbove(panel, tileWrapperOf(TOP_TILE_ID))).toBe(true);
+    expect(paintsAbove(panel, tileWrapperOf(LOWER_TILE_ID))).toBe(true);
+  });
+
+  test("nor can the highest layer the board is able to reach", () => {
+    /*
+     * UseDashboardGridDnd elevates a grabbed card imperatively, to a number
+     * well above the one the menu asks for. A real drag only happens in edit
+     * mode, where this picker is not mounted - but the arithmetic is what the
+     * boundary has to hold, and holding it here is what keeps the board from
+     * covering the dialogs that DO open over it while it is edited.
+     */
+    const tile: HTMLElement = tileWrapperOf(TOP_TILE_ID);
+    tile.style.zIndex = String(DashboardStackingLayers.canvasDraggingComponent);
+
+    const panel: HTMLElement = openAutoRefreshMenu();
+
+    expect(DashboardStackingLayers.canvasDraggingComponent).toBeGreaterThan(
+      DashboardStackingLayers.toolbarPopup,
+    );
+    expect(paintsAbove(panel, tile)).toBe(true);
+  });
+});
+
+describe("the canvas keeps its layers to itself", () => {
+  test("the positioner is the stacking context every tile lives in", () => {
+    selectTile(TOP_TILE_ID);
+
+    expect(stackingContextOf(tileWrapperOf(TOP_TILE_ID))).toBe(
+      positionerElement(),
+    );
+    expect(window.getComputedStyle(positionerElement()).isolation).toBe(
+      "isolate",
+    );
+  });
+
+  test("the positioner claims no z-index of its own", () => {
+    /*
+     * An isolated box that also took a z-index would re-enter the competition
+     * it was added to leave, and the whole board would outrank the toolbar
+     * again as one piece.
+     */
+    expect(positionerElement().style.zIndex).toBe("");
+  });
+
+  test("the toolbar's menu and the board are not even in the same contest", () => {
+    selectTile(TOP_TILE_ID);
+
+    const panel: HTMLElement = openAutoRefreshMenu();
+
+    expect(stackingContextOf(panel)).not.toBe(
+      stackingContextOf(tileWrapperOf(TOP_TILE_ID)),
+    );
+  });
+
+  test("the raise still does its job: a selected tile covers its neighbours", () => {
+    /*
+     * The other way to make this bug go away is to stop raising the tile,
+     * which would put the selection ring and the resize handles back under
+     * the neighbouring cards they overhang.
+     */
+    selectTile(TOP_TILE_ID);
+
+    expect(
+      paintsAbove(tileWrapperOf(TOP_TILE_ID), tileWrapperOf(LOWER_TILE_ID)),
+    ).toBe(true);
+  });
+});
+
+describe("the isolation is what is holding this up", () => {
+  /*
+   * Proof that the assertions above are load-bearing rather than trivially
+   * true. Both cases take the isolation away and watch the canvas's numbers
+   * escape into the page again - which is also why raising the menu on its own
+   * was never the fix.
+   */
+
+  test("without it, the shipped-before layering reproduces the report exactly", () => {
+    selectTile(TOP_TILE_ID);
+
+    const tile: HTMLElement = tileWrapperOf(TOP_TILE_ID);
+    const panel: HTMLElement = openAutoRefreshMenu();
+
+    expect(paintsAbove(panel, tile)).toBe(true);
+
+    /* The board and the menu as they shipped before the fix. */
+    positionerElement().style.isolation = "";
+    panel.style.zIndex = "10";
+
+    expect(paintsAbove(panel, tile)).toBe(false);
+  });
+
+  test("without it, even the menu's new layer loses to a widget mid-drag", () => {
+    const tile: HTMLElement = tileWrapperOf(TOP_TILE_ID);
+    const panel: HTMLElement = openAutoRefreshMenu();
+
+    tile.style.zIndex = String(DashboardStackingLayers.canvasDraggingComponent);
+
+    expect(paintsAbove(panel, tile)).toBe(true);
+
+    positionerElement().style.isolation = "";
+
+    expect(paintsAbove(panel, tile)).toBe(false);
+  });
+});

--- a/Common/Tests/UI/Utils/DashboardStackingLayers.test.ts
+++ b/Common/Tests/UI/Utils/DashboardStackingLayers.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import DashboardStackingLayers, {
+  DASHBOARD_CANVAS_ISOLATION,
+} from "../../../UI/Utils/DashboardStackingLayers";
+
+/*
+ * github.com/OneUptime/oneuptime/issues/3660.
+ *
+ * A dashboard tile that had been clicked once painted over the toolbar's
+ * auto-refresh menu, so opening the picker produced a blank white rectangle.
+ * Nothing was misconfigured: the canvas raised the selected tile to 20 so it
+ * would clear the tiles it overlaps, the toolbar menu asked for 10, and
+ * because neither box lived inside a stacking context of its own those two
+ * unrelated numbers were resolved against each other in the ROOT stacking
+ * context. 20 beat 10.
+ *
+ * So the numbers alone were never the fix and raising the menu alone would
+ * never have been either - the drag code elevates a tile to 60 while it is
+ * being moved, which outranks the menu, the Modal layer and everything else
+ * the page has. What makes the values safe is the canvas isolating itself, so
+ * that "above my neighbours on the board" stops being a claim about the page.
+ *
+ * This file pins the arithmetic. The DOM half - that the canvas really does
+ * isolate, and that a selected tile therefore cannot be compared with the menu
+ * at all - is asserted against real rendered elements in
+ * Common/Tests/App/Dashboard/DashboardToolbarPopupLayering.test.tsx, and the
+ * sources are pinned in App/Tests/Dashboard/DashboardCanvasLayering.test.ts.
+ */
+
+const COMMON_ROOT: string = path.join(__dirname, "..", "..", "..");
+
+function readCommonCode(...relativeParts: Array<string>): string {
+  return fs.readFileSync(path.join(COMMON_ROOT, ...relativeParts), "utf8");
+}
+
+/*
+ * The shell sticks its header at this layer. Read out of MasterPage rather
+ * than written down here, so moving the header moves the assertions with it.
+ */
+function appHeaderZIndex(): number {
+  const source: string = readCommonCode(
+    "UI",
+    "Components",
+    "MasterPage",
+    "MasterPage.tsx",
+  );
+
+  const match: RegExpMatchArray | null = source.match(
+    /makeTopSectionUnstick \? "" : "sticky top-0 z-(\d+)"/,
+  );
+
+  if (!match || match[1] === undefined) {
+    throw new Error(
+      "MasterPage no longer sticks its top section with a single `sticky top-0 z-N` class. Issue #3660 depends on dashboard widgets never competing with that layer - if the shell's layering changed, update this test to match.",
+    );
+  }
+
+  return Number(match[1]);
+}
+
+/* The layer every other anchored menu in the app already uses. */
+function moreMenuZIndex(): number {
+  const source: string = readCommonCode(
+    "UI",
+    "Components",
+    "MoreMenu",
+    "MoreMenu.tsx",
+  );
+
+  const match: RegExpMatchArray | null = source.match(
+    /absolute right-0 z-(\d+) mt-2 w-56 origin-top-right/,
+  );
+
+  if (!match || match[1] === undefined) {
+    throw new Error(
+      "MoreMenu's panel no longer declares its layer as a single `z-N` class in the class list this test anchors on. The dashboard toolbar's own menu is meant to sit on the same layer - re-point this reader before changing either.",
+    );
+  }
+
+  return Number(match[1]);
+}
+
+/*
+ * The layer every dialog in the app opens at - including the widget settings
+ * dialog the canvas itself renders, and the Add Widget / Variables / discard
+ * dialogs the toolbar opens while a board is being edited. Those are the
+ * overlays a widget mid-drag is actually in a position to cover.
+ */
+function modalZIndex(): number {
+  const source: string = readCommonCode(
+    "UI",
+    "Components",
+    "Modal",
+    "Modal.tsx",
+  );
+
+  const match: RegExpMatchArray | null = source.match(
+    /<div className="relative z-(\d+)">/,
+  );
+
+  if (!match || match[1] === undefined) {
+    throw new Error(
+      "Modal's root no longer declares its layer as a single `relative z-N` class. Re-point this reader before changing either Modal or the dashboard's scale.",
+    );
+  }
+
+  return Number(match[1]);
+}
+
+describe("dashboard stacking layers (issue #3660)", () => {
+  describe("the order the board is painted in", () => {
+    test("the drop placeholder sits under the widget being dragged onto it", () => {
+      expect(DashboardStackingLayers.canvasPlaceholder).toBeLessThan(
+        DashboardStackingLayers.canvasDraggingComponent,
+      );
+    });
+
+    test("the drop placeholder sits under the selected widget", () => {
+      /*
+       * The placeholder is a hint about where the card is going. Painting it
+       * over the card would hide the thing being positioned.
+       */
+      expect(DashboardStackingLayers.canvasPlaceholder).toBeLessThan(
+        DashboardStackingLayers.canvasSelectedComponent,
+      );
+    });
+
+    test("a widget under an active gesture outranks the merely selected one", () => {
+      /*
+       * Selection persists; a drag is momentary and has to clear whatever it
+       * is crossing, including the card that was selected before the grab.
+       */
+      expect(DashboardStackingLayers.canvasSelectedComponent).toBeLessThan(
+        DashboardStackingLayers.canvasDraggingComponent,
+      );
+    });
+  });
+
+  describe("the toolbar's menus", () => {
+    test("open above a selected widget - the bug in the report", () => {
+      expect(DashboardStackingLayers.toolbarPopup).toBeGreaterThan(
+        DashboardStackingLayers.canvasSelectedComponent,
+      );
+    });
+
+    test("sit on the same layer as every other anchored menu in the app", () => {
+      /*
+       * The auto-refresh menu is hand-rolled rather than a MoreMenu, which is
+       * the only reason it could drift to a different layer in the first
+       * place. Two menus in one toolbar disagreeing about their layer is a
+       * bug waiting for the first time they overlap.
+       */
+      expect(DashboardStackingLayers.toolbarPopup).toBe(moreMenuZIndex());
+    });
+
+    test("clear the app's sticky header", () => {
+      expect(DashboardStackingLayers.toolbarPopup).toBeGreaterThan(
+        appHeaderZIndex(),
+      );
+    });
+  });
+
+  describe("why the canvas has to isolate", () => {
+    test("it does isolate", () => {
+      expect(DASHBOARD_CANVAS_ISOLATION).toBe("isolate");
+    });
+
+    test("a dragged widget would otherwise outrank every dialog the app opens", () => {
+      /*
+       * This is the assertion that stops #3660 being "fixed" by raising the
+       * menu and deleting the boundary. Dragging happens in edit mode, and
+       * edit mode is full of things this number would cover in a shared
+       * stacking context: the widget settings dialog the canvas renders, the
+       * Add Widget and Variables dialogs, the discard confirmation. The
+       * elevation is held for a further 260ms after the drop, so this is not
+       * only about the frames the pointer is down for.
+       */
+      expect(DashboardStackingLayers.canvasDraggingComponent).toBeGreaterThan(
+        modalZIndex(),
+      );
+    });
+
+    test("a selected widget would otherwise outrank the app's sticky header", () => {
+      /*
+       * The unreported half of the same bug: scroll a board with a tile
+       * selected and the tile rides up over the navbar. Lowering the raise
+       * instead would put the selection ring and the resize handles back
+       * underneath the neighbours they are meant to overlap.
+       */
+      expect(
+        DashboardStackingLayers.canvasSelectedComponent,
+      ).toBeGreaterThanOrEqual(appHeaderZIndex());
+    });
+  });
+});

--- a/Common/Tests/UI/Utils/UseDashboardGridDnd.test.tsx
+++ b/Common/Tests/UI/Utils/UseDashboardGridDnd.test.tsx
@@ -10,6 +10,7 @@ import useDashboardGridDnd, {
   ResizeDirection,
 } from "../../../UI/Utils/UseDashboardGridDnd";
 import { GridRect } from "../../../Utils/Dashboard/GridLayout";
+import DashboardStackingLayers from "../../../UI/Utils/DashboardStackingLayers";
 
 /*
  * Grid used throughout: 50px units with a 10px gap, so one grid cell pitch
@@ -480,7 +481,9 @@ describe("useDashboardGridDnd — moving widgets", () => {
     // Raw pixel tracking: exactly one cell right of the origin.
     expect(element.style.transform).toBe(`translate(${CELL}px, 0px)`);
     expect(element.style.transition).toBe("none");
-    expect(element.style.zIndex).toBe("60");
+    expect(element.style.zIndex).toBe(
+      String(DashboardStackingLayers.canvasDraggingComponent),
+    );
 
     release({ x: 10 + CELL, y: 10 });
 
@@ -491,7 +494,9 @@ describe("useDashboardGridDnd — moving widgets", () => {
     expect(element.style.transform).toBe(`translate(${CELL}px, 0px)`);
     expect(element.style.transition).toContain("transform");
     expect(element.style.transition).not.toBe("none");
-    expect(element.style.zIndex).toBe("60");
+    expect(element.style.zIndex).toBe(
+      String(DashboardStackingLayers.canvasDraggingComponent),
+    );
 
     // ...and the elevation clears once the settle finishes.
     act(() => {

--- a/Common/UI/Utils/DashboardStackingLayers.ts
+++ b/Common/UI/Utils/DashboardStackingLayers.ts
@@ -1,0 +1,85 @@
+/*
+ * Paint order on a dashboard page, in one place.
+ *
+ * github.com/OneUptime/oneuptime/issues/3660. A tile that had been clicked
+ * once painted ON TOP of the toolbar's auto-refresh dropdown, so the picker
+ * opened into a white rectangle the user could not see. Both numbers behind
+ * that were reasonable on their own - the canvas raises a selected tile so it
+ * sits above the tiles it overlaps, and the dropdown asked for a modest
+ * layer - but neither element sat inside a stacking context of its own, so
+ * "above my neighbours on the board" and "above the toolbar card" were
+ * silently resolved against each other in the ROOT stacking context, and the
+ * larger number won.
+ *
+ * Numbers alone cannot fix that; the next person to raise a widget by one
+ * step re-breaks it. So the contract has two halves and both live here:
+ *
+ *   1. The canvas positioner establishes its OWN stacking context
+ *      (CANVAS_ISOLATION below). Every z-index inside the canvas is then a
+ *      statement about the other things ON THE BOARD, and cannot outrank page
+ *      chrome however large it grows. This is what actually fixes the bug -
+ *      and it fixes the unreported half of it too, because a selected tile at
+ *      20 and a dragged tile at 60 were also outranking the app's own sticky
+ *      header (`sticky top-0 z-10`, Common/UI/Components/MasterPage).
+ *
+ *   2. The toolbar's hand-rolled auto-refresh menu sits at TOOLBAR_POPUP, the
+ *      layer MoreMenu already uses (`z-50`,
+ *      Common/UI/Components/MoreMenu/MoreMenu.tsx), so the two menus in that
+ *      one toolbar stop disagreeing about how high a menu opens.
+ *
+ * These are plain numbers rather than Tailwind classes on purpose: the
+ * relationship between them is the thing that matters, and a relationship
+ * spelled as `z-10` in one file and `zIndex: 20` in another is exactly what
+ * broke. Written this way it is one import, and a test can assert the
+ * ordering instead of trusting two string literals to stay in step.
+ */
+
+export interface DashboardStackingLayerScale {
+  /**
+   * The dashed drop-target outline shown while a widget is dragged or
+   * resized. Below the widget being moved, so the card stays readable as it
+   * crosses its own placeholder.
+   */
+  canvasPlaceholder: number;
+
+  /**
+   * The selected widget. Raised so its selection ring and resize handles
+   * are not clipped by the neighbours they overlap.
+   */
+  canvasSelectedComponent: number;
+
+  /**
+   * The widget under an active drag or resize. Above everything else on the
+   * board, including the placeholder it is heading for, and held there until
+   * the settle transition finishes (see UseDashboardGridDnd).
+   */
+  canvasDraggingComponent: number;
+
+  /**
+   * Menus and panels anchored to the dashboard toolbar. Above the canvas -
+   * which, being isolated, cannot compete - and above the app's sticky
+   * header, matching MoreMenu.
+   */
+  toolbarPopup: number;
+}
+
+const DashboardStackingLayers: DashboardStackingLayerScale = {
+  canvasPlaceholder: 5,
+  canvasSelectedComponent: 20,
+  canvasDraggingComponent: 60,
+  toolbarPopup: 50,
+};
+
+/**
+ * The `isolation` value the dashboard canvas positioner carries.
+ *
+ * `isolate` is the property whose only job is to open a stacking context: it
+ * changes no layout, clips nothing, and - unlike `transform` or `filter` -
+ * does not become the containing block for `position: fixed` descendants, so
+ * portalled popups and fullscreen keep working exactly as they did.
+ */
+export type DashboardCanvasIsolation = "isolate";
+
+export const DASHBOARD_CANVAS_ISOLATION: DashboardCanvasIsolation = "isolate";
+
+export default DashboardStackingLayers;

--- a/Common/UI/Utils/UseDashboardGridDnd.ts
+++ b/Common/UI/Utils/UseDashboardGridDnd.ts
@@ -1,4 +1,5 @@
 import GridLayoutUtil, { GridRect } from "../../Utils/Dashboard/GridLayout";
+import DashboardStackingLayers from "./DashboardStackingLayers";
 import React, {
   useCallback,
   useEffect,
@@ -537,7 +538,9 @@ const useDashboardGridDnd: UseDashboardGridDndFunction = (
     if (element) {
       element.style.transition = "none";
       element.style.willChange = "transform, width, height";
-      element.style.zIndex = "60";
+      element.style.zIndex = String(
+        DashboardStackingLayers.canvasDraggingComponent,
+      );
     }
 
     document.body.style.userSelect = "none";


### PR DESCRIPTION
Fixes #3660.

## What was wrong

Clicking a widget on a dashboard selects it — in view mode too, where selection has no other visible effect at all — and the canvas raises the selected widget so its ring and its resize handles clear the neighbours they overhang.

That raise was fine. What was missing was a boundary. Nothing between the widget's wrapper and the document created a stacking context, so the canvas's "above my neighbours on the board" ended up resolved against the toolbar menu's "above the toolbar card" in the **root** stacking context — and the bigger number won:

| canvas | selected widget | auto-refresh menu | painted on top |
| --- | --- | --- | --- |
| no boundary | `auto` | `z-10` | menu |
| no boundary | **20** | **10** | **widget — the report** |
| no boundary | 20 | 50 | menu |
| no boundary | **60** (mid-drag) | **50** | **widget** |
| **`isolation: isolate`** | any | any | **menu, every time** |

Measured in a browser on a DOM mirroring the real nesting, not reasoned about. Note the fourth row: raising the menu on its own would not have been a fix.

That also explains the workaround in the report. Clicking a widget further down does not change the layering — it just moves the raised box out from under the menu, and drops the raise from the one that was under it.

## The fix

The canvas positioner isolates. Every layer inside it is then a statement about the other things on the board, and cannot reach the page however large it grows.

This closes the half of the bug nobody filed, too. Both of the canvas's numbers were competing with the app's own chrome:

- a **selected** widget (20) outranked the sticky header (`z-10`) — scroll a board with a widget clicked and it rides up over the navbar;
- a widget **mid-drag** (60) outranked the header, SideOver (30), the AI chat panel (40) and every dialog that opens over a board while it is being edited (50) — Add Widget, Variables, the discard confirmation, and the widget settings dialog. The elevation is held for a further 260 ms after the drop, so this is not only about the frames the pointer is down for.

The four layers either side of that boundary now come from one scale in `Common/UI/Utils/DashboardStackingLayers`, because a relationship written as `z-10` in one file and `zIndex: 20` in another is exactly what broke here. The auto-refresh menu — which is hand-rolled rather than a `MoreMenu`, which is how it drifted in the first place — moves onto the layer `MoreMenu` already uses, so the two menus in that one toolbar stop disagreeing about how high a menu opens.

The public dashboard mounts the same canvas and gains the boundary for free. It never reproduced the report: it hardcodes `selectedComponentId={null}` and has no edit mode, so it never emits a layer at all.

`isolate` is the repo's existing answer to this shape — `GanttChart/ChartContainer.tsx` uses the same inline form for the same reason, and the chart and map canvases use the class form. It is also the one property whose only job is to open a stacking context: it changes no layout, clips nothing, and does not become the containing block for `position: fixed` descendants, so portalled popups and fullscreen are untouched.

## Tests

36 new, at three levels.

**`Common/Tests/App/Dashboard/DashboardToolbarPopupLayering.test.tsx`** — the regression test. Renders the real toolbar and the real canvas nested as the shell nests them, performs the gesture from the report, and asserts the painting order over the rendered DOM with a model of CSS 2.1 Appendix E. **Verified to fail 7 of its 10 against the pre-fix sources**, and two of its cases take the isolation away at runtime so the rest cannot pass for free.

**`App/Tests/Dashboard/DashboardCanvasLayering.test.ts`** — source pins, in the `MapChromeHeaderLayering` idiom (App's suite has no DOM, and no stylesheet is loaded even under jsdom, so a Tailwind class is not something a test can resolve). Pins the isolation to the positioner **and nowhere else** — isolating the wrapper above it would trap the widget settings dialog, which the canvas deliberately renders outside the positioner — pins every layer to the shared scale, and reads the app's chrome numbers out of their own components so the "why the boundary is load-bearing" assertions move when the chrome does. Also pins the public dashboard's immunity, which lives in its props rather than in any file the canvas can see.

**`Common/Tests/UI/Utils/DashboardStackingLayers.test.ts`** — the arithmetic on its own, with `MoreMenu`'s and `Modal`'s layers read from source rather than written down.

`Common/Tests/UI/Utils/UseDashboardGridDnd.test.tsx` drops its two hard-coded `"60"` literals for the constant.

## Verification

- 36 new tests pass; the RTL suite fails 7/10 against the pre-fix sources.
- Existing suites green: `UseDashboardGridDnd` (30), `MapChromeHeaderLayering` + `NetworkTopologyPanelLayering` (29), `DashboardEditPermissions` + `DashboardVariablesDiscard` (30), `DashboardTimeRangeZoomWiring`, `DashboardWriteEntryPointInvariants`.
- `tsc` clean in `Common` and in `App/FeatureSet/Dashboard`; eslint clean on every touched file.

## Left alone on purpose

`Common/UI/Components/Dashboard/DashboardVariableControl.tsx` is the other toolbar popup and is still at `z-30`. It is not broken — the canvas can no longer compete with it either — and moving it to 50 would change how it stacks against SideOver and the AI chat panel, which is a separate decision from this bug.
