### PR TITLE
Fix master test failures and SaaS billing fixtures

### DIFF
--- a/App/FeatureSet/Dashboard/src/Utils/Breadcrumbs/IncidentBreadcrumbs.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Breadcrumbs/IncidentBreadcrumbs.ts
@@ -208,13 +208,10 @@ export function getIncidentsBreadcrumbs(path: string): Array<Link> | undefined {
       "View Episode",
       "Owners",
     ]),
-    ...BuildBreadcrumbLinksByTitles(PageMap.INCIDENT_EPISODE_VIEW_STATE_TIMELINE, [
-      "Project",
-      "Incidents",
-      "Episodes",
-      "View Episode",
-      "State Timeline",
-    ]),
+    ...BuildBreadcrumbLinksByTitles(
+      PageMap.INCIDENT_EPISODE_VIEW_STATE_TIMELINE,
+      ["Project", "Incidents", "Episodes", "View Episode", "State Timeline"],
+    ),
     ...BuildBreadcrumbLinksByTitles(PageMap.INCIDENT_EPISODE_VIEW_INCIDENTS, [
       "Project",
       "Incidents",
@@ -222,13 +219,10 @@ export function getIncidentsBreadcrumbs(path: string): Array<Link> | undefined {
       "View Episode",
       "Incidents",
     ]),
-    ...BuildBreadcrumbLinksByTitles(PageMap.INCIDENT_EPISODE_VIEW_INTERNAL_NOTE, [
-      "Project",
-      "Incidents",
-      "Episodes",
-      "View Episode",
-      "Private Notes",
-    ]),
+    ...BuildBreadcrumbLinksByTitles(
+      PageMap.INCIDENT_EPISODE_VIEW_INTERNAL_NOTE,
+      ["Project", "Incidents", "Episodes", "View Episode", "Private Notes"],
+    ),
     ...BuildBreadcrumbLinksByTitles(PageMap.INCIDENT_EPISODE_VIEW_PUBLIC_NOTE, [
       "Project",
       "Incidents",

--- a/App/FeatureSet/Dashboard/src/Utils/Breadcrumbs/ScheduledMaintenanceBreadcrumbs.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Breadcrumbs/ScheduledMaintenanceBreadcrumbs.ts
@@ -117,18 +117,24 @@ export function getScheduleMaintenanceBreadcrumbs(
         "Notification Logs",
       ],
     ),
-    ...BuildBreadcrumbLinksByTitles(PageMap.SCHEDULED_MAINTENANCE_VIEW_AI_LOGS, [
-      "Project",
-      "Scheduled Maintenance Events",
-      "View Scheduled Maintenance Event",
-      "AI Logs",
-    ]),
-    ...BuildBreadcrumbLinksByTitles(PageMap.SCHEDULED_MAINTENANCE_VIEW_RUNBOOKS, [
-      "Project",
-      "Scheduled Maintenance Events",
-      "View Scheduled Maintenance Event",
-      "Runbooks",
-    ]),
+    ...BuildBreadcrumbLinksByTitles(
+      PageMap.SCHEDULED_MAINTENANCE_VIEW_AI_LOGS,
+      [
+        "Project",
+        "Scheduled Maintenance Events",
+        "View Scheduled Maintenance Event",
+        "AI Logs",
+      ],
+    ),
+    ...BuildBreadcrumbLinksByTitles(
+      PageMap.SCHEDULED_MAINTENANCE_VIEW_RUNBOOKS,
+      [
+        "Project",
+        "Scheduled Maintenance Events",
+        "View Scheduled Maintenance Event",
+        "Runbooks",
+      ],
+    ),
     ...BuildBreadcrumbLinksByTitles(
       PageMap.SCHEDULED_MAINTENANCE_VIEW_AUDIT_LOGS,
       [

--- a/App/Tests/FeatureSet/PostFrontendRouteReservation.test.ts
+++ b/App/Tests/FeatureSet/PostFrontendRouteReservation.test.ts
@@ -316,6 +316,16 @@ describe("the derivation itself is sound", () => {
       "/server-monitor-ingest/server-monitor/queue/stats",
     );
     expect(paths).toContain("/workflow/model-schema/:tableName");
+
+    // Both static prefixes of the docs redirect loop must enter the guard.
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        "/docs/as-markdown/:lang/self-hosted/integration-network-access",
+        "/docs/:lang/self-hosted/integration-network-access",
+        "/docs/as-markdown/self-hosted/integration-network-access",
+        "/docs/self-hosted/integration-network-access",
+      ]),
+    );
   });
 
   test("it read routers behind every mount idiom the repo uses", () => {

--- a/App/Tests/FeatureSet/RouteReservationSource.test.ts
+++ b/App/Tests/FeatureSet/RouteReservationSource.test.ts
@@ -580,6 +580,89 @@ describe("scanAppGetPaths", () => {
     expect(result.getPaths).toEqual(["/docs", "/docs/zh/*"]);
   });
 
+  test("expands every docs redirect prefix registered in a const for-of loop", () => {
+    const result: ReturnType<typeof scanAppGetPaths> = scanAppGetPaths(
+      fixture(
+        [
+          'for (const prefix of ["/docs/as-markdown", "/docs"]) {',
+          "  app.get(`${prefix}/:lang/self-hosted/integration-network-access`, handler);",
+          "  app.get(`${prefix}/self-hosted/integration-network-access`, handler);",
+          "}",
+        ].join("\n"),
+      ),
+    );
+
+    expect(result.getPaths).toEqual([
+      "/docs/as-markdown/:lang/self-hosted/integration-network-access",
+      "/docs/:lang/self-hosted/integration-network-access",
+      "/docs/as-markdown/self-hosted/integration-network-access",
+      "/docs/self-hosted/integration-network-access",
+    ]);
+    expect(result.unreadable).toEqual([]);
+  });
+
+  test("resolves reused loop names from the enclosing loop only", () => {
+    const result: ReturnType<typeof scanAppGetPaths> = scanAppGetPaths(
+      fixture(
+        [
+          'for (const prefix of ["/first", "/second"]) {',
+          "  app.get(prefix, handler);",
+          "}",
+          'for (const prefix of ["/third"]) {',
+          "  app.get(`${prefix}/page`, handler);",
+          "}",
+          "app.get(`${prefix}/outside-loop`, handler);",
+        ].join("\n"),
+      ),
+    );
+
+    expect(result.getPaths).toEqual(["/first", "/second", "/third/page"]);
+    expect(result.unreadable).toHaveLength(1);
+    expect(result.unreadable[0]?.text).toContain("outside-loop");
+  });
+
+  test.each([
+    "const prefix of loadPrefixes()",
+    'const prefix of ["/docs", unknownPrefix]',
+    'let prefix of ["/docs"]',
+  ])("reports an unresolved loop binding: %s", (binding: string) => {
+    const result: ReturnType<typeof scanAppGetPaths> = scanAppGetPaths(
+      fixture(
+        [
+          'const prefix = "/unrelated";',
+          `for (${binding}) {`,
+          "  app.get(`${prefix}/page`, handler);",
+          "}",
+        ].join("\n"),
+      ),
+    );
+
+    expect(result.getPaths).toEqual([]);
+    expect(result.unreadable).toHaveLength(1);
+    expect(result.unreadable[0]?.reason).toMatch(/not statically resolvable/);
+  });
+
+  test.each([
+    '{ const prefix = "/other"; app.get(`${prefix}/page`, handler); }',
+    "{ const { prefix } = config; app.get(`${prefix}/page`, handler); }",
+    "register((prefix) => { app.get(`${prefix}/page`, handler); });",
+    "for (const [prefix] of nestedPrefixes) { app.get(`${prefix}/page`, handler); }",
+    "switch (mode) { case 1: const prefix = loadPrefix(); app.get(`${prefix}/page`, handler); }",
+    "switch (mode) { default: const prefix = loadPrefix(); app.get(`${prefix}/page`, handler); }",
+    "register(function prefix() { app.get(`${prefix}/page`, handler); });",
+  ])(
+    "does not substitute an outer loop for a shadowed binding: %s",
+    (body: string) => {
+      const result: ReturnType<typeof scanAppGetPaths> = scanAppGetPaths(
+        fixture(`for (const prefix of ["/docs"]) { ${body} }`),
+      );
+
+      expect(result.getPaths).toEqual([]);
+      expect(result.unreadable).toHaveLength(1);
+      expect(result.unreadable[0]?.reason).toMatch(/not statically resolvable/);
+    },
+  );
+
   test("does not pick up router.get", () => {
     expect(
       scanAppGetPaths(fixture('router.get("/x", handler);')).getPaths,

--- a/App/Tests/FeatureSet/RouteReservationSource.ts
+++ b/App/Tests/FeatureSet/RouteReservationSource.ts
@@ -295,11 +295,148 @@ function stringConstant(
   return null;
 }
 
+function bindingContainsName(binding: ts.BindingName, name: string): boolean {
+  if (ts.isIdentifier(binding)) {
+    return binding.text === name;
+  }
+
+  return binding.elements.some(
+    (element: ts.BindingElement | ts.OmittedExpression): boolean => {
+      return (
+        ts.isBindingElement(element) && bindingContainsName(element.name, name)
+      );
+    },
+  );
+}
+
+function scopeShadowsName(scope: ts.Node, name: string): boolean {
+  if (ts.isBlock(scope) || ts.isCaseBlock(scope)) {
+    const statements: Array<ts.Statement> = [];
+
+    if (ts.isBlock(scope)) {
+      statements.push(...scope.statements);
+    } else {
+      // Every switch clause shares the case block's lexical scope.
+      for (const clause of scope.clauses) {
+        statements.push(...clause.statements);
+      }
+    }
+
+    return statements.some((statement: ts.Statement): boolean => {
+      if (ts.isVariableStatement(statement)) {
+        return statement.declarationList.declarations.some(
+          (declaration: ts.VariableDeclaration): boolean => {
+            return bindingContainsName(declaration.name, name);
+          },
+        );
+      }
+
+      return (
+        (ts.isFunctionDeclaration(statement) ||
+          ts.isClassDeclaration(statement)) &&
+        statement.name?.text === name
+      );
+    });
+  }
+
+  if (ts.isFunctionLike(scope)) {
+    if (ts.isFunctionExpression(scope) && scope.name?.text === name) {
+      return true;
+    }
+
+    return scope.parameters.some(
+      (parameter: ts.ParameterDeclaration): boolean => {
+        return bindingContainsName(parameter.name, name);
+      },
+    );
+  }
+
+  if (ts.isCatchClause(scope) && scope.variableDeclaration) {
+    return bindingContainsName(scope.variableDeclaration.name, name);
+  }
+
+  if (
+    (ts.isForStatement(scope) || ts.isForInStatement(scope)) &&
+    scope.initializer &&
+    ts.isVariableDeclarationList(scope.initializer)
+  ) {
+    return scope.initializer.declarations.some(
+      (declaration: ts.VariableDeclaration): boolean => {
+        return bindingContainsName(declaration.name, name);
+      },
+    );
+  }
+
+  return false;
+}
+
+/*
+ * A const for-of binding takes each literal value in its enclosing loop.
+ * Resolve it from ancestors, so separate loops using the same binding name
+ * do not borrow each other's prefixes. Unknown iterables remain unreadable.
+ * undefined means no loop binding; null means a binding we cannot resolve.
+ */
+function forOfStringValues(
+  identifier: ts.Identifier,
+): Array<string> | null | undefined {
+  let child: ts.Node = identifier;
+  let shadowed: boolean = false;
+
+  while (child.parent) {
+    const parent: ts.Node = child.parent;
+
+    if (
+      ts.isForOfStatement(parent) &&
+      parent.statement === child &&
+      ts.isVariableDeclarationList(parent.initializer) &&
+      parent.initializer.declarations.some(
+        (declaration: ts.VariableDeclaration): boolean => {
+          return bindingContainsName(declaration.name, identifier.text);
+        },
+      )
+    ) {
+      if (
+        shadowed ||
+        !(parent.initializer.flags & ts.NodeFlags.Const) ||
+        !parent.initializer.declarations.every(
+          (declaration: ts.VariableDeclaration): boolean => {
+            return ts.isIdentifier(declaration.name);
+          },
+        ) ||
+        !ts.isArrayLiteralExpression(parent.expression)
+      ) {
+        return null;
+      }
+
+      const values: Array<string> = [];
+
+      for (const element of parent.expression.elements) {
+        if (
+          !ts.isStringLiteral(element) &&
+          !ts.isNoSubstitutionTemplateLiteral(element)
+        ) {
+          return null;
+        }
+
+        values.push(element.text);
+      }
+
+      return values;
+    }
+
+    shadowed = shadowed || scopeShadowsName(parent, identifier.text);
+    child = parent;
+  }
+
+  return undefined;
+}
+
 /*
  * Resolve an expression used as a mount path to the concrete string(s) it
  * produces, or null when that cannot be known from this file alone.
  * Handles the forms this codebase actually uses: "/x", `/${CONST}`,
- * ["/a", "/b"], a named Array<string>, and spreads inside those.
+ * ["/a", "/b"], a named Array<string>, spreads inside those, and const
+ * for-of bindings over literal string arrays.
  */
 function staticMountPaths(
   sourceFile: ts.SourceFile,
@@ -310,26 +447,41 @@ function staticMountPaths(
   }
 
   if (ts.isTemplateExpression(node)) {
-    let text: string = node.head.text;
+    let paths: Array<string> = [node.head.text];
 
     for (const span of node.templateSpans) {
       if (!ts.isIdentifier(span.expression)) {
         return null;
       }
 
-      const value: string | null = stringConstant(
-        sourceFile,
-        span.expression.text,
+      let values: Array<string> | null | undefined = forOfStringValues(
+        span.expression,
       );
 
-      if (value === null) {
+      if (values === undefined) {
+        const value: string | null = stringConstant(
+          sourceFile,
+          span.expression.text,
+        );
+        values = value === null ? null : [value];
+      }
+
+      if (values === null) {
         return null;
       }
 
-      text += value + span.literal.text;
+      const expanded: Array<string> = [];
+
+      for (const prefix of paths) {
+        for (const value of values) {
+          expanded.push(prefix + value + span.literal.text);
+        }
+      }
+
+      paths = expanded;
     }
 
-    return [text];
+    return paths;
   }
 
   if (ts.isArrayLiteralExpression(node)) {
@@ -366,6 +518,13 @@ function staticMountPaths(
   }
 
   if (ts.isIdentifier(node)) {
+    const loopValues: Array<string> | null | undefined =
+      forOfStringValues(node);
+
+    if (loopValues !== undefined) {
+      return loopValues;
+    }
+
     const initializer: ts.Expression | null = findVariableInitializer(
       sourceFile,
       node.text,

--- a/Common/Tests/App/Dashboard/BreadcrumbCoverage.test.tsx
+++ b/Common/Tests/App/Dashboard/BreadcrumbCoverage.test.tsx
@@ -92,16 +92,21 @@ afterEach(() => {
 });
 
 describe.each(products)("$name breadcrumb coverage", (product: Product) => {
-  // Use the router's inventory, not a second list of pages that can omit the
-  // same new page as the breadcrumb map.
+  /*
+   * Use the router's inventory, not a second list of pages that can omit the
+   * same new page as the breadcrumb map.
+   */
   test.each([product.landing, ...Object.keys(product.routes)])(
     "%s has a complete, navigable trail through the Page header",
     (page: string) => {
       const currentPath: string = visit(page);
-      const matchedPath: string = Navigation.getRoutePath(RouteUtil.getRoutes());
+      const matchedPath: string = Navigation.getRoutePath(
+        RouteUtil.getRoutes(),
+      );
       expect(matchedPath).toBe(RouteUtil.getRouteString(page));
 
-      const links: Array<Link> | undefined = product.getBreadcrumbs(matchedPath);
+      const links: Array<Link> | undefined =
+        product.getBreadcrumbs(matchedPath);
       expect(links).toBeDefined();
       expect(links!.length).toBeGreaterThanOrEqual(2);
       expect(links![0]?.title).toBe("Project");
@@ -122,12 +127,16 @@ describe.each(products)("$name breadcrumb coverage", (product: Product) => {
       const trail: HTMLElement = screen.getByRole("navigation", {
         name: "Breadcrumb",
       });
-      expect(within(trail).getAllByRole("listitem")).toHaveLength(links!.length);
+      expect(within(trail).getAllByRole("listitem")).toHaveLength(
+        links!.length,
+      );
       expect(trail).not.toHaveClass("hidden");
       expect(screen.getByText("Page content")).toBeInTheDocument();
-      within(trail).getAllByRole("link").forEach((anchor: HTMLElement) => {
-        expect(anchor.getAttribute("href")).not.toBe(currentPath);
-      });
+      within(trail)
+        .getAllByRole("link")
+        .forEach((anchor: HTMLElement) => {
+          expect(anchor.getAttribute("href")).not.toBe(currentPath);
+        });
     },
   );
 
@@ -172,7 +181,9 @@ describe("restored breadcrumb hierarchy", () => {
       parent: PageMap,
     ) => {
       visit(page);
-      const links: Array<Link> = getBreadcrumbs(RouteUtil.getRouteString(page))!;
+      const links: Array<Link> = getBreadcrumbs(
+        RouteUtil.getRouteString(page),
+      )!;
       expect(
         links.map((link: Link): string => {
           return link.title;

--- a/Common/Tests/UI/Components/Breadcrumbs.test.tsx
+++ b/Common/Tests/UI/Components/Breadcrumbs.test.tsx
@@ -29,8 +29,10 @@ describe("Breadcrumbs", () => {
       const nav: ReactTestInstance = testInstance.findByType("nav");
       const list: ReactTestInstance = testInstance.findByType("ol");
 
-      // JSDOM does not apply Tailwind media queries. Assert the classes that
-      // control visibility and wrapping instead of a misleading visibility check.
+      /*
+       * JSDOM does not apply Tailwind media queries. Assert the classes that
+       * control visibility and wrapping instead of a misleading visibility check.
+       */
       expect(nav.props["className"].split(" ")).toContain("block");
       expect(nav.props["className"]).not.toContain("hidden");
       expect(list.props["className"].split(" ")).toContain("flex-wrap");

--- a/Common/Tests/UI/MicrosoftTeams/MicrosoftTeamsMessagingEndpointGuidance.test.tsx
+++ b/Common/Tests/UI/MicrosoftTeams/MicrosoftTeamsMessagingEndpointGuidance.test.tsx
@@ -19,8 +19,8 @@ import MicrosoftTeamsIntegrationDocumentation from "../../../../App/FeatureSet/D
  * cheapest check an admin runs next — opening the messaging endpoint in a
  * browser — used to return "Page not found". So the docs are what has to
  * carry the diagnosis: the two directions are independent, a working alert
- * tests only one of them, and an empty Chats list is the confirmation rather
- * than a second unrelated bug.
+ * tests only one of them, and an empty Chats list calls for checking inbound
+ * delivery, authentication, and project mapping.
  *
  * These assertions are on prose because the failure was prose.
  */
@@ -174,20 +174,30 @@ describe("Self-hosted docs: the unreachable-endpoint troubleshooting section", (
     );
   });
 
-  test("states the single root cause up front", () => {
-    expect(section).toContain(
-      "**Azure Bot Service cannot reach your messaging endpoint.**",
+  test("identifies inbound delivery as a likely cause and names the checks up front", () => {
+    const introduction: string = section.trim().split("\n\n")[0]!;
+
+    expect(introduction).toContain("These symptoms often mean");
+    expect(introduction).toContain(
+      "**Azure Bot Service cannot deliver authenticated activities to your messaging endpoint**",
     );
-    expect(section).toContain("These are one failure, not two");
+    expect(introduction).toContain(
+      "Check routing, bot authentication, and project configuration",
+    );
+    expect(introduction).not.toContain("These are one failure, not two");
   });
 
   test("explains that a working alert card tests the opposite direction", () => {
     const lowered: string = section.toLowerCase();
 
     expect(lowered).toContain("oneuptime calls microsoft");
-    expect(lowered).toMatch(
-      /tells you nothing at all about the bot endpoint|working alert/,
+    expect(lowered).toContain(
+      "a working alert verifies that particular outbound send",
     );
+    expect(lowered).toContain(
+      "it does not verify every graph permission or the inbound bot endpoint",
+    );
+    expect(lowered).not.toContain("graph permissions are fine");
   });
 
   test("tabulates which paths need inbound access and which do not", () => {
@@ -216,11 +226,17 @@ describe("Self-hosted docs: the unreachable-endpoint troubleshooting section", (
     ).toBeGreaterThanOrEqual(3);
   });
 
-  test("explains why the empty Chats list confirms the diagnosis", () => {
+  test("explains what an empty Chats list means and what Refresh Chats reads", () => {
     const lowered: string = section.toLowerCase();
 
-    expect(lowered).toContain("refresh chats");
-    expect(lowered).toContain("application permissions");
+    expect(lowered).toContain("no chat has been recorded for that project");
+    expect(lowered).toContain(
+      "check incoming requests, authentication errors, and tenant/project mapping",
+    );
+    expect(lowered).toContain(
+      "**refresh chats** re-reads oneuptime's stored chats",
+    );
+    expect(lowered).not.toContain("no bot activity has ever been received");
   });
 
   test("names all three activities that register a chat, not just the install event", () => {
@@ -238,7 +254,7 @@ describe("Self-hosted docs: the unreachable-endpoint troubleshooting section", (
 
     expect(lowered).toContain("installed");
     expect(lowered).toContain("added to the conversation");
-    expect(lowered).toContain("any message sent to the bot");
+    expect(lowered).toContain("a message sent to the bot in that chat");
   });
 
   test("the inbound table describes chat registration as an activity, not an install event", () => {
@@ -255,6 +271,21 @@ describe("Self-hosted docs: the unreachable-endpoint troubleshooting section", (
   test("tells the admin to grep for the POST rather than the 404", () => {
     expect(section).toContain("Look for the POST, not for 404s");
     expect(section).toContain("grep 'POST /api/microsoft-bot/messages'");
+  });
+
+  test("checks log coverage when POSTs are absent and processing errors when they arrive", () => {
+    const lowered: string = section.toLowerCase();
+
+    expect(lowered).toContain(
+      "if there are no post lines, confirm that the correct access log is recording requests",
+    );
+    expect(lowered).toContain(
+      "check the configured azure endpoint and the network path",
+    );
+    expect(lowered).toContain(
+      "if posts arrive, inspect their responses and oneuptime's authentication or project-mapping errors",
+    );
+    expect(lowered).not.toContain("nothing inside oneuptime is at fault");
   });
 
   test("covers the certificate chain, with a command that checks it", () => {

--- a/E2E/README.md
+++ b/E2E/README.md
@@ -39,6 +39,13 @@ export HTTP_PROTOCOL=https
 export BILLING_ENABLED=true
 ```
 
+Billing-enabled feature tests require Stripe **test-mode** keys on the server.
+The shared project fixture adds Stripe's test Visa through the billing UI and
+confirms paid usage is enabled before creating monitors or telemetry keys.
+It refuses payment setup unless the dashboard's publishable key starts with
+`pk_test_`. Billing tests can pass `enablePaidUsage: false` to
+`registerAndCreateProject` to exercise the initial state without a card.
+
 ## Running Tests
 
 ### Run all tests

--- a/E2E/Tests/Dashboard/BillingPaidUsage.spec.ts
+++ b/E2E/Tests/Dashboard/BillingPaidUsage.spec.ts
@@ -1,0 +1,59 @@
+import { BASE_URL, IS_BILLING_ENABLED } from "../../Config";
+import { addTestPaymentMethod } from "./Helpers/Billing";
+import { registerAndCreateProject } from "./Helpers/ProductOnboarding";
+import { createTelemetryIngestionKey } from "./Helpers/Telemetry";
+import { APIResponse, Page, expect, test } from "@playwright/test";
+import URL from "Common/Types/API/URL";
+
+test.describe("Payment method authorizes paid usage", () => {
+  test.skip(!IS_BILLING_ENABLED, "Requires Stripe test-mode billing.");
+
+  for (const planName of ["Free", "Growth"]) {
+    test(`${planName} project can create paid resources only after adding a payment method`, async ({
+      page,
+    }: {
+      page: Page;
+    }) => {
+      test.setTimeout(300000);
+
+      const projectId: string = await registerAndCreateProject({
+        page,
+        projectNamePrefix: `E2E Billing ${planName}`,
+        preferredPlanName: planName,
+        enablePaidUsage: false,
+      });
+
+      try {
+        const blockedResponse: APIResponse = await page.request.post(
+          URL.fromString(BASE_URL.toString())
+            .addRoute("/api/telemetry-ingestion-key")
+            .toString(),
+          {
+            headers: { tenantid: projectId },
+            data: { data: { name: "Key before payment method", projectId } },
+          },
+        );
+        expect(blockedResponse.status()).toBe(402);
+        expect(await blockedResponse.json()).toMatchObject({
+          error: expect.stringContaining("Add a payment method"),
+        });
+
+        await addTestPaymentMethod({ page, projectId });
+        await createTelemetryIngestionKey({
+          page,
+          projectId,
+          keyName: "Key after payment method",
+        });
+      } finally {
+        // Project deletion also cancels its Stripe test subscriptions.
+        const deleteResponse: APIResponse = await page.request.delete(
+          URL.fromString(BASE_URL.toString())
+            .addRoute(`/api/project/${projectId}`)
+            .toString(),
+          { headers: { tenantid: projectId } },
+        );
+        expect(deleteResponse.ok()).toBe(true);
+      }
+    });
+  }
+});

--- a/E2E/Tests/Dashboard/Helpers/Billing.ts
+++ b/E2E/Tests/Dashboard/Helpers/Billing.ts
@@ -1,0 +1,104 @@
+import { BASE_URL, IS_BILLING_ENABLED } from "../../../Config";
+import { gotoProjectPage } from "./ProductOnboarding";
+import {
+  APIResponse,
+  FrameLocator,
+  Locator,
+  Page,
+  expect,
+} from "@playwright/test";
+import URL from "Common/Types/API/URL";
+
+type ProjectBillingFunction = (data: {
+  page: Page;
+  projectId: string;
+}) => Promise<void>;
+
+/*
+ * A subscription (including a paid-plan trial) does not authorize metered
+ * usage. Give feature-test projects a real Stripe test payment method through
+ * the billing UI, including its usage consent, before creating paid resources.
+ * This must never submit payment details to a live Stripe account.
+ */
+export const addTestPaymentMethod: ProjectBillingFunction = async (data: {
+  page: Page;
+  projectId: string;
+}): Promise<void> => {
+  if (!IS_BILLING_ENABLED) {
+    return;
+  }
+
+  const page: Page = data.page;
+  const usesStripeTestMode: boolean = await page.evaluate((): boolean => {
+    const browserWindow: Window & {
+      process?: { env?: Record<string, string | undefined> };
+    } = window;
+    return Boolean(
+      browserWindow.process?.env?.["BILLING_PUBLIC_KEY"]?.startsWith(
+        "pk_test_",
+      ),
+    );
+  });
+  expect(
+    usesStripeTestMode,
+    "SaaS E2E payment setup requires a Stripe test-mode publishable key (pk_test_).",
+  ).toBe(true);
+
+  const billingUrl: string = URL.fromString(BASE_URL.toString())
+    .addRoute(`/dashboard/${data.projectId}/settings/billing`)
+    .toString();
+  const addPaymentMethodButton: Locator = page.getByRole("button", {
+    name: "Add Payment Method",
+    exact: true,
+  });
+
+  await gotoProjectPage({
+    page,
+    projectId: data.projectId,
+    url: billingUrl,
+    ready: addPaymentMethodButton,
+  });
+  await addPaymentMethodButton.click();
+
+  const modal: Locator = page.getByTestId("modal");
+  await expect(modal).toBeVisible();
+  await modal
+    .getByTestId("payment-method-usage-consent")
+    .check({ timeout: 60000 });
+
+  // Stripe's bank-search helper shares the title, even for a card-only form.
+  const paymentFrame: FrameLocator = modal.frameLocator(
+    'iframe[title="Secure payment input frame"]:not([aria-hidden="true"])',
+  );
+  await paymentFrame
+    .locator('input[name="number"]')
+    .fill("4242424242424242", { timeout: 60000 });
+  await paymentFrame
+    .locator('input[name="expiry"]')
+    .fill(`12${String(new Date().getFullYear() + 3).slice(-2)}`);
+  await paymentFrame.locator('input[name="cvc"]').fill("123");
+  await paymentFrame.locator('select[name="country"]').selectOption("US");
+  await paymentFrame.locator('input[name="postalCode"]').fill("10001");
+
+  await modal.getByTestId("modal-footer-submit-button").click();
+  await expect(modal).toBeHidden({ timeout: 60000 });
+  await expect(page.getByTestId("billing-usage-status")).toContainText(
+    "A payment method is on file.",
+    { timeout: 60000 },
+  );
+  await expect(
+    page.getByRole("row").filter({ hasText: "*****4242" }),
+  ).toBeVisible({
+    timeout: 60000,
+  });
+
+  // Verify the same server-side gate used by monitor creation and ingestion.
+  const statusResponse: APIResponse = await page.request.get(
+    URL.fromString(BASE_URL.toString())
+      .addRoute("/api/billing/pay-as-you-go-status")
+      .toString(),
+    { headers: { tenantid: data.projectId } },
+  );
+  expect(statusResponse.ok()).toBe(true);
+  expect(await statusResponse.json()).toMatchObject({ isAllowed: true });
+};

--- a/E2E/Tests/Dashboard/Helpers/ProductOnboarding.ts
+++ b/E2E/Tests/Dashboard/Helpers/ProductOnboarding.ts
@@ -3,6 +3,7 @@ import { Page, expect, Response, Locator } from "@playwright/test";
 import URL from "Common/Types/API/URL";
 import Faker from "Common/Utils/Faker";
 import selectProjectPlan from "../../Helpers/selectProjectPlan";
+import { addTestPaymentMethod } from "./Billing";
 
 const projectDashboardUrlRegex: RegExp =
   /\/dashboard\/([a-f0-9-]+)(?:\/home\/?)?$/;
@@ -22,6 +23,8 @@ type RegisterAndCreateProjectFunction = (data: {
    * Specs that touch plan-gated features need this.
    */
   preferredPlanName?: string | undefined;
+  // Billing regressions can opt out to exercise a project with no card.
+  enablePaidUsage?: boolean | undefined;
 }) => Promise<string>;
 
 export const registerAndCreateProject: RegisterAndCreateProjectFunction =
@@ -29,6 +32,7 @@ export const registerAndCreateProject: RegisterAndCreateProjectFunction =
     page: Page;
     projectNamePrefix: string;
     preferredPlanName?: string | undefined;
+    enablePaidUsage?: boolean | undefined;
   }): Promise<string> => {
     const page: Page = data.page;
 
@@ -118,7 +122,15 @@ export const registerAndCreateProject: RegisterAndCreateProjectFunction =
       projectDashboardUrlRegex,
     );
     expect(projectIdMatch).not.toBeNull();
-    return projectIdMatch![1]!;
+    const projectId: string = projectIdMatch![1]!;
+
+    if (IS_BILLING_ENABLED && data.enablePaidUsage !== false) {
+      await addTestPaymentMethod({ page, projectId });
+      await page.goto(projectUrl);
+      await expect(page).toHaveURL(projectDashboardUrlRegex);
+    }
+
+    return projectId;
   };
 
 /*


### PR DESCRIPTION
Master CI fails because its route inventory test cannot read the new loop-based docs redirects, the Teams guidance tests still expect the old diagnosis, and SaaS feature fixtures create paid resources without the payment method now required by billing.

- Resolve literal `const` loop prefixes in the route test scanner, retain failures for unknown or shadowed bindings, and cover the four docs redirects and scope regressions.
- Update Teams guidance assertions to check routing, authentication, project mapping, and log coverage without presenting those symptoms as proof of a single cause.
- Add a Stripe test-mode payment method through the billing UI when preparing SaaS feature projects. Add Free/Growth regressions for rejection before payment setup and success afterward, with project cleanup.
- Apply the breadcrumb formatting corrections reported by the lint job.

Validation: 430 relevant unit tests pass. App, Common, Dashboard, and E2E compilation pass. The full root `npm run fix` passes. An isolated Stripe PaymentElement check successfully filled all five fields and verified that the auxiliary hidden iframe is excluded. Full master CI will provide the end-to-end result against the current application; the running local development server has older billing behavior.
