### PR TITLE
fix(billing): recover payment reads from rate limits

### DIFF
--- a/Common/Server/Services/BillingService.ts
+++ b/Common/Server/Services/BillingService.ts
@@ -59,6 +59,14 @@ export const METERED_BILLING_START_METADATA_KEY: string =
  */
 const CANCEL_RETRY_DELAYS_IN_MS: Array<number> = [1000, 3000];
 
+const PAYMENT_METHOD_TYPES: Array<Stripe.PaymentMethodListParams.Type> = [
+  "card",
+  "sepa_debit",
+  "us_bank_account",
+  "bacs_debit",
+];
+const PAYMENT_READ_MAX_RETRIES: number = 3;
+
 export interface Invoice {
   id: string;
   amount: number;
@@ -1277,11 +1285,62 @@ export class BillingService extends BaseService {
 
   @CaptureSpan()
   public async hasPaymentMethods(customerId: string): Promise<boolean> {
-    if ((await this.getPaymentMethods(customerId)).length > 0) {
-      return true;
+    if (!this.isBillingEnabled()) {
+      throw new BadDataException(Errors.BillingService.BILLING_NOT_ENABLED);
+    }
+
+    // Eligibility needs one attached method, without fetching or changing defaults.
+    for (const type of PAYMENT_METHOD_TYPES) {
+      const methods: Stripe.ApiList<Stripe.PaymentMethod> =
+        await this.listPaymentMethods(customerId, type, 1);
+      if (methods.data.length > 0) {
+        return true;
+      }
     }
 
     return false;
+  }
+
+  private async readPaymentProvider<T>(read: () => Promise<T>): Promise<T> {
+    for (let attempt: number = 0; ; attempt++) {
+      try {
+        return await read();
+      } catch (err) {
+        const providerError: { statusCode?: number } = err as {
+          statusCode?: number;
+        };
+        if (
+          providerError?.statusCode !== 429 ||
+          attempt >= PAYMENT_READ_MAX_RETRIES
+        ) {
+          throw err;
+        }
+
+        // Stripe's network retries do not generally cover rate-limit responses.
+        // Retry only these reads; exhausted failures must still deny paid usage.
+        const delayInMs: number = Math.round(
+          1000 * 2 ** attempt * (1 + Math.random() / 2),
+        );
+        await Sleep.sleep(delayInMs);
+      }
+    }
+  }
+
+  private async listPaymentMethods(
+    customerId: string,
+    type: Stripe.PaymentMethodListParams.Type,
+    limit?: number,
+  ): Promise<Stripe.ApiList<Stripe.PaymentMethod>> {
+    const params: Stripe.PaymentMethodListParams = {
+      customer: customerId,
+      type,
+    };
+    if (limit !== undefined) {
+      params.limit = limit;
+    }
+    return this.readPaymentProvider(() => {
+      return this.stripe.paymentMethods.list(params);
+    });
   }
 
   /**
@@ -1340,31 +1399,20 @@ export class BillingService extends BaseService {
     if (!this.isBillingEnabled()) {
       throw new BadDataException(Errors.BillingService.BILLING_NOT_ENABLED);
     }
+
     const paymentMethods: Array<PaymentMethod> = [];
 
     const cardPaymentMethods: Stripe.ApiList<Stripe.PaymentMethod> =
-      await this.stripe.paymentMethods.list({
-        customer: customerId,
-        type: "card",
-      });
+      await this.listPaymentMethods(customerId, "card");
 
     const sepaPaymentMethods: Stripe.ApiList<Stripe.PaymentMethod> =
-      await this.stripe.paymentMethods.list({
-        customer: customerId,
-        type: "sepa_debit",
-      });
+      await this.listPaymentMethods(customerId, "sepa_debit");
 
     const usBankPaymentMethods: Stripe.ApiList<Stripe.PaymentMethod> =
-      await this.stripe.paymentMethods.list({
-        customer: customerId,
-        type: "us_bank_account",
-      });
+      await this.listPaymentMethods(customerId, "us_bank_account");
 
     const bacsPaymentMethods: Stripe.ApiList<Stripe.PaymentMethod> =
-      await this.stripe.paymentMethods.list({
-        customer: customerId,
-        type: "bacs_debit",
-      });
+      await this.listPaymentMethods(customerId, "bacs_debit");
 
     cardPaymentMethods.data.forEach((item: Stripe.PaymentMethod) => {
       paymentMethods.push({
@@ -1405,7 +1453,9 @@ export class BillingService extends BaseService {
     // check if there's a default payment method.
 
     const customer: Stripe.Response<Stripe.Customer | Stripe.DeletedCustomer> =
-      await this.stripe.customers.retrieve(customerId);
+      await this.readPaymentProvider(() => {
+        return this.stripe.customers.retrieve(customerId);
+      });
 
     const defaultPaymentMethod:
       | string
@@ -1603,7 +1653,9 @@ export class BillingService extends BaseService {
     }
 
     const subscription: Stripe.Response<Stripe.Subscription> =
-      await this.stripe.subscriptions.retrieve(subscriptionId);
+      await this.readPaymentProvider(() => {
+        return this.stripe.subscriptions.retrieve(subscriptionId);
+      });
 
     return subscription;
   }

--- a/Common/Tests/Server/Services/BillingService.test.ts
+++ b/Common/Tests/Server/Services/BillingService.test.ts
@@ -1244,30 +1244,34 @@ describe("BillingService", () => {
 
     describe("hasPaymentMethods", () => {
       it("should return true if the customer has payment methods", async () => {
-        billingService.getPaymentMethods =
-          getJestMockFunction().mockResolvedValue(mockPaymentMethods);
+        mockStripe.paymentMethods.list =
+          getJestMockFunction().mockResolvedValue({
+            data: mockPaymentMethods,
+          });
 
         const result: boolean =
           await billingService.hasPaymentMethods(customerId);
 
         expect(result).toBeTruthy();
-        expect(billingService.getPaymentMethods).toHaveBeenCalledWith(
-          customerId,
-        );
+        expect(mockStripe.paymentMethods.list).toHaveBeenCalledWith({
+          customer: customerId,
+          type: "card",
+          limit: 1,
+        });
+        expect(mockStripe.paymentMethods.list).toHaveBeenCalledTimes(1);
       });
 
       it("should return false if the customer does not have payment methods", async () => {
-        const mockEmptyPaymentMethods: PaymentMethod[] = Array<PaymentMethod>();
-        billingService.getPaymentMethods =
-          getJestMockFunction().mockResolvedValue(mockEmptyPaymentMethods);
+        mockStripe.paymentMethods.list =
+          getJestMockFunction().mockResolvedValue({
+            data: [],
+          });
 
         const result: boolean =
           await billingService.hasPaymentMethods(customerId);
 
         expect(result).toBeFalsy();
-        expect(billingService.getPaymentMethods).toHaveBeenCalledWith(
-          customerId,
-        );
+        expect(mockStripe.paymentMethods.list).toHaveBeenCalledTimes(4);
       });
     });
 

--- a/Common/Tests/Server/Services/BillingServicePaymentMethodReads.test.ts
+++ b/Common/Tests/Server/Services/BillingServicePaymentMethodReads.test.ts
@@ -1,0 +1,304 @@
+import { BillingService } from "../../../Server/Services/BillingService";
+import Errors from "../../../Server/Utils/Errors";
+import Sleep from "../../../Types/Sleep";
+import { getJestSpyOn } from "../../Spy";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import Stripe from "stripe";
+
+jest.mock("stripe", () => {
+  return jest.fn(() => {
+    return {};
+  });
+});
+jest.mock("../../../Server/Services/ProjectService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../Server/Services/MailService", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../Server/Services/PayAsYouGoBillingService", () => {
+  return { __esModule: true, default: {} };
+});
+
+const CUSTOMER_ID: string = "cus_read_test";
+const PAYMENT_TYPES: Array<Stripe.PaymentMethodListParams.Type> = [
+  "card",
+  "sepa_debit",
+  "us_bank_account",
+  "bacs_debit",
+];
+const CARD: Partial<Stripe.PaymentMethod> = {
+  id: "pm_card",
+  type: "card",
+  card: { brand: "visa", last4: "4242" } as Stripe.PaymentMethod.Card,
+};
+
+function providerError(statusCode: number): Error {
+  return Object.assign(new Error(`Stripe HTTP ${statusCode}`), { statusCode });
+}
+
+describe("BillingService payment-method reads", () => {
+  let service: BillingService;
+  let list: jest.Mock;
+  let retrieveCustomer: jest.Mock;
+  let retrieveSubscription: jest.Mock;
+  let updateCustomer: jest.Mock;
+  let sleep: jest.SpyInstance;
+
+  beforeEach(() => {
+    service = new BillingService();
+    list = jest
+      .fn()
+      .mockImplementation((params: Stripe.PaymentMethodListParams) => {
+        return Promise.resolve({ data: params.type === "card" ? [CARD] : [] });
+      });
+    retrieveCustomer = jest.fn().mockResolvedValue({
+      invoice_settings: { default_payment_method: "pm_card" },
+    });
+    retrieveSubscription = jest.fn().mockResolvedValue({ id: "sub_test" });
+    updateCustomer = jest.fn().mockResolvedValue({});
+    (service as unknown as { stripe: unknown }).stripe = {
+      paymentMethods: { list },
+      customers: { retrieve: retrieveCustomer, update: updateCustomer },
+      subscriptions: { retrieve: retrieveSubscription },
+    };
+    getJestSpyOn(service, "isBillingEnabled").mockReturnValue(true);
+    sleep = getJestSpyOn(Sleep, "sleep").mockResolvedValue(undefined);
+    getJestSpyOn(Math, "random").mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    "hasPaymentMethods",
+    "getPaymentMethods",
+    "getSubscription",
+  ] as const)(
+    "%s refuses billing-disabled access before any Stripe request",
+    async (
+      method: "hasPaymentMethods" | "getPaymentMethods" | "getSubscription",
+    ) => {
+      getJestSpyOn(service, "isBillingEnabled").mockReturnValue(false);
+      await expect(service[method](CUSTOMER_ID)).rejects.toThrow(
+        Errors.BillingService.BILLING_NOT_ENABLED,
+      );
+      expect(list).not.toHaveBeenCalled();
+      expect(retrieveCustomer).not.toHaveBeenCalled();
+      expect(retrieveSubscription).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(PAYMENT_TYPES)(
+    "accepts an attached %s method and stops requesting other types",
+    async (type: Stripe.PaymentMethodListParams.Type) => {
+      list.mockImplementation((params: Stripe.PaymentMethodListParams) => {
+        return Promise.resolve({
+          data: params.type === type ? [{ id: "pm_attached" }] : [],
+        });
+      });
+      await expect(service.hasPaymentMethods(CUSTOMER_ID)).resolves.toBe(true);
+      expect(list.mock.calls).toEqual(
+        PAYMENT_TYPES.slice(0, PAYMENT_TYPES.indexOf(type) + 1).map(
+          (requestedType: Stripe.PaymentMethodListParams.Type) => {
+            return [{ customer: CUSTOMER_ID, type: requestedType, limit: 1 }];
+          },
+        ),
+      );
+      expect(retrieveCustomer).not.toHaveBeenCalled();
+      expect(updateCustomer).not.toHaveBeenCalled();
+    },
+  );
+
+  it("returns false only after every supported type has been checked", async () => {
+    list.mockResolvedValue({ data: [] });
+    await expect(service.hasPaymentMethods(CUSTOMER_ID)).resolves.toBe(false);
+    expect(list.mock.calls).toEqual(
+      PAYMENT_TYPES.map((type: Stripe.PaymentMethodListParams.Type) => {
+        return [{ customer: CUSTOMER_ID, type, limit: 1 }];
+      }),
+    );
+    expect(retrieveCustomer).not.toHaveBeenCalled();
+    expect(updateCustomer).not.toHaveBeenCalled();
+  });
+
+  it("observes a newly attached card and its subsequent removal without caching", async () => {
+    list.mockResolvedValue({ data: [] });
+    await expect(service.hasPaymentMethods(CUSTOMER_ID)).resolves.toBe(false);
+    list.mockResolvedValue({ data: [CARD] });
+    await expect(service.hasPaymentMethods(CUSTOMER_ID)).resolves.toBe(true);
+    list.mockResolvedValue({ data: [] });
+    await expect(service.hasPaymentMethods(CUSTOMER_ID)).resolves.toBe(false);
+    expect(list).toHaveBeenCalledTimes(9);
+  });
+
+  it("does not turn an unreadable bank-method list into missing payment authorization", async () => {
+    const failure: Error = providerError(429);
+    list.mockResolvedValueOnce({ data: [] }).mockRejectedValue(failure);
+    await expect(service.hasPaymentMethods(CUSTOMER_ID)).rejects.toBe(failure);
+    expect(list).toHaveBeenCalledTimes(5);
+    expect(list.mock.calls.slice(1)).toEqual(
+      Array.from({ length: 4 }, () => {
+        return [{ customer: CUSTOMER_ID, type: "sepa_debit", limit: 1 }];
+      }),
+    );
+  });
+
+  describe.each(["list", "customer", "subscription"] as const)(
+    "%s read retries",
+    (readType: "list" | "customer" | "subscription") => {
+      let request: jest.Mock;
+      let run: () => Promise<unknown>;
+
+      beforeEach(() => {
+        request =
+          readType === "list"
+            ? list
+            : readType === "customer"
+              ? retrieveCustomer
+              : retrieveSubscription;
+        run = (): Promise<unknown> => {
+          return readType === "list"
+            ? service.hasPaymentMethods(CUSTOMER_ID)
+            : readType === "customer"
+              ? service.getPaymentMethods(CUSTOMER_ID)
+              : service.getSubscription("sub_test");
+        };
+      });
+
+      it("recovers from 429 with bounded exponential backoff and jitter", async () => {
+        const failure: Error = providerError(429);
+        request
+          .mockRejectedValueOnce(failure)
+          .mockRejectedValueOnce(failure)
+          .mockRejectedValueOnce(failure);
+        await expect(run()).resolves.toBeDefined();
+        expect(request).toHaveBeenCalledTimes(4);
+        expect(sleep.mock.calls).toEqual([[1250], [2500], [5000]]);
+      });
+
+      it("propagates the exact error after exhausting 429 retries", async () => {
+        const failure: Error = providerError(429);
+        request.mockRejectedValue(failure);
+        await expect(run()).rejects.toBe(failure);
+        expect(request).toHaveBeenCalledTimes(4);
+        expect(sleep).toHaveBeenCalledTimes(3);
+        expect(updateCustomer).not.toHaveBeenCalled();
+      });
+
+      it.each([400, 401, 404, 500])(
+        "does not retry HTTP %s",
+        async (status: number) => {
+          const failure: Error = providerError(status);
+          request.mockRejectedValue(failure);
+          await expect(run()).rejects.toBe(failure);
+          expect(request).toHaveBeenCalledTimes(1);
+          expect(sleep).not.toHaveBeenCalled();
+        },
+      );
+
+      it("keeps the next lookup fresh after a previous failure", async () => {
+        const failure: Error = providerError(500);
+        request.mockRejectedValueOnce(failure);
+        await expect(run()).rejects.toBe(failure);
+        await expect(run()).resolves.toBeDefined();
+        expect(request).toHaveBeenCalledTimes(2);
+      });
+    },
+  );
+
+  it("retries only the failed list without repeating earlier successful reads", async () => {
+    const failure: Error = providerError(429);
+    list.mockResolvedValueOnce({ data: [CARD] }).mockRejectedValueOnce(failure);
+    await expect(service.getPaymentMethods(CUSTOMER_ID)).resolves.toEqual([
+      { id: "pm_card", type: "visa", last4Digits: "4242", isDefault: true },
+    ]);
+    expect(
+      list.mock.calls.map((call: [Stripe.PaymentMethodListParams]) => {
+        return call[0].type;
+      }),
+    ).toEqual([
+      "card",
+      "sepa_debit",
+      "sepa_debit",
+      "us_bank_account",
+      "bacs_debit",
+    ]);
+    expect(
+      list.mock.calls.every((call: [Stripe.PaymentMethodListParams]) => {
+        return call[0].limit === undefined;
+      }),
+    ).toBe(true);
+  });
+
+  it("sets the default once after a retried customer read", async () => {
+    retrieveCustomer
+      .mockRejectedValueOnce(providerError(429))
+      .mockResolvedValue({
+        invoice_settings: { default_payment_method: null },
+      });
+    await expect(service.getPaymentMethods(CUSTOMER_ID)).resolves.toEqual([
+      { id: "pm_card", type: "visa", last4Digits: "4242", isDefault: true },
+    ]);
+    expect(list).toHaveBeenCalledTimes(4);
+    expect(retrieveCustomer).toHaveBeenCalledTimes(2);
+    expect(updateCustomer).toHaveBeenCalledTimes(1);
+    expect(updateCustomer).toHaveBeenCalledWith(CUSTOMER_ID, {
+      invoice_settings: { default_payment_method: "pm_card" },
+    });
+  });
+
+  it("never retries a default-payment-method mutation, even on 429", async () => {
+    const failure: Error = providerError(429);
+    retrieveCustomer.mockResolvedValue({
+      invoice_settings: { default_payment_method: null },
+    });
+    updateCustomer.mockRejectedValue(failure);
+    await expect(service.getPaymentMethods(CUSTOMER_ID)).rejects.toBe(failure);
+    expect(updateCustomer).toHaveBeenCalledTimes(1);
+    expect(retrieveCustomer).toHaveBeenCalledTimes(1);
+    expect(list).toHaveBeenCalledTimes(4);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("does not reuse a partially fetched pre-confirmation payment-method list", async () => {
+    let cardAttached: boolean = false;
+    let firstSepaRead: boolean = true;
+    let finishSepa: (value: { data: [] }) => void = () => {
+      return;
+    };
+    let signalSepaStarted: () => void = () => {
+      return;
+    };
+    const sepaPending: Promise<{ data: [] }> = new Promise((resolve) => {
+      finishSepa = resolve;
+    });
+    const sepaStarted: Promise<void> = new Promise((resolve) => {
+      signalSepaStarted = resolve;
+    });
+    list.mockImplementation((params: Stripe.PaymentMethodListParams) => {
+      if (params.type === "sepa_debit" && firstSepaRead) {
+        firstSepaRead = false;
+        signalSepaStarted();
+        return sepaPending;
+      }
+      return Promise.resolve({
+        data: params.type === "card" && cardAttached ? [CARD] : [],
+      });
+    });
+
+    const beforeConfirmation: ReturnType<BillingService["getPaymentMethods"]> =
+      service.getPaymentMethods(CUSTOMER_ID);
+    await sepaStarted;
+    cardAttached = true;
+    await expect(service.getPaymentMethods(CUSTOMER_ID)).resolves.toHaveLength(
+      1,
+    );
+    finishSepa({ data: [] });
+    await expect(beforeConfirmation).resolves.toEqual([]);
+    cardAttached = false;
+    await expect(service.getPaymentMethods(CUSTOMER_ID)).resolves.toEqual([]);
+    expect(list).toHaveBeenCalledTimes(12);
+  });
+});

--- a/E2E/Tests/Dashboard/BillingPaidUsage.spec.ts
+++ b/E2E/Tests/Dashboard/BillingPaidUsage.spec.ts
@@ -33,8 +33,13 @@ test.describe("Payment method authorizes paid usage", () => {
             data: { data: { name: "Key before payment method", projectId } },
           },
         );
-        expect(blockedResponse.status()).toBe(402);
-        expect(await blockedResponse.json()).toMatchObject({
+        const blockedResponseDetail: string =
+          blockedResponse.status() >= 400
+            ? await blockedResponse.text()
+            : "Successful response body omitted.";
+        const blockedDiagnostic: string = `POST /api/telemetry-ingestion-key returned ${blockedResponse.status()}: ${blockedResponseDetail}`;
+        expect(blockedResponse.status(), blockedDiagnostic).toBe(402);
+        expect(await blockedResponse.json(), blockedDiagnostic).toMatchObject({
           error: expect.stringContaining("Add a payment method"),
         });
 
@@ -52,7 +57,14 @@ test.describe("Payment method authorizes paid usage", () => {
             .toString(),
           { headers: { tenantid: projectId } },
         );
-        expect(deleteResponse.ok()).toBe(true);
+        const deleteResponseDetail: string =
+          deleteResponse.status() >= 400
+            ? await deleteResponse.text()
+            : "Successful response body omitted.";
+        expect(
+          deleteResponse.ok(),
+          `DELETE /api/project returned ${deleteResponse.status()}: ${deleteResponseDetail}`,
+        ).toBe(true);
       }
     });
   }

--- a/E2E/Tests/Dashboard/Helpers/Billing.ts
+++ b/E2E/Tests/Dashboard/Helpers/Billing.ts
@@ -82,6 +82,20 @@ export const addTestPaymentMethod: ProjectBillingFunction = async (data: {
 
   await modal.getByTestId("modal-footer-submit-button").click();
   await expect(modal).toBeHidden({ timeout: 60000 });
+
+  // Check the gate before waiting on UI state so API failures retain their cause.
+  const statusResponse: APIResponse = await page.request.get(
+    URL.fromString(BASE_URL.toString())
+      .addRoute("/api/billing/pay-as-you-go-status")
+      .toString(),
+    { headers: { tenantid: data.projectId } },
+  );
+  const statusDiagnostic: string = `GET /api/billing/pay-as-you-go-status returned ${statusResponse.status()}: ${await statusResponse.text()}`;
+  expect(statusResponse.ok(), statusDiagnostic).toBe(true);
+  expect(await statusResponse.json(), statusDiagnostic).toMatchObject({
+    isAllowed: true,
+  });
+
   await expect(page.getByTestId("billing-usage-status")).toContainText(
     "A payment method is on file.",
     { timeout: 60000 },
@@ -91,14 +105,4 @@ export const addTestPaymentMethod: ProjectBillingFunction = async (data: {
   ).toBeVisible({
     timeout: 60000,
   });
-
-  // Verify the same server-side gate used by monitor creation and ingestion.
-  const statusResponse: APIResponse = await page.request.get(
-    URL.fromString(BASE_URL.toString())
-      .addRoute("/api/billing/pay-as-you-go-status")
-      .toString(),
-    { headers: { tenantid: data.projectId } },
-  );
-  expect(statusResponse.ok()).toBe(true);
-  expect(await statusResponse.json()).toMatchObject({ isAllowed: true });
 };


### PR DESCRIPTION
SaaS E2E exposed server errors while checking payment methods, and read-only requests to the Stripe test account returned rate-limit errors. Each paid-usage eligibility check fetched every supported payment-method list and customer details, amplifying provider traffic.

Check for an attached payment method with limited reads that return as soon as a supported method is found. Retry rate-limited payment-method, customer, and subscription reads with bounded exponential delays and jitter. Persistent provider errors still propagate, and every new authorization check reads fresh data.

The E2E billing checks now report error status and response details before waiting for UI state, making subsequent provider failures diagnosable. Successful resource payloads are omitted from diagnostics.

Validation: all 35 new payment-read regression tests passed with TypeScript diagnostics enabled. Common and E2E compilation passed. The existing BillingService suite passed on two master CI runs; the other three relevant billing suites passed locally (44 tests). Three comment/type-style errors reported by CI are corrected in #3673 and pass focused lint. The required full root formatting check and final master integration checks remain pending before patch-version release promotion.
