### PR TITLE
fix(billing): preserve payment rows and resolve lint failures

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Settings/Billing.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/Billing.tsx
@@ -139,6 +139,22 @@ const Settings: FunctionComponent<ComponentProps> = (
       }
     };
 
+  const countSyncedPaymentMethods: PromiseVoidFunction =
+    async (): Promise<void> => {
+      try {
+        // Listing again would replace the row IDs already held by the table.
+        const count: number = await ModelAPI.count<BillingPaymentMethod>({
+          modelType: BillingPaymentMethod,
+          query: {
+            projectId: ProjectUtil.getCurrentProjectId()!,
+          },
+        });
+        setPaymentMethodsCount(count);
+      } catch {
+        setPaymentMethodsCount(null);
+      }
+    };
+
   useAsyncEffect(async () => {
     /*
      * Nothing on this page can talk to Stripe when billing is off, so there is
@@ -657,9 +673,9 @@ const Settings: FunctionComponent<ComponentProps> = (
             isCreateable={false}
             isViewable={false}
             refreshToggle={paymentMethodsRefresh.toString()}
-            onItemDeleted={fetchPaymentMethodsCount}
+            onItemDeleted={countSyncedPaymentMethods}
             // Table filters can hide saved methods; plan controls need the unfiltered count.
-            onFetchSuccess={fetchPaymentMethodsCount}
+            onFetchSuccess={countSyncedPaymentMethods}
             name="Settings > Billing > Add Payment Method"
             cardProps={{
               buttons: [

--- a/Common/Server/Services/BillingService.ts
+++ b/Common/Server/Services/BillingService.ts
@@ -1316,8 +1316,10 @@ export class BillingService extends BaseService {
           throw err;
         }
 
-        // Stripe's network retries do not generally cover rate-limit responses.
-        // Retry only these reads; exhausted failures must still deny paid usage.
+        /*
+         * Stripe's network retries do not generally cover rate-limit responses.
+         * Retry only these reads; exhausted failures must still deny paid usage.
+         */
         const delayInMs: number = Math.round(
           1000 * 2 ** attempt * (1 + Math.random() / 2),
         );

--- a/Common/Tests/App/Dashboard/BillingPaidUsageFlow.test.tsx
+++ b/Common/Tests/App/Dashboard/BillingPaidUsageFlow.test.tsx
@@ -15,6 +15,7 @@ import getJestMockFunction, { MockFunction } from "../../MockType";
 import { getJestSpyOn } from "../../Spy";
 
 const getListMock: MockFunction = getJestMockFunction();
+const countMock: MockFunction = getJestMockFunction();
 const getItemMock: MockFunction = getJestMockFunction();
 const postMock: MockFunction = getJestMockFunction();
 const confirmSetupMock: MockFunction = getJestMockFunction();
@@ -28,6 +29,9 @@ jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
     default: {
       getList: (...args: Array<unknown>) => {
         return getListMock(...args);
+      },
+      count: (...args: Array<unknown>) => {
+        return countMock(...args);
       },
       getItem: (...args: Array<unknown>) => {
         return getItemMock(...args);
@@ -225,6 +229,7 @@ describe("Billing page paid usage flow", () => {
     jest.restoreAllMocks();
     billingEnabled = true;
     getListMock.mockReset().mockResolvedValue({ data: [], count: 0 });
+    countMock.mockReset().mockResolvedValue(0);
     getItemMock
       .mockReset()
       .mockResolvedValue({ paymentProviderPlanId: "free-plan" });
@@ -268,9 +273,8 @@ describe("Billing page paid usage flow", () => {
   );
 
   it("recovers plan editing through table refresh after a failed lookup, regardless of filtered rows", async () => {
-    getListMock
-      .mockRejectedValueOnce(new Error("Payment methods unavailable"))
-      .mockResolvedValueOnce({ data: [], count: 1 });
+    getListMock.mockRejectedValueOnce(new Error("Payment methods unavailable"));
+    countMock.mockResolvedValueOnce(1);
     renderBilling();
     await screen.findByTestId("payment-methods-table");
 
@@ -292,6 +296,12 @@ describe("Billing page paid usage flow", () => {
     await userEvent.click(
       screen.getByRole("button", { name: "Refresh payment methods" }),
     );
+    expect(countMock).toHaveBeenCalledTimes(1);
+    expect(countMock).toHaveBeenCalledWith({
+      modelType: BillingPaymentMethod,
+      query: { projectId },
+    });
+    expect(getListMock).toHaveBeenCalledTimes(1);
     await waitFor(() => {
       expect(changePlan).toBeEnabled();
     });
@@ -299,23 +309,23 @@ describe("Billing page paid usage flow", () => {
 
     expect(openPlanEditorMock).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    expect(getListMock).toHaveBeenCalledTimes(2);
-    expect(getListMock.mock.calls[1]?.[0]).toEqual(
-      expect.objectContaining({ query: { projectId }, limit: 1 }),
-    );
   });
 
   it("requires a payment method for plan changes after deleting the last card", async () => {
-    getListMock
-      .mockResolvedValueOnce({ data: [], count: 1 })
-      .mockResolvedValueOnce({ data: [], count: 0 });
+    getListMock.mockResolvedValueOnce({ data: [], count: 1 });
+    countMock.mockResolvedValueOnce(0);
     renderBilling();
     await screen.findByTestId("payment-methods-table");
     await userEvent.click(
       screen.getByRole("button", { name: "Remove payment method" }),
     );
     await waitFor(() => {
-      expect(getListMock).toHaveBeenCalledTimes(2);
+      expect(countMock).toHaveBeenCalledTimes(1);
+    });
+    expect(getListMock).toHaveBeenCalledTimes(1);
+    expect(countMock).toHaveBeenCalledWith({
+      modelType: BillingPaymentMethod,
+      query: { projectId },
     });
     await userEvent.click(screen.getByRole("button", { name: "Change Plan" }));
 
@@ -325,6 +335,58 @@ describe("Billing page paid usage flow", () => {
       "You need a payment method before changing your subscription plan.",
     );
     expect(openPlanEditorMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["Refresh payment methods", "Remove payment method"])(
+    "keeps plan editing available without resynchronizing table row IDs after %s",
+    async (notification: string) => {
+      getListMock.mockResolvedValueOnce({ data: [], count: 2 });
+      countMock.mockResolvedValueOnce(1);
+      renderBilling();
+      await screen.findByTestId("payment-methods-table");
+
+      await userEvent.click(screen.getByRole("button", { name: notification }));
+
+      expect(countMock).toHaveBeenCalledTimes(1);
+      expect(countMock).toHaveBeenCalledWith({
+        modelType: BillingPaymentMethod,
+        query: { projectId },
+      });
+      expect(getListMock).toHaveBeenCalledTimes(1);
+      await userEvent.click(
+        screen.getByRole("button", { name: "Change Plan" }),
+      );
+      expect(openPlanEditorMock).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    },
+  );
+
+  it("disables plan editing after a count failure and recovers on the next table refresh", async () => {
+    getListMock.mockResolvedValueOnce({ data: [], count: 1 });
+    countMock
+      .mockRejectedValueOnce(new Error("Payment method count unavailable"))
+      .mockResolvedValueOnce(1);
+    renderBilling();
+    await screen.findByTestId("payment-methods-table");
+
+    const changePlan: HTMLElement = screen.getByRole("button", {
+      name: "Change Plan",
+    });
+    const refresh: HTMLElement = screen.getByRole("button", {
+      name: "Refresh payment methods",
+    });
+    expect(changePlan).toBeEnabled();
+    await userEvent.click(refresh);
+    await waitFor(() => {
+      expect(changePlan).toBeDisabled();
+    });
+
+    await userEvent.click(refresh);
+    await waitFor(() => {
+      expect(changePlan).toBeEnabled();
+    });
+    expect(countMock).toHaveBeenCalledTimes(2);
+    expect(getListMock).toHaveBeenCalledTimes(1);
   });
 
   it("saves without an extra pricing acknowledgement and refreshes status and the card list", async () => {

--- a/Common/Tests/Server/Services/BillingServicePaymentMethodReads.test.ts
+++ b/Common/Tests/Server/Services/BillingServicePaymentMethodReads.test.ts
@@ -271,12 +271,16 @@ describe("BillingService payment-method reads", () => {
     let signalSepaStarted: () => void = () => {
       return;
     };
-    const sepaPending: Promise<{ data: [] }> = new Promise((resolve) => {
-      finishSepa = resolve;
-    });
-    const sepaStarted: Promise<void> = new Promise((resolve) => {
-      signalSepaStarted = resolve;
-    });
+    const sepaPending: Promise<{ data: [] }> = new Promise(
+      (resolve: (value: { data: [] } | PromiseLike<{ data: [] }>) => void) => {
+        finishSepa = resolve;
+      },
+    );
+    const sepaStarted: Promise<void> = new Promise(
+      (resolve: (value: void | PromiseLike<void>) => void) => {
+        signalSepaStarted = resolve;
+      },
+    );
     list.mockImplementation((params: Stripe.PaymentMethodListParams) => {
       if (params.type === "sepa_debit" && firstSepaRead) {
         firstSepaRead = false;


### PR DESCRIPTION
Payment-table refreshes were fetching the Stripe-backed payment-method list a second time after the table had stored its rows. That synchronization deletes and recreates local records, invalidating the IDs shown in the table and preventing subsequent deletion from finding the correct provider method. The post-delete callback could also race the table refresh with another synchronization.

Use the unfiltered, non-mutating payment-method count endpoint for both notifications. Initial loading and payment-method saves still synchronize with Stripe. Plan controls continue to account for methods hidden by table filters, disable after lookup failures, and recover when a subsequent count succeeds.

Also correct the three lint errors reported by master CI in the payment-read retry fix: use the required block-comment style and explicitly type the two Promise resolver parameters in its concurrency regression. These corrections preserve behavior.

Validation:
- The filtered-table recovery regression fails on the previous callback at the new count assertion.
- Both focused billing UI suites passed: 21 tests.
- The two UI files passed cached ESLint, and git diff --check is clean.
- Cached ESLint passed for both additional lint-correction files.
- All 35 payment-read regression tests passed with normal TypeScript diagnostics.
- Three existing billing suites passed locally (44 tests); BillingService.test.ts passed in two master CI runs.
- Dashboard and final Common compilation passed locally. Common compilation and dependency checking also passed in CI against the same final source tree.
- Full root formatter and master CI: in progress.
