### PR TITLE
Preserve selected monitor fields during template sync

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorStep.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorStep.tsx
@@ -1,4 +1,5 @@
 import MonitorCriteriaElement from "./MonitorCriteria";
+import MonitorTemplateSyncFields from "./MonitorTemplateSyncFields";
 import { IncidentRoleOption } from "./MonitorCriteriaIncidentForm";
 import HTTPMethod from "Common/Types/API/HTTPMethod";
 import Hostname from "Common/Types/API/Hostname";
@@ -178,6 +179,7 @@ export interface ComponentProps {
   onChange?: undefined | ((value: MonitorStep) => void);
   // onDelete?: undefined | (() => void);
   monitorType: MonitorType;
+  isMonitorTemplate?: boolean | undefined;
   allMonitorSteps: MonitorSteps;
   probes: Array<Probe>;
   monitorId?: ObjectID | undefined; // this is used to populate secrets when testing the monitor.
@@ -768,6 +770,12 @@ return {
 
   return (
     <div className="mt-5 space-y-6">
+      <MonitorTemplateSyncFields
+        monitorType={props.monitorType}
+        value={monitorStep}
+        isMonitorTemplate={props.isMonitorTemplate}
+        onChange={props.onChange}
+      />
       {/* Monitor Target Card */}
       {hasMonitorDestination && (
         <Card

--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorSteps.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorSteps.tsx
@@ -41,6 +41,7 @@ export interface ComponentProps extends CustomElementProps {
   onBlur?: () => void;
   initialValue?: MonitorSteps;
   monitorType: MonitorType;
+  isMonitorTemplate?: boolean | undefined;
   monitorName?: string | undefined; // this is used to prefill incident title and description. If not provided then it will be empty.
   monitorId?: ObjectID | undefined; // this is used to populate secrets when testing the monitor.
 }
@@ -478,6 +479,7 @@ const MonitorStepsElement: FunctionComponent<ComponentProps> = (
           return (
             <MonitorStepElement
               monitorType={props.monitorType}
+              isMonitorTemplate={props.isMonitorTemplate}
               allMonitorSteps={monitorSteps}
               key={index}
               monitorStatusDropdownOptions={monitorStatusDropdownOptions}

--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorTemplateSyncFields.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorTemplateSyncFields.tsx
@@ -88,8 +88,10 @@ const MonitorTemplateSyncFields: FunctionComponent<ComponentProps> = (
       return;
     }
 
-    // The create wizard can remount a step after the monitor type changes.
-    // Keep compatible choices and clear fields the new type cannot configure.
+    /*
+     * The create wizard can remount a step after the monitor type changes.
+     * Keep compatible choices and clear fields the new type cannot configure.
+     */
     const allowedFields: Set<string> = new Set(
       MonitorTemplateSyncFieldUtil.getFields(props.monitorType).map(
         (field: MonitorTemplateSyncField) => {

--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorTemplateSyncFields.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorTemplateSyncFields.tsx
@@ -1,0 +1,190 @@
+import MonitorStep from "Common/Types/Monitor/MonitorStep";
+import MonitorSteps from "Common/Types/Monitor/MonitorSteps";
+import MonitorTemplateSyncFieldUtil, {
+  MonitorTemplateSyncField,
+} from "Common/Types/Monitor/MonitorTemplateSyncField";
+import MonitorType from "Common/Types/Monitor/MonitorType";
+import Card from "Common/UI/Components/Card/Card";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useId,
+} from "react";
+
+export interface ComponentProps {
+  monitorType: MonitorType;
+  value: MonitorStep;
+  isMonitorTemplate?: boolean | undefined;
+  onChange?: ((value: MonitorStep) => void) | undefined;
+}
+
+export interface SummaryProps {
+  monitorType: MonitorType;
+  monitorSteps: MonitorSteps | undefined;
+}
+
+export const getMonitorTemplateSyncFieldSummary: (
+  props: SummaryProps,
+) => string = (props: SummaryProps): string => {
+  if (props.monitorType === MonitorType.NetworkDevice) {
+    return "Network device bindings are always preserved. Other step settings are copied from the template.";
+  }
+
+  const fields: Array<MonitorTemplateSyncField> =
+    MonitorTemplateSyncFieldUtil.getFields(props.monitorType);
+  const steps: Array<MonitorStep> =
+    props.monitorSteps?.data?.monitorStepsInstanceArray || [];
+  const protectedSteps: Array<string> = [];
+
+  steps.forEach((step: MonitorStep, index: number) => {
+    const labels: Array<string> = fields
+      .filter((field: MonitorTemplateSyncField) => {
+        return step.data?.doNotSyncFields?.includes(field.path);
+      })
+      .map((field: MonitorTemplateSyncField) => {
+        return field.label;
+      });
+
+    if (labels.length > 0) {
+      protectedSteps.push(
+        steps.length > 1
+          ? `Step ${index + 1}: ${labels.join(", ")}`
+          : labels.join(", "),
+      );
+    }
+  });
+
+  if (protectedSteps.length === 0) {
+    return "No fields are protected. Sync copies all step settings, including destinations and request options when applicable.";
+  }
+
+  return `These fields keep each monitor's current values during sync: ${protectedSteps.join("; ")}. All other step settings are copied from the template.`;
+};
+
+export const MonitorTemplateSyncFieldsSummary: FunctionComponent<
+  SummaryProps
+> = (props: SummaryProps): ReactElement => {
+  return (
+    <div className="mb-5 rounded-lg border border-indigo-100 bg-indigo-50 px-4 py-3 text-sm text-gray-700">
+      <h3 className="font-medium text-gray-900">Template sync settings</h3>
+      <p className="mt-1">{getMonitorTemplateSyncFieldSummary(props)}</p>
+      <p className="mt-1">
+        New monitors still start with the template's values for every field.
+      </p>
+    </div>
+  );
+};
+
+const MonitorTemplateSyncFields: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement | null => {
+  const id: string = useId();
+  const fields: Array<MonitorTemplateSyncField> =
+    MonitorTemplateSyncFieldUtil.getFields(props.monitorType);
+
+  useEffect(() => {
+    if (!props.isMonitorTemplate || !props.value.data?.doNotSyncFields) {
+      return;
+    }
+
+    // The create wizard can remount a step after the monitor type changes.
+    // Keep compatible choices and clear fields the new type cannot configure.
+    const allowedFields: Set<string> = new Set(
+      MonitorTemplateSyncFieldUtil.getFields(props.monitorType).map(
+        (field: MonitorTemplateSyncField) => {
+          return field.path;
+        },
+      ),
+    );
+    const selectedFields: Array<string> = props.value.data.doNotSyncFields;
+    const compatibleFields: Array<string> = selectedFields.filter(
+      (path: string) => {
+        return allowedFields.has(path);
+      },
+    );
+
+    if (compatibleFields.length !== selectedFields.length) {
+      const updatedStep: MonitorStep = MonitorStep.clone(props.value);
+      updatedStep.data!.doNotSyncFields = compatibleFields;
+      props.onChange?.(updatedStep);
+    }
+  }, [props.isMonitorTemplate, props.monitorType, props.value, props.onChange]);
+
+  if (!props.isMonitorTemplate || fields.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card title="Template sync settings">
+      <div className="space-y-4">
+        <p className="text-sm text-gray-500">
+          Check fields to keep each monitor's current values when syncing this
+          template to one or all linked monitors. The template's values remain
+          the defaults for new monitors. Lists such as request headers are
+          preserved in full.
+        </p>
+        <div className="divide-y divide-gray-100">
+          {fields.map((field: MonitorTemplateSyncField, index: number) => {
+            const fieldId: string = `${id}-${index}`;
+
+            return (
+              <div
+                key={field.path}
+                className="flex flex-col gap-2 py-3 first:pt-0 last:pb-0 sm:flex-row sm:items-start sm:justify-between sm:gap-6"
+              >
+                <div>
+                  <p
+                    id={`${fieldId}-name`}
+                    className="text-sm font-medium text-gray-900"
+                  >
+                    {field.label}
+                  </p>
+                  {field.description && (
+                    <p
+                      id={`${fieldId}-description`}
+                      className="mt-1 text-sm text-gray-500"
+                    >
+                      {field.description}
+                    </p>
+                  )}
+                </div>
+                <label className="flex shrink-0 cursor-pointer items-center gap-2 text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-gray-300 text-indigo-600 accent-indigo-600 focus:ring-indigo-600"
+                    aria-labelledby={`${fieldId}-name ${fieldId}-label`}
+                    aria-describedby={
+                      field.description ? `${fieldId}-description` : undefined
+                    }
+                    checked={
+                      props.value.data?.doNotSyncFields?.includes(field.path) ||
+                      false
+                    }
+                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                      const updatedStep: MonitorStep = MonitorStep.clone(
+                        props.value,
+                      );
+                      const selectedFields: Array<string> =
+                        updatedStep.data?.doNotSyncFields || [];
+
+                      updatedStep.data!.doNotSyncFields = event.target.checked
+                        ? Array.from(new Set([...selectedFields, field.path]))
+                        : selectedFields.filter((path: string) => {
+                            return path !== field.path;
+                          });
+                      props.onChange?.(updatedStep);
+                    }}
+                  />
+                  <span id={`${fieldId}-label`}>Do not sync this field</span>
+                </label>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default MonitorTemplateSyncFields;

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplates.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplates.tsx
@@ -46,6 +46,25 @@ const MonitorTemplates: FunctionComponent<PageComponentProps> = (
         isEditable={false}
         isCreateable={true}
         isViewable={true}
+        onBeforeCreate={async (
+          item: MonitorTemplate,
+        ): Promise<MonitorTemplate> => {
+          // Manual monitors skip the criteria step, so its type-change cleanup
+          // never mounts when a user returns to Defaults and chooses Manual.
+          if (item.monitorType === MonitorType.Manual && item.monitorSteps) {
+            const steps: MonitorStepsType = MonitorStepsType.clone(
+              item.monitorSteps,
+            );
+            for (const step of steps.data?.monitorStepsInstanceArray || []) {
+              if (step.data) {
+                step.data.doNotSyncFields = [];
+              }
+            }
+            item.monitorSteps = steps;
+          }
+
+          return item;
+        }}
         createEditModalWidth={ModalWidth.Large}
         cardProps={{
           title: "Monitor Templates",
@@ -213,6 +232,7 @@ const MonitorTemplates: FunctionComponent<PageComponentProps> = (
               return (
                 <MonitorStepsForm
                   {...fieldProps}
+                  isMonitorTemplate={true}
                   monitorType={value.monitorType || MonitorType.Manual}
                   monitorName={
                     value.monitorName?.trim() ||

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplates.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplates.tsx
@@ -49,8 +49,10 @@ const MonitorTemplates: FunctionComponent<PageComponentProps> = (
         onBeforeCreate={async (
           item: MonitorTemplate,
         ): Promise<MonitorTemplate> => {
-          // Manual monitors skip the criteria step, so its type-change cleanup
-          // never mounts when a user returns to Defaults and chooses Manual.
+          /*
+           * Manual monitors skip the criteria step, so its type-change cleanup
+           * never mounts when a user returns to Defaults and chooses Manual.
+           */
           if (item.monitorType === MonitorType.Manual && item.monitorSteps) {
             const steps: MonitorStepsType = MonitorStepsType.clone(
               item.monitorSteps,

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplatesView.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplatesView.tsx
@@ -45,6 +45,10 @@ import MonitorType, {
 } from "Common/Types/Monitor/MonitorType";
 import MonitorTypeUtil from "../../../Utils/MonitorType";
 import MonitorStepsForm from "../../../Components/Form/Monitor/MonitorSteps";
+import {
+  getMonitorTemplateSyncFieldSummary,
+  MonitorTemplateSyncFieldsSummary,
+} from "../../../Components/Form/Monitor/MonitorTemplateSyncFields";
 import MonitorStepsViewer from "../../../Components/Monitor/MonitorSteps/MonitorSteps";
 import MonitoringInterval from "../../../Utils/MonitorIntervalDropdownOptions";
 import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
@@ -92,6 +96,14 @@ const MonitorTemplatesView: FunctionComponent<
   const [monitorType, setMonitorType] = useState<MonitorType | undefined>(
     undefined,
   );
+  const [templateMonitorSteps, setTemplateMonitorSteps] = useState<
+    MonitorStepsType | undefined
+  >(undefined);
+
+  const protectedFieldsSummary: string = getMonitorTemplateSyncFieldSummary({
+    monitorType: monitorType || MonitorType.Manual,
+    monitorSteps: templateMonitorSteps,
+  });
 
   /*
    * The default monitor name this template gives the monitors it creates.
@@ -198,11 +210,13 @@ const MonitorTemplatesView: FunctionComponent<
             id: modelId,
             select: {
               monitorType: true,
+              monitorSteps: true,
               monitorName: true,
               templateName: true,
             },
           });
         setMonitorType(item?.monitorType);
+        setTemplateMonitorSteps(item?.monitorSteps);
         setTemplateMonitorName(item?.monitorName?.trim() || "");
         setTemplateName(item?.templateName?.trim() || "");
       } catch {
@@ -833,6 +847,7 @@ const MonitorTemplatesView: FunctionComponent<
       {/* Monitoring Criteria — only meaningful for non-Manual monitor types. */}
       {monitorType && monitorType !== MonitorType.Manual && (
         <CardModelDetail<MonitorTemplate>
+          key={monitorType}
           name="Monitoring Criteria"
           cardProps={{
             title: "Monitoring Criteria",
@@ -855,6 +870,9 @@ const MonitorTemplatesView: FunctionComponent<
           createEditModalWidth={ModalWidth.Large}
           isEditable={true}
           editButtonText="Edit Criteria"
+          onSaveSuccess={(item: MonitorTemplate) => {
+            setTemplateMonitorSteps(item.monitorSteps);
+          }}
           formFields={[
             {
               field: {
@@ -876,6 +894,7 @@ const MonitorTemplatesView: FunctionComponent<
                 return (
                   <MonitorStepsForm
                     {...fieldProps}
+                    isMonitorTemplate={true}
                     monitorType={monitorType}
                     monitorName={criteriaSeedMonitorName}
                   />
@@ -887,6 +906,9 @@ const MonitorTemplatesView: FunctionComponent<
             showDetailsInNumberOfColumns: 1,
             modelType: MonitorTemplate,
             id: "model-detail-monitor-template-criteria",
+            onItemLoaded: (item: MonitorTemplate) => {
+              setTemplateMonitorSteps(item.monitorSteps);
+            },
             fields: [
               {
                 field: {
@@ -899,10 +921,16 @@ const MonitorTemplatesView: FunctionComponent<
                     return <p>No criteria configured.</p>;
                   }
                   return (
-                    <MonitorStepsViewer
-                      monitorSteps={item.monitorSteps as MonitorStepsType}
-                      monitorType={monitorType}
-                    />
+                    <>
+                      <MonitorTemplateSyncFieldsSummary
+                        monitorSteps={item.monitorSteps as MonitorStepsType}
+                        monitorType={monitorType}
+                      />
+                      <MonitorStepsViewer
+                        monitorSteps={item.monitorSteps as MonitorStepsType}
+                        monitorType={monitorType}
+                      />
+                    </>
                   );
                 },
               },
@@ -1195,7 +1223,7 @@ const MonitorTemplatesView: FunctionComponent<
           title="Sync Criteria to Linked Monitors"
           description={
             <span>
-              {`This will overwrite ONLY the monitor criteria on ${linkedMonitorCount} monitor${linkedMonitorCount === 1 ? "" : "s"} created from this template. Monitoring interval, minimum probe agreement, name, description, labels, and custom field values will be left alone. This cannot be undone.`}
+              {`This will copy the template's criteria and step settings, including destinations and request options where applicable, to ${linkedMonitorCount} linked monitor${linkedMonitorCount === 1 ? "" : "s"}. ${protectedFieldsSummary} Monitoring interval, minimum probe agreement, name, description, labels, and custom field values will be left alone. This cannot be undone.`}
             </span>
           }
           submitButtonText="Sync Criteria"
@@ -1275,7 +1303,7 @@ const MonitorTemplatesView: FunctionComponent<
           title="Sync Monitor from Template"
           description={
             <span>
-              {`This will overwrite the criteria, monitoring interval, minimum probe agreement, and labels on "${singleSyncMonitor.name || "this monitor"}" with the template's current values. Name, description, and custom field values will be left alone. This cannot be undone.`}
+              {`This will copy the template's criteria and step settings, including destinations and request options where applicable, plus its monitoring interval, minimum probe agreement, and labels to "${singleSyncMonitor.name || "this monitor"}". ${protectedFieldsSummary} Name, description, and custom field values will be left alone. This cannot be undone.`}
             </span>
           }
           submitButtonText="Sync Now"

--- a/App/FeatureSet/Docs/Content/en/monitor/monitor-templates.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/monitor-templates.md
@@ -1,0 +1,40 @@
+# Monitor Templates
+
+Monitor templates share monitoring criteria and check settings across linked monitors. A criteria sync also copies step settings such as destinations, request headers, and timeouts unless you protect those fields.
+
+## Keep values specific to each monitor
+
+1. Open **Monitors → Settings → Templates** and select a template.
+2. Click **Edit Criteria**.
+3. In **Template sync settings**, check **Do not sync this field** beside each field you want to keep on the linked monitors.
+4. Save your changes. The template details and sync confirmation list the protected fields.
+5. Use **Sync Criteria to Linked Monitors**, or sync an individual linked monitor.
+
+For example, protect **Monitor destination** and **Request headers** on an API template. Production and staging monitors keep their own URLs and headers, while both receive the template's updated criteria and other unprotected settings.
+
+The available options depend on the monitor type. These include destinations and ports, HTTP request options, database connections, DNS settings, infrastructure selectors, and telemetry queries. Related credentials, such as a client certificate and its private key, are kept together.
+
+## How exclusions behave
+
+- Checked fields keep each existing monitor's current value, including an empty or unset value. Request headers and other collections are preserved in full.
+- Unchecked fields continue to sync from the template. Uncheck a protected field and save to copy its template value on the next sync.
+- Exclusions apply to bulk and individual syncs. They are saved on the template, not selected separately for each sync.
+- New monitors still start with the template's field values. Exclusions only affect syncing to existing monitors.
+- Criteria always sync. Criteria-only sync leaves monitoring interval, labels, and other monitor-level settings alone.
+- Existing templates have no field exclusions until you configure them. Network Device monitors continue to retain their own device binding automatically.
+
+For templates with multiple steps, protected values are matched using the step IDs. Independently created single-step monitors can also receive a single-step template. If a protected step cannot be matched, the sync is rejected before any monitor updates, so a new or reordered step cannot accidentally copy another step's destination or credentials.
+
+Before changing a saved template's monitor type, clear exclusions that do not apply to the new type in **Edit Criteria**.
+
+## API configuration
+
+Each template step accepts a `doNotSyncFields` array in its `MonitorStep.value` object. For an API monitor, protect its destination and entire header collection with:
+
+```json
+{
+  "doNotSyncFields": ["monitorDestination", "requestHeaders"]
+}
+```
+
+Omit the array or set it to `[]` to sync every supported step setting. Unsupported field names and fields that do not apply to the template's monitor type are rejected. The template's array controls sync; any such metadata on a linked monitor does not override it.

--- a/App/FeatureSet/Docs/Utils/Nav.ts
+++ b/App/FeatureSet/Docs/Utils/Nav.ts
@@ -226,6 +226,10 @@ const DocsNav: NavGroup[] = [
     title: "Monitor",
     links: [
       {
+        title: "Monitor Templates",
+        url: "/docs/monitor/monitor-templates",
+      },
+      {
         title: "Website Monitor",
         url: "/docs/monitor/website-monitor",
       },

--- a/App/Tests/Dashboard/MonitorTemplateOptionalMonitorName.test.ts
+++ b/App/Tests/Dashboard/MonitorTemplateOptionalMonitorName.test.ts
@@ -255,15 +255,12 @@ describe("Monitor Template criteria seeding survives a blank default name", () =
   test("the view page loads the template name alongside the monitor name", () => {
     const code: string = readCode(MONITOR_TEMPLATES_VIEW);
 
-    expect(code).toContain(
-      squash(`
-        select: {
-          monitorType: true,
-          monitorName: true,
-          templateName: true,
-        },
-      `),
-    );
+    const templateSelect: string | undefined = code.match(
+      /select: \{[^}]*monitorType: true[^}]*\}/,
+    )?.[0];
+    // Additional template data can be fetched without dropping either name.
+    expect(templateSelect).toContain("monitorName: true");
+    expect(templateSelect).toContain("templateName: true");
     expect(code).toContain(
       squash('setTemplateName(item?.templateName?.trim() || "");'),
     );

--- a/Common/Server/Services/MonitorTemplateService.ts
+++ b/Common/Server/Services/MonitorTemplateService.ts
@@ -16,6 +16,7 @@ import Includes from "../../Types/BaseDatabase/Includes";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
 import { JSONObject } from "../../Types/JSON";
 import MonitorSteps from "../../Types/Monitor/MonitorSteps";
+import MonitorTemplateSyncFieldUtil from "../../Types/Monitor/MonitorTemplateSyncField";
 import MonitorType from "../../Types/Monitor/MonitorType";
 import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
@@ -24,6 +25,7 @@ import Monitor from "../../Models/DatabaseModels/Monitor";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import MonitorTemplateCustomFieldUtil from "../../Utils/Monitor/MonitorTemplateCustomFieldUtil";
 import NetworkDeviceMonitorTemplateUtil from "../../Utils/Monitor/NetworkDeviceMonitorTemplateUtil";
+import MonitorTemplateSyncUtil from "../../Utils/Monitor/MonitorTemplateSyncUtil";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import ModelPermission from "../Types/Database/Permissions/Index";
 import Query from "../Types/Database/Query";
@@ -78,6 +80,29 @@ export class Service extends DatabaseService<Model> {
     super(Model);
   }
 
+  private validateSyncFields(
+    steps: MonitorSteps | JSONObject | undefined,
+    monitorType: MonitorType | undefined,
+  ): void {
+    if (!steps) {
+      return;
+    }
+
+    for (const step of MonitorSteps.fromJSON(steps).data
+      ?.monitorStepsInstanceArray || []) {
+      const fields: Array<string> | undefined =
+        MonitorTemplateSyncFieldUtil.parse(
+          step.data?.doNotSyncFields,
+          monitorType,
+        );
+      if (fields?.length && !monitorType) {
+        throw new BadDataException(
+          "Monitor type is required to configure template sync fields",
+        );
+      }
+    }
+  }
+
   /*
    * A template's monitorSteps embeds the same reference ids a monitor's does,
    * and every one of them reaches a real monitor eventually — through "create
@@ -91,6 +116,10 @@ export class Service extends DatabaseService<Model> {
   protected override async onBeforeCreate(
     createBy: CreateBy<Model>,
   ): Promise<OnCreate<Model>> {
+    this.validateSyncFields(
+      createBy.data.monitorSteps,
+      createBy.data.monitorType,
+    );
     await MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({
       monitorSteps: createBy.data.monitorSteps,
       projectId: createBy.props.tenantId || createBy.data.projectId,
@@ -103,7 +132,7 @@ export class Service extends DatabaseService<Model> {
   protected override async onBeforeUpdate(
     updateBy: UpdateBy<Model>,
   ): Promise<OnUpdate<Model>> {
-    if (!updateBy.data.monitorSteps) {
+    if (!updateBy.data.monitorSteps && !updateBy.data.monitorType) {
       return { updateBy, carryForward: null };
     }
 
@@ -117,6 +146,7 @@ export class Service extends DatabaseService<Model> {
       select: {
         projectId: true,
         monitorSteps: true,
+        monitorType: true,
       },
       limit: LIMIT_MAX,
       skip: 0,
@@ -127,6 +157,16 @@ export class Service extends DatabaseService<Model> {
     });
 
     for (const template of templates) {
+      this.validateSyncFields(
+        updateBy.data.monitorSteps === undefined
+          ? template.monitorSteps
+          : (updateBy.data.monitorSteps as MonitorSteps | JSONObject),
+        (updateBy.data.monitorType as MonitorType | undefined) ||
+          template.monitorType,
+      );
+      if (!updateBy.data.monitorSteps) {
+        continue;
+      }
       await MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({
         monitorSteps: updateBy.data.monitorSteps as MonitorSteps | JSONObject,
         projectId: updateBy.props.tenantId || template.projectId,
@@ -412,6 +452,45 @@ export class Service extends DatabaseService<Model> {
     });
   }
 
+  /** Merge protected fields before applying the device ownership binding. */
+  private buildMonitorStepsUpdate(
+    template: Model,
+    monitor: Monitor,
+  ): MonitorSteps {
+    let monitorSteps: MonitorSteps | undefined = template.monitorSteps;
+
+    if (MonitorTemplateSyncUtil.hasExcludedFields(monitorSteps)) {
+      if (!template.monitorType) {
+        throw new BadDataException("Monitor template is missing monitorType");
+      }
+      monitorSteps = MonitorTemplateSyncUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: monitorSteps,
+        currentMonitorSteps: monitor.monitorSteps,
+        monitorType: template.monitorType,
+      });
+    }
+
+    if (template.monitorType === MonitorType.NetworkDevice) {
+      monitorSteps = monitor.autoProvisionedNetworkDeviceId
+        ? NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps({
+            monitorSteps,
+            networkDeviceId: monitor.autoProvisionedNetworkDeviceId,
+          })
+        : NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
+            templateMonitorSteps: monitorSteps,
+            currentMonitorSteps: monitor.monitorSteps,
+          });
+    }
+
+    if (!monitorSteps) {
+      throw new BadDataException(
+        "Monitor template steps are required to sync criteria.",
+      );
+    }
+
+    return monitorSteps;
+  }
+
   /**
    * Push the template's current configuration onto every monitor that was
    * created from it. Sync is intentionally explicit (button-triggered) so a
@@ -491,18 +570,20 @@ export class Service extends DatabaseService<Model> {
      * while each linked monitor has its own device. A bulk JSON assignment
      * would retarget the entire fleet to the template editor's device. Sync
      * those rows individually and rebind cloned template steps to each
-     * monitor's current (or provenance-backed) device instead.
+     * monitor's current (or provenance-backed) device instead. Field exclusions
+     * also require one merge per monitor so each keeps its own protected values.
      */
-    const rebindMonitorSteps: boolean =
-      template.monitorType === MonitorType.NetworkDevice &&
-      fields.includes("monitorSteps");
+    const mergeMonitorSteps: boolean =
+      fields.includes("monitorSteps") &&
+      (template.monitorType === MonitorType.NetworkDevice ||
+        MonitorTemplateSyncUtil.hasExcludedFields(template.monitorSteps));
 
     /*
      * Custom field defaults take the same row-at-a-time path for their own
      * reason: they are overlaid on the monitor's existing bag, so the payload
      * is read from the row being written and cannot be shared.
      */
-    if (rebindMonitorSteps || syncCustomFields) {
+    if (mergeMonitorSteps || syncCustomFields) {
       let syncedMonitors: number = 0;
       const linkedMonitorQuery: Query<Monitor> = {
         monitorTemplateId: template.id!,
@@ -564,17 +645,9 @@ export class Service extends DatabaseService<Model> {
           monitor,
           data: {
             ...updateData,
-            ...(rebindMonitorSteps
+            ...(mergeMonitorSteps
               ? {
-                  monitorSteps: monitor.autoProvisionedNetworkDeviceId
-                    ? NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps({
-                        monitorSteps: template.monitorSteps,
-                        networkDeviceId: monitor.autoProvisionedNetworkDeviceId,
-                      })
-                    : NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
-                        templateMonitorSteps: template.monitorSteps,
-                        currentMonitorSteps: monitor.monitorSteps,
-                      }),
+                  monitorSteps: this.buildMonitorStepsUpdate(template, monitor),
                 }
               : {}),
             ...(syncCustomFields
@@ -801,19 +874,8 @@ export class Service extends DatabaseService<Model> {
 
     const updateData: Partial<Monitor> = this.buildUpdateData(template, fields);
 
-    if (
-      template.monitorType === MonitorType.NetworkDevice &&
-      fields.includes("monitorSteps")
-    ) {
-      updateData.monitorSteps = monitor.autoProvisionedNetworkDeviceId
-        ? NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps({
-            monitorSteps: template.monitorSteps,
-            networkDeviceId: monitor.autoProvisionedNetworkDeviceId,
-          })
-        : NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
-            templateMonitorSteps: template.monitorSteps,
-            currentMonitorSteps: monitor.monitorSteps,
-          });
+    if (updateData.monitorSteps !== undefined) {
+      updateData.monitorSteps = this.buildMonitorStepsUpdate(template, monitor);
     }
 
     /*

--- a/Common/Tests/App/Dashboard/MonitorTemplateSyncFields.test.tsx
+++ b/Common/Tests/App/Dashboard/MonitorTemplateSyncFields.test.tsx
@@ -1,0 +1,539 @@
+import "@testing-library/jest-dom";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import React, { ReactElement, useState } from "react";
+import URL from "../../../Types/API/URL";
+import Route from "../../../Types/API/Route";
+import MonitorTemplate from "../../../Models/DatabaseModels/MonitorTemplate";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import MonitorSteps from "../../../Types/Monitor/MonitorSteps";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import MonitorTemplateSyncFields, {
+  getMonitorTemplateSyncFieldSummary,
+  MonitorTemplateSyncFieldsSummary,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorTemplateSyncFields";
+import MonitorTemplates from "../../../../App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplates";
+
+type TemplateCreateCallback = (
+  item: MonitorTemplate,
+) => Promise<MonitorTemplate>;
+let templateCreateCallback: TemplateCreateCallback | undefined;
+
+jest.mock("../../../UI/Components/ModelTable/ModelTable", () => {
+  return {
+    __esModule: true,
+    default: (props: { onBeforeCreate: TemplateCreateCallback }) => {
+      templateCreateCallback = props.onBeforeCreate;
+      return null;
+    },
+  };
+});
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorSteps",
+  () => {
+    return {
+      __esModule: true,
+      default: () => {
+        return null;
+      },
+    };
+  },
+);
+
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: () => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return {
+        t: (key: string): string => {
+          return key;
+        },
+      };
+    },
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  templateCreateCallback = undefined;
+});
+
+function configuredStep(selectedFields?: Array<string>): MonitorStep {
+  const step: MonitorStep = new MonitorStep();
+  step.setMonitorDestination(URL.fromString("https://monitor.example.test"));
+  step.setRequestHeaders({
+    Authorization: "secret-header",
+    "X-Region": "west",
+  });
+  step.setRequestBody("secret-request-body");
+  step.data!.doNotFollowRedirects = false;
+  step.data!.retryCount = 0;
+  if (selectedFields) {
+    step.data!.doNotSyncFields = selectedFields;
+  }
+  return step;
+}
+
+function monitorSteps(...steps: Array<MonitorStep>): MonitorSteps {
+  const result: MonitorSteps = new MonitorSteps();
+  result.setMonitorStepsInstanceArray(steps);
+  return result;
+}
+
+type MonitorStepChangeMock = ReturnType<
+  typeof jest.fn<(value: MonitorStep) => void>
+>;
+
+interface HarnessProps {
+  initialValue: MonitorStep;
+  onChange: (value: MonitorStep) => void;
+}
+
+function Harness(props: HarnessProps): ReactElement {
+  const [step, setStep] = useState<MonitorStep>(props.initialValue);
+  return (
+    <MonitorTemplateSyncFields
+      monitorType={MonitorType.API}
+      isMonitorTemplate={true}
+      value={step}
+      onChange={(value: MonitorStep) => {
+        setStep(value);
+        props.onChange(value);
+      }}
+    />
+  );
+}
+
+describe("monitor template field sync controls", () => {
+  test("existing templates start with no fields protected and do not change on mount", () => {
+    const onChange: MonitorStepChangeMock =
+      jest.fn<(value: MonitorStep) => void>();
+    render(<Harness initialValue={configuredStep()} onChange={onChange} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Template sync settings" }),
+    ).toBeVisible();
+    const checkboxes: Array<HTMLElement> = screen.getAllByRole("checkbox");
+    expect(checkboxes.length).toBeGreaterThan(0);
+    checkboxes.forEach((checkbox: HTMLElement) => {
+      expect(checkbox).not.toBeChecked();
+    });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText(/defaults for new monitors/)).toBeVisible();
+    expect(
+      screen.getByText(/Lists such as request headers are preserved in full/),
+    ).toBeVisible();
+  });
+
+  test("checking a field emits a cloned step while keeping its default value and other settings", () => {
+    const original: MonitorStep = configuredStep();
+    const originalJson: unknown = original.toJSON();
+    const onChange: MonitorStepChangeMock =
+      jest.fn<(value: MonitorStep) => void>();
+    render(<Harness initialValue={original} onChange={onChange} />);
+
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: "Monitor destination Do not sync this field",
+      }),
+    );
+
+    const emitted: MonitorStep = onChange.mock.calls[0]![0];
+    expect(emitted).not.toBe(original);
+    expect(emitted.data?.doNotSyncFields).toEqual(["monitorDestination"]);
+    expect(emitted.data?.monitorDestination?.toString()).toBe(
+      original.data?.monitorDestination?.toString(),
+    );
+    expect(emitted.data?.requestHeaders).toEqual(original.data?.requestHeaders);
+    expect(emitted.data?.requestBody).toBe("secret-request-body");
+    expect(emitted.data?.doNotFollowRedirects).toBe(false);
+    expect(emitted.data?.retryCount).toBe(0);
+    expect(emitted.data?.id).toBe(original.data?.id);
+    expect(emitted.data?.monitorCriteria.toJSON()).toEqual(
+      original.data?.monitorCriteria.toJSON(),
+    );
+    expect(original.toJSON()).toEqual(originalJson);
+  });
+
+  test("multiple fields can be checked and one unchecked without losing other selections", () => {
+    const onChange: MonitorStepChangeMock =
+      jest.fn<(value: MonitorStep) => void>();
+    render(<Harness initialValue={configuredStep()} onChange={onChange} />);
+    const destination: HTMLElement = screen.getByRole("checkbox", {
+      name: "Monitor destination Do not sync this field",
+    });
+    const headers: HTMLElement = screen.getByRole("checkbox", {
+      name: "Request headers Do not sync this field",
+    });
+
+    fireEvent.click(destination);
+    fireEvent.click(headers);
+    expect(onChange.mock.calls[1]![0].data?.doNotSyncFields).toEqual([
+      "monitorDestination",
+      "requestHeaders",
+    ]);
+    fireEvent.click(destination);
+    expect(destination).not.toBeChecked();
+    expect(headers).toBeChecked();
+    expect(onChange.mock.calls[2]![0].data?.doNotSyncFields).toEqual([
+      "requestHeaders",
+    ]);
+    fireEvent.click(headers);
+    expect(onChange.mock.calls[3]![0].data?.doNotSyncFields).toEqual([]);
+  });
+
+  test("loads saved selections after serialization and responds to replacement values", () => {
+    const saved: MonitorStep = MonitorStep.clone(
+      configuredStep(["requestHeaders", "tlsClientAuthentication"]),
+    );
+    const { rerender } = render(
+      <MonitorTemplateSyncFields
+        monitorType={MonitorType.API}
+        isMonitorTemplate={true}
+        value={saved}
+      />,
+    );
+
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Request headers Do not sync this field",
+      }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Client certificate authentication Do not sync this field",
+      }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Monitor destination Do not sync this field",
+      }),
+    ).not.toBeChecked();
+
+    rerender(
+      <MonitorTemplateSyncFields
+        monitorType={MonitorType.API}
+        isMonitorTemplate={true}
+        value={configuredStep(["monitorDestination"])}
+      />,
+    );
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Request headers Do not sync this field",
+      }),
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Monitor destination Do not sync this field",
+      }),
+    ).toBeChecked();
+  });
+
+  test("each checkbox has an accessible field name and its visible label is clickable", () => {
+    const onChange: MonitorStepChangeMock =
+      jest.fn<(value: MonitorStep) => void>();
+    render(<Harness initialValue={configuredStep()} onChange={onChange} />);
+    const headers: HTMLElement = screen.getByRole("checkbox", {
+      name: "Request headers Do not sync this field",
+    });
+    fireEvent.click(
+      within(headers.closest("label")!).getByText("Do not sync this field"),
+    );
+    expect(headers).toBeChecked();
+    expect(headers).toHaveAccessibleDescription(
+      "Keep the monitor's entire set of request headers.",
+    );
+  });
+
+  test.each([
+    [MonitorType.API, "Request headers", "Port"],
+    [MonitorType.Website, "Monitor destination", "Request headers"],
+    [MonitorType.Ping, "Monitor destination", "Request headers"],
+    [MonitorType.Port, "Port", "Request body"],
+    [MonitorType.DNS, "DNS query name", "Request headers"],
+    [MonitorType.SQLQuery, "Database connection", "Monitor destination"],
+    [MonitorType.SyntheticMonitor, "Browsers", "Request headers"],
+    [MonitorType.Logs, "Log query configuration", "Monitor destination"],
+  ])(
+    "offers relevant fields for %s",
+    (type: MonitorType, visible: string, hidden: string) => {
+      render(
+        <MonitorTemplateSyncFields
+          monitorType={type}
+          isMonitorTemplate={true}
+          value={configuredStep()}
+        />,
+      );
+      expect(
+        screen.getByRole("checkbox", {
+          name: `${visible} Do not sync this field`,
+        }),
+      ).toBeVisible();
+      expect(
+        screen.queryByRole("checkbox", {
+          name: `${hidden} Do not sync this field`,
+        }),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  test.each([undefined, false])(
+    "is hidden on ordinary monitors when template mode is %s",
+    (isMonitorTemplate: boolean | undefined) => {
+      const { container } = render(
+        <MonitorTemplateSyncFields
+          monitorType={MonitorType.API}
+          isMonitorTemplate={isMonitorTemplate}
+          value={configuredStep(["monitorDestination"])}
+        />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    },
+  );
+
+  test.each([MonitorType.Manual, MonitorType.NetworkDevice])(
+    "offers no sync controls for %s",
+    (monitorType: MonitorType) => {
+      const { container } = render(
+        <MonitorTemplateSyncFields
+          monitorType={monitorType}
+          isMonitorTemplate={true}
+          value={configuredStep()}
+        />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    },
+  );
+
+  test("field controls in separate steps have distinct accessible labels", () => {
+    render(
+      <>
+        <MonitorTemplateSyncFields
+          monitorType={MonitorType.API}
+          isMonitorTemplate={true}
+          value={configuredStep(["requestHeaders"])}
+        />
+        <MonitorTemplateSyncFields
+          monitorType={MonitorType.API}
+          isMonitorTemplate={true}
+          value={configuredStep()}
+        />
+      </>,
+    );
+    const headers: Array<HTMLElement> = screen.getAllByRole("checkbox", {
+      name: "Request headers Do not sync this field",
+    });
+    expect(headers[0]).toBeChecked();
+    expect(headers[1]).not.toBeChecked();
+    expect(headers[0]!.getAttribute("aria-labelledby")).not.toBe(
+      headers[1]!.getAttribute("aria-labelledby"),
+    );
+  });
+
+  test.each([MonitorType.Ping, MonitorType.Website])(
+    "changing template type to %s clears incompatible selections and preserves shared fields",
+    (monitorType: MonitorType) => {
+      const original: MonitorStep = configuredStep([
+        "monitorDestination",
+        "requestHeaders",
+      ]);
+      const onChange: MonitorStepChangeMock =
+        jest.fn<(value: MonitorStep) => void>();
+      const { rerender } = render(
+        <MonitorTemplateSyncFields
+          monitorType={MonitorType.API}
+          isMonitorTemplate={true}
+          value={original}
+          onChange={onChange}
+        />,
+      );
+      expect(onChange).not.toHaveBeenCalled();
+
+      rerender(
+        <MonitorTemplateSyncFields
+          monitorType={monitorType}
+          isMonitorTemplate={true}
+          value={original}
+          onChange={onChange}
+        />,
+      );
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0]![0].data?.doNotSyncFields).toEqual([
+        "monitorDestination",
+      ]);
+      expect(original.data?.doNotSyncFields).toEqual([
+        "monitorDestination",
+        "requestHeaders",
+      ]);
+      expect(
+        screen.queryByRole("checkbox", {
+          name: "Request headers Do not sync this field",
+        }),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  test("remounting after changing template type also clears incompatible selections", () => {
+    const onChange: MonitorStepChangeMock =
+      jest.fn<(value: MonitorStep) => void>();
+    render(
+      <MonitorTemplateSyncFields
+        monitorType={MonitorType.DNS}
+        isMonitorTemplate={true}
+        value={configuredStep(["monitorDestination", "requestHeaders"])}
+        onChange={onChange}
+      />,
+    );
+    expect(onChange.mock.calls[0]![0].data?.doNotSyncFields).toEqual([]);
+  });
+
+  test("does not rewrite ordinary monitor metadata", () => {
+    const onChange: MonitorStepChangeMock =
+      jest.fn<(value: MonitorStep) => void>();
+    render(
+      <MonitorTemplateSyncFields
+        monitorType={MonitorType.Ping}
+        value={configuredStep(["requestHeaders"])}
+        onChange={onChange}
+      />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("template sync summaries", () => {
+  test("shows saved protected field labels without showing protected values", () => {
+    render(
+      <MonitorTemplateSyncFieldsSummary
+        monitorType={MonitorType.API}
+        monitorSteps={monitorSteps(
+          configuredStep(["monitorDestination", "requestHeaders"]),
+        )}
+      />,
+    );
+    expect(
+      screen.getByText(/Monitor destination, Request headers/),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/New monitors still start with the template's values/),
+    ).toBeVisible();
+    expect(
+      screen.queryByText(
+        /monitor.example.test|secret-header|secret-request-body/,
+      ),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  test("an unprotected template explicitly says destinations and request settings are copied", () => {
+    const summary: string = getMonitorTemplateSyncFieldSummary({
+      monitorType: MonitorType.API,
+      monitorSteps: monitorSteps(configuredStep()),
+    });
+    expect(summary).toContain("No fields are protected.");
+    expect(summary).toContain("destinations and request options");
+  });
+
+  test("identifies the step when different steps protect different fields", () => {
+    const summary: string = getMonitorTemplateSyncFieldSummary({
+      monitorType: MonitorType.API,
+      monitorSteps: monitorSteps(
+        configuredStep(["monitorDestination"]),
+        configuredStep(["requestHeaders"]),
+      ),
+    });
+    expect(summary).toContain(
+      "Step 1: Monitor destination; Step 2: Request headers",
+    );
+  });
+
+  test("network device bindings are described as always preserved", () => {
+    const summary: string = getMonitorTemplateSyncFieldSummary({
+      monitorType: MonitorType.NetworkDevice,
+      monitorSteps: monitorSteps(configuredStep()),
+    });
+    expect(summary).toContain("Network device bindings are always preserved.");
+    expect(summary).not.toContain("No fields are protected.");
+  });
+});
+
+describe("template creation after skipping the criteria step", () => {
+  function renderCreatePage(): void {
+    render(
+      <MonitorTemplates
+        pageRoute={new Route("/monitor-templates")}
+        currentProject={null}
+        hasPaymentMethod={true}
+      />,
+    );
+    expect(templateCreateCallback).toBeDefined();
+  }
+
+  test("switching to Manual clears prior selections from every outgoing step without mutating form state", async () => {
+    renderCreatePage();
+    const originalSteps: MonitorSteps = monitorSteps(
+      configuredStep(["monitorDestination", "requestHeaders"]),
+      configuredStep(["requestBody"]),
+    );
+    const item: MonitorTemplate = new MonitorTemplate();
+    item.monitorType = MonitorType.Manual;
+    item.monitorSteps = originalSteps;
+
+    const outgoing: MonitorTemplate = await templateCreateCallback!(item);
+    expect(outgoing.monitorSteps).not.toBe(originalSteps);
+    expect(outgoing.monitorType).toBe(MonitorType.Manual);
+    expect(outgoing.monitorSteps?.data?.monitorStepsInstanceArray).toHaveLength(
+      2,
+    );
+    for (const step of outgoing.monitorSteps?.data?.monitorStepsInstanceArray ||
+      []) {
+      expect(step.data?.doNotSyncFields).toEqual([]);
+      expect(step.data?.requestBody).toBe("secret-request-body");
+    }
+    expect(
+      originalSteps.data?.monitorStepsInstanceArray[0]?.data?.doNotSyncFields,
+    ).toEqual(["monitorDestination", "requestHeaders"]);
+    expect(
+      originalSteps.data?.monitorStepsInstanceArray[1]?.data?.doNotSyncFields,
+    ).toEqual(["requestBody"]);
+  });
+
+  test("keeps configured protections when creating an API template", async () => {
+    renderCreatePage();
+    const item: MonitorTemplate = new MonitorTemplate();
+    item.monitorType = MonitorType.API;
+    item.monitorSteps = monitorSteps(
+      configuredStep(["monitorDestination", "requestHeaders"]),
+    );
+    const before: unknown = item.monitorSteps.toJSON();
+
+    const outgoing: MonitorTemplate = await templateCreateCallback!(item);
+    expect(outgoing.monitorSteps?.toJSON()).toEqual(before);
+  });
+
+  test("creating a Manual template without criteria does not invent steps", async () => {
+    renderCreatePage();
+    const item: MonitorTemplate = new MonitorTemplate();
+    item.monitorType = MonitorType.Manual;
+
+    const outgoing: MonitorTemplate = await templateCreateCallback!(item);
+    expect(outgoing.monitorSteps).toBeUndefined();
+  });
+});

--- a/Common/Tests/Server/Services/MonitorTemplateServiceFieldSync.test.ts
+++ b/Common/Tests/Server/Services/MonitorTemplateServiceFieldSync.test.ts
@@ -1,0 +1,994 @@
+import DatabaseBaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import Label from "../../../Models/DatabaseModels/Label";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorTemplate from "../../../Models/DatabaseModels/MonitorTemplate";
+import MonitorService from "../../../Server/Services/MonitorService";
+import MonitorTemplateService, {
+  Service,
+} from "../../../Server/Services/MonitorTemplateService";
+import NetworkAlertPolicyEngineService from "../../../Server/Services/NetworkAlertPolicyEngineService";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import FindBy from "../../../Server/Types/Database/FindBy";
+import { OnCreate, OnUpdate } from "../../../Server/Types/Database/Hooks";
+import ModelPermission from "../../../Server/Types/Database/Permissions/Index";
+import Query from "../../../Server/Types/Database/Query";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import MonitorStepsProjectValidator from "../../../Server/Utils/Monitor/MonitorStepsProjectValidator";
+import HTTPMethod from "../../../Types/API/HTTPMethod";
+import URL from "../../../Types/API/URL";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import LIMIT_MAX from "../../../Types/Database/LimitMax";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import MonitorSteps from "../../../Types/Monitor/MonitorSteps";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import type { SpyInstance } from "jest-mock";
+
+// Exercise the real paging boundaries without allocating ten thousand steps.
+jest.mock("../../../Types/Database/LimitMax", () => {
+  return {
+    __esModule: true,
+    default: 3,
+    LIMIT_PER_PROJECT: 10000,
+    LIMIT_INFINITY: 999999999,
+    DEFAULT_LIMIT: 10,
+  };
+});
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const TEMPLATE_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const TEMPLATE_DEVICE_ID: string = "33333333-3333-4333-8333-333333333333";
+const MONITOR_DEVICE_ID: string = "44444444-4444-4444-8444-444444444444";
+const OWNED_DEVICE_ID: string = "55555555-5555-4555-8555-555555555555";
+const PROTECTED_FIELDS: Array<string> = [
+  "monitorDestination",
+  "requestHeaders",
+  "requestBody",
+  "retryCount",
+  "doNotFollowRedirects",
+];
+
+type SyncMode = "bulk" | "single";
+
+class TestableMonitorTemplateService extends Service {
+  public beforeCreate(
+    createBy: CreateBy<MonitorTemplate>,
+  ): Promise<OnCreate<MonitorTemplate>> {
+    return super.onBeforeCreate(createBy);
+  }
+
+  public beforeUpdate(
+    updateBy: UpdateBy<MonitorTemplate>,
+  ): Promise<OnUpdate<MonitorTemplate>> {
+    return super.onBeforeUpdate(updateBy);
+  }
+}
+
+function buildStep(data: {
+  id?: string;
+  destination: string;
+  criteriaName: string;
+  excludedFields?: Array<string>;
+}): MonitorStep {
+  const step: MonitorStep = new MonitorStep();
+  step.data!.id = data.id || "request-step";
+  step.data!.monitorDestination = URL.fromString(data.destination);
+  step.data!.monitorCriteria.data!.monitorCriteriaInstanceArray[0]!.data!.name =
+    data.criteriaName;
+  step.data!.monitorCriteria.data!.monitorCriteriaInstanceArray[0]!.data!.description =
+    data.criteriaName;
+  step.data!.requestType = HTTPMethod.POST;
+  step.data!.requestHeaders = { "X-Template": "shared" };
+  step.data!.requestBody = '{"source":"template"}';
+  step.data!.retryCount = 3;
+  step.data!.doNotFollowRedirects = true;
+  step.data!.requestTimeoutInMs = 15000;
+  step.data!.doNotSyncFields = data.excludedFields;
+  return step;
+}
+
+function buildSteps(steps: Array<MonitorStep>): MonitorSteps {
+  const result: MonitorSteps = new MonitorSteps();
+  result.data = {
+    monitorStepsInstanceArray: steps,
+    defaultMonitorStatusId: ObjectID.generate(),
+  };
+  return result;
+}
+
+function buildTemplate(
+  excludedFields: Array<string> | undefined = PROTECTED_FIELDS,
+): MonitorTemplate {
+  const template: MonitorTemplate = new MonitorTemplate();
+  template.id = TEMPLATE_ID;
+  template.projectId = PROJECT_ID;
+  template.monitorType = MonitorType.API;
+  template.monitoringInterval = "*/10 * * * *";
+  template.minimumProbeAgreement = 2;
+  template.monitorSteps = buildSteps([
+    buildStep({
+      destination: "https://template.example/health",
+      criteriaName: "Updated shared criteria",
+      excludedFields,
+    }),
+  ]);
+  return template;
+}
+
+function buildMonitor(index: number = 0): Monitor {
+  const monitor: Monitor = new Monitor();
+  monitor.id = ObjectID.generate();
+  monitor.projectId = PROJECT_ID;
+  monitor.monitorTemplateId = TEMPLATE_ID;
+  monitor.monitorType = MonitorType.API;
+  monitor.monitoringInterval = "*/2 * * * *";
+  const step: MonitorStep = buildStep({
+    destination: `https://monitor-${index}.example/health`,
+    criteriaName: "Previous local criteria",
+  });
+  step.data!.requestHeaders = { "X-Instance": `monitor-${index}` };
+  step.data!.requestBody = `{"instance":${index}}`;
+  step.data!.retryCount = 0;
+  step.data!.doNotFollowRedirects = false;
+  step.data!.requestTimeoutInMs = 1000;
+  monitor.monitorSteps = buildSteps([step]);
+  return monitor;
+}
+
+interface SyncMocks {
+  updateOne: SpyInstance<typeof MonitorService.updateOneById>;
+  updateBulk: SpyInstance<typeof MonitorService.updateBy>;
+  findMany: SpyInstance<typeof MonitorService.findBy>;
+  findOne: SpyInstance<typeof MonitorService.findOneById>;
+  permissions: SpyInstance<typeof ModelPermission.checkUpdateQueryPermissions>;
+  stamp: SpyInstance<
+    typeof NetworkAlertPolicyEngineService.onMonitorTemplateSynced
+  >;
+}
+
+function mockSync(
+  template: MonitorTemplate,
+  monitors: Array<Monitor>,
+): SyncMocks {
+  jest.spyOn(MonitorTemplateService, "findOneById").mockResolvedValue(template);
+  jest
+    .spyOn(MonitorTemplateService, "countLinkedMonitors")
+    .mockResolvedValue(monitors.length);
+
+  return {
+    updateOne: jest.spyOn(MonitorService, "updateOneById").mockResolvedValue(1),
+    updateBulk: jest
+      .spyOn(MonitorService, "updateBy")
+      .mockResolvedValue(monitors.length),
+    findMany: jest
+      .spyOn(MonitorService, "findBy")
+      .mockImplementation(
+        async (findBy: FindBy<Monitor>): Promise<Array<Monitor>> => {
+          const skip: number = Number(findBy.skip?.toString() || 0);
+          const limit: number = Number(findBy.limit?.toString() || LIMIT_MAX);
+          return monitors.slice(skip, skip + limit);
+        },
+      ),
+    findOne: jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(monitors[0] || null),
+    permissions: jest
+      .spyOn(ModelPermission, "checkUpdateQueryPermissions")
+      .mockImplementation(
+        async <TBaseModel extends DatabaseBaseModel>(
+          _model: { new (): TBaseModel },
+          query: Query<TBaseModel>,
+        ): Promise<Query<TBaseModel>> => {
+          return query;
+        },
+      ),
+    stamp: jest
+      .spyOn(NetworkAlertPolicyEngineService, "onMonitorTemplateSynced")
+      .mockResolvedValue(undefined),
+  };
+}
+
+async function sync(
+  mode: SyncMode,
+  monitor: Monitor,
+  fields: Array<string> | undefined = ["monitorSteps"],
+): Promise<void> {
+  const data: {
+    monitorTemplateId: ObjectID;
+    props: DatabaseCommonInteractionProps;
+    fields?: Array<string>;
+  } = {
+    monitorTemplateId: TEMPLATE_ID,
+    props: { isRoot: true },
+    fields,
+  };
+
+  if (mode === "single") {
+    await MonitorTemplateService.syncToMonitor({
+      ...data,
+      monitorId: monitor.id!,
+    });
+  } else {
+    await MonitorTemplateService.syncLinkedMonitors(data);
+  }
+}
+
+function writtenSteps(mocks: SyncMocks, index: number = 0): MonitorSteps {
+  return mocks.updateOne.mock.calls[index]![0].data
+    .monitorSteps as MonitorSteps;
+}
+
+function firstStep(steps: MonitorSteps): MonitorStep {
+  return steps.data!.monitorStepsInstanceArray[0]!;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("MonitorTemplateService validates saved field exclusions", () => {
+  it("saves supported fields and still validates the template's project references", async () => {
+    const service: TestableMonitorTemplateService =
+      new TestableMonitorTemplateService();
+    const template: MonitorTemplate = buildTemplate();
+    const validateReferences: SpyInstance<
+      typeof MonitorStepsProjectValidator.validateMonitorStepsBelongToProject
+    > = jest
+      .spyOn(
+        MonitorStepsProjectValidator,
+        "validateMonitorStepsBelongToProject",
+      )
+      .mockResolvedValue(undefined);
+    const createBy: CreateBy<MonitorTemplate> = {
+      data: template,
+      props: { tenantId: PROJECT_ID },
+    };
+
+    await expect(service.beforeCreate(createBy)).resolves.toEqual({
+      createBy,
+      carryForward: null,
+    });
+
+    expect(validateReferences).toHaveBeenCalledWith({
+      monitorSteps: template.monitorSteps,
+      projectId: PROJECT_ID,
+    });
+    expect(firstStep(template.monitorSteps!).data!.doNotSyncFields).toEqual(
+      PROTECTED_FIELDS,
+    );
+  });
+
+  it.each(["not-a-field", "monitorCriteria", "dnsMonitor.queryName"])(
+    "rejects unsupported API template exclusion %s before project lookup",
+    async (field: string) => {
+      const service: TestableMonitorTemplateService =
+        new TestableMonitorTemplateService();
+      const template: MonitorTemplate = buildTemplate([field]);
+      const validateReferences: SpyInstance<
+        typeof MonitorStepsProjectValidator.validateMonitorStepsBelongToProject
+      > = jest
+        .spyOn(
+          MonitorStepsProjectValidator,
+          "validateMonitorStepsBelongToProject",
+        )
+        .mockResolvedValue(undefined);
+
+      await expect(
+        service.beforeCreate({
+          data: template,
+          props: { tenantId: PROJECT_ID },
+        }),
+      ).rejects.toThrow(BadDataException);
+
+      expect(validateReferences).not.toHaveBeenCalled();
+    },
+  );
+
+  it("requires a monitor type when exclusions are configured", async () => {
+    const service: TestableMonitorTemplateService =
+      new TestableMonitorTemplateService();
+    const template: MonitorTemplate = buildTemplate();
+    delete template.monitorType;
+    jest
+      .spyOn(
+        MonitorStepsProjectValidator,
+        "validateMonitorStepsBelongToProject",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      service.beforeCreate({ data: template, props: { tenantId: PROJECT_ID } }),
+    ).rejects.toThrow("Monitor type is required");
+  });
+
+  it("continues accepting unfinished templates without exclusions", async () => {
+    const service: TestableMonitorTemplateService =
+      new TestableMonitorTemplateService();
+    const template: MonitorTemplate = buildTemplate([]);
+    delete template.monitorType;
+    jest
+      .spyOn(
+        MonitorStepsProjectValidator,
+        "validateMonitorStepsBelongToProject",
+      )
+      .mockResolvedValue(undefined);
+    const createBy: CreateBy<MonitorTemplate> = {
+      data: template,
+      props: { tenantId: PROJECT_ID },
+    };
+
+    await expect(service.beforeCreate(createBy)).resolves.toEqual({
+      createBy,
+      carryForward: null,
+    });
+  });
+
+  it("checks all steps when saving a template", async () => {
+    const service: TestableMonitorTemplateService =
+      new TestableMonitorTemplateService();
+    const template: MonitorTemplate = buildTemplate(["monitorDestination"]);
+    template.monitorSteps!.data!.monitorStepsInstanceArray.push(
+      buildStep({
+        id: "later-step",
+        destination: "https://later.example",
+        criteriaName: "Later",
+        excludedFields: ["dnsMonitor.queryName"],
+      }),
+    );
+    jest
+      .spyOn(
+        MonitorStepsProjectValidator,
+        "validateMonitorStepsBelongToProject",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      service.beforeCreate({ data: template, props: { tenantId: PROJECT_ID } }),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("uses the saved monitor type to validate a step-only update", async () => {
+    const service: TestableMonitorTemplateService =
+      new TestableMonitorTemplateService();
+    const storedTemplate: MonitorTemplate = buildTemplate([]);
+    const updatedSteps: MonitorSteps = buildTemplate([
+      "requestHeaders",
+    ]).monitorSteps!;
+    const read: SpyInstance<typeof service.findBy> = jest
+      .spyOn(service, "findBy")
+      .mockResolvedValue([storedTemplate]);
+    const validateReferences: SpyInstance<
+      typeof MonitorStepsProjectValidator.validateMonitorStepsBelongToProject
+    > = jest
+      .spyOn(
+        MonitorStepsProjectValidator,
+        "validateMonitorStepsBelongToProject",
+      )
+      .mockResolvedValue(undefined);
+    const updateBy: UpdateBy<MonitorTemplate> = {
+      query: { _id: TEMPLATE_ID },
+      data: {
+        monitorSteps: updatedSteps,
+      } as unknown as UpdateBy<MonitorTemplate>["data"],
+      props: { tenantId: PROJECT_ID },
+      limit: 1,
+      skip: 0,
+    };
+
+    await expect(service.beforeUpdate(updateBy)).resolves.toEqual({
+      updateBy,
+      carryForward: null,
+    });
+
+    expect(read.mock.calls[0]![0].select).toEqual(
+      expect.objectContaining({ monitorType: true, monitorSteps: true }),
+    );
+    expect(validateReferences).toHaveBeenCalledWith({
+      monitorSteps: updatedSteps,
+      alreadyStoredMonitorSteps: storedTemplate.monitorSteps,
+      projectId: PROJECT_ID,
+    });
+  });
+
+  it("rejects fields for another monitor type on update", async () => {
+    const service: TestableMonitorTemplateService =
+      new TestableMonitorTemplateService();
+    const storedTemplate: MonitorTemplate = buildTemplate([]);
+    jest.spyOn(service, "findBy").mockResolvedValue([storedTemplate]);
+    const validateReferences: SpyInstance<
+      typeof MonitorStepsProjectValidator.validateMonitorStepsBelongToProject
+    > = jest
+      .spyOn(
+        MonitorStepsProjectValidator,
+        "validateMonitorStepsBelongToProject",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      service.beforeUpdate({
+        query: { _id: TEMPLATE_ID },
+        data: {
+          monitorSteps: buildTemplate(["dnsMonitor.queryName"]).monitorSteps!,
+        } as unknown as UpdateBy<MonitorTemplate>["data"],
+        props: { tenantId: PROJECT_ID },
+        limit: 1,
+        skip: 0,
+      }),
+    ).rejects.toThrow(BadDataException);
+
+    expect(validateReferences).not.toHaveBeenCalled();
+  });
+
+  it("rejects a type change that would leave incompatible stored exclusions", async () => {
+    const service: TestableMonitorTemplateService =
+      new TestableMonitorTemplateService();
+    const storedTemplate: MonitorTemplate = buildTemplate(["requestHeaders"]);
+    jest.spyOn(service, "findBy").mockResolvedValue([storedTemplate]);
+    jest
+      .spyOn(
+        MonitorStepsProjectValidator,
+        "validateMonitorStepsBelongToProject",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      service.beforeUpdate({
+        query: { _id: TEMPLATE_ID },
+        data: { monitorType: MonitorType.DNS },
+        props: { tenantId: PROJECT_ID },
+        limit: 1,
+        skip: 0,
+      }),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("accepts a type change when the same update replaces its exclusions with compatible fields", async () => {
+    const service: TestableMonitorTemplateService =
+      new TestableMonitorTemplateService();
+    const storedTemplate: MonitorTemplate = buildTemplate(["requestHeaders"]);
+    jest.spyOn(service, "findBy").mockResolvedValue([storedTemplate]);
+    jest
+      .spyOn(
+        MonitorStepsProjectValidator,
+        "validateMonitorStepsBelongToProject",
+      )
+      .mockResolvedValue(undefined);
+    const updateBy: UpdateBy<MonitorTemplate> = {
+      query: { _id: TEMPLATE_ID },
+      data: {
+        monitorType: MonitorType.DNS,
+        monitorSteps: buildTemplate(["dnsMonitor.queryName"]).monitorSteps!,
+      } as unknown as UpdateBy<MonitorTemplate>["data"],
+      props: { tenantId: PROJECT_ID },
+      limit: 1,
+      skip: 0,
+    };
+
+    await expect(service.beforeUpdate(updateBy)).resolves.toEqual({
+      updateBy,
+      carryForward: null,
+    });
+  });
+
+  it("does not inspect stored exclusions for an unrelated template name update", async () => {
+    const service: TestableMonitorTemplateService =
+      new TestableMonitorTemplateService();
+    const read: SpyInstance<typeof service.findBy> = jest
+      .spyOn(service, "findBy")
+      .mockResolvedValue([buildTemplate(["not-a-field"])]);
+    const validateReferences: SpyInstance<
+      typeof MonitorStepsProjectValidator.validateMonitorStepsBelongToProject
+    > = jest
+      .spyOn(
+        MonitorStepsProjectValidator,
+        "validateMonitorStepsBelongToProject",
+      )
+      .mockResolvedValue(undefined);
+    const updateBy: UpdateBy<MonitorTemplate> = {
+      query: { _id: TEMPLATE_ID },
+      data: { templateName: "Renamed template" },
+      props: { tenantId: PROJECT_ID },
+      limit: 1,
+      skip: 0,
+    };
+
+    await expect(service.beforeUpdate(updateBy)).resolves.toEqual({
+      updateBy,
+      carryForward: null,
+    });
+
+    expect(read).not.toHaveBeenCalled();
+    expect(validateReferences).not.toHaveBeenCalled();
+  });
+});
+
+describe("MonitorTemplateService field exclusions", () => {
+  it("syncs shared criteria while every linked monitor retains its destination, headers, body and disabled options", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    const monitors: Array<Monitor> = [buildMonitor(1), buildMonitor(2)];
+    const templateBefore: JSONObject = template.monitorSteps!.toJSON();
+    const monitorBefore: Array<JSONObject> = monitors.map(
+      (monitor: Monitor): JSONObject => {
+        return monitor.monitorSteps!.toJSON();
+      },
+    );
+    const mocks: SyncMocks = mockSync(template, monitors);
+
+    const result: unknown = await MonitorTemplateService.syncLinkedMonitors({
+      monitorTemplateId: TEMPLATE_ID,
+      props: { isRoot: true },
+      fields: ["monitorSteps"],
+    });
+
+    expect(result).toEqual({ totalLinkedMonitors: 2, syncedMonitors: 2 });
+    expect(mocks.updateOne).toHaveBeenCalledTimes(2);
+    expect(mocks.updateBulk).not.toHaveBeenCalled();
+    for (let index: number = 0; index < monitors.length; index++) {
+      const current: MonitorStep = firstStep(monitors[index]!.monitorSteps!);
+      const updated: MonitorStep = firstStep(writtenSteps(mocks, index));
+      expect(updated.data!.monitorDestination!.toString()).toBe(
+        current.data!.monitorDestination!.toString(),
+      );
+      expect(updated.data!.requestHeaders).toEqual(
+        current.data!.requestHeaders,
+      );
+      expect(updated.data!.requestBody).toBe(current.data!.requestBody);
+      expect(updated.data!.retryCount).toBe(0);
+      expect(Boolean(updated.data!.doNotFollowRedirects)).toBe(false);
+      expect(updated.data!.requestTimeoutInMs).toBe(15000);
+      expect(updated.data!.doNotSyncFields).toBeUndefined();
+      expect(updated.data!.monitorCriteria.toJSON()).toEqual(
+        firstStep(template.monitorSteps!).data!.monitorCriteria.toJSON(),
+      );
+      expect(writtenSteps(mocks, index).data!.defaultMonitorStatusId).toEqual(
+        template.monitorSteps!.data!.defaultMonitorStatusId,
+      );
+      expect(Object.keys(mocks.updateOne.mock.calls[index]![0].data)).toEqual([
+        "monitorSteps",
+      ]);
+    }
+    expect(template.monitorSteps!.toJSON()).toEqual(templateBefore);
+    expect(
+      monitors.map((monitor: Monitor): JSONObject => {
+        return monitor.monitorSteps!.toJSON();
+      }),
+    ).toEqual(monitorBefore);
+    expect(mocks.stamp).toHaveBeenCalledWith({
+      monitorTemplateId: TEMPLATE_ID,
+      projectId: PROJECT_ID,
+    });
+  });
+
+  it.each(["bulk", "single"] as const)(
+    "%s sync preserves an empty header bag and an absent body instead of restoring template defaults",
+    async (mode: SyncMode) => {
+      const template: MonitorTemplate = buildTemplate();
+      const monitor: Monitor = buildMonitor();
+      firstStep(monitor.monitorSteps!).data!.requestHeaders = {};
+      delete firstStep(monitor.monitorSteps!).data!.requestBody;
+      const mocks: SyncMocks = mockSync(template, [monitor]);
+
+      await sync(mode, monitor);
+
+      const updated: MonitorStep = firstStep(writtenSteps(mocks));
+      expect(updated.data!.requestHeaders).toEqual({});
+      expect(updated.data!.requestBody).toBeUndefined();
+      expect(updated.data!.retryCount).toBe(0);
+      expect(Boolean(updated.data!.doNotFollowRedirects)).toBe(false);
+      expect(updated.data!.monitorCriteria.toJSON()).toEqual(
+        firstStep(template.monitorSteps!).data!.monitorCriteria.toJSON(),
+      );
+      expect(
+        mocks.updateOne.mock.calls[0]![0].data.monitoringInterval,
+      ).toBeUndefined();
+    },
+  );
+
+  it.each(["bulk", "single"] as const)(
+    "%s sync preserves absent headers and accepts an independently linked single step",
+    async (mode: SyncMode) => {
+      const template: MonitorTemplate = buildTemplate();
+      const monitor: Monitor = buildMonitor();
+      firstStep(monitor.monitorSteps!).data!.id = "independently-created-step";
+      delete firstStep(monitor.monitorSteps!).data!.requestHeaders;
+      const mocks: SyncMocks = mockSync(template, [monitor]);
+
+      await sync(mode, monitor);
+
+      const updated: MonitorStep = firstStep(writtenSteps(mocks));
+      expect(updated.data!.id).toBe("request-step");
+      expect(updated.data!.requestHeaders).toBeUndefined();
+      expect(updated.data!.monitorDestination!.toString()).toBe(
+        firstStep(monitor.monitorSteps!).data!.monitorDestination!.toString(),
+      );
+    },
+  );
+
+  it.each(["bulk", "single"] as const)(
+    "%s sync resumes replacing a field when its exclusion is unchecked",
+    async (mode: SyncMode) => {
+      const template: MonitorTemplate = buildTemplate(["monitorDestination"]);
+      const monitor: Monitor = buildMonitor();
+      firstStep(monitor.monitorSteps!).data!.doNotSyncFields = [
+        ...PROTECTED_FIELDS,
+      ];
+      const mocks: SyncMocks = mockSync(template, [monitor]);
+
+      await sync(mode, monitor);
+
+      const updated: MonitorStep = firstStep(writtenSteps(mocks));
+      expect(updated.data!.monitorDestination!.toString()).toBe(
+        firstStep(monitor.monitorSteps!).data!.monitorDestination!.toString(),
+      );
+      expect(updated.data!.requestHeaders).toEqual({ "X-Template": "shared" });
+      expect(updated.data!.requestBody).toBe('{"source":"template"}');
+      expect(updated.data!.retryCount).toBe(3);
+      expect(updated.data!.doNotFollowRedirects).toBe(true);
+    },
+  );
+
+  it("keeps the ordinary bulk path for old templates without exclusions", async () => {
+    const template: MonitorTemplate = buildTemplate([]);
+    const monitor: Monitor = buildMonitor();
+    firstStep(monitor.monitorSteps!).data!.doNotSyncFields = [
+      ...PROTECTED_FIELDS,
+    ];
+    const mocks: SyncMocks = mockSync(template, [monitor]);
+
+    await sync("bulk", monitor);
+
+    expect(mocks.updateOne).not.toHaveBeenCalled();
+    expect(mocks.updateBulk).toHaveBeenCalledTimes(1);
+    expect(mocks.updateBulk.mock.calls[0]![0].data.monitorSteps).toBe(
+      template.monitorSteps,
+    );
+    expect(mocks.findMany.mock.calls[0]![0].select).toEqual({ _id: true });
+  });
+
+  it.each(["bulk", "single"] as const)(
+    "%s sync merges custom field defaults with each monitor's protected step fields",
+    async (mode: SyncMode) => {
+      const template: MonitorTemplate = buildTemplate();
+      template.customFields = { Vendor: "Shared vendor", Asset: "" };
+      const monitor: Monitor = buildMonitor();
+      monitor.customFields = {
+        Vendor: "Previous vendor",
+        Asset: "local-asset-42",
+        Notes: "Keep me",
+      };
+      const mocks: SyncMocks = mockSync(template, [monitor]);
+
+      await sync(mode, monitor, ["monitorSteps", "customFields"]);
+
+      expect(mocks.updateOne.mock.calls[0]![0].data.customFields).toEqual({
+        Vendor: "Shared vendor",
+        Asset: "local-asset-42",
+        Notes: "Keep me",
+      });
+      expect(firstStep(writtenSteps(mocks)).data!.requestHeaders).toEqual({
+        "X-Instance": "monitor-0",
+      });
+      expect(
+        mocks.updateOne.mock.calls[0]![0].data.monitoringInterval,
+      ).toBeUndefined();
+    },
+  );
+
+  it.each(["bulk", "single"] as const)(
+    "%s interval and label sync does not read or validate malformed excluded steps",
+    async (mode: SyncMode) => {
+      const template: MonitorTemplate = buildTemplate(["not-a-real-field"]);
+      template.monitorSteps!.data!.monitorStepsInstanceArray.push(
+        firstStep(template.monitorSteps!),
+      );
+      const label: Label = new Label();
+      label.id = ObjectID.generate();
+      template.labels = [label];
+      const monitor: Monitor = buildMonitor();
+      delete monitor.monitorSteps;
+      const mocks: SyncMocks = mockSync(template, [monitor]);
+
+      await sync(mode, monitor, ["monitoringInterval", "labels"]);
+
+      const payload: unknown =
+        mode === "bulk"
+          ? mocks.updateBulk.mock.calls[0]![0].data
+          : mocks.updateOne.mock.calls[0]![0].data;
+      expect(payload).toEqual({
+        monitoringInterval: template.monitoringInterval,
+        labels: [label],
+      });
+      if (mode === "bulk") {
+        expect(mocks.findMany.mock.calls[0]![0].select).toEqual({ _id: true });
+        expect(mocks.updateOne).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it("scopes protected-field reads to the caller's update permissions and preserves those permissions on writes", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    const visible: Monitor = buildMonitor(1);
+    const hidden: Monitor = buildMonitor(2);
+    const label: Label = new Label();
+    label.id = ObjectID.generate();
+    const authorizedQuery: Query<Monitor> = {
+      projectId: PROJECT_ID,
+      monitorTemplateId: TEMPLATE_ID,
+      labels: [label],
+    };
+    const props: DatabaseCommonInteractionProps = {
+      tenantId: PROJECT_ID,
+      userId: ObjectID.generate(),
+    };
+    const mocks: SyncMocks = mockSync(template, [visible, hidden]);
+    mocks.permissions.mockResolvedValue(authorizedQuery);
+    mocks.findMany.mockResolvedValue([visible]);
+
+    const result: unknown = await MonitorTemplateService.syncLinkedMonitors({
+      monitorTemplateId: TEMPLATE_ID,
+      fields: ["monitorSteps"],
+      props,
+    });
+
+    expect(mocks.permissions).toHaveBeenCalledWith(
+      Monitor,
+      {
+        projectId: PROJECT_ID,
+        monitorTemplateId: TEMPLATE_ID,
+      },
+      expect.objectContaining({ monitorSteps: template.monitorSteps }),
+      props,
+    );
+    expect(mocks.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: authorizedQuery,
+        select: expect.objectContaining({ _id: true, monitorSteps: true }),
+        props: { isRoot: true },
+      }),
+    );
+    expect(mocks.updateOne).toHaveBeenCalledTimes(1);
+    expect(mocks.updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ id: visible.id, props }),
+    );
+    expect(result).toEqual({ totalLinkedMonitors: 2, syncedMonitors: 1 });
+    expect(mocks.stamp).not.toHaveBeenCalled();
+  });
+
+  it("does not read protected values or write anything when update authorization is denied", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    const monitor: Monitor = buildMonitor();
+    const mocks: SyncMocks = mockSync(template, [monitor]);
+    mocks.permissions.mockRejectedValue(
+      new BadDataException("Update permission denied"),
+    );
+
+    await expect(sync("bulk", monitor)).rejects.toThrow(
+      "Update permission denied",
+    );
+
+    expect(mocks.findMany).not.toHaveBeenCalled();
+    expect(mocks.updateOne).not.toHaveBeenCalled();
+    expect(mocks.updateBulk).not.toHaveBeenCalled();
+  });
+
+  it("uses the caller's original permissions and a linked monitor check for single-monitor sync", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    const monitor: Monitor = buildMonitor();
+    const props: DatabaseCommonInteractionProps = {
+      tenantId: PROJECT_ID,
+      userId: ObjectID.generate(),
+    };
+    const mocks: SyncMocks = mockSync(template, [monitor]);
+
+    await MonitorTemplateService.syncToMonitor({
+      monitorTemplateId: TEMPLATE_ID,
+      monitorId: monitor.id!,
+      fields: ["monitorSteps"],
+      props,
+    });
+
+    expect(mocks.updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ id: monitor.id, props }),
+    );
+    expect(firstStep(writtenSteps(mocks)).data!.requestHeaders).toEqual({
+      "X-Instance": "monitor-0",
+    });
+    monitor.monitorTemplateId = ObjectID.generate();
+    mocks.updateOne.mockClear();
+    await expect(
+      MonitorTemplateService.syncToMonitor({
+        monitorTemplateId: TEMPLATE_ID,
+        monitorId: monitor.id!,
+        fields: ["monitorSteps"],
+        props,
+      }),
+    ).rejects.toThrow("Monitor is not linked to this template");
+    expect(mocks.updateOne).not.toHaveBeenCalled();
+  });
+
+  it.each([LIMIT_MAX, LIMIT_MAX * 2 + 1])(
+    "retains unique fields across every page of a %i-monitor fleet",
+    async (count: number) => {
+      const template: MonitorTemplate = buildTemplate();
+      const monitors: Array<Monitor> = Array.from(
+        { length: count },
+        (_unused: unknown, index: number): Monitor => {
+          return buildMonitor(index);
+        },
+      );
+      const mocks: SyncMocks = mockSync(template, monitors);
+
+      const result: unknown = await MonitorTemplateService.syncLinkedMonitors({
+        monitorTemplateId: TEMPLATE_ID,
+        props: { isRoot: true },
+        fields: ["monitorSteps"],
+      });
+
+      expect(result).toEqual({
+        totalLinkedMonitors: count,
+        syncedMonitors: count,
+      });
+      expect(mocks.updateOne).toHaveBeenCalledTimes(count);
+      expect(
+        mocks.findMany.mock.calls.map((call: [FindBy<Monitor>]): number => {
+          return Number(call[0].skip);
+        }),
+      ).toEqual(
+        Array.from(
+          { length: Math.floor(count / LIMIT_MAX) + 1 },
+          (_unused: unknown, index: number): number => {
+            return index * LIMIT_MAX;
+          },
+        ),
+      );
+      expect(mocks.findMany.mock.calls[0]![0].sort).toEqual({
+        createdAt: SortOrder.Ascending,
+        _id: SortOrder.Ascending,
+      });
+      expect(
+        mocks.findMany.mock.invocationCallOrder[
+          mocks.findMany.mock.invocationCallOrder.length - 1
+        ]!,
+      ).toBeLessThan(mocks.updateOne.mock.invocationCallOrder[0]!);
+      for (let index: number = 0; index < count; index++) {
+        expect(mocks.updateOne.mock.calls[index]![0].id).toEqual(
+          monitors[index]!.id,
+        );
+        expect(
+          firstStep(writtenSteps(mocks, index)).data!.requestHeaders,
+        ).toEqual({ "X-Instance": `monitor-${index}` });
+      }
+    },
+  );
+
+  it("rejects an ambiguous unmatched step in a later page before writing the first monitor", async () => {
+    const template: MonitorTemplate = buildTemplate([
+      "monitorDestination",
+      "requestHeaders",
+    ]);
+    const monitors: Array<Monitor> = Array.from(
+      { length: LIMIT_MAX + 1 },
+      (_unused: unknown, index: number): Monitor => {
+        return buildMonitor(index);
+      },
+    );
+    const ambiguous: Monitor = monitors[monitors.length - 1]!;
+    ambiguous.monitorSteps = buildSteps([
+      buildStep({
+        id: "unrelated-a",
+        destination: "https://first.example",
+        criteriaName: "First",
+      }),
+      buildStep({
+        id: "unrelated-b",
+        destination: "https://second.example",
+        criteriaName: "Second",
+      }),
+    ]);
+    const mocks: SyncMocks = mockSync(template, monitors);
+
+    await expect(sync("bulk", monitors[0]!)).rejects.toThrow(BadDataException);
+
+    expect(mocks.findMany).toHaveBeenCalledTimes(2);
+    expect(mocks.updateOne).not.toHaveBeenCalled();
+    expect(mocks.updateBulk).not.toHaveBeenCalled();
+    expect(mocks.stamp).not.toHaveBeenCalled();
+  });
+
+  it("rejects an ambiguous single monitor without writing an update", async () => {
+    const template: MonitorTemplate = buildTemplate(["requestHeaders"]);
+    const monitor: Monitor = buildMonitor();
+    const first: MonitorStep = firstStep(monitor.monitorSteps!);
+    first.data!.id = "unrelated-a";
+    const second: MonitorStep = buildStep({
+      id: "unrelated-b",
+      destination: "https://same.example",
+      criteriaName: "Second",
+    });
+    second.data!.requestHeaders = { "X-Other": "different" };
+    monitor.monitorSteps!.data!.monitorStepsInstanceArray.push(second);
+    const mocks: SyncMocks = mockSync(template, [monitor]);
+
+    await expect(sync("single", monitor)).rejects.toThrow(BadDataException);
+
+    expect(mocks.updateOne).not.toHaveBeenCalled();
+  });
+
+  it.each(["bulk", "single"] as const)(
+    "%s sync retains automatic device ownership even when the current binding is stale",
+    async (mode: SyncMode) => {
+      const template: MonitorTemplate = buildTemplate([]);
+      template.monitorType = MonitorType.NetworkDevice;
+      firstStep(template.monitorSteps!).data!.networkDeviceMonitor = {
+        networkDeviceId: TEMPLATE_DEVICE_ID,
+        monitorInterfaces: true,
+        collectEndpoints: false,
+        oids: [],
+      };
+      const monitor: Monitor = buildMonitor();
+      monitor.monitorType = MonitorType.NetworkDevice;
+      monitor.autoProvisionedNetworkDeviceId = new ObjectID(OWNED_DEVICE_ID);
+      firstStep(monitor.monitorSteps!).data!.networkDeviceMonitor = {
+        networkDeviceId: MONITOR_DEVICE_ID,
+        monitorInterfaces: false,
+        collectEndpoints: false,
+        oids: [],
+      };
+      const mocks: SyncMocks = mockSync(template, [monitor]);
+
+      await sync(mode, monitor);
+
+      expect(
+        firstStep(writtenSteps(mocks)).data!.networkDeviceMonitor!
+          .networkDeviceId,
+      ).toBe(OWNED_DEVICE_ID);
+      expect(
+        firstStep(writtenSteps(mocks)).data!.monitorCriteria.toJSON(),
+      ).toEqual(
+        firstStep(template.monitorSteps!).data!.monitorCriteria.toJSON(),
+      );
+      expect(
+        firstStep(template.monitorSteps!).data!.networkDeviceMonitor!
+          .networkDeviceId,
+      ).toBe(TEMPLATE_DEVICE_ID);
+    },
+  );
+
+  it("keeps a manual network monitor's device while syncing shared criteria", async () => {
+    const template: MonitorTemplate = buildTemplate([]);
+    template.monitorType = MonitorType.NetworkDevice;
+    firstStep(template.monitorSteps!).data!.networkDeviceMonitor = {
+      networkDeviceId: TEMPLATE_DEVICE_ID,
+      monitorInterfaces: true,
+      collectEndpoints: false,
+      oids: [],
+    };
+    const monitor: Monitor = buildMonitor();
+    monitor.monitorType = MonitorType.NetworkDevice;
+    firstStep(monitor.monitorSteps!).data!.networkDeviceMonitor = {
+      networkDeviceId: MONITOR_DEVICE_ID,
+      monitorInterfaces: false,
+      collectEndpoints: false,
+      oids: [],
+    };
+    const mocks: SyncMocks = mockSync(template, [monitor]);
+
+    await sync("bulk", monitor);
+
+    expect(
+      firstStep(writtenSteps(mocks)).data!.networkDeviceMonitor!
+        .networkDeviceId,
+    ).toBe(MONITOR_DEVICE_ID);
+    expect(
+      firstStep(writtenSteps(mocks)).data!.monitorCriteria.toJSON(),
+    ).toEqual(firstStep(template.monitorSteps!).data!.monitorCriteria.toJSON());
+  });
+});

--- a/Common/Tests/Types/Monitor/MonitorStepTemplateSyncFields.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorStepTemplateSyncFields.test.ts
@@ -1,0 +1,107 @@
+import { JSONObject } from "../../../Types/JSON";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import MonitorSteps from "../../../Types/Monitor/MonitorSteps";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+
+describe("MonitorStep template sync field policy persistence", () => {
+  test("policy survives step and step-list serialization, cloning, and schema validation", (): void => {
+    const step: MonitorStep = new MonitorStep();
+    step.data!.doNotSyncFields = [
+      "monitorDestination",
+      "requestHeaders",
+      "tlsClientAuthentication",
+    ];
+    const json: JSONObject = step.toJSON();
+
+    expect((json["value"] as JSONObject)["doNotSyncFields"]).toEqual(
+      step.data!.doNotSyncFields,
+    );
+    expect(MonitorStep.fromJSON(json).data!.doNotSyncFields).toEqual(
+      step.data!.doNotSyncFields,
+    );
+    expect(MonitorStep.clone(step).data!.doNotSyncFields).toEqual(
+      step.data!.doNotSyncFields,
+    );
+    expect(MonitorStep.getSchema().safeParse(json).success).toBe(true);
+    const steps: MonitorSteps = new MonitorSteps();
+    steps.setMonitorStepsInstanceArray([step]);
+    expect(
+      MonitorSteps.clone(steps).data!.monitorStepsInstanceArray[0]!.data!
+        .doNotSyncFields,
+    ).toEqual(step.data!.doNotSyncFields);
+  });
+
+  test("legacy steps do not acquire a policy when serialized", (): void => {
+    const step: MonitorStep = new MonitorStep();
+    expect(step.data!.doNotSyncFields).toBeUndefined();
+    expect(step.toJSON()["value"]).not.toHaveProperty("doNotSyncFields");
+    expect(
+      MonitorStep.fromJSON(step.toJSON()).data!.doNotSyncFields,
+    ).toBeUndefined();
+  });
+
+  test.each([
+    null,
+    "requestHeaders",
+    {},
+    [1],
+    ["requestHeaders", false],
+    ["id"],
+    ["monitorCriteria"],
+    ["requestHeaders.Authorization"],
+    ["unknownField"],
+  ])("rejects invalid persisted and API policy %j", (value: unknown): void => {
+    const json: JSONObject = new MonitorStep().toJSON();
+    (json["value"] as JSONObject)["doNotSyncFields"] = value as never;
+    expect((): void => {
+      MonitorStep.fromJSON(json);
+    }).toThrow();
+    expect(MonitorStep.getSchema().safeParse(json).success).toBe(false);
+  });
+
+  test("validates policy against the step's monitor type", (): void => {
+    const step: MonitorStep = new MonitorStep();
+    step.data!.doNotSyncFields = ["requestHeaders"];
+    expect(MonitorStep.getValidationError(step, MonitorType.DNS)).toContain(
+      "Unsupported do not sync field: requestHeaders",
+    );
+  });
+
+  test("does not mutate or share the policy array during a step clone", (): void => {
+    const step: MonitorStep = new MonitorStep();
+    step.data!.doNotSyncFields = ["requestHeaders"];
+    const cloned: MonitorStep = MonitorStep.clone(step);
+    cloned.data!.doNotSyncFields!.push("requestBody");
+    expect(step.data!.doNotSyncFields).toEqual(["requestHeaders"]);
+  });
+
+  test.each([
+    ["doNotFollowRedirects", false],
+    ["allowSelfSignedCertificates", false],
+    ["requestBody", ""],
+    ["customCode", ""],
+    ["tlsClientCertificate", ""],
+    ["tlsClientKey", ""],
+    ["tlsClientKeyPassphrase", ""],
+    ["retryCount", 0],
+    ["retryCountOnError", 0],
+  ])(
+    "preserves explicit falsy %s through persistence",
+    (
+      key: string | number | boolean,
+      value: string | number | boolean,
+    ): void => {
+      const step: MonitorStep = new MonitorStep();
+      (step.data as unknown as Record<string, unknown>)[String(key)] = value;
+      expect((step.toJSON()["value"] as JSONObject)[String(key)]).toBe(value);
+      expect(
+        (
+          MonitorStep.fromJSON(step.toJSON()).data as unknown as Record<
+            string,
+            unknown
+          >
+        )[String(key)],
+      ).toBe(value);
+    },
+  );
+});

--- a/Common/Tests/Types/Monitor/MonitorTemplateSyncField.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorTemplateSyncField.test.ts
@@ -1,0 +1,172 @@
+import BadDataException from "../../../Types/Exception/BadDataException";
+import MonitorTemplateSyncFieldUtil, {
+  MonitorTemplateSyncField,
+} from "../../../Types/Monitor/MonitorTemplateSyncField";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+
+describe("MonitorTemplateSyncFieldUtil", () => {
+  test.each(Object.values(MonitorType))(
+    "%s exposes distinct, validated field options",
+    (monitorType: MonitorType): void => {
+      const fields: Array<MonitorTemplateSyncField> =
+        MonitorTemplateSyncFieldUtil.getFields(monitorType);
+      const paths: Array<string> = fields.map(
+        (field: MonitorTemplateSyncField): string => {
+          return field.path;
+        },
+      );
+      expect(new Set(paths).size).toBe(paths.length);
+      expect(MonitorTemplateSyncFieldUtil.parse(paths, monitorType)).toEqual(
+        paths,
+      );
+      for (const field of fields) {
+        expect(field.label.length).toBeGreaterThan(0);
+        for (const path of MonitorTemplateSyncFieldUtil.getPaths(field.path)) {
+          expect(path).not.toMatch(
+            /(^|\.)(id|monitorCriteria|doNotSyncFields)(\.|$)/,
+          );
+          expect(path.split(".").length).toBeLessThanOrEqual(2);
+        }
+      }
+    },
+  );
+
+  test("omitted policy stays omitted and empty policy stays empty", (): void => {
+    expect(MonitorTemplateSyncFieldUtil.parse(undefined)).toBeUndefined();
+    expect(MonitorTemplateSyncFieldUtil.parse([])).toEqual([]);
+  });
+
+  test("deduplicates a policy without modifying the supplied array", (): void => {
+    const input: Array<string> = [
+      "requestHeaders",
+      "monitorDestination",
+      "requestHeaders",
+    ];
+    expect(MonitorTemplateSyncFieldUtil.parse(input, MonitorType.API)).toEqual([
+      "requestHeaders",
+      "monitorDestination",
+    ]);
+    expect(input).toEqual([
+      "requestHeaders",
+      "monitorDestination",
+      "requestHeaders",
+    ]);
+  });
+
+  test.each([
+    null,
+    "requestHeaders",
+    0,
+    false,
+    {},
+    ["requestHeaders", null],
+    [1],
+    [[]],
+  ])("rejects malformed policy %j", (value: unknown): void => {
+    expect((): void => {
+      MonitorTemplateSyncFieldUtil.parse(value);
+    }).toThrow(BadDataException);
+  });
+
+  test.each([
+    "id",
+    "monitorCriteria",
+    "monitorCriteria.monitorCriteriaInstanceArray",
+    "doNotSyncFields",
+    "requestHeaders.Authorization",
+    "unknownField",
+    "networkDeviceMonitor.networkDeviceId",
+  ])("rejects non-selectable field %s", (path: string): void => {
+    expect((): void => {
+      MonitorTemplateSyncFieldUtil.parse([path]);
+    }).toThrow("Unsupported do not sync field");
+    expect((): void => {
+      MonitorTemplateSyncFieldUtil.getPaths(path);
+    }).toThrow("Unsupported do not sync field");
+  });
+
+  test("rejects a field belonging to a different monitor type", (): void => {
+    expect((): void => {
+      MonitorTemplateSyncFieldUtil.parse(["requestHeaders"], MonitorType.DNS);
+    }).toThrow("Unsupported do not sync field");
+    expect((): void => {
+      MonitorTemplateSyncFieldUtil.parse(
+        ["dnsMonitor.queryName"],
+        MonitorType.API,
+      );
+    }).toThrow("Unsupported do not sync field");
+  });
+
+  test("TLS credentials are a single option", (): void => {
+    expect(
+      MonitorTemplateSyncFieldUtil.getPaths("tlsClientAuthentication"),
+    ).toEqual([
+      "tlsClientCertificate",
+      "tlsClientKey",
+      "tlsClientKeyPassphrase",
+    ]);
+    expect((): void => {
+      MonitorTemplateSyncFieldUtil.parse(["tlsClientKey"]);
+    }).toThrow();
+  });
+
+  test("Website options include only settings used by website checks", (): void => {
+    const websiteFields: Array<string> = MonitorTemplateSyncFieldUtil.getFields(
+      MonitorType.Website,
+    ).map((field: MonitorTemplateSyncField): string => {
+      return field.path;
+    });
+    expect(websiteFields).toEqual([
+      "monitorDestination",
+      "requestTimeoutInMs",
+      "retryCount",
+      "doNotFollowRedirects",
+      "allowSelfSignedCertificates",
+      "tlsClientAuthentication",
+    ]);
+    for (const apiField of ["requestHeaders", "requestType", "requestBody"]) {
+      expect((): void => {
+        MonitorTemplateSyncFieldUtil.parse([apiField], MonitorType.Website);
+      }).toThrow("Unsupported do not sync field");
+      expect(
+        MonitorTemplateSyncFieldUtil.parse([apiField], MonitorType.API),
+      ).toEqual([apiField]);
+    }
+  });
+
+  test.each(["sqlMonitor", "databaseMonitor"])(
+    "%s connection includes all authentication and endpoint fields",
+    (prefix: string): void => {
+      expect(
+        MonitorTemplateSyncFieldUtil.getPaths(`${prefix}.connection`),
+      ).toEqual(
+        [
+          "databaseType",
+          "host",
+          "port",
+          "databaseName",
+          "username",
+          "password",
+          "useWindowsIntegratedAuthentication",
+          "useSsl",
+          "rejectUnauthorizedSsl",
+        ].map((key: string): string => {
+          return `${prefix}.${key}`;
+        }),
+      );
+    },
+  );
+
+  test.each([
+    MonitorType.Manual,
+    MonitorType.IncomingRequest,
+    MonitorType.IncomingEmail,
+    MonitorType.Server,
+    MonitorType.NetworkDevice,
+  ])(
+    "%s has no misleading exclusions for criteria or automatically preserved bindings",
+    (monitorType: MonitorType): void => {
+      expect(MonitorTemplateSyncFieldUtil.getFields(monitorType)).toEqual([]);
+    },
+  );
+});

--- a/Common/Tests/Utils/Monitor/MonitorTemplateSyncUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/MonitorTemplateSyncUtil.test.ts
@@ -1,0 +1,590 @@
+import HTTPMethod from "../../../Types/API/HTTPMethod";
+import Hostname from "../../../Types/API/Hostname";
+import URL from "../../../Types/API/URL";
+import IP from "../../../Types/IP/IP";
+import { JSONObject } from "../../../Types/JSON";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import { MonitorStepDatabaseMonitorUtil } from "../../../Types/Monitor/MonitorStepDatabaseMonitor";
+import { MonitorStepDnsMonitorUtil } from "../../../Types/Monitor/MonitorStepDnsMonitor";
+import { MonitorStepExternalStatusPageMonitorUtil } from "../../../Types/Monitor/MonitorStepExternalStatusPageMonitor";
+import {
+  MonitorStepKubernetesMonitorUtil,
+  KubernetesResourceScope,
+} from "../../../Types/Monitor/MonitorStepKubernetesMonitor";
+import { MonitorStepLogMonitorUtil } from "../../../Types/Monitor/MonitorStepLogMonitor";
+import { MonitorStepSqlMonitorUtil } from "../../../Types/Monitor/MonitorStepSqlMonitor";
+import MonitorSteps from "../../../Types/Monitor/MonitorSteps";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import Port from "../../../Types/Port";
+import MonitorTemplateSyncUtil from "../../../Utils/Monitor/MonitorTemplateSyncUtil";
+
+function step(id: string, exclusions?: Array<string>): MonitorStep {
+  const result: MonitorStep = new MonitorStep();
+  result.data!.id = id;
+  result.data!.doNotSyncFields = exclusions;
+  result.data!.monitorDestination = URL.fromString(`https://${id}.example.com`);
+  return result;
+}
+
+function steps(...items: Array<MonitorStep>): MonitorSteps {
+  const result: MonitorSteps = new MonitorSteps();
+  result.setMonitorStepsInstanceArray(items);
+  result.setDefaultMonitorStatusId(ObjectID.generate());
+  return result;
+}
+
+function sync(
+  template: MonitorStep,
+  current: MonitorStep | undefined,
+  monitorType: MonitorType = MonitorType.API,
+): MonitorStep {
+  return MonitorTemplateSyncUtil.buildSyncedMonitorSteps({
+    templateMonitorSteps: steps(template),
+    currentMonitorSteps: current ? steps(current) : undefined,
+    monitorType,
+  }).data!.monitorStepsInstanceArray[0]!;
+}
+
+describe("MonitorTemplateSyncUtil", () => {
+  test("criteria sync keeps each monitor's destination and headers while updating unchecked fields", (): void => {
+    const template: MonitorStep = step("template", [
+      "monitorDestination",
+      "requestHeaders",
+    ]);
+    template.data!.requestHeaders = {
+      "X-Template": "template",
+      Authorization: "template-secret",
+    };
+    template.data!.requestType = HTTPMethod.POST;
+    template.data!.requestBody = "template body";
+    const current: MonitorStep = step("current");
+    current.data!.requestHeaders = {
+      Authorization: "{{monitorSecrets.productionToken}}",
+    };
+    current.data!.requestBody = "old body";
+    const templateSteps: MonitorSteps = steps(template);
+    const result: MonitorSteps =
+      MonitorTemplateSyncUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: templateSteps,
+        currentMonitorSteps: steps(current),
+        monitorType: MonitorType.API,
+      });
+    const synced: MonitorStep = result.data!.monitorStepsInstanceArray[0]!;
+
+    expect(synced.data!.monitorDestination!.toString()).toBe(
+      "https://current.example.com/",
+    );
+    expect(synced.data!.requestHeaders).toEqual(current.data!.requestHeaders);
+    expect(synced.data!.requestHeaders).not.toHaveProperty("X-Template");
+    expect(synced.data!.requestType).toBe(HTTPMethod.POST);
+    expect(synced.data!.requestBody).toBe("template body");
+    expect(synced.data!.monitorCriteria.toJSON()).toEqual(
+      template.data!.monitorCriteria.toJSON(),
+    );
+    expect(synced.data!.id).toBe("template");
+    expect(result.data!.defaultMonitorStatusId!.toString()).toBe(
+      templateSteps.data!.defaultMonitorStatusId!.toString(),
+    );
+    expect(synced.data).not.toHaveProperty("doNotSyncFields");
+  });
+
+  test("separate monitors retain separate values across repeated syncs", (): void => {
+    const template: MonitorStep = step("template", [
+      "monitorDestination",
+      "requestHeaders",
+    ]);
+    const currentA: MonitorStep = step("service-a");
+    const currentB: MonitorStep = step("service-b");
+    currentA.data!.requestHeaders = { Authorization: "token-a" };
+    currentB.data!.requestHeaders = { Authorization: "token-b" };
+    const first: MonitorStep = sync(template, currentA);
+    template.data!.requestBody = "revised";
+    const repeated: MonitorStep = sync(template, first);
+    const other: MonitorStep = sync(template, currentB);
+    expect(repeated.data!.requestHeaders).toEqual({ Authorization: "token-a" });
+    expect(repeated.data!.requestBody).toBe("revised");
+    expect(other.data!.requestHeaders).toEqual({ Authorization: "token-b" });
+    expect(other.data!.monitorDestination!.toString()).toBe(
+      "https://service-b.example.com/",
+    );
+  });
+
+  test("unchecking a field restores template updates and monitor-only metadata is ignored", (): void => {
+    const template: MonitorStep = step("template", []);
+    template.data!.requestHeaders = { Authorization: "template" };
+    const current: MonitorStep = step("current", [
+      "requestHeaders",
+      "monitorDestination",
+    ]);
+    current.data!.requestHeaders = { Authorization: "current" };
+    const result: MonitorStep = sync(template, current);
+    expect(result.data!.requestHeaders).toEqual(template.data!.requestHeaders);
+    expect(result.data!.monitorDestination!.toString()).toBe(
+      template.data!.monitorDestination!.toString(),
+    );
+    expect(result.data!.doNotSyncFields).toBeUndefined();
+  });
+
+  test("legacy templates without exclusions copy all template settings without needing existing steps", (): void => {
+    const template: MonitorStep = step("template");
+    template.data!.requestHeaders = { "X-Shared": "shared" };
+    const result: MonitorStep = sync(template, undefined);
+    expect(result.toJSON()).toEqual(template.toJSON());
+    expect(result).not.toBe(template);
+  });
+
+  test.each([{}, undefined])(
+    "protected headers retain the existing empty or absent dictionary %j",
+    (headers: Record<string, string> | undefined): void => {
+      const template: MonitorStep = step("template", ["requestHeaders"]);
+      template.data!.requestHeaders = { Authorization: "template-secret" };
+      const current: MonitorStep = step("current");
+      current.data!.requestHeaders = headers;
+      const result: MonitorStep = sync(template, current);
+      expect(result.data!.requestHeaders).toEqual(headers);
+      expect(
+        (result.toJSON()["value"] as JSONObject)["requestHeaders"],
+      ).toEqual(headers);
+    },
+  );
+
+  test("a deleted protected property is not reintroduced", (): void => {
+    const template: MonitorStep = step("template", ["requestBody"]);
+    template.data!.requestBody = "sensitive template body";
+    const current: MonitorStep = step("current");
+    delete current.data!.requestBody;
+    const result: MonitorStep = sync(template, current);
+    expect(result.data).not.toHaveProperty("requestBody");
+    expect(result.toJSON()["value"]).not.toHaveProperty("requestBody");
+  });
+
+  test("explicit false, empty strings and zero survive protected sync and persistence", (): void => {
+    const template: MonitorStep = step("template", [
+      "requestBody",
+      "retryCount",
+      "doNotFollowRedirects",
+      "allowSelfSignedCertificates",
+    ]);
+    template.data!.requestBody = "template body";
+    template.data!.retryCount = 3;
+    template.data!.doNotFollowRedirects = true;
+    template.data!.allowSelfSignedCertificates = true;
+    const current: MonitorStep = step("current");
+    current.data!.requestBody = "";
+    current.data!.retryCount = 0;
+    current.data!.doNotFollowRedirects = false;
+    current.data!.allowSelfSignedCertificates = false;
+    const restored: MonitorStep = MonitorStep.fromJSON(
+      sync(template, current).toJSON(),
+    );
+    expect(restored.data).toMatchObject({
+      requestBody: "",
+      retryCount: 0,
+      doNotFollowRedirects: false,
+      allowSelfSignedCertificates: false,
+    });
+  });
+
+  test("TLS certificate, key and passphrase remain a consistent set, including an absent passphrase", (): void => {
+    const template: MonitorStep = step("template", ["tlsClientAuthentication"]);
+    template.data!.tlsClientCertificate = "template-cert";
+    template.data!.tlsClientKey = "template-key";
+    template.data!.tlsClientKeyPassphrase = "template-password";
+    const current: MonitorStep = step("current");
+    current.data!.tlsClientCertificate = "{{monitorSecrets.cert}}";
+    current.data!.tlsClientKey = "{{monitorSecrets.key}}";
+    delete current.data!.tlsClientKeyPassphrase;
+    const result: MonitorStep = sync(template, current);
+    expect(result.data!.tlsClientCertificate).toBe(
+      current.data!.tlsClientCertificate,
+    );
+    expect(result.data!.tlsClientKey).toBe(current.data!.tlsClientKey);
+    expect(result.data).not.toHaveProperty("tlsClientKeyPassphrase");
+  });
+
+  test.each([
+    new IP("192.0.2.10"),
+    new Hostname("service.internal"),
+    URL.fromString("https://production.example.com/health?key=value"),
+  ])(
+    "preserves typed destinations and ports",
+    (destination: IP | Hostname | URL): void => {
+      const template: MonitorStep = step("template", [
+        "monitorDestination",
+        "monitorDestinationPort",
+      ]);
+      template.data!.monitorDestinationPort = new Port(80);
+      const current: MonitorStep = step("current");
+      current.data!.monitorDestination = destination;
+      current.data!.monitorDestinationPort = new Port(8443);
+      const result: MonitorStep = sync(template, current, MonitorType.Port);
+      expect(result.data!.monitorDestination).toBeInstanceOf(
+        destination.constructor,
+      );
+      expect(result.data!.monitorDestination!.toString()).toBe(
+        destination.toString(),
+      );
+      expect(result.data!.monitorDestination).not.toBe(destination);
+      expect(result.data!.monitorDestinationPort).toBeInstanceOf(Port);
+      expect(result.data!.monitorDestinationPort!.toString()).toBe("8443");
+    },
+  );
+
+  test("matches protected steps by stable ID even when current steps are reordered", (): void => {
+    const templateA: MonitorStep = step("a", ["requestHeaders"]);
+    const templateB: MonitorStep = step("b", ["monitorDestination"]);
+    const currentA: MonitorStep = step("a");
+    currentA.data!.requestHeaders = { Authorization: "a-secret" };
+    const currentB: MonitorStep = step("b");
+    currentB.data!.monitorDestination = URL.fromString(
+      "https://b-production.example.com",
+    );
+    const result: MonitorSteps =
+      MonitorTemplateSyncUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: steps(templateA, templateB),
+        currentMonitorSteps: steps(currentB, currentA),
+        monitorType: MonitorType.API,
+      });
+    expect(
+      result.data!.monitorStepsInstanceArray[0]!.data!.requestHeaders,
+    ).toEqual(currentA.data!.requestHeaders);
+    expect(
+      result.data!.monitorStepsInstanceArray[1]!.data!.monitorDestination!.toString(),
+    ).toBe("https://b-production.example.com/");
+  });
+
+  test.each([
+    [
+      steps(step("a", ["requestHeaders"]), step("b")),
+      steps(step("x"), step("y")),
+    ],
+    [steps(step("a", ["requestHeaders"])), steps(step("a"), step("a"))],
+    [steps(step("a", ["requestHeaders"]), step("a")), steps(step("a"))],
+    [steps(step("a", ["requestHeaders"])), steps()],
+    [steps(step("a", ["requestHeaders"])), undefined],
+  ])(
+    "rejects ambiguous or absent protected step matches",
+    (
+      templateMonitorSteps: MonitorSteps,
+      currentMonitorSteps: MonitorSteps | undefined,
+    ): void => {
+      expect((): void => {
+        MonitorTemplateSyncUtil.buildSyncedMonitorSteps({
+          templateMonitorSteps,
+          currentMonitorSteps,
+          monitorType: MonitorType.API,
+        });
+      }).toThrow("cannot be matched");
+    },
+  );
+
+  test("rejects missing step identity even for a single-step fallback", (): void => {
+    const template: MonitorStep = step("template", ["requestHeaders"]);
+    template.data!.id = "";
+    expect((): void => {
+      sync(template, step("current"));
+    }).toThrow("cannot be matched");
+    template.data!.id = "template";
+    const current: MonitorStep = step("current");
+    current.data!.id = "";
+    expect((): void => {
+      sync(template, current);
+    }).toThrow("cannot be matched");
+  });
+
+  test("new unprotected template steps do not require a matching old step", (): void => {
+    const result: MonitorSteps =
+      MonitorTemplateSyncUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: steps(
+          step("existing", ["requestHeaders"]),
+          step("new"),
+        ),
+        currentMonitorSteps: steps(step("existing")),
+        monitorType: MonitorType.API,
+      });
+    expect(
+      result.data!.monitorStepsInstanceArray.map(
+        (item: MonitorStep): string => {
+          return item.data!.id;
+        },
+      ),
+    ).toEqual(["existing", "new"]);
+  });
+
+  test("failed matching does not partially change either input", (): void => {
+    const template: MonitorSteps = steps(
+      step("matched", ["requestHeaders"]),
+      step("new", ["requestBody"]),
+    );
+    const current: MonitorSteps = steps(step("matched"));
+    const templateBefore: JSONObject = template.toJSON();
+    const currentBefore: JSONObject = current.toJSON();
+    expect((): void => {
+      MonitorTemplateSyncUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: template,
+        currentMonitorSteps: current,
+        monitorType: MonitorType.API,
+      });
+    }).toThrow();
+    expect(template.toJSON()).toEqual(templateBefore);
+    expect(current.toJSON()).toEqual(currentBefore);
+  });
+
+  test("deeply isolates criteria and nested configuration from both inputs", (): void => {
+    const template: MonitorStep = step("template", ["requestHeaders"]);
+    template.data!.kubernetesMonitor =
+      MonitorStepKubernetesMonitorUtil.getDefault();
+    template.data!.kubernetesMonitor.resourceFilters = {
+      namespace: "template",
+    };
+    const current: MonitorStep = step("current");
+    current.data!.requestHeaders = { Authorization: "current" };
+    const templateBefore: JSONObject = template.toJSON();
+    const currentBefore: JSONObject = current.toJSON();
+    const result: MonitorStep = sync(template, current);
+    result.data!.requestHeaders!["Authorization"] = "changed";
+    result.data!.kubernetesMonitor!.resourceFilters.namespace = "changed";
+    result.data!.monitorCriteria.data!.monitorCriteriaInstanceArray.splice(0);
+    expect(template.toJSON()).toEqual(templateBefore);
+    expect(current.toJSON()).toEqual(currentBefore);
+  });
+
+  test("nested DNS exclusions preserve the resolver while other check settings update", (): void => {
+    const template: MonitorStep = step("template", [
+      "dnsMonitor.queryName",
+      "dnsMonitor.resolver",
+    ]);
+    template.data!.dnsMonitor = {
+      ...MonitorStepDnsMonitorUtil.getDefault(),
+      queryName: "template.example.com",
+      hostname: "1.1.1.1",
+      port: 53,
+      timeout: 9000,
+    };
+    const current: MonitorStep = step("current");
+    current.data!.dnsMonitor = {
+      ...MonitorStepDnsMonitorUtil.getDefault(),
+      queryName: "production.example.com",
+      hostname: "192.0.2.53",
+      port: 5353,
+      timeout: 1000,
+    };
+    expect(
+      sync(template, current, MonitorType.DNS).data!.dnsMonitor,
+    ).toMatchObject({
+      queryName: "production.example.com",
+      hostname: "192.0.2.53",
+      port: 5353,
+      timeout: 9000,
+    });
+  });
+
+  test("nested absent values remain absent without importing template defaults", (): void => {
+    const template: MonitorStep = step("template", [
+      "externalStatusPageMonitor.components",
+    ]);
+    template.data!.externalStatusPageMonitor = {
+      ...MonitorStepExternalStatusPageMonitorUtil.getDefault(),
+      statusPageUrl: "https://status.example.com",
+      componentGroupName: "Template Group",
+      componentName: "Template Component",
+    };
+    const current: MonitorStep = step("current");
+    const result: MonitorStep = sync(
+      template,
+      current,
+      MonitorType.ExternalStatusPage,
+    );
+    expect(result.data!.externalStatusPageMonitor!.statusPageUrl).toBe(
+      "https://status.example.com",
+    );
+    expect(result.data!.externalStatusPageMonitor).not.toHaveProperty(
+      "componentGroupName",
+    );
+    expect(result.data!.externalStatusPageMonitor).not.toHaveProperty(
+      "componentName",
+    );
+    expect(
+      (result.toJSON()["value"] as JSONObject)["externalStatusPageMonitor"],
+    ).not.toHaveProperty("componentName");
+  });
+
+  test("can restore an excluded nested field when the template config is missing", (): void => {
+    const template: MonitorStep = step("template", [
+      "externalStatusPageMonitor.statusPageUrl",
+    ]);
+    const current: MonitorStep = step("current");
+    current.data!.externalStatusPageMonitor = {
+      ...MonitorStepExternalStatusPageMonitorUtil.getDefault(),
+      statusPageUrl: "https://status.production.example.com",
+    };
+    expect(
+      sync(template, current, MonitorType.ExternalStatusPage).data!
+        .externalStatusPageMonitor,
+    ).toEqual({ statusPageUrl: "https://status.production.example.com" });
+  });
+
+  test("does not create a nested config when the protected field is absent on both inputs", (): void => {
+    const result: MonitorStep = sync(
+      step("template", ["externalStatusPageMonitor.components"]),
+      step("current"),
+      MonitorType.ExternalStatusPage,
+    );
+    expect(result.data!.externalStatusPageMonitor).toBeUndefined();
+  });
+
+  test.each([MonitorType.SQLQuery, MonitorType.Database])(
+    "%s preserves connection credentials while syncing check configuration",
+    (monitorType: MonitorType): void => {
+      const prefix: "sqlMonitor" | "databaseMonitor" =
+        monitorType === MonitorType.SQLQuery ? "sqlMonitor" : "databaseMonitor";
+      const template: MonitorStep = step("template", [`${prefix}.connection`]);
+      const current: MonitorStep = step("current");
+      const defaults:
+        | ReturnType<typeof MonitorStepSqlMonitorUtil.getDefault>
+        | ReturnType<typeof MonitorStepDatabaseMonitorUtil.getDefault> =
+        monitorType === MonitorType.SQLQuery
+          ? MonitorStepSqlMonitorUtil.getDefault()
+          : MonitorStepDatabaseMonitorUtil.getDefault();
+      template.data![prefix] = {
+        ...defaults,
+        host: "template.example.com",
+        username: "template",
+        password: "template",
+        statementTimeoutInMs: 20000,
+      } as never;
+      current.data![prefix] = {
+        ...defaults,
+        host: "production.example.com",
+        username: "production",
+        password: "{{monitorSecrets.databasePassword}}",
+        port: 5433,
+        useSsl: true,
+        rejectUnauthorizedSsl: false,
+        statementTimeoutInMs: 1000,
+      } as never;
+      const result: MonitorStep = sync(template, current, monitorType);
+      expect(result.data![prefix]).toMatchObject({
+        host: "production.example.com",
+        username: "production",
+        password: "{{monitorSecrets.databasePassword}}",
+        port: 5433,
+        useSsl: true,
+        rejectUnauthorizedSsl: false,
+        statementTimeoutInMs: 20000,
+      });
+      expect(MonitorStep.fromJSON(result.toJSON()).data![prefix]).toEqual(
+        result.data![prefix],
+      );
+    },
+  );
+
+  test("does not normalize missing DNSSEC values while copying protected fields", (): void => {
+    const template: MonitorStep = step("template", [
+      "dnssecMonitor.resolvers",
+      "dnssecMonitor.checkNameserverConsistency",
+    ]);
+    template.data!.dnssecMonitor = {
+      domainName: "template.example.com",
+      resolvers: ["1.1.1.1"],
+      checkNameserverConsistency: true,
+      signatureExpiryWarningDays: 7,
+      timeout: 10000,
+      retries: 3,
+    };
+    const current: MonitorStep = step("current");
+    current.data!.dnssecMonitor = {
+      domainName: "current.example.com",
+      checkNameserverConsistency: false,
+    } as never;
+    const result: MonitorStep = sync(template, current, MonitorType.DNSSEC);
+    expect(result.data!.dnssecMonitor).not.toHaveProperty("resolvers");
+    expect(result.data!.dnssecMonitor!.checkNameserverConsistency).toBe(false);
+    expect(
+      (result.toJSON()["value"] as JSONObject)["dnssecMonitor"],
+    ).not.toHaveProperty("resolvers");
+  });
+
+  test("Kubernetes keeps the cluster and complete resource selectors without changing metric queries", (): void => {
+    const template: MonitorStep = step("template", [
+      "kubernetesMonitor.clusterIdentifier",
+      "kubernetesMonitor.resources",
+    ]);
+    template.data!.kubernetesMonitor = {
+      ...MonitorStepKubernetesMonitorUtil.getDefault(),
+      clusterIdentifier: "template",
+      resourceScope: KubernetesResourceScope.Cluster,
+      resourceFilters: { namespace: "template" },
+    };
+    const current: MonitorStep = step("current");
+    current.data!.kubernetesMonitor = {
+      ...MonitorStepKubernetesMonitorUtil.getDefault(),
+      clusterIdentifier: "production",
+      resourceScope: KubernetesResourceScope.Pod,
+      resourceFilters: { namespace: "production", podName: "app-1" },
+    };
+    const result: MonitorStep = sync(template, current, MonitorType.Kubernetes);
+    expect(result.data!.kubernetesMonitor).toMatchObject({
+      clusterIdentifier: "production",
+      resourceScope: KubernetesResourceScope.Pod,
+      resourceFilters: { namespace: "production", podName: "app-1" },
+      metricViewConfig: template.data!.kubernetesMonitor.metricViewConfig,
+    });
+    result.data!.kubernetesMonitor!.resourceFilters.podName = "changed";
+    expect(current.data!.kubernetesMonitor.resourceFilters.podName).toBe(
+      "app-1",
+    );
+  });
+
+  test("whole telemetry configuration retains nested arrays and typed service IDs without sharing references", (): void => {
+    const template: MonitorStep = step("template", ["logMonitor"]);
+    template.data!.logMonitor = MonitorStepLogMonitorUtil.getDefault();
+    const current: MonitorStep = step("current");
+    const serviceId: ObjectID = ObjectID.generate();
+    current.data!.logMonitor = {
+      ...MonitorStepLogMonitorUtil.getDefault(),
+      telemetryServiceIds: [serviceId],
+      entityKeys: ["production-host"],
+      attributes: { environment: "production", accepted: false },
+      body: "",
+      lastXSecondsOfLogs: 300,
+    };
+    const result: MonitorStep = sync(template, current, MonitorType.Logs);
+    expect(result.data!.logMonitor).toEqual(current.data!.logMonitor);
+    expect(result.data!.logMonitor!.telemetryServiceIds[0]).toBeInstanceOf(
+      ObjectID,
+    );
+    expect(result.data!.logMonitor!.telemetryServiceIds[0]).not.toBe(serviceId);
+    result.data!.logMonitor!.entityKeys!.push("other-host");
+    expect(current.data!.logMonitor.entityKeys).toEqual(["production-host"]);
+  });
+
+  test("detects exclusions and rejects invalid template policy before copying", (): void => {
+    expect(MonitorTemplateSyncUtil.hasExcludedFields(undefined)).toBe(false);
+    expect(
+      MonitorTemplateSyncUtil.hasExcludedFields(steps(step("template"))),
+    ).toBe(false);
+    expect(
+      MonitorTemplateSyncUtil.hasExcludedFields(steps(step("template", []))),
+    ).toBe(false);
+    expect(
+      MonitorTemplateSyncUtil.hasExcludedFields(
+        steps(step("template", ["requestHeaders"])),
+      ),
+    ).toBe(true);
+    expect((): void => {
+      sync(step("template", ["id"]), step("current"));
+    }).toThrow("Unsupported do not sync field");
+    expect((): void => {
+      sync(step("template", ["dnsMonitor.queryName"]), step("current"));
+    }).toThrow("Unsupported do not sync field");
+    expect((): void => {
+      MonitorTemplateSyncUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: undefined,
+        currentMonitorSteps: undefined,
+        monitorType: MonitorType.API,
+      });
+    }).toThrow("Monitor template steps are required");
+  });
+});

--- a/Common/Types/Monitor/MonitorStep.ts
+++ b/Common/Types/Monitor/MonitorStep.ts
@@ -84,6 +84,7 @@ import MonitorStepIoTMonitor, {
 import MetricsViewConfig from "../Metrics/MetricsViewConfig";
 import MetricQueryConfigData from "../Metrics/MetricQueryConfigData";
 import Zod, { ZodSchema } from "../../Utils/Schema/Zod";
+import MonitorTemplateSyncFieldUtil from "./MonitorTemplateSyncField";
 
 /*
  * Caps and defaults for per-step request timeout and retry settings.
@@ -120,6 +121,8 @@ export const clampMonitorRetryCount: (value: number) => number = (
 
 export interface MonitorStepType {
   id: string;
+  // Template policy: keep these fields from each linked monitor during sync.
+  doNotSyncFields?: Array<string> | undefined;
   monitorDestination?: URL | IP | Hostname | undefined;
 
   monitorCriteria: MonitorCriteria;
@@ -756,6 +759,15 @@ export default class MonitorStep extends DatabaseProperty {
       return "Monitor Step is required.";
     }
 
+    try {
+      MonitorTemplateSyncFieldUtil.parse(
+        value.data.doNotSyncFields,
+        monitorType,
+      );
+    } catch (error) {
+      return (error as Error).message;
+    }
+
     // If the monitor type is incoming request, then the monitor destination is not required
     if (
       !value.data.monitorDestination &&
@@ -1035,24 +1047,26 @@ export default class MonitorStep extends DatabaseProperty {
         _type: ObjectType.MonitorStep,
         value: {
           id: this.data.id,
+          doNotSyncFields: MonitorTemplateSyncFieldUtil.parse(
+            this.data.doNotSyncFields,
+          ),
           monitorDestination:
             this.data?.monitorDestination?.toJSON() || undefined,
-          doNotFollowRedirects: this.data.doNotFollowRedirects || undefined,
-          allowSelfSignedCertificates:
-            this.data.allowSelfSignedCertificates || undefined,
-          tlsClientCertificate: this.data.tlsClientCertificate || undefined,
-          tlsClientKey: this.data.tlsClientKey || undefined,
-          tlsClientKeyPassphrase: this.data.tlsClientKeyPassphrase || undefined,
+          doNotFollowRedirects: this.data.doNotFollowRedirects,
+          allowSelfSignedCertificates: this.data.allowSelfSignedCertificates,
+          tlsClientCertificate: this.data.tlsClientCertificate,
+          tlsClientKey: this.data.tlsClientKey,
+          tlsClientKeyPassphrase: this.data.tlsClientKeyPassphrase,
           monitorDestinationPort:
             this.data?.monitorDestinationPort?.toJSON() || undefined,
           monitorCriteria: this.data.monitorCriteria.toJSON(),
           requestType: this.data.requestType,
           requestHeaders: this.data.requestHeaders || undefined,
-          requestBody: this.data.requestBody || undefined,
-          customCode: this.data.customCode || undefined,
+          requestBody: this.data.requestBody,
+          customCode: this.data.customCode,
           screenSizeTypes: this.data.screenSizeTypes || undefined,
           browserTypes: this.data.browserTypes || undefined,
-          retryCountOnError: this.data.retryCountOnError || undefined,
+          retryCountOnError: this.data.retryCountOnError,
           requestTimeoutInMs: this.data.requestTimeoutInMs || undefined,
           retryCount:
             this.data.retryCount === undefined
@@ -1220,15 +1234,18 @@ export default class MonitorStep extends DatabaseProperty {
 
     monitorStep.data = JSONFunctions.deserialize({
       id: json["id"] as string,
+      doNotSyncFields: MonitorTemplateSyncFieldUtil.parse(
+        json["doNotSyncFields"],
+      ),
       monitorDestination: monitorDestination || undefined,
-      doNotFollowRedirects: json["doNotFollowRedirects"] || undefined,
+      doNotFollowRedirects: json["doNotFollowRedirects"] ?? undefined,
       allowSelfSignedCertificates:
-        json["allowSelfSignedCertificates"] || undefined,
+        json["allowSelfSignedCertificates"] ?? undefined,
       tlsClientCertificate:
-        (json["tlsClientCertificate"] as string) || undefined,
-      tlsClientKey: (json["tlsClientKey"] as string) || undefined,
+        (json["tlsClientCertificate"] as string) ?? undefined,
+      tlsClientKey: (json["tlsClientKey"] as string) ?? undefined,
       tlsClientKeyPassphrase:
-        (json["tlsClientKeyPassphrase"] as string) || undefined,
+        (json["tlsClientKeyPassphrase"] as string) ?? undefined,
       monitorDestinationPort: monitorDestinationPort || undefined,
       monitorCriteria: MonitorCriteria.fromJSON(
         json["monitorCriteria"] as JSONObject,
@@ -1236,12 +1253,12 @@ export default class MonitorStep extends DatabaseProperty {
       requestType: (json["requestType"] as HTTPMethod) || HTTPMethod.GET,
       requestHeaders:
         (json["requestHeaders"] as Dictionary<string>) || undefined,
-      requestBody: (json["requestBody"] as string) || undefined,
-      customCode: (json["customCode"] as string) || undefined,
+      requestBody: (json["requestBody"] as string) ?? undefined,
+      customCode: (json["customCode"] as string) ?? undefined,
       screenSizeTypes:
         (json["screenSizeTypes"] as Array<ScreenSizeType>) || undefined,
       browserTypes: (json["browserTypes"] as Array<BrowserType>) || undefined,
-      retryCountOnError: (json["retryCountOnError"] as number) || undefined,
+      retryCountOnError: (json["retryCountOnError"] as number) ?? undefined,
       requestTimeoutInMs: (json["requestTimeoutInMs"] as number) || undefined,
       retryCount:
         json["retryCount"] === undefined || json["retryCount"] === null
@@ -1362,6 +1379,16 @@ export default class MonitorStep extends DatabaseProperty {
       _type: Zod.literal(ObjectType.MonitorStep),
       value: Zod.object({
         id: Zod.string(),
+        doNotSyncFields: Zod.array(
+          Zod.string().refine((value: string): boolean => {
+            try {
+              MonitorTemplateSyncFieldUtil.parse([value]);
+              return true;
+            } catch {
+              return false;
+            }
+          }, "Unsupported do not sync field"),
+        ).optional(),
         monitorDestination: Zod.any().optional(),
         monitorCriteria: Zod.any(),
         requestType: Zod.any(),

--- a/Common/Types/Monitor/MonitorTemplateSyncField.ts
+++ b/Common/Types/Monitor/MonitorTemplateSyncField.ts
@@ -1,0 +1,291 @@
+import BadDataException from "../Exception/BadDataException";
+import MonitorType from "./MonitorType";
+
+export interface MonitorTemplateSyncField {
+  path: string;
+  label: string;
+  description?: string;
+}
+
+/**
+ * The shared catalogue for the template editor and sync service. Only these
+ * named fields can be preserved; criteria and step identities always sync.
+ * Some options preserve related values together to keep credentials and
+ * resource selectors consistent.
+ */
+export default class MonitorTemplateSyncFieldUtil {
+  public static getFields(
+    monitorType: MonitorType,
+  ): Array<MonitorTemplateSyncField> {
+    const fields: Array<MonitorTemplateSyncField> = [];
+    const add: (path: string, label: string, description?: string) => void = (
+      path: string,
+      label: string,
+      description?: string,
+    ): void => {
+      fields.push({ path, label, ...(description ? { description } : {}) });
+    };
+
+    if (
+      [
+        MonitorType.Website,
+        MonitorType.API,
+        MonitorType.Ping,
+        MonitorType.IP,
+        MonitorType.Port,
+        MonitorType.SSLCertificate,
+      ].includes(monitorType)
+    ) {
+      add("monitorDestination", "Monitor destination");
+      add("requestTimeoutInMs", "Request timeout");
+      add("retryCount", "Retry count");
+    }
+
+    if (monitorType === MonitorType.API) {
+      add(
+        "requestHeaders",
+        "Request headers",
+        "Keep the monitor's entire set of request headers.",
+      );
+      add("requestType", "Request method");
+      add("requestBody", "Request body");
+    }
+
+    if ([MonitorType.Website, MonitorType.API].includes(monitorType)) {
+      add("doNotFollowRedirects", "Redirect behavior");
+      add("allowSelfSignedCertificates", "Allow self-signed certificates");
+      add(
+        "tlsClientAuthentication",
+        "Client certificate authentication",
+        "Keep the certificate, private key, and key passphrase together.",
+      );
+    }
+
+    if (monitorType === MonitorType.Port) {
+      add("monitorDestinationPort", "Port");
+    }
+
+    if (
+      [MonitorType.SyntheticMonitor, MonitorType.CustomJavaScriptCode].includes(
+        monitorType,
+      )
+    ) {
+      add("customCode", "Check code");
+    }
+
+    if (monitorType === MonitorType.SyntheticMonitor) {
+      add("browserTypes", "Browsers");
+      add("screenSizeTypes", "Screen sizes");
+      add("retryCountOnError", "Retry count on error");
+    }
+
+    if (monitorType === MonitorType.DNS) {
+      add("dnsMonitor.queryName", "DNS query name");
+      add("dnsMonitor.recordType", "DNS record type");
+      add(
+        "dnsMonitor.resolver",
+        "DNS resolver",
+        "Keep the DNS server and port together.",
+      );
+      add("dnsMonitor.timeout", "DNS timeout");
+      add("dnsMonitor.retries", "DNS retries");
+    }
+
+    if (monitorType === MonitorType.Domain) {
+      add("domainMonitor.domainName", "Domain name");
+      add("domainMonitor.lookupMethod", "Domain lookup method");
+      add("domainMonitor.timeout", "Lookup timeout");
+      add("domainMonitor.retries", "Lookup retries");
+    }
+
+    if (monitorType === MonitorType.DNSSEC) {
+      add("dnssecMonitor.domainName", "Domain name");
+      add("dnssecMonitor.resolvers", "DNS resolvers");
+      add(
+        "dnssecMonitor.checkNameserverConsistency",
+        "Nameserver consistency check",
+      );
+      add(
+        "dnssecMonitor.signatureExpiryWarningDays",
+        "Signature expiry warning",
+      );
+      add("dnssecMonitor.timeout", "DNSSEC timeout");
+      add("dnssecMonitor.retries", "DNSSEC retries");
+    }
+
+    if ([MonitorType.SQLQuery, MonitorType.Database].includes(monitorType)) {
+      const prefix: string =
+        monitorType === MonitorType.SQLQuery ? "sqlMonitor" : "databaseMonitor";
+      add(
+        `${prefix}.connection`,
+        "Database connection",
+        "Keep the database engine, host, port, database name, credentials, and TLS settings together.",
+      );
+      add(`${prefix}.connectionTimeoutInMs`, "Connection timeout");
+      add(`${prefix}.statementTimeoutInMs`, "Statement timeout");
+      if (monitorType === MonitorType.SQLQuery) {
+        add("sqlMonitor.query", "SQL query");
+        add("sqlMonitor.maxRows", "Maximum result rows");
+      } else {
+        add("databaseMonitor.enabledMetricGroups", "Collected metric groups");
+      }
+    }
+
+    if (monitorType === MonitorType.ExternalStatusPage) {
+      add("externalStatusPageMonitor.statusPageUrl", "Status page URL");
+      add("externalStatusPageMonitor.provider", "Status page provider");
+      add(
+        "externalStatusPageMonitor.components",
+        "Status page components",
+        "Keep the selected component group and component together.",
+      );
+      add("externalStatusPageMonitor.timeout", "Status page timeout");
+      add("externalStatusPageMonitor.retries", "Status page retries");
+    }
+
+    const infrastructure: Partial<
+      Record<MonitorType, [string, string, string]>
+    > = {
+      [MonitorType.Kubernetes]: [
+        "kubernetesMonitor",
+        "clusterIdentifier",
+        "Kubernetes cluster",
+      ],
+      [MonitorType.Docker]: ["dockerMonitor", "hostIdentifier", "Docker host"],
+      [MonitorType.Host]: ["hostMonitor", "hostIdentifier", "Host"],
+      [MonitorType.Podman]: ["podmanMonitor", "hostIdentifier", "Podman host"],
+      [MonitorType.Proxmox]: [
+        "proxmoxMonitor",
+        "clusterIdentifier",
+        "Proxmox cluster",
+      ],
+      [MonitorType.DockerSwarm]: [
+        "dockerSwarmMonitor",
+        "clusterIdentifier",
+        "Docker Swarm cluster",
+      ],
+      [MonitorType.Ceph]: ["cephMonitor", "clusterIdentifier", "Ceph cluster"],
+      [MonitorType.IoTDevice]: ["iotMonitor", "fleetIdentifier", "IoT fleet"],
+    };
+    const infrastructureConfig: [string, string, string] | undefined =
+      infrastructure[monitorType];
+    if (infrastructureConfig) {
+      const [prefix, identity, label]: [string, string, string] =
+        infrastructureConfig;
+      add(`${prefix}.${identity}`, label);
+      if (monitorType === MonitorType.Kubernetes) {
+        add(`${prefix}.resources`, "Resource scope and filters");
+      } else if (
+        [MonitorType.Docker, MonitorType.Podman].includes(monitorType)
+      ) {
+        add(`${prefix}.containerFilters`, "Container filters");
+      } else if (monitorType !== MonitorType.Host) {
+        add(`${prefix}.resourceFilters`, "Resource filters");
+      }
+      add(`${prefix}.metricViewConfig`, "Metric queries");
+      add(`${prefix}.rollingTime`, "Query time window");
+    }
+
+    const telemetry: Partial<Record<MonitorType, [string, string]>> = {
+      [MonitorType.Logs]: ["logMonitor", "Log query configuration"],
+      [MonitorType.SecurityEvents]: [
+        "securityEventsMonitor",
+        "Security event query configuration",
+      ],
+      [MonitorType.Traces]: ["traceMonitor", "Trace query configuration"],
+      [MonitorType.Metrics]: ["metricMonitor", "Metric query configuration"],
+      [MonitorType.Exceptions]: [
+        "exceptionMonitor",
+        "Exception query configuration",
+      ],
+      [MonitorType.Profiles]: ["profileMonitor", "Profile query configuration"],
+    };
+    const telemetryConfig: [string, string] | undefined =
+      telemetry[monitorType];
+    if (telemetryConfig) {
+      add(...telemetryConfig);
+    }
+
+    return fields;
+  }
+
+  public static parse(
+    value: unknown,
+    monitorType?: MonitorType,
+  ): Array<string> | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (
+      !Array.isArray(value) ||
+      value.some((path: unknown): boolean => {
+        return typeof path !== "string";
+      })
+    ) {
+      throw new BadDataException(
+        "Do not sync fields must be an array of supported field names.",
+      );
+    }
+
+    const allowedFields: Set<string> = new Set(
+      (monitorType === undefined ? Object.values(MonitorType) : [monitorType])
+        .flatMap((type: MonitorType): Array<MonitorTemplateSyncField> => {
+          return this.getFields(type);
+        })
+        .map((field: MonitorTemplateSyncField): string => {
+          return field.path;
+        }),
+    );
+
+    for (const path of value) {
+      if (!allowedFields.has(path)) {
+        throw new BadDataException(`Unsupported do not sync field: ${path}.`);
+      }
+    }
+
+    return [...new Set(value as Array<string>)];
+  }
+
+  public static getPaths(field: string): Array<string> {
+    // Validate even when called independently of parse: never traverse arbitrary paths.
+    this.parse([field]);
+    if (field === "tlsClientAuthentication") {
+      return ["tlsClientCertificate", "tlsClientKey", "tlsClientKeyPassphrase"];
+    }
+    if (field === "dnsMonitor.resolver") {
+      return ["dnsMonitor.hostname", "dnsMonitor.port"];
+    }
+    if (
+      ["sqlMonitor.connection", "databaseMonitor.connection"].includes(field)
+    ) {
+      const prefix: string = field.split(".")[0]!;
+      return [
+        "databaseType",
+        "host",
+        "port",
+        "databaseName",
+        "username",
+        "password",
+        "useWindowsIntegratedAuthentication",
+        "useSsl",
+        "rejectUnauthorizedSsl",
+      ].map((key: string): string => {
+        return `${prefix}.${key}`;
+      });
+    }
+    if (field === "externalStatusPageMonitor.components") {
+      return [
+        "externalStatusPageMonitor.componentGroupName",
+        "externalStatusPageMonitor.componentName",
+      ];
+    }
+    if (field === "kubernetesMonitor.resources") {
+      return [
+        "kubernetesMonitor.resourceScope",
+        "kubernetesMonitor.resourceFilters",
+      ];
+    }
+    return [field];
+  }
+}

--- a/Common/Utils/Monitor/MonitorTemplateSyncUtil.ts
+++ b/Common/Utils/Monitor/MonitorTemplateSyncUtil.ts
@@ -1,0 +1,164 @@
+import BadDataException from "../../Types/Exception/BadDataException";
+import MonitorStep from "../../Types/Monitor/MonitorStep";
+import MonitorSteps from "../../Types/Monitor/MonitorSteps";
+import MonitorTemplateSyncFieldUtil from "../../Types/Monitor/MonitorTemplateSyncField";
+import MonitorType from "../../Types/Monitor/MonitorType";
+
+export default class MonitorTemplateSyncUtil {
+  public static hasExcludedFields(steps: MonitorSteps | undefined): boolean {
+    return Boolean(
+      steps?.data?.monitorStepsInstanceArray.some(
+        (step: MonitorStep): boolean => {
+          return (
+            (MonitorTemplateSyncFieldUtil.parse(step.data?.doNotSyncFields)
+              ?.length || 0) > 0
+          );
+        },
+      ),
+    );
+  }
+
+  public static buildSyncedMonitorSteps(data: {
+    templateMonitorSteps: MonitorSteps | undefined;
+    currentMonitorSteps: MonitorSteps | undefined;
+    monitorType: MonitorType;
+  }): MonitorSteps {
+    if (!data.templateMonitorSteps?.data) {
+      throw new BadDataException(
+        "Monitor template steps are required to sync criteria.",
+      );
+    }
+
+    const result: MonitorSteps = this.cloneValue(data.templateMonitorSteps);
+    const templateSteps: Array<MonitorStep> =
+      data.templateMonitorSteps.data.monitorStepsInstanceArray;
+    const currentSteps: Array<MonitorStep> =
+      data.currentMonitorSteps?.data?.monitorStepsInstanceArray || [];
+
+    for (const [
+      index,
+      step,
+    ] of result.data!.monitorStepsInstanceArray.entries()) {
+      const excludedFields: Array<string> =
+        MonitorTemplateSyncFieldUtil.parse(
+          step.data?.doNotSyncFields,
+          data.monitorType,
+        ) || [];
+
+      // This is a template policy, not a monitor override.
+      if (step.data) {
+        delete step.data.doNotSyncFields;
+      }
+      if (excludedFields.length === 0) {
+        continue;
+      }
+
+      const templateStep: MonitorStep = templateSteps[index]!;
+      const hasUniqueTemplateId: boolean =
+        Boolean(templateStep.data?.id?.trim()) &&
+        templateSteps.filter((candidate: MonitorStep): boolean => {
+          return candidate.data?.id === templateStep.data?.id;
+        }).length === 1;
+      const matches: Array<MonitorStep> = currentSteps.filter(
+        (current: MonitorStep): boolean => {
+          return Boolean(
+            templateStep.data?.id && current.data?.id === templateStep.data.id,
+          );
+        },
+      );
+      const matchingStep: MonitorStep | undefined =
+        matches.length === 1
+          ? matches[0]
+          : matches.length === 0 &&
+              templateSteps.length === 1 &&
+              currentSteps.length === 1
+            ? currentSteps[0]
+            : undefined;
+
+      if (
+        !hasUniqueTemplateId ||
+        !matchingStep?.data?.id?.trim() ||
+        !step.data
+      ) {
+        throw new BadDataException(
+          "Cannot preserve fields because a template step cannot be matched to an existing monitor step. Match step IDs, or use a single-step template with a single-step monitor.",
+        );
+      }
+
+      for (const field of excludedFields) {
+        for (const path of MonitorTemplateSyncFieldUtil.getPaths(field)) {
+          this.preservePath(
+            step.data as unknown as Record<string, unknown>,
+            matchingStep.data as unknown as Record<string, unknown>,
+            path.split("."),
+          );
+        }
+      }
+    }
+
+    return result;
+  }
+
+  private static preservePath(
+    target: Record<string, unknown>,
+    source: Record<string, unknown>,
+    path: Array<string>,
+  ): void {
+    const key: string = path[0]!;
+    if (path.length === 1) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = this.cloneValue(source[key]);
+      } else {
+        delete target[key];
+      }
+      return;
+    }
+
+    const sourceChild: unknown = source[key];
+    const targetChild: unknown = target[key];
+    if (!targetChild || typeof targetChild !== "object") {
+      if (!sourceChild || typeof sourceChild !== "object") {
+        return;
+      }
+      target[key] = {};
+    }
+    this.preservePath(
+      target[key] as Record<string, unknown>,
+      sourceChild && typeof sourceChild === "object"
+        ? (sourceChild as Record<string, unknown>)
+        : {},
+      path.slice(1),
+    );
+  }
+
+  /**
+   * Clone configuration without a serialization round trip: that normalizes
+   * old values and can invent defaults for fields that should remain absent.
+   * Keeping prototypes also keeps URL, ObjectID and criteria methods usable.
+   */
+  private static cloneValue<T>(value: T): T {
+    if (value === null || typeof value !== "object") {
+      return value;
+    }
+    if (value instanceof Date) {
+      return new Date(value.getTime()) as T;
+    }
+    if (Array.isArray(value)) {
+      return value.map((item: unknown): unknown => {
+        return this.cloneValue(item);
+      }) as T;
+    }
+    const result: Record<string, unknown> = Object.create(
+      Object.getPrototypeOf(value),
+    );
+    for (const key of Object.keys(value)) {
+      Object.defineProperty(result, key, {
+        value: this.cloneValue((value as Record<string, unknown>)[key]),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return result as T;
+  }
+}

--- a/E2E/Tests/Dashboard/Helpers/ProductOnboarding.ts
+++ b/E2E/Tests/Dashboard/Helpers/ProductOnboarding.ts
@@ -17,6 +17,7 @@ const projectDashboardUrlRegex: RegExp =
 type RegisterAndCreateProjectFunction = (data: {
   page: Page;
   projectNamePrefix: string;
+  email?: string | undefined;
   /*
    * Only used when billing is enabled: selects this plan by its visible name
    * (e.g. "Growth") instead of whichever plan happens to unlock submit first.
@@ -31,6 +32,7 @@ export const registerAndCreateProject: RegisterAndCreateProjectFunction =
   async (data: {
     page: Page;
     projectNamePrefix: string;
+    email?: string | undefined;
     preferredPlanName?: string | undefined;
     enablePaidUsage?: boolean | undefined;
   }): Promise<string> => {
@@ -54,7 +56,7 @@ export const registerAndCreateProject: RegisterAndCreateProjectFunction =
       }
     }
 
-    const email: string = Faker.generateEmail().toString();
+    const email: string = data.email || Faker.generateEmail().toString();
 
     await page.getByTestId("email").click();
     await page.getByTestId("email").fill(email);

--- a/E2E/Tests/Dashboard/MonitorTemplateFieldSync.spec.ts
+++ b/E2E/Tests/Dashboard/MonitorTemplateFieldSync.spec.ts
@@ -1,0 +1,413 @@
+import { registerAndCreateProject } from "./Helpers/ProductOnboarding";
+import {
+  buildUrl,
+  createItem,
+  getItem,
+  getProjectDefaults,
+  JSONish,
+  ProjectDefaults,
+  requestJson,
+  toId,
+} from "./Helpers/MonitorAlerting";
+import {
+  APIResponse,
+  Browser,
+  Locator,
+  Page,
+  TestInfo,
+  expect,
+  test,
+} from "@playwright/test";
+import ObjectID from "Common/Types/ObjectID";
+import URL from "Common/Types/API/URL";
+
+test.describe.configure({ mode: "serial" });
+
+function firstStep(steps: JSONish): JSONish {
+  return steps["value"]["monitorStepsInstanceArray"][0]["value"];
+}
+
+function buildSteps(defaults: ProjectDefaults, name: string): JSONish {
+  return {
+    _type: "MonitorSteps",
+    value: {
+      defaultMonitorStatusId: defaults.operationalMonitorStatusId,
+      monitorStepsInstanceArray: [
+        {
+          _type: "MonitorStep",
+          value: {
+            id: ObjectID.generate().toString(),
+            monitorDestination: URL.fromString(
+              `https://${name}.example.com`,
+            ).toJSON(),
+            requestType: "GET",
+            requestHeaders: { "X-Environment": name },
+            requestBody: "",
+            requestTimeoutInMs: 5000,
+            retryCount: 0,
+            monitorCriteria: {
+              _type: "MonitorCriteria",
+              value: {
+                monitorCriteriaInstanceArray: [
+                  {
+                    _type: "MonitorCriteriaInstance",
+                    value: {
+                      id: ObjectID.generate().toString(),
+                      name: "Shared availability criteria",
+                      description: `Criteria for ${name}`,
+                      filterCondition: "All",
+                      filters: [{ checkOn: "Is Online", filterType: "True" }],
+                      createIncidents: false,
+                      createAlerts: false,
+                      changeMonitorStatus: false,
+                      incidents: [],
+                      alerts: [],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+}
+
+function criteriaDescription(step: JSONish): string {
+  return step["monitorCriteria"]["value"]["monitorCriteriaInstanceArray"][0][
+    "value"
+  ]["description"];
+}
+
+async function capture(
+  page: Page,
+  testInfo: TestInfo,
+  name: string,
+): Promise<void> {
+  const path: string = testInfo.outputPath(`${name}.png`);
+  await page.screenshot({ path });
+  await testInfo.attach(name, { path, contentType: "image/png" });
+}
+
+test.describe("Monitor template field sync settings", () => {
+  let page: Page;
+  let projectId: string;
+  let templateId: string;
+  let templateSteps: JSONish;
+  let defaults: ProjectDefaults;
+  const monitorIds: Array<string> = [];
+
+  test.beforeAll(async ({ browser }: { browser: Browser }) => {
+    test.setTimeout(300000);
+    page = await browser.newPage({ viewport: { width: 1440, height: 1080 } });
+    projectId = await registerAndCreateProject({
+      page,
+      projectNamePrefix: "Template Sync Settings",
+      email: `template-sync-${Date.now()}@example.test`,
+      preferredPlanName: "Growth",
+    });
+    defaults = await getProjectDefaults({ page, projectId });
+    templateSteps = buildSteps(defaults, "template-default");
+    firstStep(templateSteps)["requestTimeoutInMs"] = 17000;
+    const template: JSONish = await createItem({
+      page,
+      projectId,
+      path: "/api/monitor-template",
+      item: {
+        projectId,
+        templateName: "API availability checks",
+        templateDescription:
+          "Shared criteria with independent destinations and headers",
+        monitorType: "API",
+        monitorSteps: templateSteps,
+        monitoringInterval: "*/10 * * * *",
+        minimumProbeAgreement: 1,
+      },
+    });
+    templateId = toId(template["_id"]);
+    for (const name of ["production-api", "staging-api"]) {
+      const monitor: JSONish = await createItem({
+        page,
+        projectId,
+        path: "/api/monitor",
+        item: {
+          projectId,
+          name,
+          monitorType: "API",
+          monitorTemplateId: templateId,
+          monitorSteps: buildSteps(defaults, name),
+          monitoringInterval: "*/5 * * * *",
+          minimumProbeAgreement: 1,
+        },
+      });
+      monitorIds.push(toId(monitor["_id"]));
+    }
+  });
+
+  test.afterAll(async () => {
+    await page?.close();
+  });
+
+  test("saves field exclusions in the editor and preserves different monitor values during bulk criteria sync", async () => {
+    await page.goto(
+      buildUrl(
+        `/dashboard/${projectId}/monitors/settings/templates/${templateId}`,
+      ),
+    );
+    await page
+      .getByRole("button", { name: "Edit Criteria", exact: true })
+      .click();
+    const modal: Locator = page.getByTestId("modal");
+    await expect(modal).toBeVisible();
+    const destination: Locator = modal.getByRole("checkbox", {
+      name: "Monitor destination Do not sync this field",
+      exact: true,
+    });
+    const headers: Locator = modal.getByRole("checkbox", {
+      name: "Request headers Do not sync this field",
+      exact: true,
+    });
+    await destination.waitFor({ state: "visible", timeout: 60000 });
+    await expect(destination).not.toBeChecked();
+    await expect(headers).not.toBeChecked();
+    await destination.check();
+    await headers.check();
+    await capture(page, test.info(), "template-field-sync-editor");
+    await page.getByTestId("modal-footer-submit-button").click();
+    await expect(modal).toBeHidden();
+    await page.reload();
+    await expect(
+      page
+        .getByText(
+          /These fields keep each monitor's current values during sync: Monitor destination, Request headers/,
+        )
+        .first(),
+    ).toBeVisible();
+
+    const saved: JSONish = await getItem({
+      page,
+      projectId,
+      path: "/api/monitor-template",
+      id: templateId,
+      select: { monitorSteps: true },
+    });
+    templateSteps = saved["monitorSteps"];
+    expect(firstStep(templateSteps)["doNotSyncFields"]).toEqual([
+      "monitorDestination",
+      "requestHeaders",
+    ]);
+    // Selections survive reopening the editor, not just its local state.
+    await page
+      .getByRole("button", { name: "Edit Criteria", exact: true })
+      .click();
+    await expect(destination).toBeChecked({ timeout: 60000 });
+    await expect(headers).toBeChecked();
+    await modal.getByRole("button", { name: "Cancel", exact: true }).click();
+    await expect(modal).toBeHidden();
+
+    await page
+      .getByRole("button", {
+        name: /^Sync Criteria to (?:2 )?Linked Monitors$/,
+      })
+      .click();
+    const syncDialog: Locator = page.getByRole("dialog", {
+      name: "Sync Criteria to Linked Monitors",
+      exact: true,
+    });
+    await expect(syncDialog).toBeVisible();
+    await expect(syncDialog).toContainText(
+      "Monitor destination, Request headers",
+    );
+    await capture(page, test.info(), "template-field-sync-confirmation");
+    await syncDialog.getByTestId("modal-footer-submit-button").click();
+    await expect(syncDialog).toBeHidden();
+    const resultDialog: Locator = page.getByRole("dialog", {
+      name: "Done",
+      exact: true,
+    });
+    await expect(resultDialog).toContainText("Synced criteria onto 2 monitors");
+    await resultDialog.getByRole("button", { name: "OK", exact: true }).click();
+    await capture(page, test.info(), "template-field-sync-summary");
+
+    for (const [index, name] of ["production-api", "staging-api"].entries()) {
+      const monitor: JSONish = await getItem({
+        page,
+        projectId,
+        path: "/api/monitor",
+        id: monitorIds[index]!,
+        select: { monitorSteps: true, monitoringInterval: true },
+      });
+      const step: JSONish = firstStep(monitor["monitorSteps"]);
+      expect(step["monitorDestination"]["value"]).toBe(
+        URL.fromString(`https://${name}.example.com`).toString(),
+      );
+      expect(step["requestHeaders"]).toEqual({ "X-Environment": name });
+      expect(step["requestTimeoutInMs"]).toBe(17000);
+      expect(criteriaDescription(step)).toBe("Criteria for template-default");
+      expect(monitor["monitoringInterval"]).toBe("*/5 * * * *");
+    }
+  });
+
+  test("individual sync preserves empty headers and new monitors still receive template defaults", async () => {
+    const monitor: JSONish = await getItem({
+      page,
+      projectId,
+      path: "/api/monitor",
+      id: monitorIds[0]!,
+      select: { monitorSteps: true },
+    });
+    const steps: JSONish = monitor["monitorSteps"];
+    firstStep(steps)["requestHeaders"] = {};
+    await requestJson({
+      page,
+      projectId,
+      method: "put",
+      path: `/api/monitor/${monitorIds[0]}`,
+      body: { data: { monitorSteps: steps } },
+    });
+    await requestJson({
+      page,
+      projectId,
+      path: `/api/monitor-template/${templateId}/sync-to-monitor/${monitorIds[0]}`,
+      body: {},
+    });
+    const synced: JSONish = await getItem({
+      page,
+      projectId,
+      path: "/api/monitor",
+      id: monitorIds[0]!,
+      select: { monitorSteps: true, monitoringInterval: true },
+    });
+    expect(firstStep(synced["monitorSteps"])["requestHeaders"]).toEqual({});
+    expect(
+      firstStep(synced["monitorSteps"])["monitorDestination"]["value"],
+    ).toBe(URL.fromString("https://production-api.example.com").toString());
+    expect(synced["monitoringInterval"]).toBe("*/10 * * * *");
+
+    await page
+      .getByRole("button", {
+        name: "Create Monitor from Template",
+        exact: true,
+      })
+      .click();
+    const createForm: Locator = page.locator("#create-monitor-form");
+    await expect(createForm).toBeVisible({ timeout: 30000 });
+    await createForm
+      .getByPlaceholder("Monitor Name")
+      .fill("New API from defaults");
+    const nextOrCreate: Locator = page.getByTestId("Create Monitor");
+    await nextOrCreate.click();
+    await page
+      .getByText("Monitor Criteria", { exact: true })
+      .first()
+      .waitFor({ state: "visible", timeout: 60000 });
+    await expect(createForm.getByRole("textbox").first()).toHaveValue(
+      URL.fromString("https://template-default.example.com").toString(),
+    );
+    await expect(
+      createForm.getByPlaceholder("Header Name").first(),
+    ).toHaveValue("X-Environment");
+    await expect(
+      createForm.getByPlaceholder("Header Value").first(),
+    ).toHaveValue("template-default");
+    await capture(page, test.info(), "new-monitor-template-defaults");
+    await nextOrCreate.click();
+    await expect(
+      createForm.getByText("Monitoring Interval", { exact: true }),
+    ).toBeVisible();
+    await nextOrCreate.click();
+    await expect(nextOrCreate).toHaveText("Create Monitor");
+    await nextOrCreate.click();
+    const monitorViewPattern: RegExp = new RegExp(
+      `/dashboard/${projectId}/monitors/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:/|$)`,
+      "i",
+    );
+    await expect(page).toHaveURL(monitorViewPattern, { timeout: 60000 });
+    const createdMonitorId: string = page.url().match(monitorViewPattern)![1]!;
+    const newMonitor: JSONish = await getItem({
+      page,
+      projectId,
+      path: "/api/monitor",
+      id: createdMonitorId,
+      select: {
+        monitorSteps: true,
+        monitorTemplateId: true,
+        monitoringInterval: true,
+      },
+    });
+    expect(toId(newMonitor["monitorTemplateId"])).toBe(templateId);
+    expect(newMonitor["monitoringInterval"]).toBe("*/10 * * * *");
+    expect(
+      firstStep(newMonitor["monitorSteps"])["monitorDestination"]["value"],
+    ).toBe(URL.fromString("https://template-default.example.com").toString());
+    expect(firstStep(newMonitor["monitorSteps"])["requestHeaders"]).toEqual({
+      "X-Environment": "template-default",
+    });
+  });
+
+  test("rejects unsupported fields through the API without changing the saved template", async () => {
+    for (const field of ["monitorCriteria", "databaseMonitor.connection"]) {
+      const invalidSteps: JSONish = JSON.parse(JSON.stringify(templateSteps));
+      firstStep(invalidSteps)["doNotSyncFields"] = [field];
+      const response: APIResponse = await page.request.put(
+        buildUrl(`/api/monitor-template/${templateId}`),
+        {
+          headers: { tenantid: projectId, projectid: projectId },
+          data: { data: { monitorSteps: invalidSteps } },
+        },
+      );
+      expect(response.status()).toBe(400);
+    }
+    const saved: JSONish = await getItem({
+      page,
+      projectId,
+      path: "/api/monitor-template",
+      id: templateId,
+      select: { monitorSteps: true },
+    });
+    expect(firstStep(saved["monitorSteps"])["doNotSyncFields"]).toEqual([
+      "monitorDestination",
+      "requestHeaders",
+    ]);
+  });
+
+  test("unchecking an exclusion restores sync for that field only", async () => {
+    await page.goto(
+      buildUrl(
+        `/dashboard/${projectId}/monitors/settings/templates/${templateId}`,
+      ),
+    );
+    await page
+      .getByRole("button", { name: "Edit Criteria", exact: true })
+      .click();
+    const modal: Locator = page.getByTestId("modal");
+    await modal
+      .getByRole("checkbox", {
+        name: "Request headers Do not sync this field",
+        exact: true,
+      })
+      .uncheck();
+    await page.getByTestId("modal-footer-submit-button").click();
+    await expect(modal).toBeHidden();
+    await requestJson({
+      page,
+      projectId,
+      path: `/api/monitor-template/${templateId}/sync-to-monitor/${monitorIds[0]}`,
+      body: { fields: ["monitorSteps"] },
+    });
+    const synced: JSONish = await getItem({
+      page,
+      projectId,
+      path: "/api/monitor",
+      id: monitorIds[0]!,
+      select: { monitorSteps: true },
+    });
+    expect(
+      firstStep(synced["monitorSteps"])["monitorDestination"]["value"],
+    ).toBe(URL.fromString("https://production-api.example.com").toString());
+    expect(firstStep(synced["monitorSteps"])["requestHeaders"]).toEqual({
+      "X-Environment": "template-default",
+    });
+  });
+});


### PR DESCRIPTION
### Small Description

Syncing monitor-template criteria could overwrite every linked monitor's destination and request headers. This adds **Do not sync this field** controls to template steps. For example, production and staging monitors can retain their individual URLs and headers while receiving the same updated criteria.

- Selected fields retain each existing monitor's value during bulk and individual sync, including empty, absent, false, and zero values. Unchecked settings continue to sync.
- Options cover destinations, API request settings, database connections, DNS settings, infrastructure selectors, and telemetry queries. Collections are preserved in full; related credentials and resource selectors are grouped together.
- Protected steps match by unique IDs, with a fallback when both template and monitor contain one step. Ambiguous or unmatched protected steps fail before bulk writes. Existing network-device bindings and custom-field merging remain intact.
- The template details and confirmation dialogs show the saved protections. New monitors still receive template defaults through the existing create wizard.

Existing templates retain their behavior until exclusions are selected. The policy is stored in the existing step JSON; no database migration is required. Added user documentation and server validation of allowed fields.

### Validation

- 336 relevant tests passed: 151 core, 85 service, 29 typed UI, and 71 existing App tests. The new 34-case service suite also passed standard typed Jest on Node 26 in CI.
- Common, App, Dashboard, and E2E compilation passed locally. Documentation anchor checks passed.
- Four browser E2E cases cover saving/reloading exclusions, bulk and individual sync, new-monitor defaults through the real create wizard, invalid API options, and restoring sync by unchecking a field. Browser execution is awaiting the isolated development app build.
- All test and compile jobs passed on the initial commit. Seven UI lint formatting issues found by CI are corrected in the follow-up commit. Root `npm run fix` and focused lint checks remain in progress under heavy local machine load.

### Pull Request Checklist

- [ ] All jobs pass before requesting review.
- [ ] Local lint complete.
- [x] Relevant regression and integration tests added.

### Screenshots

These are **component previews using the production components with sample data**, showing the protected destination and headers plus the live summary. Full-app screenshots will be added after browser verification.

Desktop:

![Desktop preview of monitor template sync settings](https://raw.githubusercontent.com/OneUptime/oneuptime/7bbe8ed7beb5e64f00c7544398f454bd606fc5d9/desktop.png)

Mobile:

<img src="https://raw.githubusercontent.com/OneUptime/oneuptime/7bbe8ed7beb5e64f00c7544398f454bd606fc5d9/mobile.png" alt="Mobile preview of monitor template sync settings" width="390" />
