### PR TITLE
fix(status-page): keep nested resource search responsive

### DIFF
--- a/App/FeatureSet/StatusPage/src/Components/Search/ResourceSearchBox.tsx
+++ b/App/FeatureSet/StatusPage/src/Components/Search/ResourceSearchBox.tsx
@@ -9,6 +9,7 @@ export interface ComponentProps {
   /* How many resources survive the current query, and how many there are. */
   matchedCount: number;
   totalCount: number;
+  isPending?: boolean | undefined;
 }
 
 /*
@@ -71,7 +72,7 @@ const ResourceSearchBox: FunctionComponent<ComponentProps> = (
               props.onChange("");
             }
           }}
-          className="block w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-10 text-sm text-gray-900 shadow-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          className="block w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-10 text-sm text-gray-900 shadow-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 [&::-webkit-search-cancel-button]:appearance-none"
         />
         {hasQuery && (
           <button
@@ -95,6 +96,7 @@ const ResourceSearchBox: FunctionComponent<ComponentProps> = (
          * and an assertive region would interrupt the visitor's own typing.
          */
         aria-live="polite"
+        aria-busy={Boolean(props.isPending)}
         className="mt-1.5 min-h-[1rem] px-1 text-xs text-gray-500"
         data-testid="status-page-resource-search-count"
       >

--- a/App/FeatureSet/StatusPage/src/Pages/Overview/Overview.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Overview/Overview.tsx
@@ -211,8 +211,10 @@ const Overview: FunctionComponent<PageComponentProps> = (
     Math.max(statusPage?.showUptimeHistoryInDays || 90, 1),
     90,
   );
-  // The history window belongs to the fetched snapshot. Typing must not give
-  // every chart new dates or change an uptime reading without new status data.
+  /*
+   * The history window belongs to the fetched snapshot. Typing must not give
+   * every chart new dates or change an uptime reading without new status data.
+   */
   const endDate: Date = lastRefreshedAt;
   const startDate: Date = useMemo(() => {
     return OneUptimeDate.getSomeDaysAgoFromDate(endDate, uptimeHistoryDays);
@@ -785,8 +787,10 @@ const Overview: FunctionComponent<PageComponentProps> = (
     );
   };
 
-  // Search only selects these elements; their timelines, incidents and charts
-  // are rebuilt when the payload, history window or language changes.
+  /*
+   * Search only selects these elements; their timelines, incidents and charts
+   * are rebuilt when the payload, history window or language changes.
+   */
   const monitorOverviews: Map<
     StatusPageResource,
     Array<ReactElement>

--- a/App/FeatureSet/StatusPage/src/Pages/Overview/Overview.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Overview/Overview.tsx
@@ -54,6 +54,7 @@ import StatusPageResource from "Common/Models/DatabaseModels/StatusPageResource"
 import React, {
   FunctionComponent,
   ReactElement,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -148,6 +149,8 @@ const Overview: FunctionComponent<PageComponentProps> = (
   });
 
   const [searchQuery, setSearchQuery] = useState<string>("");
+  // Keep typing and clearing responsive while React reveals history charts.
+  const deferredSearchQuery: string = useDeferredValue(searchQuery);
   const [
     scheduledMaintenanceEventsPublicNotes,
     setScheduledMaintenanceEventsPublicNotes,
@@ -208,8 +211,12 @@ const Overview: FunctionComponent<PageComponentProps> = (
     Math.max(statusPage?.showUptimeHistoryInDays || 90, 1),
     90,
   );
-  const startDate: Date = OneUptimeDate.getSomeDaysAgo(uptimeHistoryDays);
-  const endDate: Date = OneUptimeDate.getCurrentDate();
+  // The history window belongs to the fetched snapshot. Typing must not give
+  // every chart new dates or change an uptime reading without new status data.
+  const endDate: Date = lastRefreshedAt;
+  const startDate: Date = useMemo(() => {
+    return OneUptimeDate.getSomeDaysAgoFromDate(endDate, uptimeHistoryDays);
+  }, [endDate, uptimeHistoryDays]);
   const [currentStatus, setCurrentStatus] = useState<MonitorStatus | null>(
     null,
   );
@@ -597,12 +604,17 @@ const Overview: FunctionComponent<PageComponentProps> = (
    */
   const searchResult: StatusPageResourceSearchResult = useMemo(() => {
     return StatusPageResourceSearchUtil.search({
-      query: searchQuery,
+      query: deferredSearchQuery,
       statusPageResources: statusPageResources,
       statusPageGroups: resourceGroups,
       statusPageGroupTreeIndex: groupTreeIndex,
     });
-  }, [searchQuery, statusPageResources, resourceGroups, groupTreeIndex]);
+  }, [
+    deferredSearchQuery,
+    statusPageResources,
+    resourceGroups,
+    groupTreeIndex,
+  ]);
 
   type IsResourceVisibleFunction = (resource: StatusPageResource) => boolean;
 
@@ -629,87 +641,113 @@ const Overview: FunctionComponent<PageComponentProps> = (
     group: StatusPageGroup;
   }) => GroupRollup | null;
 
-  const getGroupRollup: GetGroupRollupFunction = (data: {
-    group: StatusPageGroup;
-  }): GroupRollup | null => {
-    /*
-     * Everything under this group, at any depth. A group with nothing under it
-     * reports no rollup at all - see getRollupKind.
-     */
-    const resourcesInSubtree: Array<StatusPageResource> =
-      StatusPageResourceUptimeUtil.getResourcesInStatusPageGroupAndDescendants({
-        statusPageGroup: data.group,
-        statusPageResources: statusPageResources,
-        allStatusPageGroups: resourceGroups,
-        statusPageGroupTreeIndex: groupTreeIndex,
-      });
-
-    const currentStatus: MonitorStatus =
-      StatusPageResourceUptimeUtil.getCurrentStatusPageGroupStatus({
-        statusPageGroup: data.group,
-        monitorStatusTimelines: monitorStatusTimelines,
-        statusPageResources: statusPageResources,
-        monitorStatuses: monitorStatuses,
-        monitorGroupCurrentStatuses: monitorGroupCurrentStatuses,
-        allStatusPageGroups: resourceGroups,
-        statusPageGroupTreeIndex: groupTreeIndex,
-      });
-
-    const color: string = currentStatus?.color?.toString() || Green.toString();
-
-    const isCurrentlyDown: boolean = Boolean(
-      (statusPage?.downtimeMonitorStatuses || []).find(
-        (downtimeStatus: MonitorStatus) => {
-          return (
-            currentStatus?.id?.toString() === downtimeStatus?.id?.toString()
-          );
-        },
-      ),
-    );
-
-    const uptimePercent: number | null = data.group.showUptimePercent
-      ? StatusPageResourceUptimeUtil.calculateAvgUptimePercentOfStatusPageGroup(
+  const groupRollups: Map<StatusPageGroup, GroupRollup | null> = useMemo(() => {
+    const getGroupRollup: GetGroupRollupFunction = (data: {
+      group: StatusPageGroup;
+    }): GroupRollup | null => {
+      /*
+       * Everything under this group, at any depth. A group with nothing under it
+       * reports no rollup at all - see getRollupKind.
+       */
+      const resourcesInSubtree: Array<StatusPageResource> =
+        StatusPageResourceUptimeUtil.getResourcesInStatusPageGroupAndDescendants(
           {
             statusPageGroup: data.group,
-            monitorStatusTimelines: monitorStatusTimelines,
-            precision:
-              data.group.uptimePercentPrecision || UptimePrecision.ONE_DECIMAL,
-            downtimeMonitorStatuses: statusPage?.downtimeMonitorStatuses || [],
             statusPageResources: statusPageResources,
-            monitorsInGroup: monitorsInGroup,
-            uptimeWindow: { startDate: startDate, endDate: endDate },
             allStatusPageGroups: resourceGroups,
             statusPageGroupTreeIndex: groupTreeIndex,
           },
-        )
-      : null;
+        );
 
-    const kind: StatusPageGroupRollupKind =
-      StatusPageGroupNestingLayoutUtil.getRollupKind({
-        showUptimePercent: Boolean(data.group.showUptimePercent),
-        showCurrentStatus: Boolean(data.group.showCurrentStatus),
-        isCurrentlyDown: isCurrentlyDown,
-        uptimePercent: uptimePercent,
-        resourceCountInSubtree: resourcesInSubtree.length,
-      });
+      const currentStatus: MonitorStatus =
+        StatusPageResourceUptimeUtil.getCurrentStatusPageGroupStatus({
+          statusPageGroup: data.group,
+          monitorStatusTimelines: monitorStatusTimelines,
+          statusPageResources: statusPageResources,
+          monitorStatuses: monitorStatuses,
+          monitorGroupCurrentStatuses: monitorGroupCurrentStatuses,
+          allStatusPageGroups: resourceGroups,
+          statusPageGroupTreeIndex: groupTreeIndex,
+        });
 
-    if (kind === StatusPageGroupRollupKind.UptimePercent) {
-      return {
-        label: `${uptimePercent}${t("overview.uptimeSuffix")}`,
-        color: color,
-      };
-    }
+      const color: string =
+        currentStatus?.color?.toString() || Green.toString();
 
-    if (kind === StatusPageGroupRollupKind.CurrentStatus) {
-      return {
-        label:
-          translateStatusName(currentStatus?.name) || t("overview.operational"),
-        color: color,
-      };
-    }
+      const isCurrentlyDown: boolean = Boolean(
+        (statusPage?.downtimeMonitorStatuses || []).find(
+          (downtimeStatus: MonitorStatus) => {
+            return (
+              currentStatus?.id?.toString() === downtimeStatus?.id?.toString()
+            );
+          },
+        ),
+      );
 
-    return null;
-  };
+      const uptimePercent: number | null = data.group.showUptimePercent
+        ? StatusPageResourceUptimeUtil.calculateAvgUptimePercentOfStatusPageGroup(
+            {
+              statusPageGroup: data.group,
+              monitorStatusTimelines: monitorStatusTimelines,
+              precision:
+                data.group.uptimePercentPrecision ||
+                UptimePrecision.ONE_DECIMAL,
+              downtimeMonitorStatuses:
+                statusPage?.downtimeMonitorStatuses || [],
+              statusPageResources: statusPageResources,
+              monitorsInGroup: monitorsInGroup,
+              uptimeWindow: { startDate: startDate, endDate: endDate },
+              allStatusPageGroups: resourceGroups,
+              statusPageGroupTreeIndex: groupTreeIndex,
+            },
+          )
+        : null;
+
+      const kind: StatusPageGroupRollupKind =
+        StatusPageGroupNestingLayoutUtil.getRollupKind({
+          showUptimePercent: Boolean(data.group.showUptimePercent),
+          showCurrentStatus: Boolean(data.group.showCurrentStatus),
+          isCurrentlyDown: isCurrentlyDown,
+          uptimePercent: uptimePercent,
+          resourceCountInSubtree: resourcesInSubtree.length,
+        });
+
+      if (kind === StatusPageGroupRollupKind.UptimePercent) {
+        return {
+          label: `${uptimePercent}${t("overview.uptimeSuffix")}`,
+          color: color,
+        };
+      }
+
+      if (kind === StatusPageGroupRollupKind.CurrentStatus) {
+        return {
+          label:
+            translateStatusName(currentStatus?.name) ||
+            t("overview.operational"),
+          color: color,
+        };
+      }
+
+      return null;
+    };
+
+    return new Map(
+      resourceGroups.map((group: StatusPageGroup) => {
+        return [group, getGroupRollup({ group })];
+      }),
+    );
+  }, [
+    resourceGroups,
+    statusPageResources,
+    groupTreeIndex,
+    monitorStatusTimelines,
+    monitorStatuses,
+    monitorGroupCurrentStatuses,
+    statusPage,
+    monitorsInGroup,
+    startDate,
+    endDate,
+    t,
+  ]);
 
   /*
    * Every bar in one resource list is drawn over the same window and sits in the
@@ -746,6 +784,225 @@ const Overview: FunctionComponent<PageComponentProps> = (
       </div>
     );
   };
+
+  // Search only selects these elements; their timelines, incidents and charts
+  // are rebuilt when the payload, history window or language changes.
+  const monitorOverviews: Map<
+    StatusPageResource,
+    Array<ReactElement>
+  > = useMemo(() => {
+    const overviews: Map<StatusPageResource, Array<ReactElement>> = new Map();
+    for (const resource of statusPageResources) {
+      const elements: Array<ReactElement> = [];
+      /*
+       * Keyed on the resource rather than on a fresh random number, so a
+       * resource is not torn down and remounted on every render - that used
+       * to throw away an open incident day modal. A resource with no id of
+       * its own falls back to its position, and the two branches below are
+       * namespaced apart because nothing stops one resource from carrying
+       * both a monitor and a monitor group.
+       */
+      const resourceKey: string =
+        resource._id?.toString() || `position-${overviews.size}`;
+
+      // if it's a monitor
+
+      if (resource.monitor) {
+        let currentStatus: MonitorStatus | undefined = monitorStatuses.find(
+          (status: MonitorStatus) => {
+            return (
+              status._id?.toString() ===
+              resource.monitor?.currentMonitorStatusId?.toString()
+            );
+          },
+        );
+
+        if (!currentStatus) {
+          currentStatus = new MonitorStatus();
+          currentStatus.name = t("overview.operational");
+          currentStatus.color = Green;
+        }
+
+        const monitorId: string = resource.monitor?._id?.toString() || "";
+
+        const monitorIncidents: Array<UptimeBarTooltipIncident> =
+          timelineIncidents.filter((incident: UptimeBarTooltipIncident) => {
+            return incident.monitorIds.some((id: ObjectID) => {
+              return id.toString() === monitorId;
+            });
+          });
+
+        elements.push(
+          <MonitorOverview
+            key={`monitor-${resourceKey}`}
+            showTimeAxisLabels={false}
+            monitorName={resource.displayName || resource.monitor?.name || ""}
+            statusPageHistoryChartBarColorRules={
+              statusPageHistoryChartBarColorRules
+            }
+            downtimeMonitorStatuses={statusPage?.downtimeMonitorStatuses || []}
+            description={resource.displayDescription || ""}
+            tooltip={resource.displayTooltip || ""}
+            currentStatus={currentStatus}
+            showUptimePercent={Boolean(resource.showUptimePercent)}
+            uptimePrecision={
+              resource.uptimePercentPrecision || UptimePrecision.ONE_DECIMAL
+            }
+            monitorStatusTimeline={StatusPageResourceUptimeUtil.getMonitorStatusTimelineForResource(
+              {
+                statusPageResource: resource,
+                monitorStatusTimelines: monitorStatusTimelines,
+                monitorsInGroup: monitorsInGroup,
+              },
+            )}
+            startDate={startDate}
+            endDate={endDate}
+            showHistoryChart={resource.showStatusHistoryChart}
+            showCurrentStatus={resource.showCurrentStatus}
+            uptimeGraphHeight={10}
+            defaultBarColor={statusPage?.defaultBarColor || Green}
+            uptimeHistoryDays={uptimeHistoryDays}
+            incidents={monitorIncidents}
+            onIncidentClick={(incidentId: string) => {
+              Navigation.navigate(
+                RouteUtil.populateRouteParams(
+                  StatusPageUtil.isPreviewPage()
+                    ? (RouteMap[PageMap.PREVIEW_INCIDENT_DETAIL] as Route)
+                    : (RouteMap[PageMap.INCIDENT_DETAIL] as Route),
+                  new ObjectID(incidentId),
+                ),
+              );
+            }}
+          />,
+        );
+      }
+
+      // if it's a monitor group, then...
+
+      if (resource.monitorGroupId) {
+        let currentStatus: MonitorStatus | undefined = monitorStatuses.find(
+          (status: MonitorStatus) => {
+            return (
+              status._id?.toString() ===
+              monitorGroupCurrentStatuses[
+                resource.monitorGroupId?.toString() || ""
+              ]?.toString()
+            );
+          },
+        );
+
+        if (!currentStatus) {
+          currentStatus = new MonitorStatus();
+          currentStatus.name = t("overview.operational");
+          currentStatus.color = Green;
+        }
+
+        // Get monitor IDs in this group
+        const groupMonitorIds: Array<string> = (
+          monitorsInGroup[resource.monitorGroupId?.toString() || ""] || []
+        ).map((id: ObjectID) => {
+          return id.toString();
+        });
+
+        const groupIncidents: Array<UptimeBarTooltipIncident> =
+          timelineIncidents.filter((incident: UptimeBarTooltipIncident) => {
+            return incident.monitorIds.some((id: ObjectID) => {
+              return groupMonitorIds.includes(id.toString());
+            });
+          });
+
+        elements.push(
+          <MonitorOverview
+            key={`monitor-group-${resourceKey}`}
+            showTimeAxisLabels={false}
+            monitorName={resource.displayName || resource.monitor?.name || ""}
+            showUptimePercent={Boolean(resource.showUptimePercent)}
+            uptimePrecision={
+              resource.uptimePercentPrecision || UptimePrecision.ONE_DECIMAL
+            }
+            statusPageHistoryChartBarColorRules={
+              statusPageHistoryChartBarColorRules
+            }
+            description={resource.displayDescription || ""}
+            tooltip={resource.displayTooltip || ""}
+            currentStatus={currentStatus}
+            monitorStatusTimeline={StatusPageResourceUptimeUtil.getMonitorStatusTimelineForResource(
+              {
+                statusPageResource: resource,
+                monitorStatusTimelines: monitorStatusTimelines,
+                monitorsInGroup: monitorsInGroup,
+              },
+            )}
+            downtimeMonitorStatuses={statusPage?.downtimeMonitorStatuses || []}
+            startDate={startDate}
+            endDate={endDate}
+            showHistoryChart={resource.showStatusHistoryChart}
+            showCurrentStatus={resource.showCurrentStatus}
+            uptimeGraphHeight={10}
+            defaultBarColor={statusPage?.defaultBarColor || Green}
+            uptimeHistoryDays={uptimeHistoryDays}
+            incidents={groupIncidents}
+            onIncidentClick={(incidentId: string) => {
+              Navigation.navigate(
+                RouteUtil.populateRouteParams(
+                  StatusPageUtil.isPreviewPage()
+                    ? (RouteMap[PageMap.PREVIEW_INCIDENT_DETAIL] as Route)
+                    : (RouteMap[PageMap.INCIDENT_DETAIL] as Route),
+                  new ObjectID(incidentId),
+                ),
+              );
+            }}
+          />,
+        );
+      }
+      overviews.set(resource, elements);
+    }
+    return overviews;
+  }, [
+    statusPageResources,
+    monitorStatuses,
+    timelineIncidents,
+    statusPageHistoryChartBarColorRules,
+    statusPage,
+    monitorStatusTimelines,
+    monitorsInGroup,
+    monitorGroupCurrentStatuses,
+    startDate,
+    endDate,
+    uptimeHistoryDays,
+    t,
+  ]);
+
+  const overallUptime: number | null = useMemo(() => {
+    if (
+      !currentStatus?.isOperationalState ||
+      !statusPage?.showOverallUptimePercentOnStatusPage
+    ) {
+      return null;
+    }
+    return StatusPageResourceUptimeUtil.calculateAvgUptimePercentageOfAllResources(
+      {
+        monitorStatusTimelines,
+        statusPageResources,
+        downtimeMonitorStatuses: statusPage.downtimeMonitorStatuses || [],
+        precision:
+          statusPage.overallUptimePercentPrecision ||
+          UptimePrecision.TWO_DECIMAL,
+        resourceGroups,
+        monitorsInGroup,
+        uptimeWindow: { startDate, endDate },
+      },
+    );
+  }, [
+    currentStatus,
+    statusPage,
+    monitorStatusTimelines,
+    statusPageResources,
+    resourceGroups,
+    monitorsInGroup,
+    startDate,
+    endDate,
+  ]);
 
   if (isLoading) {
     return (
@@ -792,171 +1049,7 @@ const Overview: FunctionComponent<PageComponentProps> = (
           continue;
         }
 
-        /*
-         * Keyed on the resource rather than on a fresh random number, so a
-         * resource is not torn down and remounted on every render - that used
-         * to throw away an open incident day modal. A resource with no id of
-         * its own falls back to its position, and the two branches below are
-         * namespaced apart because nothing stops one resource from carrying
-         * both a monitor and a monitor group.
-         */
-        const resourceKey: string =
-          resource._id?.toString() || `position-${elements.length}`;
-
-        // if it's a monitor
-
-        if (resource.monitor) {
-          let currentStatus: MonitorStatus | undefined = monitorStatuses.find(
-            (status: MonitorStatus) => {
-              return (
-                status._id?.toString() ===
-                resource.monitor?.currentMonitorStatusId?.toString()
-              );
-            },
-          );
-
-          if (!currentStatus) {
-            currentStatus = new MonitorStatus();
-            currentStatus.name = t("overview.operational");
-            currentStatus.color = Green;
-          }
-
-          const monitorId: string = resource.monitor?._id?.toString() || "";
-
-          const monitorIncidents: Array<UptimeBarTooltipIncident> =
-            timelineIncidents.filter((incident: UptimeBarTooltipIncident) => {
-              return incident.monitorIds.some((id: ObjectID) => {
-                return id.toString() === monitorId;
-              });
-            });
-
-          elements.push(
-            <MonitorOverview
-              key={`monitor-${resourceKey}`}
-              showTimeAxisLabels={false}
-              monitorName={resource.displayName || resource.monitor?.name || ""}
-              statusPageHistoryChartBarColorRules={
-                statusPageHistoryChartBarColorRules
-              }
-              downtimeMonitorStatuses={
-                statusPage?.downtimeMonitorStatuses || []
-              }
-              description={resource.displayDescription || ""}
-              tooltip={resource.displayTooltip || ""}
-              currentStatus={currentStatus}
-              showUptimePercent={Boolean(resource.showUptimePercent)}
-              uptimePrecision={
-                resource.uptimePercentPrecision || UptimePrecision.ONE_DECIMAL
-              }
-              monitorStatusTimeline={StatusPageResourceUptimeUtil.getMonitorStatusTimelineForResource(
-                {
-                  statusPageResource: resource,
-                  monitorStatusTimelines: monitorStatusTimelines,
-                  monitorsInGroup: monitorsInGroup,
-                },
-              )}
-              startDate={startDate}
-              endDate={endDate}
-              showHistoryChart={resource.showStatusHistoryChart}
-              showCurrentStatus={resource.showCurrentStatus}
-              uptimeGraphHeight={10}
-              defaultBarColor={statusPage?.defaultBarColor || Green}
-              uptimeHistoryDays={uptimeHistoryDays}
-              incidents={monitorIncidents}
-              onIncidentClick={(incidentId: string) => {
-                Navigation.navigate(
-                  RouteUtil.populateRouteParams(
-                    StatusPageUtil.isPreviewPage()
-                      ? (RouteMap[PageMap.PREVIEW_INCIDENT_DETAIL] as Route)
-                      : (RouteMap[PageMap.INCIDENT_DETAIL] as Route),
-                    new ObjectID(incidentId),
-                  ),
-                );
-              }}
-            />,
-          );
-        }
-
-        // if it's a monitor group, then...
-
-        if (resource.monitorGroupId) {
-          let currentStatus: MonitorStatus | undefined = monitorStatuses.find(
-            (status: MonitorStatus) => {
-              return (
-                status._id?.toString() ===
-                monitorGroupCurrentStatuses[
-                  resource.monitorGroupId?.toString() || ""
-                ]?.toString()
-              );
-            },
-          );
-
-          if (!currentStatus) {
-            currentStatus = new MonitorStatus();
-            currentStatus.name = t("overview.operational");
-            currentStatus.color = Green;
-          }
-
-          // Get monitor IDs in this group
-          const groupMonitorIds: Array<string> = (
-            monitorsInGroup[resource.monitorGroupId?.toString() || ""] || []
-          ).map((id: ObjectID) => {
-            return id.toString();
-          });
-
-          const groupIncidents: Array<UptimeBarTooltipIncident> =
-            timelineIncidents.filter((incident: UptimeBarTooltipIncident) => {
-              return incident.monitorIds.some((id: ObjectID) => {
-                return groupMonitorIds.includes(id.toString());
-              });
-            });
-
-          elements.push(
-            <MonitorOverview
-              key={`monitor-group-${resourceKey}`}
-              showTimeAxisLabels={false}
-              monitorName={resource.displayName || resource.monitor?.name || ""}
-              showUptimePercent={Boolean(resource.showUptimePercent)}
-              uptimePrecision={
-                resource.uptimePercentPrecision || UptimePrecision.ONE_DECIMAL
-              }
-              statusPageHistoryChartBarColorRules={
-                statusPageHistoryChartBarColorRules
-              }
-              description={resource.displayDescription || ""}
-              tooltip={resource.displayTooltip || ""}
-              currentStatus={currentStatus}
-              monitorStatusTimeline={StatusPageResourceUptimeUtil.getMonitorStatusTimelineForResource(
-                {
-                  statusPageResource: resource,
-                  monitorStatusTimelines: monitorStatusTimelines,
-                  monitorsInGroup: monitorsInGroup,
-                },
-              )}
-              downtimeMonitorStatuses={
-                statusPage?.downtimeMonitorStatuses || []
-              }
-              startDate={startDate}
-              endDate={endDate}
-              showHistoryChart={resource.showStatusHistoryChart}
-              showCurrentStatus={resource.showCurrentStatus}
-              uptimeGraphHeight={10}
-              defaultBarColor={statusPage?.defaultBarColor || Green}
-              uptimeHistoryDays={uptimeHistoryDays}
-              incidents={groupIncidents}
-              onIncidentClick={(incidentId: string) => {
-                Navigation.navigate(
-                  RouteUtil.populateRouteParams(
-                    StatusPageUtil.isPreviewPage()
-                      ? (RouteMap[PageMap.PREVIEW_INCIDENT_DETAIL] as Route)
-                      : (RouteMap[PageMap.INCIDENT_DETAIL] as Route),
-                    new ObjectID(incidentId),
-                  ),
-                );
-              }}
-            />,
-          );
-        }
+        elements.push(...(monitorOverviews.get(resource) || []));
       }
     }
 
@@ -1457,7 +1550,7 @@ const Overview: FunctionComponent<PageComponentProps> = (
       });
     }
 
-    const rollup: GroupRollup | null = getGroupRollup({ group: group });
+    const rollup: GroupRollup | null = groupRollups.get(group) || null;
 
     return (
       <ResourceGroupSection
@@ -1706,23 +1799,8 @@ const Overview: FunctionComponent<PageComponentProps> = (
                 textOnRight={
                   currentStatus.isOperationalState &&
                   statusPage?.showOverallUptimePercentOnStatusPage
-                    ? (StatusPageResourceUptimeUtil.calculateAvgUptimePercentageOfAllResources(
-                        {
-                          monitorStatusTimelines: monitorStatusTimelines,
-                          statusPageResources: statusPageResources,
-                          downtimeMonitorStatuses:
-                            statusPage.downtimeMonitorStatuses || [],
-                          precision:
-                            statusPage.overallUptimePercentPrecision ||
-                            UptimePrecision.TWO_DECIMAL,
-                          resourceGroups: resourceGroups,
-                          monitorsInGroup: monitorsInGroup,
-                          uptimeWindow: {
-                            startDate: startDate,
-                            endDate: endDate,
-                          },
-                        },
-                      )?.toString() || "100") + t("overview.uptimeSuffix")
+                    ? (overallUptime?.toString() || "100") +
+                      t("overview.uptimeSuffix")
                     : undefined
                 }
                 textClassName="text-white text-lg flex justify-between w-full"
@@ -1754,6 +1832,7 @@ const Overview: FunctionComponent<PageComponentProps> = (
               onChange={setSearchQuery}
               matchedCount={searchResult.matchedResourceCount}
               totalCount={searchResult.totalResourceCount}
+              isPending={searchQuery !== deferredSearchQuery}
             />
           )}
 
@@ -1766,7 +1845,10 @@ const Overview: FunctionComponent<PageComponentProps> = (
             statusPageResourceCount: statusPageResources.length,
             statusPageGroupCount: resourceGroups.length,
           }) && (
-            <div className="mt-5 mb-6 space-y-3 sm:space-y-5">
+            <div
+              className="mt-5 mb-6 space-y-3 sm:space-y-5"
+              aria-busy={searchQuery !== deferredSearchQuery}
+            >
               {statusPageResources.filter((resource: StatusPageResource) => {
                 return (
                   !resource.statusPageGroupId && isResourceVisible(resource)
@@ -1813,7 +1895,7 @@ const Overview: FunctionComponent<PageComponentProps> = (
                     defaultValue: "No matching resources",
                   })}
                   description={t("search.noResultsDescription", {
-                    query: searchQuery.trim(),
+                    query: deferredSearchQuery.trim(),
                     defaultValue:
                       'Nothing on this page matches "{{query}}". Try a shorter search.',
                   })}

--- a/Common/Tests/App/StatusPage/StatusPageOverviewLiveAndSearch.test.tsx
+++ b/Common/Tests/App/StatusPage/StatusPageOverviewLiveAndSearch.test.tsx
@@ -120,8 +120,10 @@ jest.mock(
  * factory that closes over module scope is a load-order trap.
  */
 jest.mock("react-i18next", () => {
-  // A real i18next translation function is stable between language changes.
-  // Keeping the same function here makes render-cache assertions realistic.
+  /*
+   * A real i18next translation function is stable between language changes.
+   * Keeping the same function here makes render-cache assertions realistic.
+   */
   const t: (
     key: string,
     opts?: { defaultValue?: string } & Record<string, unknown>,
@@ -295,8 +297,10 @@ function overviewPayload(
 }
 
 const SEARCH_SNAPSHOT_TIME: Date = new Date("2026-09-09T12:00:00.000Z");
-// Browser performance tests cover 90 days; seven days keeps these calculation-
-// count regressions fast while still rendering real history for 40 resources.
+/*
+ * Browser performance tests cover 90 days; seven days keeps these calculation-
+ * count regressions fast while still rendering real history for 40 resources.
+ */
 const SEARCH_HISTORY_DAYS: number = 7;
 const OFFLINE_STATUS_ID: string = "66666666-6666-4666-8666-666666666666";
 const MONITOR_GROUP_ID: string = "90000000-0000-4000-8000-000000000040";
@@ -363,8 +367,10 @@ function largeOverviewPayload(updated: boolean = false): JSONObject {
       showUptimePercent: true,
     };
 
-    // The final resource is a monitor group so the same search and refresh
-    // assertions exercise both kinds of status-page resource.
+    /*
+     * The final resource is a monitor group so the same search and refresh
+     * assertions exercise both kinds of status-page resource.
+     */
     if (index === 40) {
       delete resourceData["monitor"];
       delete resourceData["monitorId"];
@@ -760,8 +766,10 @@ describe("Status page overview - searching a large page with uptime history", ()
     const input: HTMLElement = searchInput();
     input.focus();
 
-    // The same 40 charts survive each query. Advancing time catches Date
-    // objects recreated on each input render even when their props look alike.
+    /*
+     * The same 40 charts survive each query. Advancing time catches Date
+     * objects recreated on each input render even when their props look alike.
+     */
     for (const query of ["s", "se", "ser", "serv", "servi", "service"]) {
       act(() => {
         jest.advanceTimersByTime(1000);
@@ -833,8 +841,10 @@ describe("Status page overview - searching a large page with uptime history", ()
     expect(screen.getAllByTestId("day-uptime-graph")).toHaveLength(40);
     expect(screen.getAllByTestId("day-uptime-graph")[0]).toBe(chart);
     expect(screen.getByText("Service 40")).toBeInTheDocument();
-    // Charts that return to the DOM mount again; the continuously visible
-    // chart and the data derived from the loaded payload stay reusable.
+    /*
+     * Charts that return to the DOM mount again; the continuously visible
+     * chart and the data derived from the loaded payload stay reusable.
+     */
     expect(monitorWorkCounts(work, monitorId)).toEqual(monitorCounts);
     expect(payloadWorkCounts(work)).toEqual(payloadCounts);
   });

--- a/Common/Tests/App/StatusPage/StatusPageOverviewLiveAndSearch.test.tsx
+++ b/Common/Tests/App/StatusPage/StatusPageOverviewLiveAndSearch.test.tsx
@@ -1,6 +1,13 @@
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import React, { act } from "react";
+import { SpyInstance } from "jest-mock";
 import {
   afterEach,
   beforeEach,
@@ -16,6 +23,10 @@ import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
 import LocalStorage from "../../../UI/Utils/LocalStorage";
 import Navigation from "../../../UI/Utils/Navigation";
+import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusTimeline";
+import StatusPageResourceUptimeUtil from "../../../Utils/StatusPage/ResourceUptime";
+import UptimeUtil from "../../../Utils/Uptime/UptimeUtil";
+import Overview from "../../../../App/FeatureSet/StatusPage/src/Pages/Overview/Overview";
 
 /*
  * Contract under test - the two things the status page overview gained: it
@@ -109,57 +120,54 @@ jest.mock(
  * factory that closes over module scope is a load-order trap.
  */
 jest.mock("react-i18next", () => {
+  // A real i18next translation function is stable between language changes.
+  // Keeping the same function here makes render-cache assertions realistic.
+  const t: (
+    key: string,
+    opts?: { defaultValue?: string } & Record<string, unknown>,
+  ) => string = (
+    key: string,
+    opts?: { defaultValue?: string } & Record<string, unknown>,
+  ): string => {
+    let out: string = opts?.defaultValue ?? key;
+
+    for (const name of Object.keys(opts || {})) {
+      const raw: unknown = (opts as Record<string, unknown>)[name];
+
+      // Common's translateValue also passes i18next's boolean options.
+      if (
+        name === "defaultValue" ||
+        (typeof raw !== "string" && typeof raw !== "number")
+      ) {
+        continue;
+      }
+
+      const value: string = String(raw);
+
+      if (out.includes(`{{${name}}}`)) {
+        out = out.split(`{{${name}}}`).join(value);
+      } else {
+        out = `${out} ${value}`;
+      }
+    }
+
+    return out;
+  };
+
   return {
-    /*
-     * The status page's own i18n bootstrap does i18n.use(initReactI18next) at
-     * import time, so the mock has to keep that export alive or the module
-     * graph fails before a single test runs.
-     */
+    // The status page's i18n bootstrap needs this at import time.
     initReactI18next: {
       type: "3rdParty",
       init: () => {},
     },
     useTranslation: () => {
       return {
-        t: (
-          key: string,
-          opts?: { defaultValue?: string } & Record<string, unknown>,
-        ): string => {
-          let out: string = opts?.defaultValue ?? key;
-
-          for (const name of Object.keys(opts || {})) {
-            const raw: unknown = (opts as Record<string, unknown>)[name];
-
-            /*
-             * defaultValue is not an interpolation value, and neither are
-             * i18next's own switches - Common's translateValue passes
-             * keySeparator and nsSeparator as booleans on every call.
-             */
-            if (
-              name === "defaultValue" ||
-              (typeof raw !== "string" && typeof raw !== "number")
-            ) {
-              continue;
-            }
-
-            const value: string = String(raw);
-
-            if (out.includes(`{{${name}}}`)) {
-              out = out.split(`{{${name}}}`).join(value);
-            } else {
-              out = `${out} ${value}`;
-            }
-          }
-
-          return out;
-        },
+        t: t,
         i18n: { resolvedLanguage: "en", language: "en" },
       };
     },
   };
 });
-
-import Overview from "../../../../App/FeatureSet/StatusPage/src/Pages/Overview/Overview";
 
 type ObjectIdJson = { _type: string; value: string };
 
@@ -283,6 +291,146 @@ function overviewPayload(
       isOperationalState: true,
       color: color("#22c55e"),
     },
+  };
+}
+
+const SEARCH_SNAPSHOT_TIME: Date = new Date("2026-09-09T12:00:00.000Z");
+// Browser performance tests cover 90 days; seven days keeps these calculation-
+// count regressions fast while still rendering real history for 40 resources.
+const SEARCH_HISTORY_DAYS: number = 7;
+const OFFLINE_STATUS_ID: string = "66666666-6666-4666-8666-666666666666";
+const MONITOR_GROUP_ID: string = "90000000-0000-4000-8000-000000000040";
+const LARGE_PAGE_GROUPS: Array<{
+  id: string;
+  name: string;
+  parentId?: string | undefined;
+}> = [
+  { id: "group-platform", name: "Platform" },
+  { id: "group-europe", name: "Europe", parentId: "group-platform" },
+  { id: "group-core", name: "Core", parentId: "group-europe" },
+  { id: "group-east", name: "Pool East", parentId: "group-core" },
+  { id: "group-west", name: "Pool West", parentId: "group-core" },
+];
+
+function largeOverviewPayload(updated: boolean = false): JSONObject {
+  const operationalStatus: JSONObject = {
+    _id: OPERATIONAL_STATUS_ID,
+    name: "Operational",
+    priority: 1,
+    isOperationalState: true,
+    color: color("#22c55e"),
+  };
+  const offlineStatus: JSONObject = {
+    _id: OFFLINE_STATUS_ID,
+    name: "Offline",
+    priority: 2,
+    isOperationalState: false,
+    color: color("#ef4444"),
+  };
+  const startDate: Date = new Date(
+    SEARCH_SNAPSHOT_TIME.getTime() - SEARCH_HISTORY_DAYS * 24 * 60 * 60 * 1000,
+  );
+  const midpoint: Date = new Date(
+    SEARCH_SNAPSHOT_TIME.getTime() -
+      (SEARCH_HISTORY_DAYS / 2) * 24 * 60 * 60 * 1000,
+  );
+  const resources: Array<JSONObject> = [];
+  const timelines: Array<JSONObject> = [];
+
+  for (let index: number = 1; index <= 40; index++) {
+    const suffix: string = index.toString().padStart(12, "0");
+    const monitorId: string = `80000000-0000-4000-8000-${suffix}`;
+    const resourceId: string = `70000000-0000-4000-8000-${suffix}`;
+    const name: string = `Service ${index.toString().padStart(2, "0")}`;
+    const isDown: boolean = updated && (index === 1 || index === 40);
+    const hasRecovered: boolean = updated && index === 2;
+
+    const resourceData: JSONObject = {
+      ...resource({
+        id: resourceId,
+        name: name,
+        groupId: index <= 20 ? "group-east" : "group-west",
+      }),
+      monitorId: objectId(monitorId),
+      monitor: {
+        _id: monitorId,
+        name: name,
+        currentMonitorStatusId: objectId(
+          isDown ? OFFLINE_STATUS_ID : OPERATIONAL_STATUS_ID,
+        ),
+      },
+      showStatusHistoryChart: true,
+      showUptimePercent: true,
+    };
+
+    // The final resource is a monitor group so the same search and refresh
+    // assertions exercise both kinds of status-page resource.
+    if (index === 40) {
+      delete resourceData["monitor"];
+      delete resourceData["monitorId"];
+      resourceData["monitorGroupId"] = objectId(MONITOR_GROUP_ID);
+    }
+    resources.push(resourceData);
+
+    const initialStatus: JSONObject = hasRecovered
+      ? offlineStatus
+      : operationalStatus;
+    timelines.push({
+      _id: `timeline-initial-${index}`,
+      monitorId: objectId(monitorId),
+      monitorStatusId: objectId(
+        hasRecovered ? OFFLINE_STATUS_ID : OPERATIONAL_STATUS_ID,
+      ),
+      monitorStatus: initialStatus,
+      startsAt: { _type: "DateTime", value: startDate.toISOString() },
+      ...(isDown || hasRecovered
+        ? { endsAt: { _type: "DateTime", value: midpoint.toISOString() } }
+        : {}),
+    });
+
+    if (isDown || hasRecovered) {
+      timelines.push({
+        _id: `timeline-changed-${index}`,
+        monitorId: objectId(monitorId),
+        monitorStatusId: objectId(
+          isDown ? OFFLINE_STATUS_ID : OPERATIONAL_STATUS_ID,
+        ),
+        monitorStatus: isDown ? offlineStatus : operationalStatus,
+        startsAt: { _type: "DateTime", value: midpoint.toISOString() },
+      });
+    }
+  }
+
+  return {
+    ...overviewPayload(),
+    statusPage: {
+      _id: STATUS_PAGE_ID,
+      showUptimeHistoryInDays: SEARCH_HISTORY_DAYS,
+      showOverallUptimePercentOnStatusPage: true,
+      downtimeMonitorStatuses: [offlineStatus],
+      defaultBarColor: color("#22c55e"),
+    },
+    resourceGroups: LARGE_PAGE_GROUPS.map(
+      (data: (typeof LARGE_PAGE_GROUPS)[number]): JSONObject => {
+        return {
+          ...group(data),
+          isExpandedByDefault: true,
+          showUptimePercent: true,
+        };
+      },
+    ),
+    statusPageResources: resources,
+    monitorStatuses: [operationalStatus, offlineStatus],
+    monitorStatusTimelines: timelines,
+    monitorsInGroup: {
+      [MONITOR_GROUP_ID]: [objectId("80000000-0000-4000-8000-000000000040")],
+    },
+    monitorGroupCurrentStatuses: {
+      [MONITOR_GROUP_ID]: objectId(
+        updated ? OFFLINE_STATUS_ID : OPERATIONAL_STATUS_ID,
+      ),
+    },
+    overallStatus: updated ? offlineStatus : operationalStatus,
   };
 }
 
@@ -487,6 +635,340 @@ describe("Status page overview - searching for a resource", () => {
     await typeSearch("checkout");
 
     expect(postCallCount).toBe(callsAfterLoad);
+  });
+});
+
+describe("Status page overview - searching a large page with uptime history", () => {
+  const navigate: typeof Navigation.navigate = Navigation.navigate;
+
+  function observeHistoryWork(): {
+    timelines: SpyInstance<
+      typeof StatusPageResourceUptimeUtil.getMonitorStatusTimelineForResource
+    >;
+    groupUptime: SpyInstance<
+      typeof StatusPageResourceUptimeUtil.calculateAvgUptimePercentOfStatusPageGroup
+    >;
+    groupStatus: SpyInstance<
+      typeof StatusPageResourceUptimeUtil.getCurrentStatusPageGroupStatus
+    >;
+    overallUptime: SpyInstance<
+      typeof StatusPageResourceUptimeUtil.calculateAvgUptimePercentageOfAllResources
+    >;
+    uptime: SpyInstance<typeof UptimeUtil.calculateUptimePercentage>;
+    events: SpyInstance<typeof UptimeUtil.getNonOverlappingMonitorEvents>;
+  } {
+    return {
+      timelines: jest.spyOn(
+        StatusPageResourceUptimeUtil,
+        "getMonitorStatusTimelineForResource",
+      ),
+      groupUptime: jest.spyOn(
+        StatusPageResourceUptimeUtil,
+        "calculateAvgUptimePercentOfStatusPageGroup",
+      ),
+      groupStatus: jest.spyOn(
+        StatusPageResourceUptimeUtil,
+        "getCurrentStatusPageGroupStatus",
+      ),
+      overallUptime: jest.spyOn(
+        StatusPageResourceUptimeUtil,
+        "calculateAvgUptimePercentageOfAllResources",
+      ),
+      uptime: jest.spyOn(UptimeUtil, "calculateUptimePercentage"),
+      events: jest.spyOn(UptimeUtil, "getNonOverlappingMonitorEvents"),
+    };
+  }
+
+  type HistoryWork = ReturnType<typeof observeHistoryWork>;
+
+  function payloadWorkCounts(work: HistoryWork): Record<string, number> {
+    return {
+      timelines: work.timelines.mock.calls.length,
+      groupUptime: work.groupUptime.mock.calls.length,
+      groupStatus: work.groupStatus.mock.calls.length,
+      overallUptime: work.overallUptime.mock.calls.length,
+    };
+  }
+
+  function monitorWorkCounts(
+    work: HistoryWork,
+    monitorId: string,
+  ): Record<string, number> {
+    const containsMonitor: (
+      timelines: Array<MonitorStatusTimeline>,
+    ) => boolean = (timelines: Array<MonitorStatusTimeline>): boolean => {
+      return timelines.some((timeline: MonitorStatusTimeline): boolean => {
+        return timeline.monitorId?.toString() === monitorId;
+      });
+    };
+
+    return {
+      uptime: work.uptime.mock.calls.filter(
+        (
+          call: Parameters<typeof UptimeUtil.calculateUptimePercentage>,
+        ): boolean => {
+          return containsMonitor(call[0]);
+        },
+      ).length,
+      events: work.events.mock.calls.filter(
+        (
+          call: Parameters<typeof UptimeUtil.getNonOverlappingMonitorEvents>,
+        ): boolean => {
+          return containsMonitor(call[0]);
+        },
+      ).length,
+    };
+  }
+
+  beforeEach(() => {
+    postCallCount = 0;
+    localStorage.clear();
+    LocalStorage.setItem("statusPageId", new ObjectID(STATUS_PAGE_ID));
+    window.history.replaceState({}, "", "/");
+    Navigation.navigate = (): void => {};
+    setDocumentVisibility("visible");
+    jest.useFakeTimers();
+    jest.setSystemTime(SEARCH_SNAPSHOT_TIME);
+    mockRespondToPost = (): PostResponse => {
+      return successResponse(largeOverviewPayload());
+    };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    Navigation.navigate = navigate;
+    jest.restoreAllMocks();
+  });
+
+  test("successive keystrokes reuse all unchanged history and uptime calculations", async () => {
+    const work: HistoryWork = observeHistoryWork();
+    await renderOverview();
+
+    expect(screen.getAllByTestId("day-uptime-graph")).toHaveLength(40);
+    expect(screen.getAllByTestId("uptime-bar").length).toBeGreaterThan(
+      40 * (SEARCH_HISTORY_DAYS - 1),
+    );
+    expect(screen.getAllByTestId("status-page-group-header")).toHaveLength(5);
+    expect(work.groupUptime).toHaveBeenCalled();
+    expect(work.overallUptime).toHaveBeenCalled();
+    expect(work.events).toHaveBeenCalled();
+
+    const payloadCounts: Record<string, number> = payloadWorkCounts(work);
+    const uptimeCount: number = work.uptime.mock.calls.length;
+    const eventCount: number = work.events.mock.calls.length;
+    const callsAfterLoad: number = postCallCount;
+    const input: HTMLElement = searchInput();
+    input.focus();
+
+    // The same 40 charts survive each query. Advancing time catches Date
+    // objects recreated on each input render even when their props look alike.
+    for (const query of ["s", "se", "ser", "serv", "servi", "service"]) {
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      await typeSearch(query);
+      expect(input).toHaveValue(query);
+      expect(input).toHaveFocus();
+      expect(
+        screen.getByTestId("status-page-resource-search-count"),
+      ).toHaveTextContent("40 of 40 resources");
+      expect(screen.getAllByTestId("day-uptime-graph")).toHaveLength(40);
+      expect(payloadWorkCounts(work)).toEqual(payloadCounts);
+      expect(work.uptime).toHaveBeenCalledTimes(uptimeCount);
+      expect(work.events).toHaveBeenCalledTimes(eventCount);
+    }
+
+    await typeSearch("SERVICE");
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("status-page-resource-search-clear"));
+    });
+
+    expect(searchInput()).toBe(input);
+    expect(input).toHaveValue("");
+    expect(input).toHaveFocus();
+    expect(screen.getAllByTestId("day-uptime-graph")).toHaveLength(40);
+    expect(payloadWorkCounts(work)).toEqual(payloadCounts);
+    expect(work.uptime).toHaveBeenCalledTimes(uptimeCount);
+    expect(work.events).toHaveBeenCalledTimes(eventCount);
+    expect(postCallCount).toBe(callsAfterLoad);
+  });
+
+  test("narrowing and clearing a query preserves the surviving chart and its calculations", async () => {
+    const work: HistoryWork = observeHistoryWork();
+    await renderOverview();
+
+    const payloadCounts: Record<string, number> = payloadWorkCounts(work);
+    const monitorId: string = "80000000-0000-4000-8000-000000000001";
+    const monitorCounts: Record<string, number> = monitorWorkCounts(
+      work,
+      monitorId,
+    );
+    const chart: HTMLElement = screen.getAllByTestId("day-uptime-graph")[0]!;
+    const input: HTMLElement = searchInput();
+    input.focus();
+
+    await typeSearch("service 0");
+    expect(screen.getAllByTestId("day-uptime-graph")).toHaveLength(9);
+    await typeSearch("service 01");
+
+    expect(screen.getByText("Service 01")).toBeInTheDocument();
+    expect(screen.queryByText("Service 02")).not.toBeInTheDocument();
+    expect(screen.queryByText("Pool West")).not.toBeInTheDocument();
+    expect(screen.getByTestId("day-uptime-graph")).toBe(chart);
+    expect(
+      screen.getByTestId("status-page-resource-search-count"),
+    ).toHaveTextContent("1 of 40 resources");
+    for (const ancestor of ["Platform", "Europe", "Core", "Pool East"]) {
+      expect(screen.getByText(ancestor)).toBeInTheDocument();
+    }
+    expect(monitorWorkCounts(work, monitorId)).toEqual(monitorCounts);
+    expect(payloadWorkCounts(work)).toEqual(payloadCounts);
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Escape" });
+    });
+
+    expect(input).toHaveValue("");
+    expect(input).toHaveFocus();
+    expect(screen.getAllByTestId("day-uptime-graph")).toHaveLength(40);
+    expect(screen.getAllByTestId("day-uptime-graph")[0]).toBe(chart);
+    expect(screen.getByText("Service 40")).toBeInTheDocument();
+    // Charts that return to the DOM mount again; the continuously visible
+    // chart and the data derived from the loaded payload stay reusable.
+    expect(monitorWorkCounts(work, monitorId)).toEqual(monitorCounts);
+    expect(payloadWorkCounts(work)).toEqual(payloadCounts);
+  });
+
+  test("replacement, no results, and clearing reuse the loaded data and keep input focus", async () => {
+    const work: HistoryWork = observeHistoryWork();
+    await renderOverview();
+
+    const payloadCounts: Record<string, number> = payloadWorkCounts(work);
+    const callsAfterLoad: number = postCallCount;
+    const input: HTMLElement = searchInput();
+    input.focus();
+
+    await typeSearch("service 01");
+    await typeSearch("service 40");
+    expect(screen.getByText("Service 40")).toBeInTheDocument();
+    expect(screen.queryByText("Service 01")).not.toBeInTheDocument();
+    expect(screen.getByText("Pool West")).toBeInTheDocument();
+    expect(screen.queryByText("Pool East")).not.toBeInTheDocument();
+
+    await typeSearch("missing resource");
+    expect(screen.getByText("No matching resources")).toBeInTheDocument();
+    expect(screen.queryByTestId("day-uptime-graph")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("status-page-resource-search-count"),
+    ).toHaveTextContent("0 of 40 resources");
+    expect(input).toHaveFocus();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("status-page-resource-search-clear"));
+    });
+
+    expect(input).toHaveValue("");
+    expect(input).toHaveFocus();
+    expect(screen.queryByText("No matching resources")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("day-uptime-graph")).toHaveLength(40);
+    expect(screen.getAllByTestId("status-page-group-header")).toHaveLength(5);
+    expect(payloadWorkCounts(work)).toEqual(payloadCounts);
+    expect(postCallCount).toBe(callsAfterLoad);
+  });
+
+  test("matching a group keeps all its descendants at four nested levels", async () => {
+    await renderOverview();
+
+    await typeSearch("pool east");
+
+    expect(
+      screen.getByTestId("status-page-resource-search-count"),
+    ).toHaveTextContent("20 of 40 resources");
+    expect(screen.getAllByTestId("day-uptime-graph")).toHaveLength(20);
+    expect(screen.getByText("Service 01")).toBeInTheDocument();
+    expect(screen.getByText("Service 20")).toBeInTheDocument();
+    expect(screen.queryByText("Service 21")).not.toBeInTheDocument();
+    expect(screen.queryByText("Pool West")).not.toBeInTheDocument();
+    for (const ancestor of ["Platform", "Europe", "Core", "Pool East"]) {
+      expect(screen.getByText(ancestor)).toBeInTheDocument();
+    }
+
+    await typeSearch("europe");
+    expect(screen.getAllByTestId("day-uptime-graph")).toHaveLength(40);
+    expect(
+      screen.getByTestId("status-page-resource-search-count"),
+    ).toHaveTextContent("40 of 40 resources");
+  });
+
+  test("refresh invalidates cached history, status, uptime, and the reporting window", async () => {
+    const work: HistoryWork = observeHistoryWork();
+    await renderOverview();
+    await typeSearch("service");
+
+    const payloadCounts: Record<string, number> = payloadWorkCounts(work);
+    const initialWindowEnd: Date = work.uptime.mock.calls[0]![3]!.endDate;
+    const input: HTMLElement = searchInput();
+    input.focus();
+    expect(screen.getByRole("status")).toHaveTextContent("Operational");
+    expect(
+      screen.queryByText("50overview.uptimeSuffix"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByTestId("status-page-group-rollup")[0],
+    ).toHaveTextContent("100overview.uptimeSuffix");
+
+    jest.setSystemTime(
+      new Date(SEARCH_SNAPSHOT_TIME.getTime() + 5 * 60 * 1000),
+    );
+    mockRespondToPost = (): PostResponse => {
+      return successResponse(largeOverviewPayload(true));
+    };
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("status-page-refresh-button"));
+    });
+
+    expect(input).toHaveValue("service");
+    expect(input).toHaveFocus();
+    expect(screen.getAllByTestId("day-uptime-graph")).toHaveLength(40);
+    expect(screen.getByRole("status")).toHaveTextContent("Offline");
+    expect(
+      screen.getAllByTestId("status-page-group-rollup")[0],
+    ).toHaveTextContent("Offline");
+    expect(screen.getByText("50overview.uptimeSuffix")).toBeInTheDocument();
+    expect(
+      screen.getByText("Service 40").parentElement?.parentElement,
+    ).toHaveTextContent("Offline");
+    const recoveredChart: HTMLElement =
+      screen.getAllByTestId("day-uptime-graph")[1]!;
+    expect(
+      within(recoveredChart)
+        .getAllByTestId("uptime-bar")
+        .some((bar: HTMLElement): boolean => {
+          return bar.style.backgroundColor === "rgb(239, 68, 68)";
+        }),
+    ).toBe(true);
+    expect(work.timelines.mock.calls.length).toBeGreaterThan(
+      payloadCounts["timelines"]!,
+    );
+    expect(work.groupUptime.mock.calls.length).toBeGreaterThan(
+      payloadCounts["groupUptime"]!,
+    );
+    expect(work.groupStatus.mock.calls.length).toBeGreaterThan(
+      payloadCounts["groupStatus"]!,
+    );
+    const refreshedWindowEnd: Date =
+      work.uptime.mock.calls[work.uptime.mock.calls.length - 1]![3]!.endDate;
+    expect(refreshedWindowEnd.getTime()).toBeGreaterThan(
+      initialWindowEnd.getTime(),
+    );
+
+    const refreshedCounts: Record<string, number> = payloadWorkCounts(work);
+    const refreshedUptimeCount: number = work.uptime.mock.calls.length;
+    const refreshedEventCount: number = work.events.mock.calls.length;
+    await typeSearch("SERVICE");
+    expect(payloadWorkCounts(work)).toEqual(refreshedCounts);
+    expect(work.uptime).toHaveBeenCalledTimes(refreshedUptimeCount);
+    expect(work.events).toHaveBeenCalledTimes(refreshedEventCount);
   });
 });
 

--- a/Common/Tests/App/StatusPage/StatusPageResourceSearchBox.test.tsx
+++ b/Common/Tests/App/StatusPage/StatusPageResourceSearchBox.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { describe, expect, jest, test } from "@jest/globals";
+import ResourceSearchBox from "../../../../App/FeatureSet/StatusPage/src/Components/Search/ResourceSearchBox";
 
 jest.mock("react-i18next", () => {
   return {
@@ -25,8 +26,6 @@ jest.mock("react-i18next", () => {
     },
   };
 });
-
-import ResourceSearchBox from "../../../../App/FeatureSet/StatusPage/src/Components/Search/ResourceSearchBox";
 
 /*
  * Contract under test - the field that answers "which of these is mine?".
@@ -53,6 +52,7 @@ function renderBox(
       onChange={props.onChange || onChange}
       matchedCount={props.matchedCount === undefined ? 12 : props.matchedCount}
       totalCount={props.totalCount === undefined ? 12 : props.totalCount}
+      isPending={props.isPending}
     />,
   );
 
@@ -96,6 +96,20 @@ describe("ResourceSearchBox", () => {
 });
 
 describe("ResourceSearchBox - the result count", () => {
+  test("marks the previous count busy while the next results are rendering", () => {
+    renderBox({
+      value: "0660",
+      matchedCount: 40,
+      totalCount: 40,
+      isPending: true,
+    });
+
+    expect(input()).toHaveValue("0660");
+    expect(
+      screen.getByTestId("status-page-resource-search-count"),
+    ).toHaveAttribute("aria-busy", "true");
+  });
+
   test("says how much of the page survived the query", () => {
     renderBox({ value: "checkout", matchedCount: 3, totalCount: 42 });
 
@@ -122,6 +136,9 @@ describe("ResourceSearchBox - the result count", () => {
     expect(
       screen.getByTestId("status-page-resource-search-count"),
     ).toHaveAttribute("aria-live", "polite");
+    expect(
+      screen.getByTestId("status-page-resource-search-count"),
+    ).toHaveAttribute("aria-busy", "false");
   });
 
   test("the field points at the count so it is read with the field", () => {

--- a/Common/Tests/UI/Components/MonitorGraphs/Uptime.test.tsx
+++ b/Common/Tests/UI/Components/MonitorGraphs/Uptime.test.tsx
@@ -36,9 +36,15 @@ function makeStatus(isDown: boolean): MonitorStatus {
 }
 
 function makeTimeline(status: MonitorStatus): MonitorStatusTimeline {
+  const statusId: ObjectID | null = status.id;
+
+  if (!statusId) {
+    throw new Error("Test status must have an ID.");
+  }
+
   const timeline: MonitorStatusTimeline = new MonitorStatusTimeline();
   timeline.monitorId = new ObjectID("monitor-1");
-  timeline.monitorStatusId = status.id;
+  timeline.monitorStatusId = statusId;
   timeline.monitorStatus = status;
   timeline.startsAt = new Date("2026-01-02T01:00:00.000Z");
   timeline.endsAt = new Date("2026-01-02T23:00:00.000Z");

--- a/Common/Tests/UI/Components/MonitorGraphs/Uptime.test.tsx
+++ b/Common/Tests/UI/Components/MonitorGraphs/Uptime.test.tsx
@@ -18,7 +18,11 @@ import StatusPageHistoryChartBarColorRule from "../../../../Models/DatabaseModel
 jest.mock("react-i18next", () => {
   return {
     useTranslation: () => {
-      return { t: (key: string): string => key };
+      return {
+        t: (key: string): string => {
+          return key;
+        },
+      };
     },
   };
 });
@@ -79,9 +83,11 @@ function renderHistory(overrides: Partial<ComponentProps> = {}): {
   };
   const snapshots: Array<HistorySnapshot> = [];
 
-  // Observe actual committed bars, including the first paint. Checking only
-  // the settled DOM misses an empty or stale history followed by an effect
-  // that rebuilds every bar when a search reveals many resources at once.
+  /*
+   * Observe actual committed bars, including the first paint. Checking only
+   * the settled DOM misses an empty or stale history followed by an effect
+   * that rebuilds every bar when a search reveals many resources at once.
+   */
   const recordCommit: () => void = (): void => {
     const bars: Array<HTMLElement> = Array.from(
       document.querySelectorAll<HTMLElement>('[data-testid="uptime-bar"]'),

--- a/Common/Tests/UI/Components/MonitorGraphs/Uptime.test.tsx
+++ b/Common/Tests/UI/Components/MonitorGraphs/Uptime.test.tsx
@@ -1,0 +1,289 @@
+/** @timezone UTC */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React, { Profiler } from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import { SpyInstance } from "jest-mock";
+import MonitorUptimeGraph, {
+  ComponentProps,
+} from "../../../../UI/Components/MonitorGraphs/Uptime";
+import UptimeUtil from "../../../../UI/Components/MonitorGraphs/UptimeUtil";
+import { Green, Red } from "../../../../Types/BrandColors";
+import Color from "../../../../Types/Color";
+import ObjectID from "../../../../Types/ObjectID";
+import MonitorStatus from "../../../../Models/DatabaseModels/MonitorStatus";
+import MonitorStatusTimeline from "../../../../Models/DatabaseModels/MonitorStatusTimeline";
+import StatusPageHistoryChartBarColorRule from "../../../../Models/DatabaseModels/StatusPageHistoryChartBarColorRule";
+
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return { t: (key: string): string => key };
+    },
+  };
+});
+
+const START_DATE: Date = new Date("2026-01-01T12:00:00.000Z");
+const END_DATE: Date = new Date("2026-01-03T12:00:00.000Z");
+
+function makeStatus(isDown: boolean): MonitorStatus {
+  const status: MonitorStatus = new MonitorStatus();
+  status._id = isDown ? "status-down" : "status-up";
+  status.name = isDown ? "Offline" : "Operational";
+  status.color = isDown ? Red : Green;
+  status.priority = isDown ? 2 : 1;
+  return status;
+}
+
+function makeTimeline(status: MonitorStatus): MonitorStatusTimeline {
+  const timeline: MonitorStatusTimeline = new MonitorStatusTimeline();
+  timeline.monitorId = new ObjectID("monitor-1");
+  timeline.monitorStatusId = status.id;
+  timeline.monitorStatus = status;
+  timeline.startsAt = new Date("2026-01-02T01:00:00.000Z");
+  timeline.endsAt = new Date("2026-01-02T23:00:00.000Z");
+  return timeline;
+}
+
+function makeRule(color: Color): StatusPageHistoryChartBarColorRule {
+  const rule: StatusPageHistoryChartBarColorRule =
+    new StatusPageHistoryChartBarColorRule();
+  rule.barColor = color;
+  rule.uptimePercentGreaterThanOrEqualTo = 0;
+  return rule;
+}
+
+interface HistorySnapshot {
+  labels: Array<string | null>;
+  colors: Array<string>;
+}
+
+function renderHistory(overrides: Partial<ComponentProps> = {}): {
+  snapshots: Array<HistorySnapshot>;
+  rerenderHistory: (nextProps: Partial<ComponentProps>) => void;
+} {
+  const down: MonitorStatus = makeStatus(true);
+  let props: ComponentProps = {
+    startDate: START_DATE,
+    endDate: END_DATE,
+    items: [makeTimeline(down)],
+    downtimeMonitorStatuses: [down],
+    defaultBarColor: Green,
+    ...overrides,
+  };
+  const snapshots: Array<HistorySnapshot> = [];
+
+  // Observe actual committed bars, including the first paint. Checking only
+  // the settled DOM misses an empty or stale history followed by an effect
+  // that rebuilds every bar when a search reveals many resources at once.
+  const recordCommit: () => void = (): void => {
+    const bars: Array<HTMLElement> = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid="uptime-bar"]'),
+    );
+    snapshots.push({
+      labels: bars.map((bar: HTMLElement) => {
+        return bar.getAttribute("aria-label");
+      }),
+      colors: bars.map((bar: HTMLElement) => {
+        return bar.style.backgroundColor;
+      }),
+    });
+  };
+
+  const view: ReturnType<typeof render> = render(
+    <Profiler id="history" onRender={recordCommit}>
+      <MonitorUptimeGraph {...props} />
+    </Profiler>,
+  );
+
+  return {
+    snapshots: snapshots,
+    rerenderHistory: (nextProps: Partial<ComponentProps>): void => {
+      props = { ...props, ...nextProps };
+      view.rerender(
+        <Profiler id="history" onRender={recordCommit}>
+          <MonitorUptimeGraph {...props} />
+        </Profiler>,
+      );
+    },
+  };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("MonitorUptimeGraph - histories revealed by search", () => {
+  test("the first paint contains the complete history and correct downtime", () => {
+    const { snapshots } = renderHistory();
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    for (const snapshot of snapshots) {
+      expect(snapshot.labels).toHaveLength(3);
+      expect(snapshot.labels[1]).toContain("0% uptime");
+    }
+    expect(screen.getAllByTestId("uptime-bar")[1]).toHaveStyle({
+      backgroundColor: Red.toString(),
+    });
+  });
+
+  test("custom bar rules are applied on the first paint", () => {
+    const { snapshots } = renderHistory({
+      barColorRules: [makeRule(new Color("#123456"))],
+    });
+
+    expect(snapshots[0]?.colors[1]).toBe("rgb(18, 52, 86)");
+    expect(snapshots[0]?.labels[1]).toContain("0% uptime");
+  });
+
+  test("an unrelated render reuses timeline calculations", () => {
+    const calculateEvents: SpyInstance<
+      typeof UptimeUtil.getNonOverlappingMonitorEvents
+    > = jest.spyOn(UptimeUtil, "getNonOverlappingMonitorEvents");
+    const { rerenderHistory } = renderHistory();
+    const originalBar: HTMLElement | undefined =
+      screen.getAllByTestId("uptime-bar")[1];
+
+    rerenderHistory({ height: 10 });
+    rerenderHistory({ height: 12 });
+
+    expect(calculateEvents).toHaveBeenCalledTimes(1);
+    expect(screen.getAllByTestId("uptime-bar")[1]).toBe(originalBar);
+  });
+
+  test("a refreshed timeline updates every committed reading without stale downtime", () => {
+    const calculateEvents: SpyInstance<
+      typeof UptimeUtil.getNonOverlappingMonitorEvents
+    > = jest.spyOn(UptimeUtil, "getNonOverlappingMonitorEvents");
+    const { snapshots, rerenderHistory } = renderHistory();
+    snapshots.length = 0;
+
+    rerenderHistory({ items: [makeTimeline(makeStatus(false))] });
+
+    expect(calculateEvents).toHaveBeenCalledTimes(2);
+    expect(snapshots.length).toBeGreaterThan(0);
+    for (const snapshot of snapshots) {
+      expect(snapshot.labels[1]).toContain("100% uptime");
+    }
+    expect(screen.getAllByTestId("uptime-bar")[1]).toHaveStyle({
+      backgroundColor: Green.toString(),
+    });
+  });
+
+  test("clearing the timeline immediately removes the old readings", () => {
+    const { snapshots, rerenderHistory } = renderHistory();
+    snapshots.length = 0;
+
+    rerenderHistory({ items: [] });
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    for (const snapshot of snapshots) {
+      expect(snapshot.labels).toHaveLength(3);
+      for (const label of snapshot.labels) {
+        expect(label).toContain("no data");
+      }
+    }
+  });
+
+  test("changing the date window paints the new number of days immediately", () => {
+    const { snapshots, rerenderHistory } = renderHistory();
+    snapshots.length = 0;
+
+    rerenderHistory({
+      startDate: new Date("2026-01-02T12:00:00.000Z"),
+    });
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    for (const snapshot of snapshots) {
+      expect(snapshot.labels).toHaveLength(2);
+      expect(snapshot.labels[0]).toContain("0% uptime");
+    }
+    expect(screen.getByTestId("day-uptime-graph")).toHaveAttribute(
+      "aria-label",
+      "Uptime history for the last 2 days",
+    );
+  });
+});
+
+describe("MonitorUptimeGraph - refreshed chart settings", () => {
+  test("replacing color rules uses the new color without recalculating events", () => {
+    const calculateEvents: SpyInstance<
+      typeof UptimeUtil.getNonOverlappingMonitorEvents
+    > = jest.spyOn(UptimeUtil, "getNonOverlappingMonitorEvents");
+    const { snapshots, rerenderHistory } = renderHistory({
+      barColorRules: [makeRule(new Color("#123456"))],
+    });
+    snapshots.length = 0;
+
+    rerenderHistory({ barColorRules: [makeRule(new Color("#654321"))] });
+
+    expect(calculateEvents).toHaveBeenCalledTimes(1);
+    expect(snapshots[0]?.colors[1]).toBe("rgb(101, 67, 33)");
+  });
+
+  test.each([undefined, []])(
+    "removed color rules %p restore status colors",
+    (rules: Array<StatusPageHistoryChartBarColorRule> | undefined) => {
+      const { rerenderHistory } = renderHistory({
+        barColorRules: [makeRule(new Color("#123456"))],
+      });
+
+      rerenderHistory({ barColorRules: rules });
+
+      expect(screen.getAllByTestId("uptime-bar")[1]).toHaveStyle({
+        backgroundColor: Red.toString(),
+      });
+    },
+  );
+
+  test("a changed downtime definition updates the reading", () => {
+    const { rerenderHistory } = renderHistory();
+
+    rerenderHistory({ downtimeMonitorStatuses: [] });
+
+    expect(screen.getAllByTestId("uptime-bar")[1]).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("100% uptime"),
+    );
+  });
+});
+
+describe("MonitorUptimeGraph - loading and recovery", () => {
+  test("loading hides the history until the supplied timeline is ready", () => {
+    const { snapshots, rerenderHistory } = renderHistory({ isLoading: true });
+
+    expect(screen.getByTestId("component-loader")).toBeInTheDocument();
+    expect(screen.queryByTestId("day-uptime-graph")).not.toBeInTheDocument();
+    snapshots.length = 0;
+
+    rerenderHistory({ isLoading: false });
+
+    expect(screen.queryByTestId("component-loader")).not.toBeInTheDocument();
+    expect(snapshots[0]?.labels[1]).toContain("0% uptime");
+  });
+
+  test("an error keeps its refresh action and recovery draws the current timeline", () => {
+    const onRefreshClick: ReturnType<typeof jest.fn<() => void>> =
+      jest.fn<() => void>();
+    const { rerenderHistory } = renderHistory({
+      error: "Timeline unavailable",
+      onRefreshClick: onRefreshClick,
+    });
+
+    expect(screen.getByText("Timeline unavailable")).toBeInTheDocument();
+    expect(screen.queryByTestId("day-uptime-graph")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("refresh-button"));
+    expect(onRefreshClick).toHaveBeenCalledTimes(1);
+
+    rerenderHistory({
+      error: undefined,
+      items: [makeTimeline(makeStatus(false))],
+    });
+
+    expect(screen.queryByText("Timeline unavailable")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("uptime-bar")[1]).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("100% uptime"),
+    );
+  });
+});

--- a/Common/Tests/UI/Components/TooltipLazyContent.test.tsx
+++ b/Common/Tests/UI/Components/TooltipLazyContent.test.tsx
@@ -1,0 +1,371 @@
+import "@testing-library/jest-dom";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import React, { ReactElement } from "react";
+import { ReferenceElement } from "tippy.js";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import Tooltip from "../../../UI/Components/Tooltip/Tooltip";
+
+type ContentRenderMock = ReturnType<typeof jest.fn<() => void>>;
+
+function ObservedContent(props: {
+  onRender: ContentRenderMock;
+  text: string;
+}): ReactElement {
+  props.onRender();
+  return <div>{props.text}</div>;
+}
+
+async function hover(trigger: HTMLElement): Promise<void> {
+  fireEvent.mouseEnter(trigger);
+  await act(async () => {
+    jest.advanceTimersByTime(150);
+  });
+}
+
+async function focus(trigger: HTMLElement): Promise<void> {
+  act(() => {
+    trigger.focus();
+  });
+  await act(async () => {
+    jest.advanceTimersByTime(150);
+  });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  jest.useRealTimers();
+});
+
+describe("Tooltip - deferred history content", () => {
+  test("a collection does not render unopened tooltip content", () => {
+    const onRender: ContentRenderMock = jest.fn<() => void>();
+
+    render(
+      <div>
+        {Array.from({ length: 90 }, (_value: unknown, index: number) => {
+          return (
+            <Tooltip
+              key={index}
+              lazy={true}
+              richContent={
+                <ObservedContent onRender={onRender} text={`Day ${index}`} />
+              }
+            >
+              <button type="button">Read day {index}</button>
+            </Tooltip>
+          );
+        })}
+      </div>,
+    );
+
+    expect(screen.getAllByRole("button")).toHaveLength(90);
+    for (const trigger of screen.getAllByRole("button")) {
+      // Deferring only portal content still creates ninety Popper/Tippy
+      // instances when a search opens one resource's history.
+      expect((trigger as ReferenceElement)._tippy).toBeUndefined();
+    }
+    expect(onRender).not.toHaveBeenCalled();
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  test("hover renders the requested tooltip without replacing its trigger", async () => {
+    const onRender: ContentRenderMock = jest.fn<() => void>();
+    render(
+      <Tooltip
+        lazy={true}
+        richContent={<ObservedContent onRender={onRender} text="75% uptime" />}
+      >
+        <button type="button">Read uptime</button>
+      </Tooltip>,
+    );
+    const trigger: HTMLElement = screen.getByRole("button");
+
+    await hover(trigger);
+
+    expect(onRender).toHaveBeenCalled();
+    expect(screen.getByRole("tooltip")).toHaveTextContent("75% uptime");
+    expect(screen.getByRole("button")).toBe(trigger);
+  });
+
+  test("keyboard focus opens deferred content and remains on the original button", async () => {
+    const onRender: ContentRenderMock = jest.fn<() => void>();
+    render(
+      <Tooltip
+        lazy={true}
+        richContent={
+          <ObservedContent onRender={onRender} text="No incidents" />
+        }
+      >
+        <button type="button">Read uptime</button>
+      </Tooltip>,
+    );
+    const trigger: HTMLElement = screen.getByRole("button");
+
+    await focus(trigger);
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("No incidents");
+    expect(screen.getByRole("button")).toBe(trigger);
+    expect(trigger).toHaveFocus();
+  });
+
+  test("only the opened tooltip in a collection renders its content", async () => {
+    const firstRender: ContentRenderMock = jest.fn<() => void>();
+    const secondRender: ContentRenderMock = jest.fn<() => void>();
+    render(
+      <div>
+        <Tooltip
+          lazy={true}
+          richContent={
+            <ObservedContent onRender={firstRender} text="First day" />
+          }
+        >
+          <button type="button">First</button>
+        </Tooltip>
+        <Tooltip
+          lazy={true}
+          richContent={
+            <ObservedContent onRender={secondRender} text="Second day" />
+          }
+        >
+          <button type="button">Second</button>
+        </Tooltip>
+      </div>,
+    );
+
+    await hover(screen.getByRole("button", { name: "Second" }));
+
+    expect(
+      (screen.getByRole("button", { name: "First" }) as ReferenceElement)
+        ._tippy,
+    ).toBeUndefined();
+    expect(
+      (screen.getByRole("button", { name: "Second" }) as ReferenceElement)
+        ._tippy,
+    ).toBeDefined();
+    expect(firstRender).not.toHaveBeenCalled();
+    expect(secondRender).toHaveBeenCalled();
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Second day");
+  });
+
+  test("a refresh before opening shows the newest content without rendering the old content", async () => {
+    const oldRender: ContentRenderMock = jest.fn<() => void>();
+    const newRender: ContentRenderMock = jest.fn<() => void>();
+    const { rerender } = render(
+      <Tooltip
+        lazy={true}
+        richContent={
+          <ObservedContent onRender={oldRender} text="Old reading" />
+        }
+      >
+        <button type="button">Read uptime</button>
+      </Tooltip>,
+    );
+
+    rerender(
+      <Tooltip
+        lazy={true}
+        richContent={
+          <ObservedContent onRender={newRender} text="Current reading" />
+        }
+      >
+        <button type="button">Read uptime</button>
+      </Tooltip>,
+    );
+
+    expect(oldRender).not.toHaveBeenCalled();
+    expect(newRender).not.toHaveBeenCalled();
+
+    await hover(screen.getByRole("button"));
+
+    expect(oldRender).not.toHaveBeenCalled();
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Current reading");
+  });
+
+  test("an open tooltip receives updated content without moving focus", async () => {
+    const onRender: ContentRenderMock = jest.fn<() => void>();
+    const { rerender } = render(
+      <Tooltip
+        lazy={true}
+        richContent={<ObservedContent onRender={onRender} text="75% uptime" />}
+      >
+        <button type="button">Read uptime</button>
+      </Tooltip>,
+    );
+    const trigger: HTMLElement = screen.getByRole("button");
+    await focus(trigger);
+
+    rerender(
+      <Tooltip
+        lazy={true}
+        richContent={<ObservedContent onRender={onRender} text="100% uptime" />}
+      >
+        <button type="button">Read uptime</button>
+      </Tooltip>,
+    );
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("100% uptime");
+    expect(screen.getByRole("tooltip")).not.toHaveTextContent("75% uptime");
+    expect(screen.getByRole("button")).toBe(trigger);
+    expect(trigger).toHaveFocus();
+  });
+
+  test("blur hides the tooltip and refocusing opens it again", async () => {
+    render(
+      <div>
+        <Tooltip lazy={true} richContent={<div>No incidents</div>}>
+          <button type="button">Read uptime</button>
+        </Tooltip>
+        <button type="button">Next resource</button>
+      </div>,
+    );
+    const trigger: HTMLElement = screen.getByRole("button", {
+      name: "Read uptime",
+    });
+    await focus(trigger);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("No incidents");
+
+    await focus(screen.getByRole("button", { name: "Next resource" }));
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await focus(trigger);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("No incidents");
+    expect(trigger).toHaveFocus();
+  });
+
+  test("hovering again after leaving reopens a lazy text tooltip", async () => {
+    render(
+      <Tooltip lazy={true} text="Resource details">
+        <button type="button">Read details</button>
+      </Tooltip>,
+    );
+    const trigger: HTMLElement = screen.getByRole("button");
+    await hover(trigger);
+
+    fireEvent.mouseLeave(trigger);
+    await act(async () => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await hover(trigger);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Resource details");
+  });
+
+  test("the trigger's existing event handlers still receive hover and focus", async () => {
+    const onMouseEnter: ReturnType<typeof jest.fn<() => void>> =
+      jest.fn<() => void>();
+    const onFocus: ReturnType<typeof jest.fn<() => void>> =
+      jest.fn<() => void>();
+    render(
+      <Tooltip lazy={true} text="Resource details">
+        <button type="button" onMouseEnter={onMouseEnter} onFocus={onFocus}>
+          Read details
+        </button>
+      </Tooltip>,
+    );
+    const trigger: HTMLElement = screen.getByRole("button");
+
+    await hover(trigger);
+    await focus(trigger);
+
+    expect(onMouseEnter).toHaveBeenCalledTimes(1);
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Resource details");
+  });
+
+  test("a disabled trigger cannot open a lazy tooltip", async () => {
+    const onRender: ContentRenderMock = jest.fn<() => void>();
+    render(
+      <Tooltip
+        lazy={true}
+        richContent={
+          <ObservedContent onRender={onRender} text="Resource details" />
+        }
+      >
+        <button type="button" disabled={true}>
+          Read details
+        </button>
+      </Tooltip>,
+    );
+    const trigger: HTMLElement = screen.getByRole("button");
+
+    await hover(trigger);
+    await focus(trigger);
+
+    expect(onRender).not.toHaveBeenCalled();
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(trigger).not.toHaveFocus();
+  });
+});
+
+describe("Tooltip - existing callers", () => {
+  test("ordinary rich tooltips continue rendering content before opening", async () => {
+    const onRender: ContentRenderMock = jest.fn<() => void>();
+    render(
+      <Tooltip
+        richContent={
+          <ObservedContent onRender={onRender} text="Resource details" />
+        }
+      >
+        <button type="button">Read details</button>
+      </Tooltip>,
+    );
+
+    expect(onRender).toHaveBeenCalled();
+    await hover(screen.getByRole("button"));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Resource details");
+  });
+
+  test.each([undefined, true])(
+    "plain text tooltips open with lazy=%p",
+    async (lazy: boolean | undefined) => {
+      render(
+        <Tooltip text="Resource details" lazy={lazy}>
+          <button type="button">Read details</button>
+        </Tooltip>,
+      );
+
+      await hover(screen.getByRole("button"));
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Resource details");
+    },
+  );
+
+  test("without content the child remains unwrapped and interactive", async () => {
+    const onClick: ReturnType<typeof jest.fn<() => void>> =
+      jest.fn<() => void>();
+    const { container } = render(
+      <Tooltip lazy={true}>
+        <button type="button" onClick={onClick}>
+          Read uptime
+        </button>
+      </Tooltip>,
+    );
+    const trigger: HTMLElement = screen.getByRole("button");
+
+    await focus(trigger);
+    fireEvent.click(trigger);
+
+    expect(container.firstElementChild).toBe(trigger);
+    expect(trigger).toHaveFocus();
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/Common/Tests/UI/Components/TooltipLazyContent.test.tsx
+++ b/Common/Tests/UI/Components/TooltipLazyContent.test.tsx
@@ -77,8 +77,10 @@ describe("Tooltip - deferred history content", () => {
 
     expect(screen.getAllByRole("button")).toHaveLength(90);
     for (const trigger of screen.getAllByRole("button")) {
-      // Deferring only portal content still creates ninety Popper/Tippy
-      // instances when a search opens one resource's history.
+      /*
+       * Deferring only portal content still creates ninety Popper/Tippy
+       * instances when a search opens one resource's history.
+       */
       expect((trigger as ReferenceElement)._tippy).toBeUndefined();
     }
     expect(onRender).not.toHaveBeenCalled();

--- a/Common/UI/Components/Graphs/DayUptimeGraph.tsx
+++ b/Common/UI/Components/Graphs/DayUptimeGraph.tsx
@@ -12,6 +12,7 @@ import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -65,7 +66,12 @@ export interface ComponentProps {
 const DayUptimeGraph: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const [days, setDays] = useState<number>(0);
+  const days: number = useMemo(() => {
+    return OneUptimeDate.getNumberOfDaysBetweenDatesInclusive(
+      props.startDate,
+      props.endDate,
+    );
+  }, [props.startDate, props.endDate]);
 
   /*
    * The strip is one tab stop with a roving tabindex inside it - see
@@ -99,15 +105,6 @@ const DayUptimeGraph: FunctionComponent<ComponentProps> = (
 
     barRefs.current[focusedBarIndex]?.focus();
   }, [focusedBarIndex]);
-
-  useEffect(() => {
-    setDays(
-      OneUptimeDate.getNumberOfDaysBetweenDatesInclusive(
-        props.startDate,
-        props.endDate,
-      ),
-    );
-  }, [props.startDate, props.endDate]);
 
   const activeBarIndex: number = DayUptimeGraphUtil.getActiveBarIndex({
     storedIndex: focusedBarIndex,
@@ -360,6 +357,7 @@ const DayUptimeGraph: FunctionComponent<ComponentProps> = (
     return (
       <Tooltip
         key={dayNumber}
+        lazy={true}
         richContent={
           <UptimeBarTooltip
             date={todaysDay}

--- a/Common/UI/Components/MonitorGraphs/Uptime.tsx
+++ b/Common/UI/Components/MonitorGraphs/Uptime.tsx
@@ -13,12 +13,7 @@ import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusT
 import StatusPageHistoryChartBarColorRule from "../../../Models/DatabaseModels/StatusPageHistoryChartBarColorRule";
 import UptimeBarTooltipIncident from "../../../Types/Monitor/UptimeBarTooltipIncident";
 import UptimeHistoryLabels from "../../../Types/Monitor/UptimeHistoryLabels";
-import React, {
-  FunctionComponent,
-  ReactElement,
-  useEffect,
-  useState,
-} from "react";
+import React, { FunctionComponent, ReactElement, useMemo } from "react";
 
 export type MonitorEvent = CommonMonitorEvent;
 
@@ -47,29 +42,22 @@ export interface ComponentProps {
 const MonitorUptimeGraph: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const [events, setEvents] = useState<Array<Event>>([]);
-
-  const [barColorRules, setBarColorRules] = useState<BarChartRule[]>([]);
-
-  useEffect(() => {
-    const eventList: Array<Event> = UptimeUtil.getNonOverlappingMonitorEvents(
-      props.items,
-    );
-    setEvents(eventList);
+  // A search can reveal many histories at once. Derive their data before the
+  // first paint instead of painting empty bars and rebuilding them in effects.
+  const events: Array<Event> = useMemo(() => {
+    return UptimeUtil.getNonOverlappingMonitorEvents(props.items);
   }, [props.items]);
 
-  useEffect(() => {
-    if (props.barColorRules) {
-      setBarColorRules(
-        props.barColorRules.map((rule: StatusPageHistoryChartBarColorRule) => {
-          return {
-            barColor: rule.barColor!,
-            uptimePercentGreaterThanOrEqualTo:
-              rule.uptimePercentGreaterThanOrEqualTo!,
-          };
-        }),
-      );
-    }
+  const barColorRules: Array<BarChartRule> = useMemo(() => {
+    return (props.barColorRules || []).map(
+      (rule: StatusPageHistoryChartBarColorRule): BarChartRule => {
+        return {
+          barColor: rule.barColor!,
+          uptimePercentGreaterThanOrEqualTo:
+            rule.uptimePercentGreaterThanOrEqualTo!,
+        };
+      },
+    );
   }, [props.barColorRules]);
 
   if (props.isLoading) {

--- a/Common/UI/Components/MonitorGraphs/Uptime.tsx
+++ b/Common/UI/Components/MonitorGraphs/Uptime.tsx
@@ -42,8 +42,10 @@ export interface ComponentProps {
 const MonitorUptimeGraph: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  // A search can reveal many histories at once. Derive their data before the
-  // first paint instead of painting empty bars and rebuilding them in effects.
+  /*
+   * A search can reveal many histories at once. Derive their data before the
+   * first paint instead of painting empty bars and rebuilding them in effects.
+   */
   const events: Array<Event> = useMemo(() => {
     return UptimeUtil.getNonOverlappingMonitorEvents(props.items);
   }, [props.items]);

--- a/Common/UI/Components/Tooltip/Tooltip.tsx
+++ b/Common/UI/Components/Tooltip/Tooltip.tsx
@@ -1,5 +1,10 @@
 import Tippy from "@tippyjs/react";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, {
+  cloneElement,
+  FunctionComponent,
+  ReactElement,
+  useState,
+} from "react";
 import "tippy.js/dist/tippy.css";
 import "tippy.js/themes/light-border.css";
 import "tippy.js/animations/shift-away-subtle.css";
@@ -8,10 +13,16 @@ export interface ComponentProps {
   text?: string | undefined;
   children: ReactElement;
   richContent?: ReactElement | undefined;
+  // Large collections can wait to create a tooltip until first opened.
+  lazy?: boolean | undefined;
 }
 
-const Tooltip: FunctionComponent<ComponentProps> = (
-  props: ComponentProps,
+interface PopupProps extends ComponentProps {
+  reference?: HTMLElement | undefined;
+}
+
+const TooltipPopup: FunctionComponent<PopupProps> = (
+  props: PopupProps,
 ): ReactElement => {
   if (!props.text && !props.richContent) {
     return props.children;
@@ -47,6 +58,9 @@ const Tooltip: FunctionComponent<ComponentProps> = (
        * impossible to build under it.
        */
       content={tooltipContent}
+      {...(props.reference
+        ? { reference: props.reference, showOnCreate: true }
+        : { children: props.children })}
       interactive={isRich}
       trigger="mouseenter focus"
       hideOnClick={false}
@@ -65,9 +79,39 @@ const Tooltip: FunctionComponent<ComponentProps> = (
          */
         expanded: false,
       }}
-    >
-      {props.children}
-    </Tippy>
+    />
+  );
+};
+
+const Tooltip: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [reference, setReference] = useState<HTMLElement | null>(null);
+
+  if (!props.lazy || (!props.text && !props.richContent)) {
+    return <TooltipPopup {...props} />;
+  }
+
+  // Keep the trigger in the same place before and after opening. Wrapping it
+  // in Tippy on first interaction would replace the DOM node and lose focus.
+  // Tippy attaches its normal hover, focus and interactive-hide handlers to
+  // this external reference once, when the visitor first uses the tooltip.
+  const child: ReactElement<React.HTMLAttributes<HTMLElement>> = props.children;
+
+  return (
+    <>
+      {cloneElement(child, {
+        onMouseEnter: (event: React.MouseEvent<HTMLElement>) => {
+          child.props.onMouseEnter?.(event);
+          setReference(event.currentTarget);
+        },
+        onFocus: (event: React.FocusEvent<HTMLElement>) => {
+          child.props.onFocus?.(event);
+          setReference(event.currentTarget);
+        },
+      })}
+      {reference && <TooltipPopup {...props} reference={reference} />}
+    </>
   );
 };
 

--- a/Common/UI/Components/Tooltip/Tooltip.tsx
+++ b/Common/UI/Components/Tooltip/Tooltip.tsx
@@ -92,10 +92,12 @@ const Tooltip: FunctionComponent<ComponentProps> = (
     return <TooltipPopup {...props} />;
   }
 
-  // Keep the trigger in the same place before and after opening. Wrapping it
-  // in Tippy on first interaction would replace the DOM node and lose focus.
-  // Tippy attaches its normal hover, focus and interactive-hide handlers to
-  // this external reference once, when the visitor first uses the tooltip.
+  /*
+   * Keep the trigger in the same place before and after opening. Wrapping it
+   * in Tippy on first interaction would replace the DOM node and lose focus.
+   * Tippy attaches its normal hover, focus and interactive-hide handlers to
+   * this external reference once, when the visitor first uses the tooltip.
+   */
   const child: ReactElement<React.HTMLAttributes<HTMLElement>> = props.children;
 
   return (

--- a/E2E/StatusPageSearch/Fixture.js
+++ b/E2E/StatusPageSearch/Fixture.js
@@ -1,0 +1,172 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import {
+  BrowserRouter,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
+import Overview from "../../App/FeatureSet/StatusPage/src/Pages/Overview/Overview";
+import API from "../../App/FeatureSet/StatusPage/src/Utils/API";
+import StatusPageUtil from "../../App/FeatureSet/StatusPage/src/Utils/StatusPage";
+import "../../App/FeatureSet/StatusPage/src/Utils/i18n";
+import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import MonitorStatus from "Common/Models/DatabaseModels/MonitorStatus";
+import MonitorStatusTimeline from "Common/Models/DatabaseModels/MonitorStatusTimeline";
+import StatusPage from "Common/Models/DatabaseModels/StatusPage";
+import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
+import StatusPageResource from "Common/Models/DatabaseModels/StatusPageResource";
+import Color from "Common/Types/Color";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import ObjectID from "Common/Types/ObjectID";
+import Route from "Common/Types/API/Route";
+import Navigation from "Common/UI/Utils/Navigation";
+
+// The actual public Overview, parsing, search, rollups and 90-day charts run
+// unchanged. Only the overview API response is synthetic and deterministic.
+const id = (value) =>
+  `00000000-0000-4000-8000-${String(value).padStart(12, "0")}`;
+const pageId = id(1);
+const operational = Object.assign(new MonitorStatus(), {
+  _id: id(2),
+  name: "Operational",
+  color: new Color("#16a34a"),
+  isOperationalState: true,
+  priority: 1,
+});
+const offline = Object.assign(new MonitorStatus(), {
+  _id: id(3),
+  name: "Offline",
+  color: new Color("#dc2626"),
+  isOperationalState: false,
+  priority: 2,
+});
+const statusPage = Object.assign(new StatusPage(), {
+  _id: pageId,
+  name: "Resource search regression",
+  showUptimeHistoryInDays: 90,
+  showOverallUptimePercentOnStatusPage: true,
+  downtimeMonitorStatuses: [offline],
+  defaultBarColor: operational.color,
+});
+const groups = ["Production", "Europe", "London", "Databases"].map(
+  (name, index) =>
+    Object.assign(new StatusPageGroup(), {
+      _id: id(10 + index),
+      name,
+      parentStatusPageGroupId: index ? new ObjectID(id(9 + index)) : undefined,
+      isExpandedByDefault: true,
+      showCurrentStatus: true,
+      showUptimePercent: true,
+      order: index,
+    }),
+);
+const resources = [];
+const timelines = [];
+for (let index = 0; index < 40; index++) {
+  const monitor = Object.assign(new Monitor(), {
+    _id: id(100 + index),
+    name: `Internal monitor ${index}`,
+    currentMonitorStatusId: operational.id,
+  });
+  resources.push(
+    Object.assign(new StatusPageResource(), {
+      _id: id(200 + index),
+      displayName:
+        index === 39
+          ? "Database 0660"
+          : `Service ${String(index + 1).padStart(4, "0")}`,
+      displayDescription: index === 38 ? "Customer billing API" : undefined,
+      monitor,
+      monitorId: monitor.id,
+      statusPageGroupId: groups[Math.floor(index / 10)].id,
+      showStatusHistoryChart: true,
+      showCurrentStatus: true,
+      showUptimePercent: true,
+      order: index,
+    }),
+  );
+  // An actual timeline, including an outage inside the visible window, keeps
+  // the regression representative of the expensive uptime rollup path.
+  const now = Date.now();
+  const day = 86400000;
+  [
+    [now - 100 * day, now - 2 * day, operational],
+    [now - 2 * day, now - 2 * day + 3600000, offline],
+    [now - 2 * day + 3600000, undefined, operational],
+  ].forEach(([startsAt, endsAt, status], part) => {
+    timelines.push(
+      Object.assign(new MonitorStatusTimeline(), {
+        _id: id(1000 + index * 3 + part),
+        monitorId: monitor.id,
+        monitorStatusId: status.id,
+        monitorStatus: status,
+        startsAt: new Date(startsAt),
+        endsAt: endsAt ? new Date(endsAt) : undefined,
+      }),
+    );
+  });
+}
+
+window.__statusPageSearchFixture = { requests: 0, refreshOffline: false };
+API.post = async ({ url }) => {
+  if (!url.toString().endsWith(`/overview/${pageId}`)) {
+    throw new Error(`Unexpected fixture request: ${url}`);
+  }
+  window.__statusPageSearchFixture.requests += 1;
+  const refreshOffline = window.__statusPageSearchFixture.refreshOffline;
+  const freshResources = resources.map((resource, index) => {
+    if (!refreshOffline || index !== 39) {
+      return resource;
+    }
+    return Object.assign(new StatusPageResource(), resource, {
+      monitor: Object.assign(new Monitor(), resource.monitor, {
+        currentMonitorStatusId: offline.id,
+      }),
+    });
+  });
+  return new HTTPResponse(
+    200,
+    {
+      statusPage: BaseModel.toJSONObject(statusPage, StatusPage),
+      resourceGroups: BaseModel.toJSONObjectArray(groups, StatusPageGroup),
+      statusPageResources: BaseModel.toJSONObjectArray(
+        freshResources,
+        StatusPageResource,
+      ),
+      monitorStatuses: BaseModel.toJSONObjectArray(
+        [operational, offline],
+        MonitorStatus,
+      ),
+      monitorStatusTimelines: BaseModel.toJSONObjectArray(
+        timelines,
+        MonitorStatusTimeline,
+      ),
+      overallStatus: BaseModel.toJSONObject(
+        refreshOffline ? offline : operational,
+        MonitorStatus,
+      ),
+    },
+    {},
+  );
+};
+StatusPageUtil.setStatusPageId(new ObjectID(pageId));
+StatusPageUtil.setIsPrivateStatusPage(false);
+
+function Fixture() {
+  Navigation.setNavigateHook(useNavigate());
+  Navigation.setLocation(useLocation());
+  Navigation.setParams(useParams());
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-4 sm:px-8">
+      <Overview pageRoute={new Route("/")} onLoadComplete={() => {}} />
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")).render(
+  <BrowserRouter>
+    <Fixture />
+  </BrowserRouter>,
+);

--- a/E2E/StatusPageSearch/README.md
+++ b/E2E/StatusPageSearch/README.md
@@ -1,0 +1,20 @@
+# Public status page resource search
+
+Run `npm run test-status-page-search-ui` from `E2E` after installing its and
+`Common`'s dependencies and Playwright Chromium.
+
+This suite builds the actual public Overview and its search, nested resource
+groups, rollups and history charts. Only the overview API response is replaced
+with deterministic, serialized model data: 40 resources across four nesting
+levels, each with 90 days of history and an outage. It needs no database or
+running OneUptime services. The fixture listens only on `127.0.0.1:4200`.
+
+Desktop and mobile Chromium cover rapid `0660` typing, clearing then typing a
+new query, no results, Escape/focus, case/whitespace matching, group/description
+matches, collapse restoration and refreshing status while a filter is active.
+They also check hover/focus history tooltips and keyboard access to the day dialog.
+The rapid-input test attaches timing diagnostics without machine-dependent
+performance assertions. Artifacts are under `output/playwright/status-page-search`.
+
+This checks real browser rendering and client interactions; backend overview
+queries and the deployed app's routing/authentication are outside this fixture.

--- a/E2E/StatusPageSearch/ResourceSearch.spec.ts
+++ b/E2E/StatusPageSearch/ResourceSearch.spec.ts
@@ -1,0 +1,258 @@
+import { expect, Locator, Page, test, TestInfo } from "@playwright/test";
+
+interface FixtureState {
+  requests: number;
+  refreshOffline: boolean;
+  inputFrames?: Array<{ value: string; durationMs: number }>;
+}
+
+declare global {
+  interface Window {
+    __statusPageSearchFixture: FixtureState;
+  }
+}
+
+test.beforeEach(async ({ page }: { page: Page }) => {
+  await page.goto("/");
+  await expect(page.getByTestId("status-page-overview")).toBeVisible();
+  await expect(page.getByTestId("day-uptime-graph")).toHaveCount(40);
+  await expect(page.getByTestId("uptime-bar")).toHaveCount(40 * 91);
+});
+
+test("keeps every character while rapidly narrowing 40 nested resource histories", async ({
+  page,
+}: { page: Page }, testInfo: TestInfo) => {
+  const search: Locator = page.getByRole("searchbox", {
+    name: "Search resources",
+  });
+  const pageErrors: Array<string> = [];
+  page.on("pageerror", (error: Error) => {
+    pageErrors.push(error.message);
+  });
+  await search.evaluate((input: HTMLInputElement): void => {
+    window.__statusPageSearchFixture.inputFrames = [];
+    input.addEventListener("input", (): void => {
+      const startedAt: number = performance.now();
+      const value: string = input.value;
+      requestAnimationFrame((): void => {
+        window.__statusPageSearchFixture.inputFrames?.push({
+          value,
+          durationMs: performance.now() - startedAt,
+        });
+      });
+    });
+  });
+  const startedAt: number = Date.now();
+  await search.pressSequentially("0660");
+  await expect(search).toHaveValue("0660");
+  await expect(search).toBeFocused();
+  await expect(
+    page.getByTestId("status-page-resource-search-count"),
+  ).toHaveText("1 of 40 resources");
+  await expect(page.getByText("Database 0660", { exact: true })).toBeVisible();
+  await expect(page.getByText("Service 0001", { exact: true })).toHaveCount(0);
+  await expect(page.getByTestId("status-page-group-header")).toHaveCount(4);
+  await expect(page.getByTestId("day-uptime-graph")).toHaveCount(1);
+  const typingDurationMs: number = Date.now() - startedAt;
+  await page.screenshot({
+    path: testInfo.outputPath("filtered-resources.png"),
+    fullPage: true,
+  });
+
+  const clearStartedAt: number = Date.now();
+  await page.getByRole("button", { name: "Clear search", exact: true }).click();
+  await expect(search).toHaveValue("");
+  await expect(search).toBeFocused();
+  await expect(page.getByTestId("day-uptime-graph")).toHaveCount(40);
+  const clearDurationMs: number = Date.now() - clearStartedAt;
+  await page.screenshot({ path: testInfo.outputPath("cleared-search.png") });
+
+  /*
+   * Start a new query immediately after clearing: delayed work from the first
+   * query must never overwrite this text or leave the old resource on screen.
+   */
+  await search.pressSequentially("0039");
+  await expect(search).toHaveValue("0039");
+  await expect(search).toBeFocused();
+  await expect(
+    page.getByTestId("status-page-resource-search-count"),
+  ).toHaveText("1 of 40 resources");
+  await expect(page.getByText("Service 0039", { exact: true })).toBeVisible();
+  await expect(page.getByText("Database 0660", { exact: true })).toHaveCount(0);
+
+  /*
+   * Interrupt restoration of all 40 charts with a new query: do not wait for
+   * the cleared results before sending the next keystrokes.
+   */
+  await page.getByRole("button", { name: "Clear search", exact: true }).click();
+  await search.pressSequentially("0660");
+  await expect(search).toHaveValue("0660");
+  await expect(search).toBeFocused();
+  await expect(
+    page.getByTestId("status-page-resource-search-count"),
+  ).toHaveText("1 of 40 resources");
+  await expect(page.getByText("Database 0660", { exact: true })).toBeVisible();
+  await expect(page.getByText("Service 0039", { exact: true })).toHaveCount(0);
+  await expect(page.getByTestId("day-uptime-graph")).toHaveCount(1);
+  expect(
+    await page.evaluate((): number => {
+      return window.__statusPageSearchFixture.requests;
+    }),
+  ).toBe(1);
+  expect(pageErrors).toEqual([]);
+  // Diagnostic only: correctness does not depend on host/CI rendering speed.
+  await testInfo.attach("search-responsiveness", {
+    body: JSON.stringify({
+      typingDurationMs,
+      clearDurationMs,
+      // Input event to the next animation frame, without Playwright round trips.
+      inputFrames: await page.evaluate(() => {
+        return window.__statusPageSearchFixture.inputFrames;
+      }),
+    }),
+    contentType: "application/json",
+  });
+});
+
+test("handles a replacement query, no results and Escape without losing focus", async ({
+  page,
+}: {
+  page: Page;
+}) => {
+  const search: Locator = page.getByRole("searchbox", {
+    name: "Search resources",
+  });
+  await search.fill("0660");
+  await search.fill("missing-resource");
+  await expect(search).toHaveValue("missing-resource");
+  await expect(
+    page.getByTestId("status-page-resource-search-count"),
+  ).toHaveText("0 of 40 resources");
+  await expect(
+    page.getByText("No matching resources", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByTestId("day-uptime-graph")).toHaveCount(0);
+  await expect(search).toBeFocused();
+
+  await search.press("Escape");
+  await expect(search).toHaveValue("");
+  await expect(search).toBeFocused();
+  await expect(page.getByTestId("day-uptime-graph")).toHaveCount(40);
+  await expect(
+    page.getByTestId("status-page-resource-search-count"),
+  ).toHaveText("");
+  await expect(
+    page.getByText("No matching resources", { exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Clear search", exact: true }),
+  ).toHaveCount(0);
+  expect(
+    await page.evaluate((): boolean => {
+      return document.documentElement.scrollWidth <= window.innerWidth;
+    }),
+  ).toBe(true);
+});
+
+test("finds descriptions and complete group subtrees while preserving collapsed groups", async ({
+  page,
+}: {
+  page: Page;
+}) => {
+  const search: Locator = page.getByRole("searchbox", {
+    name: "Search resources",
+  });
+  const production: Locator = page
+    .getByTestId("status-page-group-header")
+    .filter({ hasText: "Production" });
+  await production.click();
+  await expect(production).toHaveAttribute("aria-expanded", "false");
+  await search.fill("  eUrOpE  ");
+  await expect(
+    page.getByTestId("status-page-resource-search-count"),
+  ).toHaveText("30 of 40 resources");
+  await expect(production).toHaveAttribute("aria-expanded", "true");
+  await expect(page.getByTestId("day-uptime-graph")).toHaveCount(30);
+  await expect(page.getByText("Service 0011", { exact: true })).toBeVisible();
+  await expect(page.getByText("Database 0660", { exact: true })).toBeVisible();
+  await expect(page.getByText("Service 0001", { exact: true })).toHaveCount(0);
+
+  await search.fill("billing");
+  await expect(
+    page.getByTestId("status-page-resource-search-count"),
+  ).toHaveText("1 of 40 resources");
+  await expect(page.getByText("Service 0039", { exact: true })).toBeVisible();
+  await expect(page.getByTestId("status-page-group-header")).toHaveCount(4);
+  await search.press("Escape");
+  await expect(production).toHaveAttribute("aria-expanded", "false");
+  await expect(page.getByTestId("day-uptime-graph")).toHaveCount(0);
+  await production.click();
+  await expect(page.getByTestId("day-uptime-graph")).toHaveCount(40);
+});
+
+test("keeps the query and displays fresh status after an overview refresh", async ({
+  page,
+}: {
+  page: Page;
+}) => {
+  const search: Locator = page.getByRole("searchbox", {
+    name: "Search resources",
+  });
+  await search.fill("0660");
+  await expect(page.getByTestId("day-uptime-graph")).toHaveCount(1);
+  await page.evaluate((): void => {
+    window.__statusPageSearchFixture.refreshOffline = true;
+  });
+  await page.getByRole("button", { name: "Refresh", exact: true }).click();
+  await expect(
+    page.getByText("Some Resources are Offline", { exact: true }),
+  ).toBeVisible();
+  // The matched resource and every ancestor rollup must use the fresh status.
+  await expect(page.getByText("Offline", { exact: true })).toHaveCount(5);
+  await expect(search).toHaveValue("0660");
+  await expect(
+    page.getByTestId("status-page-resource-search-count"),
+  ).toHaveText("1 of 40 resources");
+  await expect(page.getByTestId("day-uptime-graph")).toHaveCount(1);
+  expect(
+    await page.evaluate((): number => {
+      return window.__statusPageSearchFixture.requests;
+    }),
+  ).toBe(2);
+});
+
+test("keeps history tooltips and the day dialog accessible after filtering", async ({
+  page,
+}: {
+  page: Page;
+}) => {
+  await page.getByRole("searchbox", { name: "Search resources" }).fill("0660");
+  await expect(page.getByTestId("day-uptime-graph")).toHaveCount(1);
+  const day: Locator = page.getByTestId("uptime-bar").nth(88);
+  await day.scrollIntoViewIfNeeded();
+  await day.hover();
+  await expect(page.getByRole("tooltip")).toBeVisible();
+  await expect(page.getByRole("tooltip")).toContainText("Uptime");
+  await expect(page.getByRole("tooltip")).toContainText("Offline");
+  await page.mouse.move(0, 0);
+  await expect(page.getByRole("tooltip")).toBeHidden();
+  // Create another day's tooltip using only focus, before it has ever hovered.
+  const keyboardDay: Locator = page.getByTestId("uptime-bar").nth(87);
+  await keyboardDay.focus();
+  await expect(keyboardDay).toBeFocused();
+  await expect(page.getByRole("tooltip")).toBeVisible();
+  await expect(page.getByRole("tooltip")).toContainText("Uptime");
+  await expect(page.getByRole("tooltip")).not.toContainText("Offline");
+  await page.getByRole("searchbox", { name: "Search resources" }).focus();
+  await expect(page.getByRole("tooltip")).toBeHidden();
+  await day.focus();
+  await expect(day).toBeFocused();
+  await expect(page.getByRole("tooltip")).toBeVisible();
+  await day.press("Enter");
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await expect(page.getByRole("dialog")).toContainText("Uptime");
+  await expect(page.getByRole("dialog")).toContainText("Offline");
+  await page.getByRole("dialog").press("Escape");
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(day).toBeFocused();
+});

--- a/E2E/StatusPageSearch/server.js
+++ b/E2E/StatusPageSearch/server.js
@@ -1,0 +1,74 @@
+/* Builds and serves the real Overview without requiring an app or database. */
+const fs = require("fs");
+const http = require("http");
+const path = require("path");
+const { createConfig } = require("../../Common/UI/esbuild-config.js");
+const esbuild = require("../../Common/node_modules/esbuild");
+const repository = path.resolve(__dirname, "../..");
+const output = path.join(
+  repository,
+  "output/playwright/status-page-search/fixture",
+);
+const port = Number(process.env.STATUS_PAGE_SEARCH_FIXTURE_PORT || 4200);
+const config = createConfig({
+  serviceName: "status-page-search-fixture",
+  publicPath: "/dist/",
+  entryPoint: path.join(__dirname, "Fixture.js"),
+  outdir: output,
+  additionalAlias: {
+    Common: path.join(repository, "Common"),
+    react: path.join(repository, "Common/node_modules/react"),
+    "react-dom": path.join(repository, "Common/node_modules/react-dom"),
+  },
+});
+config.target = "es2022";
+config.loader[".js"] = "jsx";
+config.sourcemap = false;
+config.minify = false;
+config.logLevel = "warning";
+const tailwind = path.join(
+  repository,
+  "Common/Server/Static/Vendor/tailwind/tailwind-3.4.5.js",
+);
+const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Status page search regression</title><script>window.process={env:{HOST:"localhost",HTTP_PROTOCOL:"http",BILLING_ENABLED:"false",VERSION:"1.0.0",NODE_ENV:"development"}};window.global=window;</script><script src="/tailwind.js"></script><style>body{margin:0;background:#f8fafc;font-family:Inter,ui-sans-serif,system-ui,sans-serif}*{box-sizing:border-box}</style></head><body><div id="root"></div><script type="module" src="/dist/Fixture.js"></script></body></html>`;
+async function main() {
+  fs.mkdirSync(output, { recursive: true });
+  await esbuild.build(config);
+  if (process.argv.includes("--build-only")) {
+    return;
+  }
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url, `http://127.0.0.1:${port}`);
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader(
+      "Content-Security-Policy",
+      "connect-src 'self'; font-src 'self' data:;",
+    );
+    if (url.pathname === "/tailwind.js") {
+      response.setHeader("Content-Type", "application/javascript");
+      fs.createReadStream(tailwind).pipe(response);
+      return;
+    }
+    if (url.pathname.startsWith("/dist/")) {
+      const file = path.resolve(output, url.pathname.slice(6));
+      if (!file.startsWith(output + path.sep) || !fs.existsSync(file)) {
+        response.writeHead(404).end();
+        return;
+      }
+      response.setHeader("Content-Type", "application/javascript");
+      fs.createReadStream(file).pipe(response);
+      return;
+    }
+    response.setHeader("Content-Type", "text/html");
+    response.end(html);
+  });
+  server.listen(port, "127.0.0.1", () =>
+    console.log(`Status page search fixture ready at http://127.0.0.1:${port}`),
+  );
+  process.on("SIGTERM", () => server.close());
+  process.on("SIGINT", () => server.close());
+}
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/E2E/package.json
+++ b/E2E/package.json
@@ -8,6 +8,7 @@
   },
   "main": "index.js",
   "scripts": {
+    "test-status-page-search-ui": "playwright test --config playwright.status-page-search.config.ts",
     "preinstall": "npx playwright install-deps && npx playwright install",
     "test": "playwright test || (curl $E2E_TESTS_FAILED_WEBHOOK_URL && exit 1)",
     "dep-check": "npm install -g depcheck && depcheck ./ --skip-missing=true",

--- a/E2E/playwright.status-page-search.config.ts
+++ b/E2E/playwright.status-page-search.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "path";
+
+export default defineConfig({
+  testDir: "./StatusPageSearch",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: false,
+  workers: 1,
+  timeout: 60000,
+  expect: { timeout: 10000 },
+  retries: 0,
+  reporter: [["list"]],
+  outputDir: "../output/playwright/status-page-search/test-results",
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "mobile-chromium", use: { ...devices["Pixel 5"] } },
+  ],
+  use: {
+    baseURL: "http://127.0.0.1:4200",
+    timezoneId: "UTC",
+    locale: "en-GB",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  webServer: {
+    command: "node StatusPageSearch/server.js",
+    cwd: path.resolve(__dirname),
+    url: "http://127.0.0.1:4200",
+    timeout: 300000,
+    reuseExistingServer: false,
+  },
+});


### PR DESCRIPTION
Typing in the public status-page resource search rerendered nested uptime summaries and every history chart. Clearing a filter also created thousands of hidden tooltip instances, leaving the input unresponsive.

Cache resource render data and group/overall uptime per fetched snapshot, keep input updates ahead of result rendering, and create history tooltips only when hovered or focused. Search counts, ancestor matches, collapse restoration, clear/Escape focus, history dialogs, and background status refreshes remain covered.

Validation:
- 10 desktop/mobile Chromium scenarios passed with 40 resources, four nested group levels, and 90-day histories.
- The final rapid clear-and-retype scenario also passed on desktop and mobile after the last UI adjustment.
- 153 focused overview, search, graph, tooltip, and group-expansion tests passed. All 71 tests in the four changed test suites also passed with type checking (57 locally in an isolated container, 14 in CI).
- Common and StatusPage compilation passed in CI; StatusPage and E2E compilation also passed locally.
- The configured development site returns HTTP 502, so browser checks build the real Overview with a deterministic mocked API response in an isolated local fixture.

Root `npm run fix` was attempted locally; heavy host memory pressure prevented that run from completing. The complete CI lint run identified 12 formatting findings in this change, all now corrected and verified with the exact lint rules and Prettier. Five existing errors in `MonitorTemplateSyncFields.tsx` also fail [master's lint job](https://github.com/OneUptime/oneuptime/actions/runs/34355778926/job/102479959251); that file is unchanged by this PR.

Closes #3674.
