### PR TITLE
fix(dashboard): stop project selection bouncing users off global pages

### DIFF
--- a/App/FeatureSet/Dashboard/src/Utils/ProjectNavigation.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/ProjectNavigation.ts
@@ -1,3 +1,57 @@
+/*
+ * Dashboard pages that live outside any project: the user profile pages, the
+ * cross-project inboxes, project invitations, on-call policies and logout.
+ * Their URLs carry no project id, so the `currentRoute.includes(projectId)`
+ * test below can never be true for them -- which is exactly why selecting a
+ * project used to throw the user off whichever of these pages they had just
+ * deep-linked, bookmarked or reloaded, and onto the project home page.
+ *
+ * Written out rather than read from RouteMap so this module stays free of the
+ * dashboard route graph and its browser-only dependencies, and so the
+ * select/switch matrix remains testable without a DOM. ProjectNavigation.test
+ * reads RouteMap's source and fails if a project-independent route is added
+ * without being listed here, so the two cannot drift apart silently.
+ *
+ * /dashboard (INIT) and /dashboard/welcome (WELCOME) are deliberately absent.
+ * They are the two routes whose whole purpose is to hand the user off into a
+ * project: /dashboard is the post-login landing page, and /dashboard/welcome is
+ * where a brand new project is created -- ProjectPicker calls onProjectSelected
+ * with the freshly created project, and the navigation this helper returns is
+ * what carries the user into it. Exempting either would strand the user on a
+ * loader or a welcome screen.
+ */
+export const projectIndependentRoutes: Array<string> = [
+  "/dashboard/user-profile/overview",
+  "/dashboard/user-profile/password-management",
+  "/dashboard/user-profile/two-factor-auth",
+  "/dashboard/user-profile/profile-picture",
+  "/dashboard/user-profile/delete-account",
+  "/dashboard/active-incidents",
+  "/dashboard/active-alerts",
+  "/dashboard/active-alert-episodes",
+  "/dashboard/active-incident-episodes",
+  "/dashboard/project-invitations",
+  "/dashboard/my-on-call-policies",
+  "/dashboard/logout",
+];
+
+/**
+ * Whether the user is currently sitting on a page that belongs to no project,
+ * and therefore should not be navigated away from just because a project got
+ * selected underneath them. Tolerates a trailing slash, a query string and a
+ * fragment, because this is matched against a live browser URL.
+ */
+export function isProjectIndependentRoute(currentRoute: string): boolean {
+  const path: string = currentRoute
+    .split("?")[0]!
+    .split("#")[0]!
+    .replace(/\/+$/, "");
+
+  return projectIndependentRoutes.some((routePath: string): boolean => {
+    return path === routePath || path.startsWith(routePath + "/");
+  });
+}
+
 export interface ProjectSelectionNavigationInput {
   /** The current route as a string (e.g. Navigation.getCurrentRoute().toString()). */
   currentRoute: string;
@@ -33,6 +87,10 @@ export interface ProjectSelectionNavigationDecision {
  * select/switch matrix is unit-testable without a DOM or router:
  *
  * - URL already contains the project id → do nothing (deep-link reload case).
+ * - URL belongs to no project at all (user profile, cross-project inboxes,
+ *   invitations, on-call policies, logout) and this is not a switch between two
+ *   projects → do nothing, so a deep link or reload of one of those pages is
+ *   not bounced to the project home page.
  * - First selection in this document (login/auto-select) → plain SPA navigate.
  * - Switching from one project to a different one → forceNavigate (full
  *   reload) to reset every mounted component that still holds the old
@@ -65,6 +123,28 @@ export function getProjectSelectionNavigationDecision(
   const isSwitchingBetweenProjects: boolean = Boolean(
     input.previousProjectId && input.previousProjectId !== projectId,
   );
+
+  /*
+   * The user is on a page that belongs to no project, so there is no project
+   * id in the URL for the check above to match. Selecting a project on boot --
+   * the auto-select that runs on every login, reload and deep link -- must not
+   * bounce them off it. This is what made a reload of, say, the passkey
+   * settings page land on the project home page instead.
+   *
+   * An actual switch between two projects still navigates: forceNavigate is
+   * how a mounted page holding the old project's data gets reset, and these
+   * pages are no exception.
+   */
+  if (
+    !isSwitchingBetweenProjects &&
+    isProjectIndependentRoute(input.currentRoute)
+  ) {
+    return {
+      shouldNavigate: false,
+      forceNavigate: false,
+      routePath: routePath,
+    };
+  }
 
   return {
     shouldNavigate: true,

--- a/App/Tests/Dashboard/ProjectNavigation.test.ts
+++ b/App/Tests/Dashboard/ProjectNavigation.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
 import {
   ProjectSelectionNavigationDecision,
   getProjectSelectionNavigationDecision,
+  isProjectIndependentRoute,
+  projectIndependentRoutes,
 } from "../../FeatureSet/Dashboard/src/Utils/ProjectNavigation";
 
 /*
@@ -117,6 +121,113 @@ describe("getProjectSelectionNavigationDecision", () => {
     });
   });
 
+  /*
+   * A dashboard page whose URL carries no project id at all. Selecting a
+   * project on boot -- the auto-select that runs on every login, reload and
+   * deep link -- used to navigate the user straight off these pages and onto
+   * the project home page, because `currentRoute.includes(projectId)` can
+   * never be true for a URL that has no project id in it. Reloading the
+   * passkey settings page was how CI kept catching it: the Add Passkey button
+   * mounted, then the redirect tore it out of the DOM mid-click.
+   */
+  describe("pages that belong to no project", () => {
+    const PROJECT_INDEPENDENT_ROUTES: Array<string> = projectIndependentRoutes;
+
+    test.each(PROJECT_INDEPENDENT_ROUTES)(
+      "a boot-time selection leaves the user on %s",
+      (currentRoute: string) => {
+        const decision: ProjectSelectionNavigationDecision =
+          getProjectSelectionNavigationDecision({
+            currentRoute: currentRoute,
+            selectedProjectId: PROJECT_A,
+            previousProjectId: null,
+          });
+
+        expect(decision.shouldNavigate).toBe(false);
+        expect(decision.forceNavigate).toBe(false);
+      },
+    );
+
+    test.each(PROJECT_INDEPENDENT_ROUTES)(
+      "%s is recognised as project-independent",
+      (currentRoute: string) => {
+        expect(isProjectIndependentRoute(currentRoute)).toBe(true);
+      },
+    );
+
+    test("re-selecting the same project also leaves the user where they are", () => {
+      const decision: ProjectSelectionNavigationDecision =
+        getProjectSelectionNavigationDecision({
+          currentRoute: "/dashboard/user-profile/two-factor-auth",
+          selectedProjectId: PROJECT_A,
+          previousProjectId: PROJECT_A,
+        });
+
+      expect(decision.shouldNavigate).toBe(false);
+    });
+
+    test("a trailing slash or query string does not defeat the match", () => {
+      expect(
+        isProjectIndependentRoute("/dashboard/user-profile/two-factor-auth/"),
+      ).toBe(true);
+      expect(
+        isProjectIndependentRoute(
+          "/dashboard/project-invitations?invite=abc123",
+        ),
+      ).toBe(true);
+    });
+
+    /*
+     * The state-reset semantics of a real project switch are unchanged. A page
+     * still mounted with the old project's data has to be torn down, and these
+     * pages get no exemption from that.
+     */
+    test("switching between two projects still forces a full navigation", () => {
+      const decision: ProjectSelectionNavigationDecision =
+        getProjectSelectionNavigationDecision({
+          currentRoute: "/dashboard/my-on-call-policies",
+          selectedProjectId: PROJECT_B,
+          previousProjectId: PROJECT_A,
+        });
+
+      expect(decision.shouldNavigate).toBe(true);
+      expect(decision.forceNavigate).toBe(true);
+      expect(decision.routePath).toBe("/dashboard/" + PROJECT_B);
+    });
+  });
+
+  /*
+   * The two routes that exist to hand the user off into a project. /dashboard
+   * is the post-login landing page, and /dashboard/welcome is where a new
+   * project is created -- ProjectPicker calls onProjectSelected with the
+   * freshly created project and this navigation is what carries the user into
+   * it. Exempting either would strand the user on a loader or a welcome
+   * screen.
+   */
+  describe("bootstrap routes still hand off to the project", () => {
+    test.each(["/dashboard", "/dashboard/welcome"])(
+      "%s navigates on a boot-time selection",
+      (currentRoute: string) => {
+        const decision: ProjectSelectionNavigationDecision =
+          getProjectSelectionNavigationDecision({
+            currentRoute: currentRoute,
+            selectedProjectId: PROJECT_A,
+            previousProjectId: null,
+          });
+
+        expect(decision.shouldNavigate).toBe(true);
+        expect(decision.routePath).toBe("/dashboard/" + PROJECT_A);
+      },
+    );
+
+    test.each(["/dashboard", "/dashboard/welcome"])(
+      "%s is not treated as project-independent",
+      (currentRoute: string) => {
+        expect(isProjectIndependentRoute(currentRoute)).toBe(false);
+      },
+    );
+  });
+
   describe("degenerate inputs", () => {
     test("a missing project id never navigates — /dashboard/undefined would be worse than staying put", () => {
       const decision: ProjectSelectionNavigationDecision =
@@ -153,5 +264,108 @@ describe("getProjectSelectionNavigationDecision", () => {
       expect(decision.shouldNavigate).toBe(true);
       expect(decision.forceNavigate).toBe(false);
     });
+  });
+});
+
+/*
+ * ProjectNavigation deliberately does not import RouteMap: it must stay free of
+ * the dashboard route graph and its browser-only dependencies so the
+ * select/switch matrix is testable without a DOM. That leaves its list of
+ * project-independent routes able to fall behind RouteMap, so read RouteMap's
+ * source and compare the two.
+ *
+ * A route is project-independent when its path never interpolates
+ * RouteParams.ProjectID. INIT and WELCOME are the two documented exceptions --
+ * they exist to hand the user off into a project, so the helper must keep
+ * navigating there.
+ */
+describe("the project-independent route list tracks RouteMap", () => {
+  const HANDOFF_PAGES: Array<string> = ["INIT", "WELCOME"];
+
+  const ROUTE_MAP_SOURCE: string = fs.readFileSync(
+    path.join(
+      __dirname,
+      "..",
+      "..",
+      "FeatureSet",
+      "Dashboard",
+      "src",
+      "Utils",
+      "RouteMap.ts",
+    ),
+    "utf8",
+  );
+
+  type RouteMapEntry = { page: string; routePath: string };
+
+  function routeMapEntries(): Array<RouteMapEntry> {
+    const pattern: RegExp =
+      /\[PageMap\.([A-Z0-9_]+)\]:\s*new Route\(\s*`([^`]*)`/g;
+    const entries: Array<RouteMapEntry> = [];
+    let match: RegExpExecArray | null = pattern.exec(ROUTE_MAP_SOURCE);
+
+    while (match) {
+      entries.push({
+        page: match[1] as string,
+        routePath: (match[2] as string).replace(/\s+/g, ""),
+      });
+      match = pattern.exec(ROUTE_MAP_SOURCE);
+    }
+
+    return entries;
+  }
+
+  const entries: Array<RouteMapEntry> = routeMapEntries();
+
+  test("RouteMap parses into a realistic number of routes", () => {
+    // Guards the assertions below against the pattern silently matching nothing.
+    expect(entries.length).toBeGreaterThanOrEqual(500);
+  });
+
+  test("every project-independent route in RouteMap is covered", () => {
+    const uncovered: Array<string> = entries
+      .filter((entry: RouteMapEntry): boolean => {
+        return (
+          !entry.routePath.includes("RouteParams.ProjectID") &&
+          !HANDOFF_PAGES.includes(entry.page)
+        );
+      })
+      .map((entry: RouteMapEntry): string => {
+        return entry.routePath;
+      })
+      .filter((routePath: string): boolean => {
+        return !isProjectIndependentRoute(routePath);
+      });
+
+    expect(uncovered).toEqual([]);
+  });
+
+  test("nothing in the list is actually a project-scoped route", () => {
+    const projectScopedPaths: Array<string> = entries
+      .filter((entry: RouteMapEntry): boolean => {
+        return entry.routePath.includes("RouteParams.ProjectID");
+      })
+      .map((entry: RouteMapEntry): string => {
+        return entry.routePath;
+      });
+
+    for (const routePath of projectScopedPaths) {
+      expect(isProjectIndependentRoute(routePath)).toBe(false);
+    }
+  });
+
+  test("the two handoff routes are excluded on purpose, not by accident", () => {
+    const handoffPaths: Array<string> = entries
+      .filter((entry: RouteMapEntry): boolean => {
+        return HANDOFF_PAGES.includes(entry.page);
+      })
+      .map((entry: RouteMapEntry): string => {
+        return entry.routePath;
+      });
+
+    expect(handoffPaths).toHaveLength(HANDOFF_PAGES.length);
+    for (const routePath of handoffPaths) {
+      expect(isProjectIndependentRoute(routePath)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## The bug

Deep-linking, bookmarking or reloading any dashboard page that belongs to no project lands you on the project home page instead of the page you asked for.

Affected pages, all of whose URLs carry no project id:

| Route |
| --- |
| `/dashboard/user-profile/overview` |
| `/dashboard/user-profile/password-management` |
| `/dashboard/user-profile/two-factor-auth` |
| `/dashboard/user-profile/profile-picture` |
| `/dashboard/user-profile/delete-account` |
| `/dashboard/active-incidents` |
| `/dashboard/active-alerts` |
| `/dashboard/active-alert-episodes` |
| `/dashboard/active-incident-episodes` |
| `/dashboard/project-invitations` |
| `/dashboard/my-on-call-policies` |
| `/dashboard/logout` |

## Why

`getProjectSelectionNavigationDecision` decides whether a project selection should change the URL. Its "already where we want to be" test is `currentRoute.includes(projectId)`. A project-independent URL contains no project id, so that test can never pass for one, and the boot-time auto-select that runs on every login, reload and deep link navigates the user away.

## The fix

Recognise those routes and stay put, unless this is an actual switch between two projects. `forceNavigate` is how a page still holding the old project's data gets reset, and these pages get no exemption from that.

`/dashboard` and `/dashboard/welcome` keep navigating. They exist to hand the user off into a project, and `/dashboard/welcome` is where a newly created project is selected, so exempting either would strand the user on a loader or a welcome screen.

The route list is written out rather than read from `RouteMap`, so the module stays free of the dashboard route graph and its browser-only dependencies and the decision matrix remains testable without a DOM. A new test reads `RouteMap`'s source and fails if a project-independent route is added without being listed, so the two cannot drift apart.

## How this surfaced

The end-to-end job on master has been red on this for at least two runs, reported as a flaky passkey test. The suite reloads the passkey settings page, the Add Passkey button mounts, and the redirect tears it out of the DOM mid-click.

```
TimeoutError: locator.click: Timeout 30000ms exceeded.
  - waiting for getByTestId('add-passkey')
    - locator resolved to <button data-testid="add-passkey" ...>
    - element was detached from the DOM, retrying
```

The page snapshot captured at the timeout shows the project home page, not the profile page. It failed identically on `194a197f8`, before the VMware merge, so it is not a regression from that change.

## Tests

`App/Tests/Dashboard/ProjectNavigation.test.ts` grows from 13 to 45 tests:

- every project-independent route stays put on a boot-time selection
- a trailing slash, query string or fragment does not defeat the match
- re-selecting the same project also stays put
- switching between two projects still forces a full navigation
- both handoff routes still navigate, and are excluded on purpose rather than by accident
- the drift guard: every project-independent route in `RouteMap` is covered, and no project-scoped route is

All 296 Dashboard suites pass, 10336 tests.