### PR TITLE
fix(billing): stop the payment-method read storm that reds master

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -969,7 +969,7 @@ jobs:
         run: |
           export $(grep -v '^#' config.env | xargs)
           export APP_TAG=${{needs.read-version.outputs.major_minor}}-test
-          docker compose -f docker-compose.dev.yml up --exit-code-from e2e --abort-on-container-exit e2e || (docker compose -f docker-compose.dev.yml logs e2e && exit 1)
+          docker compose -f docker-compose.dev.yml up --exit-code-from e2e --abort-on-container-exit e2e || (docker compose -f docker-compose.dev.yml logs e2e; bash ./Tests/Scripts/dump-container-logs.sh docker-compose.billing.yml; exit 1)
       - name: Upload test results
         uses: actions/upload-artifact@v4
         # Run this on failure
@@ -1046,7 +1046,7 @@ jobs:
         run: |
           export $(grep -v '^#' config.env | xargs)
           export APP_TAG=${{needs.read-version.outputs.major_minor}}-test
-          docker compose -f docker-compose.dev.yml up --exit-code-from e2e --abort-on-container-exit e2e || (docker compose -f docker-compose.dev.yml logs e2e && exit 1)
+          docker compose -f docker-compose.dev.yml up --exit-code-from e2e --abort-on-container-exit e2e || (docker compose -f docker-compose.dev.yml logs e2e; bash ./Tests/Scripts/dump-container-logs.sh docker-compose.yml; exit 1)
       - name: Upload test results
         uses: actions/upload-artifact@v4
         # Run this on failure

--- a/Common/Server/Services/BillingPaymentMethodService.ts
+++ b/Common/Server/Services/BillingPaymentMethodService.ts
@@ -9,10 +9,92 @@ import BadDataException from "../../Types/Exception/BadDataException";
 import Model from "../../Models/DatabaseModels/BillingPaymentMethod";
 import Project from "../../Models/DatabaseModels/Project";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import Dictionary from "../../Types/Dictionary";
+import ObjectID from "../../Types/ObjectID";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /*
+   * Every read of this model re-syncs it from the payment provider, and one
+   * billing page render issues two list requests at once (the table itself,
+   * and the unfiltered count beside it). That was 10 provider reads - four
+   * payment-method types plus the customer, twice - fired simultaneously for a
+   * single page, on top of a hard delete and re-insert of the same rows from
+   * both requests at once. Against a rate-limited account that is what makes a
+   * read fail; it also raced the two re-syncs against each other in Postgres.
+   *
+   * Collapse only requests that genuinely overlap in time: a caller arriving
+   * while a sync is in flight awaits that one instead of starting a second.
+   * Nothing is cached beyond the in-flight window, so a payment method added
+   * a moment ago is still read fresh by the next request.
+   */
+  private syncsInFlight: Dictionary<Promise<Array<PaymentMethod>>> = {};
+
+  private syncPaymentMethodsFromProvider(data: {
+    projectId: ObjectID;
+    customerId: string;
+  }): Promise<Array<PaymentMethod>> {
+    const key: string = data.projectId.toString();
+
+    const inFlight: Promise<Array<PaymentMethod>> | undefined =
+      this.syncsInFlight[key];
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const sync: Promise<Array<PaymentMethod>> = this.runPaymentMethodSync(
+      data,
+    ).finally(() => {
+      delete this.syncsInFlight[key];
+    });
+
+    this.syncsInFlight[key] = sync;
+
+    return sync;
+  }
+
+  private async runPaymentMethodSync(data: {
+    projectId: ObjectID;
+    customerId: string;
+  }): Promise<Array<PaymentMethod>> {
+    const paymentMethods: Array<PaymentMethod> =
+      await BillingService.getPaymentMethods(data.customerId);
+
+    await this.deleteBy({
+      query: {
+        projectId: data.projectId,
+      },
+      limit: LIMIT_PER_PROJECT,
+      skip: 0,
+      props: {
+        isRoot: true,
+        ignoreHooks: true,
+      },
+    });
+
+    for (const paymentMethod of paymentMethods) {
+      const billingPaymentMethod: Model = new Model();
+
+      billingPaymentMethod.projectId = data.projectId;
+
+      billingPaymentMethod.paymentMethodType = paymentMethod.type;
+      billingPaymentMethod.last4Digits = paymentMethod.last4Digits;
+      billingPaymentMethod.isDefault = paymentMethod.isDefault;
+      billingPaymentMethod.paymentProviderPaymentMethodId = paymentMethod.id;
+      billingPaymentMethod.paymentProviderCustomerId = data.customerId;
+
+      await this.create({
+        data: billingPaymentMethod,
+        props: {
+          isRoot: true,
+        },
+      });
+    }
+
+    return paymentMethods;
   }
 
   @CaptureSpan()
@@ -45,39 +127,10 @@ export class Service extends DatabaseService<Model> {
     }
 
     const paymentMethods: Array<PaymentMethod> =
-      await BillingService.getPaymentMethods(project.paymentProviderCustomerId);
-
-    await this.deleteBy({
-      query: {
-        projectId: findBy.props.tenantId!,
-      },
-      limit: LIMIT_PER_PROJECT,
-      skip: 0,
-      props: {
-        isRoot: true,
-        ignoreHooks: true,
-      },
-    });
-
-    for (const paymentMethod of paymentMethods) {
-      const billingPaymentMethod: Model = new Model();
-
-      billingPaymentMethod.projectId = project.id!;
-
-      billingPaymentMethod.paymentMethodType = paymentMethod.type;
-      billingPaymentMethod.last4Digits = paymentMethod.last4Digits;
-      billingPaymentMethod.isDefault = paymentMethod.isDefault;
-      billingPaymentMethod.paymentProviderPaymentMethodId = paymentMethod.id;
-      billingPaymentMethod.paymentProviderCustomerId =
-        project.paymentProviderCustomerId;
-
-      await this.create({
-        data: billingPaymentMethod,
-        props: {
-          isRoot: true,
-        },
+      await this.syncPaymentMethodsFromProvider({
+        projectId: project.id!,
+        customerId: project.paymentProviderCustomerId,
       });
-    }
 
     return { findBy, carryForward: paymentMethods };
   }

--- a/Common/Server/Services/BillingService.ts
+++ b/Common/Server/Services/BillingService.ts
@@ -21,6 +21,8 @@ import Email from "../../Types/Email";
 import EmailTemplateType from "../../Types/Email/EmailTemplateType";
 import APIException from "../../Types/Exception/ApiException";
 import BadDataException from "../../Types/Exception/BadDataException";
+import Exception from "../../Types/Exception/Exception";
+import ServiceUnavailableException from "../../Types/Exception/ServiceUnavailableException";
 import ProductType from "../../Types/MeteredPlan/ProductType";
 import ObjectID from "../../Types/ObjectID";
 import Sleep from "../../Types/Sleep";
@@ -65,7 +67,47 @@ const PAYMENT_METHOD_TYPES: Array<Stripe.PaymentMethodListParams.Type> = [
   "us_bank_account",
   "bacs_debit",
 ];
-const PAYMENT_READ_MAX_RETRIES: number = 3;
+/*
+ * Four attempts spread over 1s+2s+4s was the whole budget, and CI showed it
+ * spent: every failing read took 9-10s and then 500'd, which is this ladder
+ * running out while Stripe was still rate-limiting. One more attempt roughly
+ * doubles the window without making a user-facing request pathological.
+ */
+const PAYMENT_READ_MAX_RETRIES: number = 4;
+
+// Ceiling for a single wait, so a large Retry-After cannot hang the request.
+const PAYMENT_READ_MAX_RETRY_DELAY_IN_MS: number = 8000;
+
+/*
+ * stripe-node defaults maxNetworkRetries to 0, so out of the box a dropped
+ * socket, a 409, a Stripe-side 5xx, or a 400 that Stripe itself marks retryable
+ * with `Stripe-Should-Retry: true` (lock_timeout is the common one) is not
+ * retried at all - it surfaces as a raw StripeError, which is not an
+ * OneUptime Exception, so the express handler answers an opaque
+ * 500 {"error":"Server Error"}. That is a user-visible failure of the billing
+ * page on a single upstream hiccup. The SDK's own retry generates an
+ * idempotency key per attempt, so it is safe for writes as well as reads.
+ */
+const STRIPE_MAX_NETWORK_RETRIES: number = 2;
+
+/*
+ * The SDK default is 80s. A request holding a worker for 80s on a hung socket
+ * outlives every caller that waits on it, so fail fast enough to retry.
+ */
+const STRIPE_REQUEST_TIMEOUT_IN_MS: number = 20000;
+
+/*
+ * Node's socket-level failures, which reach us with no HTTP status. Mirrors
+ * stripe-node's own CONNECTION_CLOSED_ERROR_CODES plus the timeout cases.
+ */
+const RETRYABLE_CONNECTION_ERROR_CODES: Array<string> = [
+  "ECONNRESET",
+  "EPIPE",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "EAI_AGAIN",
+  "ENOTFOUND",
+];
 
 export interface Invoice {
   id: string;
@@ -87,6 +129,8 @@ export class BillingService extends BaseService {
 
   private stripe: Stripe = new Stripe(BillingPrivateKey, {
     apiVersion: "2022-08-01",
+    maxNetworkRetries: STRIPE_MAX_NETWORK_RETRIES,
+    timeout: STRIPE_REQUEST_TIMEOUT_IN_MS,
   });
 
   // returns billing id of the customer.
@@ -1301,31 +1345,130 @@ export class BillingService extends BaseService {
     return false;
   }
 
+  /**
+   * A read that could not be completed is not the same answer as "no payment
+   * method", so this never converts a failure into a value - it retries, and
+   * then reports the outage as one. Callers stay free to fail closed.
+   */
   private async readPaymentProvider<T>(read: () => Promise<T>): Promise<T> {
     for (let attempt: number = 0; ; attempt++) {
       try {
         return await read();
       } catch (err) {
-        const providerError: { statusCode?: number } = err as {
-          statusCode?: number;
-        };
-        if (
-          providerError?.statusCode !== 429 ||
-          attempt >= PAYMENT_READ_MAX_RETRIES
-        ) {
+        if (!BillingService.isRetryablePaymentProviderRead(err)) {
+          /*
+           * A 400/401/404 is this request being wrong - a bad key, a customer
+           * that is not there. Keep it exactly as it came: renaming it "could
+           * not reach the provider" would send the reader somewhere else.
+           */
           throw err;
         }
 
+        if (attempt >= PAYMENT_READ_MAX_RETRIES) {
+          throw BillingService.toPaymentProviderReadFailure(err);
+        }
+
         /*
-         * Stripe's network retries do not generally cover rate-limit responses.
-         * Retry only these reads; exhausted failures must still deny paid usage.
+         * The SDK's own network retries are immediate and few; this is the
+         * longer, jittered wait a sustained rate limit needs. An exhausted
+         * read still denies paid usage - it never answers "no payment method".
          */
-        const delayInMs: number = Math.round(
-          1000 * 2 ** attempt * (1 + Math.random() / 2),
+        await Sleep.sleep(
+          BillingService.getPaymentReadRetryDelay(err, attempt),
         );
-        await Sleep.sleep(delayInMs);
       }
     }
+  }
+
+  /**
+   * Stripe answers a rate limit with Retry-After when it knows how long the
+   * caller should wait. Preferring our own doubling over Stripe's own number
+   * is how a retry ladder ends up firing all of its attempts inside a window
+   * the provider already said was too small.
+   */
+  private static getPaymentReadRetryDelay(
+    err: unknown,
+    attempt: number,
+  ): number {
+    const backoffInMs: number = Math.round(
+      1000 * 2 ** attempt * (1 + Math.random() / 2),
+    );
+
+    const headers: Record<string, string | undefined> =
+      ((err ?? {}) as { headers?: Record<string, string | undefined> })
+        .headers || {};
+    const retryAfterInSeconds: number = Number(
+      headers["retry-after"] ?? headers["Retry-After"],
+    );
+
+    if (!Number.isFinite(retryAfterInSeconds) || retryAfterInSeconds <= 0) {
+      return backoffInMs;
+    }
+
+    return Math.min(
+      Math.max(backoffInMs, retryAfterInSeconds * 1000),
+      PAYMENT_READ_MAX_RETRY_DELAY_IN_MS,
+    );
+  }
+
+  /**
+   * Rate limits are the documented case, but a read can also fail with no HTTP
+   * response at all - a reset or timed-out socket, which arrives with
+   * statusCode undefined - or with Stripe's own 5xx. The SDK retries those too
+   * now (STRIPE_MAX_NETWORK_RETRIES); this outer loop adds the longer,
+   * jittered backoff that a sustained rate limit needs.
+   */
+  private static isRetryablePaymentProviderRead(err: unknown): boolean {
+    const providerError: {
+      statusCode?: number;
+      type?: string;
+      code?: string;
+    } = (err ?? {}) as {
+      statusCode?: number;
+      type?: string;
+      code?: string;
+    };
+
+    if (typeof providerError.statusCode === "number") {
+      return (
+        providerError.statusCode === 429 || providerError.statusCode >= 500
+      );
+    }
+
+    /*
+     * No HTTP response was read at all. Retry only the transport failures we
+     * can name - a programming error also lands here with no statusCode, and
+     * retrying one four times just delays the real report.
+     */
+    return (
+      providerError.type === "StripeConnectionError" ||
+      providerError.type === "StripeAPIError" ||
+      RETRYABLE_CONNECTION_ERROR_CODES.includes(providerError.code || "")
+    );
+  }
+
+  /**
+   * A raw StripeError is not an OneUptime Exception, so it reaches the express
+   * handler's fallback branch and becomes an opaque 500 {"error":"Server
+   * Error"} - indistinguishable from a bug in OneUptime, and carrying nothing
+   * an operator or an E2E diagnostic can act on. Name the real condition
+   * instead: the payment provider could not be reached.
+   */
+  private static toPaymentProviderReadFailure(err: unknown): unknown {
+    if (err instanceof Exception) {
+      return err;
+    }
+
+    const providerError: { statusCode?: number; code?: string; type?: string } =
+      (err ?? {}) as { statusCode?: number; code?: string; type?: string };
+
+    logger.error(err);
+
+    return new ServiceUnavailableException(
+      `Could not reach the payment provider to read payment methods${
+        providerError.code ? ` (${providerError.code})` : ""
+      }. Please try again.`,
+    );
   }
 
   private async listPaymentMethods(

--- a/Common/Tests/Server/Services/BillingPaymentMethodServiceSync.test.ts
+++ b/Common/Tests/Server/Services/BillingPaymentMethodServiceSync.test.ts
@@ -1,0 +1,137 @@
+import { Service as BillingPaymentMethodService } from "../../../Server/Services/BillingPaymentMethodService";
+import BillingService, {
+  PaymentMethod,
+} from "../../../Server/Services/BillingService";
+import ProjectService from "../../../Server/Services/ProjectService";
+import ObjectID from "../../../Types/ObjectID";
+import { getJestSpyOn } from "../../Spy";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("stripe", () => {
+  return jest.fn(() => {
+    return {};
+  });
+});
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const CUSTOMER_ID: string = "cus_sync_test";
+
+const CARD: PaymentMethod = {
+  id: "pm_card",
+  type: "visa",
+  last4Digits: "4242",
+  isDefault: true,
+};
+
+type SettledFunction = () => Promise<void>;
+
+/*
+ * Lets both callers get past their own awaits and reach the shared sync before
+ * anything is asserted, without leaning on a fixed sleep.
+ */
+const settle: SettledFunction = async (): Promise<void> => {
+  for (let i: number = 0; i < 20; i++) {
+    await Promise.resolve();
+  }
+  await new Promise((resolve: (value: void) => void) => {
+    setTimeout(resolve, 5);
+  });
+};
+
+/*
+ * One billing page render issues two BillingPaymentMethod list requests at the
+ * same time - the table, and the unfiltered count next to it - and every list
+ * re-syncs the model from Stripe with five provider reads before it answers.
+ * That doubled the provider traffic for a single page view, and pointed two
+ * concurrent hard-delete-then-reinsert passes at the same rows.
+ */
+describe("BillingPaymentMethodService provider sync", () => {
+  let service: BillingPaymentMethodService;
+  let getPaymentMethods: jest.Mock;
+  let deleteBy: jest.Mock;
+  let create: jest.Mock;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    service = new BillingPaymentMethodService();
+
+    getJestSpyOn(ProjectService, "findOneById").mockResolvedValue({
+      id: PROJECT_ID,
+      paymentProviderCustomerId: CUSTOMER_ID,
+    } as never);
+
+    // Slow enough that a second caller is guaranteed to arrive mid-read.
+    getPaymentMethods = getJestSpyOn(
+      BillingService,
+      "getPaymentMethods",
+    ).mockImplementation((): Promise<Array<PaymentMethod>> => {
+      return new Promise((resolve: (value: Array<PaymentMethod>) => void) => {
+        setTimeout(() => {
+          return resolve([CARD]);
+        }, 40);
+      });
+    }) as unknown as jest.Mock;
+
+    deleteBy = getJestSpyOn(service, "deleteBy").mockResolvedValue(
+      undefined as never,
+    ) as unknown as jest.Mock;
+    create = getJestSpyOn(service, "create").mockResolvedValue(
+      undefined as never,
+    ) as unknown as jest.Mock;
+  });
+
+  type OnBeforeFind = (findBy: unknown) => Promise<unknown>;
+
+  const find: () => Promise<unknown> = (): Promise<unknown> => {
+    return (service as unknown as { onBeforeFind: OnBeforeFind }).onBeforeFind({
+      props: { tenantId: PROJECT_ID },
+    });
+  };
+
+  it("reads the provider once for two overlapping list requests", async () => {
+    const first: Promise<unknown> = find();
+    const second: Promise<unknown> = find();
+
+    await Promise.all([first, second]);
+
+    expect(getPaymentMethods).toHaveBeenCalledTimes(1);
+    // And only one delete-then-reinsert pass touched the rows.
+    expect(deleteBy).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives both overlapping callers the same answer", async () => {
+    const [a, b]: Array<unknown> = await Promise.all([find(), find()]);
+
+    expect((a as { carryForward: Array<PaymentMethod> }).carryForward).toEqual([
+      CARD,
+    ]);
+    expect((b as { carryForward: Array<PaymentMethod> }).carryForward).toEqual([
+      CARD,
+    ]);
+  });
+
+  it("does not cache past the in-flight window, so a newly added card is seen", async () => {
+    await find();
+    expect(getPaymentMethods).toHaveBeenCalledTimes(1);
+
+    /*
+     * A later, non-overlapping request must go back to the provider. This is
+     * the "add a card, then look at the table" path, so a cache here would
+     * show the user a table that does not contain the card they just added.
+     */
+    await find();
+    expect(getPaymentMethods).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not strand later callers when a provider read fails", async () => {
+    getPaymentMethods.mockRejectedValueOnce(new Error("provider unreachable"));
+
+    await expect(find()).rejects.toThrow("provider unreachable");
+    await settle();
+
+    // The failed sync must not be left in flight for every request after it.
+    await find();
+    expect(getPaymentMethods).toHaveBeenCalledTimes(2);
+  });
+});

--- a/Common/Tests/Server/Services/BillingServicePaymentMethodReads.test.ts
+++ b/Common/Tests/Server/Services/BillingServicePaymentMethodReads.test.ts
@@ -1,4 +1,5 @@
 import { BillingService } from "../../../Server/Services/BillingService";
+import ServiceUnavailableException from "../../../Types/Exception/ServiceUnavailableException";
 import Errors from "../../../Server/Utils/Errors";
 import Sleep from "../../../Types/Sleep";
 import { getJestSpyOn } from "../../Spy";
@@ -21,6 +22,12 @@ jest.mock("../../../Server/Services/PayAsYouGoBillingService", () => {
 });
 
 const CUSTOMER_ID: string = "cus_read_test";
+/*
+ * Mirrors the service's own constants. Kept here rather than exported so the
+ * test states the contract it is asserting instead of restating the code.
+ */
+const PAYMENT_READ_MAX_RETRIES: number = 4;
+const PAYMENT_READ_MAX_RETRY_DELAY_IN_MS: number = 8000;
 const PAYMENT_TYPES: Array<Stripe.PaymentMethodListParams.Type> = [
   "card",
   "sepa_debit",
@@ -136,10 +143,16 @@ describe("BillingService payment-method reads", () => {
   it("does not turn an unreadable bank-method list into missing payment authorization", async () => {
     const failure: Error = providerError(429);
     list.mockResolvedValueOnce({ data: [] }).mockRejectedValue(failure);
-    await expect(service.hasPaymentMethods(CUSTOMER_ID)).rejects.toBe(failure);
-    expect(list).toHaveBeenCalledTimes(5);
+    /*
+     * The answer that matters is "we could not tell", never `false` - a read
+     * that failed must not read as "this project has no payment method".
+     */
+    await expect(service.hasPaymentMethods(CUSTOMER_ID)).rejects.toThrow(
+      ServiceUnavailableException,
+    );
+    expect(list).toHaveBeenCalledTimes(1 + (PAYMENT_READ_MAX_RETRIES + 1));
     expect(list.mock.calls.slice(1)).toEqual(
-      Array.from({ length: 4 }, () => {
+      Array.from({ length: PAYMENT_READ_MAX_RETRIES + 1 }, () => {
         return [{ customer: CUSTOMER_ID, type: "sepa_debit", limit: 1 }];
       }),
     );
@@ -178,17 +191,26 @@ describe("BillingService payment-method reads", () => {
         expect(sleep.mock.calls).toEqual([[1250], [2500], [5000]]);
       });
 
-      it("propagates the exact error after exhausting 429 retries", async () => {
+      it("reports an unreachable provider after exhausting 429 retries", async () => {
         const failure: Error = providerError(429);
         request.mockRejectedValue(failure);
-        await expect(run()).rejects.toBe(failure);
-        expect(request).toHaveBeenCalledTimes(4);
-        expect(sleep).toHaveBeenCalledTimes(3);
+        /*
+         * A raw Stripe error is not an OneUptime Exception, so it used to
+         * reach the express handler's fallback and become an opaque
+         * 500 {"error":"Server Error"} - which told an operator, and the E2E
+         * diagnostic that prints the body, precisely nothing.
+         */
+        await expect(run()).rejects.toThrow(ServiceUnavailableException);
+        await expect(run()).rejects.toThrow(/payment provider/i);
+        expect(request).toHaveBeenCalledTimes(
+          2 * (PAYMENT_READ_MAX_RETRIES + 1),
+        );
+        expect(sleep).toHaveBeenCalledTimes(2 * PAYMENT_READ_MAX_RETRIES);
         expect(updateCustomer).not.toHaveBeenCalled();
       });
 
-      it.each([400, 401, 404, 500])(
-        "does not retry HTTP %s",
+      it.each([400, 401, 404])(
+        "does not retry HTTP %s, which a second attempt cannot fix",
         async (status: number) => {
           const failure: Error = providerError(status);
           request.mockRejectedValue(failure);
@@ -198,8 +220,40 @@ describe("BillingService payment-method reads", () => {
         },
       );
 
+      it.each([500, 502, 503])(
+        "retries HTTP %s, which is the provider failing rather than the request",
+        async (status: number) => {
+          const failure: Error = providerError(status);
+          request.mockRejectedValueOnce(failure);
+          await expect(run()).resolves.toBeDefined();
+          expect(request).toHaveBeenCalledTimes(2);
+          expect(sleep).toHaveBeenCalledTimes(1);
+        },
+      );
+
+      it("prefers the provider's Retry-After over its own backoff", async () => {
+        const failure: Error = Object.assign(providerError(429), {
+          headers: { "retry-after": "3" },
+        });
+        request.mockRejectedValueOnce(failure);
+        await expect(run()).resolves.toBeDefined();
+        // 3s from Retry-After beats the 1.25s first rung.
+        expect(sleep.mock.calls).toEqual([[3000]]);
+      });
+
+      it("never waits longer than the ceiling, whatever Retry-After asks for", async () => {
+        const failure: Error = Object.assign(providerError(429), {
+          headers: { "retry-after": "600" },
+        });
+        request.mockRejectedValueOnce(failure);
+        await expect(run()).resolves.toBeDefined();
+        expect(sleep.mock.calls).toEqual([
+          [PAYMENT_READ_MAX_RETRY_DELAY_IN_MS],
+        ]);
+      });
+
       it("keeps the next lookup fresh after a previous failure", async () => {
-        const failure: Error = providerError(500);
+        const failure: Error = providerError(400);
         request.mockRejectedValueOnce(failure);
         await expect(run()).rejects.toBe(failure);
         await expect(run()).resolves.toBeDefined();

--- a/Tests/Scripts/dump-container-logs.sh
+++ b/Tests/Scripts/dump-container-logs.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Dump the containers that serve /api/* into ./E2E, so a failing e2e run
+# carries the reason with it.
+#
+# The express error handler answers a 500 with a fixed {"error":"Server Error"}
+# for anything that is not an OneUptime Exception (Common/Server/Utils/
+# StartServer.ts). The class, the message and the stack only ever reach the
+# app container's stdout, and the e2e job used to dump the e2e container alone
+# — so every one of those 500s arrived in CI unexplained and the runner was
+# torn down with the answer on it.
+#
+# Runs on a path that is already failing, so it never fails: no `set -e`, and
+# every command is allowed to fall over quietly.
+
+set +e
+
+COMPOSE_FILE="${1:-docker-compose.yml}"
+OUT_DIR="${2:-./E2E/container-logs}"
+TAIL="${3:-20000}"
+
+# app serves /api/*; ingress fronts it; probe/postgres/clickhouse/valkey are
+# where an infrastructure failure would show up first.
+SERVICES="app ingress probe-1 postgres clickhouse valkey"
+
+mkdir -p "$OUT_DIR"
+
+echo "Dumping container logs from ${COMPOSE_FILE} into ${OUT_DIR}"
+
+for service in $SERVICES; do
+  out="${OUT_DIR}/${service}.log"
+  docker compose -f "$COMPOSE_FILE" logs --no-color --timestamps --tail="$TAIL" "$service" >"$out" 2>&1
+  if [ -s "$out" ]; then
+    echo "  ${service}: $(wc -l <"$out" | tr -d ' ') lines -> ${out}"
+  else
+    echo "  ${service}: no log captured"
+    rm -f "$out"
+  fi
+done
+
+# Surface the errors inline too. The uploaded artifact is the full record, but
+# a reader looking at the failed step should not have to download it first.
+if [ -f "${OUT_DIR}/app.log" ]; then
+  echo ""
+  echo "===== last 100 error lines from the app container ====="
+  grep -iE "error|exception|unhandled|stripe" "${OUT_DIR}/app.log" | tail -100
+  echo "===== end app container errors ====="
+fi
+
+exit 0


### PR DESCRIPTION
## What is red

Only one workflow is failing on master: **Push Test Images to Docker Hub and GitHub Container Registry**, job `test-e2e-test-saas` — 5 of the last 5 master pushes. Everything else is green.

The other two recent reds were already fixed on master and are confirmed passing:

| Job | Failure | Status |
|---|---|---|
| Common Test | `SecurityEventLastErrorColumnWidth`, `GoogleSecOpsConnectionsErrors` suites failed to run | fixed by `0e3b36477d`, re-ran both — pass |
| App Test | `BackupCodesCardWiring` suite failed to run | self-healed, green since |
| test-e2e-test-self-hosted | `Passkeys.spec.ts:177` — `add-passkey` detached mid-click | fixed by `d4698a0806` (project auto-select was navigating the SPA off the page) |

## Root cause

`test-e2e-test-saas` last passed on 2026-09-08; `b240925c8c` (2026-09-09) then made `addTestPaymentMethod` mandatory for every project. It has been red ever since.

All 24 failures are the **first test of their describe block** — the `beforeAll` that enrols a card. The Playwright traces in the run artifact name the cause: every failing request takes 9–10 seconds and then answers 500.

```
GET  /api/billing/pay-as-you-go-status               500   9636ms
POST /api/billing-payment-methods/get-list?limit=1   500   9092ms
POST /api/billing-payment-methods/get-list?limit=10  500  10305ms
POST /api/telemetry-ingestion-key                    402  11587ms   <- succeeded, but only just
```

9–10s is `readPaymentProvider`'s own ladder — 4 attempts over 1s+2s+4s — running out. Stripe was rate-limiting for longer than the budget. A raw `StripeError` is not an OneUptime `Exception`, so it reached the express handler's fallback and became an opaque `{"error":"Server Error"}`.

The 27 "`*****4242` row never appeared" failures are the same thing one layer up — the `error-context.md` page snapshots show the payment-methods table rendering a **"Server Error"** row, in **27 of 27** cases.

What made the rate limit reachable is call volume. Every read of `BillingPaymentMethod` re-syncs it from Stripe — four payment-method types plus the customer, five reads — and one billing page render issues **two** list requests at once (the table, and the unfiltered count beside it). Ten reads fired together for a single page view, then each failure retried four more times.

## The fix

**Cut the volume** — overlapping re-syncs for a project collapse into one. Halves the provider reads per page render, and stops two concurrent hard-delete-then-reinsert passes racing over the same rows in Postgres. Nothing is cached beyond the in-flight window, so a card added a moment ago is still read fresh.

**Make the retry budget mean something** — honour Stripe's `Retry-After` instead of always doubling from 1s, plus one more attempt. Firing a whole ladder inside a window the provider already said was too small is what produced the flat 9–10s failures.

**Retry what is actually retryable** — 5xx and named transport failures, not only 429. A 400/401/404 still propagates untouched: that is this request being wrong, and renaming it would send the reader somewhere else.

**Configure the Stripe client** — `maxNetworkRetries: 2` and a 20s timeout. The SDK defaults to **zero** retries and an 80s timeout, so a dropped socket, a 409, or a `lock_timeout` that Stripe itself marks retryable was not retried at all.

**Stop answering an opaque 500** — an exhausted read is now a 503 naming the payment provider, so a transient upstream outage is distinguishable from a OneUptime defect.

**Capture the app container logs on e2e failure.** The stack behind every one of these 500s was already being logged — to a container whose logs CI threw away, which is why five consecutive red runs produced 86 identical unactionable lines. Both e2e jobs now dump the API-serving containers into `./E2E`, which the existing artifact upload already collects.

Deliberately **not** changed: `globalTimeout` and `retries` in `playwright.config.ts`. The suite blows its 90-minute ceiling *because* of these failures — widening either would turn CI green while leaving the billing page returning "Server Error" to real users.

## Verification

- `BillingServicePaymentMethodReads` — 47 pass, updated to state the new contract (retryable vs not, `Retry-After` preference, the delay ceiling) rather than the old 429-only one.
- New `BillingPaymentMethodServiceSync` — 4 pass, covering the single-flight window, that it does **not** cache past it (the "add a card, then look at the table" path), and that a failed sync does not strand later callers.
- Full billing surface: 13 suites, 385 tests, all passing.
- `tsc --noEmit` clean on Common; eslint clean on every changed file.

**What I could not verify:** `test-e2e-test-saas` only triggers on push to master and needs the Stripe test-mode secrets, so it cannot run on this PR — the fix is validated by unit tests and by the trace evidence above, not by a green run of the job itself.

Two things worth a maintainer's judgement, not changed here:
1. `test-release.yaml` has `concurrency: cancel-in-progress: true` and the job takes ~2.5h, so most master runs are cancelled by the next push. Even a correct fix may show up as "cancelled" rather than green.
2. If the job still fails after this, the uploaded `E2E/container-logs/app.log` will now contain the actual exception — that was the point of the log capture.
