### PR TITLE
Speed up dashboard startup with smaller bundles and fewer requests

### DIFF
--- a/App/FeatureSet/Dashboard/src/App.tsx
+++ b/App/FeatureSet/Dashboard/src/App.tsx
@@ -35,29 +35,10 @@ import PageLoader from "Common/UI/Components/Loader/PageLoader";
 import ErrorBoundary from "Common/UI/Components/ErrorBoundary";
 import { RoutesProps } from "./Types/RoutesProps";
 
-// Static page imports
+// Keep the landing and recovery pages available in the initial bundle.
 import Welcome from "./Pages/Onboarding/Welcome";
 import Home from "./Pages/Home/Home";
-import AICopilot from "./Pages/AICopilot/AICopilot";
-import Sso from "./Pages/Onboarding/SSO";
-import NotOperationalMonitors from "./Pages/Home/NotOperationalMonitors";
-import HomeActiveAlerts from "./Pages/Home/ActiveAlerts";
-import OngoingScheduledEvents from "./Pages/Home/OngoingScheduledMaintenance";
-import HomeActiveEpisodes from "./Pages/Home/ActiveEpisodes";
-import HomeActiveIncidentEpisodes from "./Pages/Home/ActiveIncidentEpisodes";
-import SettingsDangerZone from "./Pages/Settings/DangerZone";
 import Logout from "./Pages/Logout/Logout";
-import UserProfilePicture from "./Pages/Global/UserProfile/Picture";
-import UserProfileOverview from "./Pages/Global/UserProfile/Index";
-import UserProfilePassword from "./Pages/Global/UserProfile/Password";
-import UseTwoFactorAuth from "./Pages/Global/UserProfile/TwoFactorAuth";
-import UserProfileDelete from "./Pages/Global/UserProfile/DeleteAccount";
-import ProjectInvitations from "./Pages/Global/ProjectInvitations";
-import ActiveIncidents from "./Pages/Global/ActiveIncidents";
-import ActiveAlerts from "./Pages/Global/ActiveAlerts";
-import ActiveAlertEpisodes from "./Pages/Global/ActiveAlertEpisodes";
-import ActiveIncidentEpisodes from "./Pages/Global/ActiveIncidentEpisodes";
-import MyOnCallPolicies from "./Pages/Global/MyOnCallPolicies";
 import PageNotFound from "./Pages/PageNotFound/PageNotFound";
 
 /*
@@ -74,6 +55,67 @@ import PageNotFound from "./Pages/PageNotFound/PageNotFound";
 type LazyRoutes = React.LazyExoticComponent<
   React.FunctionComponent<PageComponentProps>
 >;
+
+// Secondary pages download only when their route is opened.
+const AICopilot: LazyRoutes = lazy(() => {
+  return import("./Pages/AICopilot/AICopilot");
+});
+const Sso: LazyRoutes = lazy(() => {
+  return import("./Pages/Onboarding/SSO");
+});
+const NotOperationalMonitors: LazyRoutes = lazy(() => {
+  return import("./Pages/Home/NotOperationalMonitors");
+});
+const HomeActiveAlerts: LazyRoutes = lazy(() => {
+  return import("./Pages/Home/ActiveAlerts");
+});
+const OngoingScheduledEvents: LazyRoutes = lazy(() => {
+  return import("./Pages/Home/OngoingScheduledMaintenance");
+});
+const HomeActiveEpisodes: LazyRoutes = lazy(() => {
+  return import("./Pages/Home/ActiveEpisodes");
+});
+const HomeActiveIncidentEpisodes: LazyRoutes = lazy(() => {
+  return import("./Pages/Home/ActiveIncidentEpisodes");
+});
+const SettingsDangerZone: React.LazyExoticComponent<
+  typeof import("./Pages/Settings/DangerZone").default
+> = lazy(() => {
+  return import("./Pages/Settings/DangerZone");
+});
+const UserProfilePicture: LazyRoutes = lazy(() => {
+  return import("./Pages/Global/UserProfile/Picture");
+});
+const UserProfileOverview: LazyRoutes = lazy(() => {
+  return import("./Pages/Global/UserProfile/Index");
+});
+const UserProfilePassword: LazyRoutes = lazy(() => {
+  return import("./Pages/Global/UserProfile/Password");
+});
+const UseTwoFactorAuth: LazyRoutes = lazy(() => {
+  return import("./Pages/Global/UserProfile/TwoFactorAuth");
+});
+const UserProfileDelete: LazyRoutes = lazy(() => {
+  return import("./Pages/Global/UserProfile/DeleteAccount");
+});
+const ProjectInvitations: LazyRoutes = lazy(() => {
+  return import("./Pages/Global/ProjectInvitations");
+});
+const ActiveIncidents: LazyRoutes = lazy(() => {
+  return import("./Pages/Global/ActiveIncidents");
+});
+const ActiveAlerts: LazyRoutes = lazy(() => {
+  return import("./Pages/Global/ActiveAlerts");
+});
+const ActiveAlertEpisodes: LazyRoutes = lazy(() => {
+  return import("./Pages/Global/ActiveAlertEpisodes");
+});
+const ActiveIncidentEpisodes: LazyRoutes = lazy(() => {
+  return import("./Pages/Global/ActiveIncidentEpisodes");
+});
+const MyOnCallPolicies: LazyRoutes = lazy(() => {
+  return import("./Pages/Global/MyOnCallPolicies");
+});
 
 const InitRoutes: React.LazyExoticComponent<
   React.FunctionComponent<RoutesProps>

--- a/App/FeatureSet/Dashboard/src/Components/Header/Header.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Header/Header.tsx
@@ -494,134 +494,159 @@ const DashboardHeader: FunctionComponent<ComponentProps> = (
     Array<OnCallDutyPolicy>
   >([]);
 
-  const fetchCurrentOnCallDutyPolicies: PromiseVoidFunction =
-    async (): Promise<void> => {
-      try {
-        const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
-
-        if (projectId) {
-          const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
-            await API.get<JSONObject>({
-              url: URL.fromString(APP_API_URL.toString()).addRoute(
-                `/${
-                  new OnCallDutyPolicy().crudApiPath
-                }/current-on-duty-escalation-policies`,
-              ),
-              data: {},
-              headers: ModelAPI.getCommonHeaders(),
-            });
-
-          if (response.isFailure()) {
-            throw response;
-          }
-
-          const result: JSONObject = response.jsonData as JSONObject;
-
-          const escalationRulesByUser: Array<OnCallDutyPolicyEscalationRuleUser> =
-            DatabaseBaseModel.fromJSONArray(
-              result["escalationRulesByUser"] as Array<JSONObject>,
-              OnCallDutyPolicyEscalationRuleUser,
-            ) as Array<OnCallDutyPolicyEscalationRuleUser>;
-
-          const escalationRulesByTeam: Array<OnCallDutyPolicyEscalationRuleTeam> =
-            DatabaseBaseModel.fromJSONArray(
-              result["escalationRulesByTeam"] as Array<JSONObject>,
-              OnCallDutyPolicyEscalationRuleTeam,
-            ) as Array<OnCallDutyPolicyEscalationRuleTeam>;
-
-          const escalationRulesBySchedule: Array<OnCallDutyPolicyEscalationRuleSchedule> =
-            DatabaseBaseModel.fromJSONArray(
-              result["escalationRulesBySchedule"] as Array<JSONObject>,
-              OnCallDutyPolicyEscalationRuleSchedule,
-            ) as Array<OnCallDutyPolicyEscalationRuleSchedule>;
-
-          setCurrentOnCallDutyEscalationPolicyUser(escalationRulesByUser);
-          setCurrentOnCallDutyEscalationPolicyTeam(escalationRulesByTeam);
-          setCurrentOnCallDutyEscalationPolicySchedule(
-            escalationRulesBySchedule,
-          );
-
-          // now get the current on call schedules fron escalationRulesBySchedule
-          const currentOnCallPolicies: Array<OnCallDutyPolicy> = [];
-
-          for (const escalationRule of escalationRulesBySchedule) {
-            const onCallPolicy: OnCallDutyPolicy | undefined =
-              escalationRule.onCallDutyPolicy;
-
-            if (onCallPolicy) {
-              // check if the onCallPolicy is already in the currentOnCallSchedules
-              const onCallPolicyIndex: number = currentOnCallPolicies.findIndex(
-                (schedule: OnCallDutyPolicy) => {
-                  return (
-                    schedule.id?.toString() === onCallPolicy.id?.toString()
-                  );
-                },
-              );
-
-              if (onCallPolicyIndex === -1) {
-                currentOnCallPolicies.push(onCallPolicy);
-              }
-            }
-          }
-
-          // do the same for users and teams.
-          for (const escalationRule of escalationRulesByUser) {
-            const onCallPolicy: OnCallDutyPolicy | undefined =
-              escalationRule.onCallDutyPolicy;
-            if (onCallPolicy) {
-              // check if the onCallPolicy is already in the currentOnCallSchedules
-              const onCallPolicyIndex: number = currentOnCallPolicies.findIndex(
-                (schedule: OnCallDutyPolicy) => {
-                  return (
-                    schedule.id?.toString() === onCallPolicy.id?.toString()
-                  );
-                },
-              );
-              if (onCallPolicyIndex === -1) {
-                currentOnCallPolicies.push(onCallPolicy);
-              }
-            }
-          }
-
-          // do the same for teams.
-
-          for (const escalationRule of escalationRulesByTeam) {
-            const onCallPolicy: OnCallDutyPolicy | undefined =
-              escalationRule.onCallDutyPolicy;
-            if (onCallPolicy) {
-              // check if the onCallPolicy is already in the currentOnCallSchedules
-              const onCallPolicyIndex: number = currentOnCallPolicies.findIndex(
-                (schedule: OnCallDutyPolicy) => {
-                  return (
-                    schedule.id?.toString() === onCallPolicy.id?.toString()
-                  );
-                },
-              );
-              if (onCallPolicyIndex === -1) {
-                currentOnCallPolicies.push(onCallPolicy);
-              }
-            }
-          }
-
-          setCurrentOnCallPolicies(currentOnCallPolicies);
-        }
-      } catch (err) {
-        if (
-          err instanceof HTTPErrorResponse &&
-          SSOAuthorizationException.isException(err.message)
-        ) {
-          return;
-        }
-
-        setOnCallDutyPolicyFetchError(t("header.onCallPoliciesFetchError"));
-      }
-    };
+  const currentProjectId: string | undefined =
+    ProjectUtil.getCurrentProjectId()?.toString();
 
   useEffect(() => {
+    let isCancelled: boolean = false;
+
+    setCurrentOnCallPolicies([]);
+    setCurrentOnCallDutyEscalationPolicyUser([]);
+    setCurrentOnCallDutyEscalationPolicyTeam([]);
+    setCurrentOnCallDutyEscalationPolicySchedule([]);
+    setOnCallDutyPolicyFetchError(null);
+
+    const fetchCurrentOnCallDutyPolicies: PromiseVoidFunction =
+      async (): Promise<void> => {
+        try {
+          if (currentProjectId) {
+            const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+              await API.get<JSONObject>({
+                url: URL.fromString(APP_API_URL.toString()).addRoute(
+                  `/${
+                    new OnCallDutyPolicy().crudApiPath
+                  }/current-on-duty-escalation-policies`,
+                ),
+                data: {},
+                headers: ModelAPI.getCommonHeaders(),
+              });
+
+            if (response.isFailure()) {
+              throw response;
+            }
+
+            if (isCancelled) {
+              return;
+            }
+
+            const result: JSONObject = response.jsonData as JSONObject;
+
+            const escalationRulesByUser: Array<OnCallDutyPolicyEscalationRuleUser> =
+              DatabaseBaseModel.fromJSONArray(
+                result["escalationRulesByUser"] as Array<JSONObject>,
+                OnCallDutyPolicyEscalationRuleUser,
+              ) as Array<OnCallDutyPolicyEscalationRuleUser>;
+
+            const escalationRulesByTeam: Array<OnCallDutyPolicyEscalationRuleTeam> =
+              DatabaseBaseModel.fromJSONArray(
+                result["escalationRulesByTeam"] as Array<JSONObject>,
+                OnCallDutyPolicyEscalationRuleTeam,
+              ) as Array<OnCallDutyPolicyEscalationRuleTeam>;
+
+            const escalationRulesBySchedule: Array<OnCallDutyPolicyEscalationRuleSchedule> =
+              DatabaseBaseModel.fromJSONArray(
+                result["escalationRulesBySchedule"] as Array<JSONObject>,
+                OnCallDutyPolicyEscalationRuleSchedule,
+              ) as Array<OnCallDutyPolicyEscalationRuleSchedule>;
+
+            setCurrentOnCallDutyEscalationPolicyUser(escalationRulesByUser);
+            setCurrentOnCallDutyEscalationPolicyTeam(escalationRulesByTeam);
+            setCurrentOnCallDutyEscalationPolicySchedule(
+              escalationRulesBySchedule,
+            );
+
+            // now get the current on call schedules fron escalationRulesBySchedule
+            const currentOnCallPolicies: Array<OnCallDutyPolicy> = [];
+
+            for (const escalationRule of escalationRulesBySchedule) {
+              const onCallPolicy: OnCallDutyPolicy | undefined =
+                escalationRule.onCallDutyPolicy;
+
+              if (onCallPolicy) {
+                // check if the onCallPolicy is already in the currentOnCallSchedules
+                const onCallPolicyIndex: number =
+                  currentOnCallPolicies.findIndex(
+                    (schedule: OnCallDutyPolicy) => {
+                      return (
+                        schedule.id?.toString() === onCallPolicy.id?.toString()
+                      );
+                    },
+                  );
+
+                if (onCallPolicyIndex === -1) {
+                  currentOnCallPolicies.push(onCallPolicy);
+                }
+              }
+            }
+
+            // do the same for users and teams.
+            for (const escalationRule of escalationRulesByUser) {
+              const onCallPolicy: OnCallDutyPolicy | undefined =
+                escalationRule.onCallDutyPolicy;
+              if (onCallPolicy) {
+                // check if the onCallPolicy is already in the currentOnCallSchedules
+                const onCallPolicyIndex: number =
+                  currentOnCallPolicies.findIndex(
+                    (schedule: OnCallDutyPolicy) => {
+                      return (
+                        schedule.id?.toString() === onCallPolicy.id?.toString()
+                      );
+                    },
+                  );
+                if (onCallPolicyIndex === -1) {
+                  currentOnCallPolicies.push(onCallPolicy);
+                }
+              }
+            }
+
+            // do the same for teams.
+
+            for (const escalationRule of escalationRulesByTeam) {
+              const onCallPolicy: OnCallDutyPolicy | undefined =
+                escalationRule.onCallDutyPolicy;
+              if (onCallPolicy) {
+                // check if the onCallPolicy is already in the currentOnCallSchedules
+                const onCallPolicyIndex: number =
+                  currentOnCallPolicies.findIndex(
+                    (schedule: OnCallDutyPolicy) => {
+                      return (
+                        schedule.id?.toString() === onCallPolicy.id?.toString()
+                      );
+                    },
+                  );
+                if (onCallPolicyIndex === -1) {
+                  currentOnCallPolicies.push(onCallPolicy);
+                }
+              }
+            }
+
+            setCurrentOnCallPolicies(currentOnCallPolicies);
+          }
+        } catch (err) {
+          if (isCancelled) {
+            return;
+          }
+
+          if (
+            err instanceof HTTPErrorResponse &&
+            SSOAuthorizationException.isException(err.message)
+          ) {
+            return;
+          }
+
+          setOnCallDutyPolicyFetchError(t("header.onCallPoliciesFetchError"));
+        }
+      };
+
     fetchCurrentOnCallDutyPolicies().catch(() => {
       // ignore this.
     });
-  }, [props.selectedProject]);
+
+    return () => {
+      isCancelled = true;
+    };
+    // Cached and refreshed Project instances share one lookup for the same id.
+  }, [currentProjectId]);
 
   const showAddCardButton: boolean = Boolean(
     BILLING_ENABLED &&

--- a/App/Tests/Dashboard/AppShellWiring.test.ts
+++ b/App/Tests/Dashboard/AppShellWiring.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "@jest/globals";
 import fs from "fs";
 import path from "path";
+import ts from "typescript";
 
 /*
  * Source-pinning tests for the Dashboard app shell (App.tsx). The App suite
@@ -30,8 +31,6 @@ const DASHBOARD_SRC: string = path.join(
   "src",
 );
 
-const ROUTES_DIR: string = path.join(DASHBOARD_SRC, "Routes");
-
 /*
  * Comments are stripped before matching: App.tsx's own comments narrate the
  * old AllRoutes-barrel behaviour, and an assertion about the code must read
@@ -47,20 +46,42 @@ const APP_SOURCE: string = stripComments(
 
 function dynamicImportSpecifiers(source: string): Array<string> {
   const specifiers: Array<string> = [];
-  const pattern: RegExp = /\bimport\(\s*["']([^"']+)["']\s*\)/g;
+  const sourceFile: ts.SourceFile = ts.createSourceFile(
+    "App.tsx",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
 
-  let match: RegExpExecArray | null = pattern.exec(source);
-
-  while (match !== null) {
-    specifiers.push(match[1] as string);
-    match = pattern.exec(source);
-  }
+  // Import types describe lazy page props but never download a module.
+  const visit: (node: ts.Node) => void = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments[0] &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      specifiers.push(node.arguments[0].text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
 
   return specifiers;
 }
 
 describe("route splitting: each route group owns its chunk", () => {
   const specifiers: Array<string> = dynamicImportSpecifiers(APP_SOURCE);
+
+  test("counts runtime imports without counting a page's imported props type", () => {
+    expect(
+      dynamicImportSpecifiers(`
+        type Page = typeof import("./Pages/Example").default;
+        const Page = lazy(() => import("./Pages/Example"));
+      `),
+    ).toEqual(["./Pages/Example"]);
+  });
 
   test("App.tsx still declares a healthy number of lazy route groups", () => {
     // Guards the assertions below against the patterns silently matching nothing.
@@ -73,9 +94,9 @@ describe("route splitting: each route group owns its chunk", () => {
     }
   });
 
-  test("every lazily-imported module lives under ./Routes/", () => {
+  test("every lazily-imported module is a route group or standalone page", () => {
     for (const specifier of specifiers) {
-      expect(specifier).toMatch(/^\.\/Routes\//);
+      expect(specifier).toMatch(/^\.\/(Routes|Pages)\//);
     }
   });
 
@@ -100,8 +121,7 @@ describe("route splitting: each route group owns its chunk", () => {
      * mappings without hardcoding the list here.
      */
     for (const specifier of specifiers) {
-      const moduleName: string = specifier.replace(/^\.\/Routes\//, "");
-      const modulePath: string = path.join(ROUTES_DIR, moduleName + ".tsx");
+      const modulePath: string = path.join(DASHBOARD_SRC, specifier + ".tsx");
 
       expect([specifier, fs.existsSync(modulePath)]).toEqual([specifier, true]);
     }

--- a/Common/Tests/App/Dashboard/DashboardHeaderRequests.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardHeaderRequests.test.tsx
@@ -124,8 +124,10 @@ jest.mock("react-i18next", () => {
   };
 });
 
-// Keep the real header, notification bell, and error modal. These unrelated
-// controls have their own effects and are covered by the header layout tests.
+/*
+ * Keep the real header, notification bell, and error modal. These unrelated
+ * controls have their own effects and are covered by the header layout tests.
+ */
 jest.mock(
   "../../../../App/FeatureSet/Dashboard/src/Components/Header/ProjectPicker",
   () => {

--- a/Common/Tests/App/Dashboard/DashboardHeaderRequests.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardHeaderRequests.test.tsx
@@ -1,0 +1,439 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import React, { ReactElement } from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import Project from "../../../Models/DatabaseModels/Project";
+import DashboardHeader from "../../../../App/FeatureSet/Dashboard/src/Components/Header/Header";
+
+const getMock: MockFunction = getJestMockFunction();
+const countMock: MockFunction = getJestMockFunction();
+const currentProjectIdMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../Utils/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      get: (...args: Array<unknown>) => {
+        return getMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      count: (...args: Array<unknown>) => {
+        return countMock(...args);
+      },
+      getCommonHeaders: () => {
+        return {
+          tenantid: currentProjectIdMock()?.toString(),
+        };
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: () => {
+        return currentProjectIdMock();
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Realtime", () => {
+  return {
+    __esModule: true,
+    default: {
+      listenToModelEvent: () => {
+        return () => {};
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      getUserId: () => {
+        return new ObjectID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+      },
+    },
+  };
+});
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Utils/IncidentState",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        getUnresolvedIncidentStates: async () => {
+          return [];
+        },
+      },
+    };
+  },
+);
+
+jest.mock("../../../../App/FeatureSet/Dashboard/src/Utils/AlertState", () => {
+  return {
+    __esModule: true,
+    default: {
+      getUnresolvedAlertStates: async () => {
+        return [];
+      },
+    },
+  };
+});
+
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return {
+        t: (key: string, options?: { count?: number }): string => {
+          return options?.count === undefined ? key : `${key}:${options.count}`;
+        },
+      };
+    },
+  };
+});
+
+// Keep the real header, notification bell, and error modal. These unrelated
+// controls have their own effects and are covered by the header layout tests.
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Header/ProjectPicker",
+  () => {
+    return () => {
+      return null;
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Header/UserProfile",
+  () => {
+    return () => {
+      return null;
+    };
+  },
+);
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Header/Logo",
+  () => {
+    return () => {
+      return null;
+    };
+  },
+);
+
+const PROJECT_A: string = "11111111-1111-1111-1111-111111111111";
+const PROJECT_B: string = "22222222-2222-2222-2222-222222222222";
+const POLICY_A: string = "33333333-3333-3333-3333-333333333333";
+const POLICY_B: string = "44444444-4444-4444-4444-444444444444";
+const POLICY_C: string = "55555555-5555-5555-5555-555555555555";
+
+interface DeferredResponse {
+  promise: Promise<HTTPResponse<JSONObject>>;
+  resolve: (response: HTTPResponse<JSONObject>) => void;
+  reject: (error: Error) => void;
+}
+
+function deferredResponse(): DeferredResponse {
+  let resolve!: DeferredResponse["resolve"];
+  let reject!: DeferredResponse["reject"];
+
+  const promise: Promise<HTTPResponse<JSONObject>> = new Promise(
+    (
+      resolvePromise: DeferredResponse["resolve"],
+      rejectPromise: DeferredResponse["reject"],
+    ) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    },
+  );
+
+  return { promise, resolve, reject };
+}
+
+function responseForPolicies(
+  policyIds: Array<string> = [],
+): HTTPResponse<JSONObject> {
+  const rules: Array<JSONObject> = policyIds.map((id: string) => {
+    return {
+      onCallDutyPolicy: { _id: id, name: `Policy ${id}` },
+    };
+  });
+
+  return new HTTPResponse<JSONObject>(
+    200,
+    {
+      escalationRulesByUser: rules,
+      escalationRulesByTeam: [],
+      escalationRulesBySchedule: [],
+    },
+    {},
+  );
+}
+
+function project(id: string): Project {
+  const result: Project = new Project();
+  result.id = new ObjectID(id);
+  result.name = "Example project";
+  return result;
+}
+
+function header(selectedProject: Project | null): ReactElement {
+  return (
+    <DashboardHeader
+      projects={selectedProject ? [selectedProject] : []}
+      onProjectSelected={() => {}}
+      showProjectModal={false}
+      onProjectModalClose={() => {}}
+      selectedProject={selectedProject}
+    />
+  );
+}
+
+function selectCurrentProject(id: string | null): void {
+  // The real getter constructs a new ObjectID on every call.
+  currentProjectIdMock.mockImplementation(() => {
+    return id ? new ObjectID(id) : null;
+  });
+}
+
+function openNotifications(): void {
+  fireEvent.click(screen.getByRole("button", { name: "View notifications" }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  selectCurrentProject(PROJECT_A);
+  getMock.mockResolvedValue(responseForPolicies());
+  countMock.mockResolvedValue(0);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("dashboard header on-call requests", () => {
+  test("shares the cached-project boot lookup with subsequent project selection", async () => {
+    const pending: DeferredResponse = deferredResponse();
+    getMock.mockReturnValue(pending.promise);
+    const view: ReturnType<typeof render> = render(header(null));
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(getMock.mock.calls[0]?.[0].headers.tenantid).toBe(PROJECT_A);
+
+    view.rerender(header(project(PROJECT_A)));
+    view.rerender(header(project(PROJECT_A)));
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pending.resolve(responseForPolicies([POLICY_A]));
+    });
+
+    openNotifications();
+    expect(screen.getByText("header.onDutyOne:1")).toBeInTheDocument();
+  });
+
+  test("does not repeat a completed lookup when the project object is refreshed", async () => {
+    getMock.mockResolvedValue(responseForPolicies([POLICY_A]));
+    const view: ReturnType<typeof render> = render(header(project(PROJECT_A)));
+
+    await act(async () => {});
+
+    view.rerender(header(project(PROJECT_A)));
+    view.rerender(header(project(PROJECT_A)));
+    await act(async () => {});
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    openNotifications();
+    expect(screen.getByText("header.onDutyOne:1")).toBeInTheDocument();
+  });
+
+  test("skips the request until a project id is available", async () => {
+    selectCurrentProject(null);
+    const view: ReturnType<typeof render> = render(header(null));
+    await act(async () => {});
+
+    expect(getMock).not.toHaveBeenCalled();
+
+    selectCurrentProject(PROJECT_A);
+    view.rerender(header(project(PROJECT_A)));
+    await act(async () => {});
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(getMock.mock.calls[0]?.[0].headers.tenantid).toBe(PROJECT_A);
+  });
+
+  test("fetches a different project and clears the previous notification while loading", async () => {
+    getMock.mockResolvedValueOnce(responseForPolicies([POLICY_A]));
+    const view: ReturnType<typeof render> = render(header(project(PROJECT_A)));
+    await act(async () => {});
+    openNotifications();
+    expect(screen.getByText("header.onDutyOne:1")).toBeInTheDocument();
+
+    const pending: DeferredResponse = deferredResponse();
+    getMock.mockReturnValueOnce(pending.promise);
+    selectCurrentProject(PROJECT_B);
+    view.rerender(header(project(PROJECT_B)));
+
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(getMock.mock.calls[1]?.[0].headers.tenantid).toBe(PROJECT_B);
+    expect(screen.queryByText("header.onDutyOne:1")).not.toBeInTheDocument();
+
+    await act(async () => {
+      pending.resolve(responseForPolicies([POLICY_B, POLICY_C]));
+    });
+
+    expect(screen.getByText("header.onDutyOther:2")).toBeInTheDocument();
+  });
+
+  test("ignores a former project's late success after a newer lookup completes", async () => {
+    const oldRequest: DeferredResponse = deferredResponse();
+    getMock.mockReturnValueOnce(oldRequest.promise);
+    const view: ReturnType<typeof render> = render(header(project(PROJECT_A)));
+
+    selectCurrentProject(PROJECT_B);
+    getMock.mockResolvedValueOnce(responseForPolicies([POLICY_B, POLICY_C]));
+    view.rerender(header(project(PROJECT_B)));
+    await act(async () => {});
+
+    await act(async () => {
+      oldRequest.resolve(responseForPolicies([POLICY_A]));
+    });
+
+    openNotifications();
+    expect(screen.getByText("header.onDutyOther:2")).toBeInTheDocument();
+    expect(screen.queryByText("header.onDutyOne:1")).not.toBeInTheDocument();
+  });
+
+  test("ignores a former project's late failure", async () => {
+    const oldRequest: DeferredResponse = deferredResponse();
+    getMock.mockReturnValueOnce(oldRequest.promise);
+    const view: ReturnType<typeof render> = render(header(project(PROJECT_A)));
+
+    selectCurrentProject(PROJECT_B);
+    view.rerender(header(project(PROJECT_B)));
+    await act(async () => {
+      oldRequest.reject(new Error("Old project failed"));
+    });
+
+    expect(
+      screen.queryByText("header.onCallPoliciesFetchError"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("discards an old lookup even when the user returns to the same project", async () => {
+    const oldRequest: DeferredResponse = deferredResponse();
+    getMock.mockReturnValueOnce(oldRequest.promise);
+    const view: ReturnType<typeof render> = render(header(project(PROJECT_A)));
+
+    selectCurrentProject(PROJECT_B);
+    view.rerender(header(project(PROJECT_B)));
+    await act(async () => {});
+
+    selectCurrentProject(PROJECT_A);
+    getMock.mockResolvedValueOnce(responseForPolicies([POLICY_B, POLICY_C]));
+    view.rerender(header(project(PROJECT_A)));
+    await act(async () => {});
+
+    await act(async () => {
+      oldRequest.resolve(responseForPolicies([POLICY_A]));
+    });
+
+    expect(getMock).toHaveBeenCalledTimes(3);
+    openNotifications();
+    expect(screen.getByText("header.onDutyOther:2")).toBeInTheDocument();
+  });
+
+  test("clears project notifications when there is no longer a current project", async () => {
+    getMock.mockResolvedValueOnce(responseForPolicies([POLICY_A]));
+    const view: ReturnType<typeof render> = render(header(project(PROJECT_A)));
+    await act(async () => {});
+    openNotifications();
+
+    selectCurrentProject(null);
+    view.rerender(header(null));
+    await act(async () => {});
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("header.onDutyOne:1")).not.toBeInTheDocument();
+  });
+
+  test.each(["rejection", "http failure"])(
+    "still shows errors for the current project's %s",
+    async (failure: string) => {
+      if (failure === "rejection") {
+        getMock.mockRejectedValueOnce(new Error("Request failed"));
+      } else {
+        getMock.mockResolvedValueOnce(
+          new HTTPErrorResponse(500, { message: "Request failed" }, {}),
+        );
+      }
+
+      render(header(project(PROJECT_A)));
+      await act(async () => {});
+
+      expect(
+        screen.getByText("header.onCallPoliciesFetchError"),
+      ).toBeInTheDocument();
+    },
+  );
+
+  test("continues to suppress the expected SSO authorization error", async () => {
+    getMock.mockResolvedValueOnce(
+      new HTTPErrorResponse(401, { message: "SSO Authorization Required" }, {}),
+    );
+    render(header(project(PROJECT_A)));
+    await act(async () => {});
+
+    expect(
+      screen.queryByText("header.onCallPoliciesFetchError"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("starts a fresh lookup after unmounting and remounting the header", async () => {
+    const oldRequest: DeferredResponse = deferredResponse();
+    getMock.mockReturnValueOnce(oldRequest.promise);
+    const view: ReturnType<typeof render> = render(header(project(PROJECT_A)));
+    view.unmount();
+
+    getMock.mockResolvedValueOnce(responseForPolicies([POLICY_B, POLICY_C]));
+    render(header(project(PROJECT_A)));
+    await act(async () => {
+      oldRequest.resolve(responseForPolicies([POLICY_A]));
+    });
+
+    expect(getMock).toHaveBeenCalledTimes(2);
+    openNotifications();
+    expect(screen.getByText("header.onDutyOther:2")).toBeInTheDocument();
+  });
+});

--- a/Common/Tests/App/Dashboard/DashboardLazyPages.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardLazyPages.test.tsx
@@ -301,9 +301,11 @@ afterEach(() => {
 });
 
 function renderApp(path: string): void {
-  const App: React.FunctionComponent = jest.requireActual<{
-    default: React.FunctionComponent;
-  }>(`${dashboardSource}/App`).default;
+  const App: React.FunctionComponent = (
+    jest.requireActual(`${dashboardSource}/App`) as {
+      default: React.FunctionComponent;
+    }
+  ).default;
   render(
     <Router.MemoryRouter
       initialEntries={[path]}

--- a/Common/Tests/App/Dashboard/DashboardLazyPages.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardLazyPages.test.tsx
@@ -1,0 +1,452 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import * as Router from "react-router-dom";
+import PageMap from "../../../../App/FeatureSet/Dashboard/src/Utils/PageMap";
+import RouteMap from "../../../../App/FeatureSet/Dashboard/src/Utils/RouteMap";
+import type PageComponentProps from "../../../../App/FeatureSet/Dashboard/src/Pages/PageComponentProps";
+import type { ComponentProps as MasterPageProps } from "../../../../App/FeatureSet/Dashboard/src/Components/MasterPage/MasterPage";
+import type Project from "../../../Models/DatabaseModels/Project";
+import Route from "../../../Types/API/Route";
+import { CHUNK_LOAD_RELOAD_STORAGE_KEY } from "../../../UI/Components/ErrorBoundary";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * Render the real App, router, Suspense and error boundary. Mock page bodies at
+ * the module boundary so we can observe when each import actually executes,
+ * without making API calls or importing every feature's UI into this suite.
+ */
+const dashboardSource: string = "../../../../App/FeatureSet/Dashboard/src";
+const project: Project = { _id: "project-one", name: "Project One" } as Project;
+const homePath: string = "/dashboard/project-one/home/";
+const loadedPages: Array<string> = [];
+const eagerPages: Array<string> = [];
+const pageProps: Map<
+  string,
+  PageComponentProps & { onProjectDeleted?: () => Promise<void> }
+> = new Map();
+const getListMock: MockFunction = getJestMockFunction();
+const navigateMock: MockFunction = getJestMockFunction();
+let navigateHook: Router.NavigateFunction;
+let currentPath: string = homePath;
+let failingModule: string | undefined;
+
+interface PageCase {
+  page: PageMap;
+  module: string;
+}
+
+const secondaryPages: Array<PageCase> = [
+  { page: PageMap.PROJECT_SSO, module: "Onboarding/SSO" },
+  { page: PageMap.AI_COPILOT, module: "AICopilot/AICopilot" },
+  { page: PageMap.AI_COPILOT_CONVERSATION, module: "AICopilot/AICopilot" },
+  {
+    page: PageMap.HOME_NOT_OPERATIONAL_MONITORS,
+    module: "Home/NotOperationalMonitors",
+  },
+  { page: PageMap.HOME_ACTIVE_ALERTS, module: "Home/ActiveAlerts" },
+  {
+    page: PageMap.HOME_ONGOING_SCHEDULED_MAINTENANCE_EVENTS,
+    module: "Home/OngoingScheduledMaintenance",
+  },
+  { page: PageMap.HOME_ACTIVE_EPISODES, module: "Home/ActiveEpisodes" },
+  {
+    page: PageMap.HOME_ACTIVE_INCIDENT_EPISODES,
+    module: "Home/ActiveIncidentEpisodes",
+  },
+  { page: PageMap.SETTINGS_DANGERZONE, module: "Settings/DangerZone" },
+  { page: PageMap.USER_PROFILE_PICTURE, module: "Global/UserProfile/Picture" },
+  { page: PageMap.USER_PROFILE_OVERVIEW, module: "Global/UserProfile/Index" },
+  {
+    page: PageMap.USER_PROFILE_PASSWORD,
+    module: "Global/UserProfile/Password",
+  },
+  {
+    page: PageMap.USER_TWO_FACTOR_AUTH,
+    module: "Global/UserProfile/TwoFactorAuth",
+  },
+  {
+    page: PageMap.USER_PROFILE_DELETE,
+    module: "Global/UserProfile/DeleteAccount",
+  },
+  { page: PageMap.PROJECT_INVITATIONS, module: "Global/ProjectInvitations" },
+  { page: PageMap.ACTIVE_INCIDENTS, module: "Global/ActiveIncidents" },
+  { page: PageMap.ACTIVE_ALERTS, module: "Global/ActiveAlerts" },
+  { page: PageMap.ACTIVE_ALERT_EPISODES, module: "Global/ActiveAlertEpisodes" },
+  {
+    page: PageMap.ACTIVE_INCIDENT_EPISODES,
+    module: "Global/ActiveIncidentEpisodes",
+  },
+  { page: PageMap.MY_ON_CALL_POLICIES, module: "Global/MyOnCallPolicies" },
+];
+
+jest.mock("../../../UI/Config", () => {
+  return {
+    BILLING_ENABLED: false,
+    APP_API_URL: {
+      toString: () => {
+        return "http://localhost/api";
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ErrorSupportBundle", () => {
+  return { downloadErrorSupportBundle: jest.fn() };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<unknown>) => {
+        return getListMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      getFriendlyMessage: (error: Error) => {
+        return error.message;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Navigation", () => {
+  return {
+    __esModule: true,
+    default: {
+      setNavigateHook: (hook: Router.NavigateFunction) => {
+        navigateHook = hook;
+      },
+      setLocation: (location: Router.Location) => {
+        currentPath = location.pathname;
+      },
+      setParams: jest.fn(),
+      getCurrentRoute: () => {
+        return new Route(currentPath);
+      },
+      navigate: (route: Route) => {
+        navigateMock(route);
+        navigateHook(route.toString());
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Project", () => {
+  return { __esModule: true, default: { setCurrentProject: jest.fn() } };
+});
+
+jest.mock("../../../UI/Utils/GlobalEvents", () => {
+  return {
+    __esModule: true,
+    default: { addEventListener: jest.fn(), removeEventListener: jest.fn() },
+  };
+});
+
+jest.mock("../../../Models/DatabaseModels/Project", () => {
+  return { __esModule: true, default: class Project {} };
+});
+
+jest.mock("../../../Models/DatabaseModels/BillingPaymentMethod", () => {
+  return { __esModule: true, default: class BillingPaymentMethod {} };
+});
+
+jest.mock("../../../UI/Components/Loader/PageLoader", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return <div data-testid="page-loader">Loading page</div>;
+    },
+  };
+});
+
+function pathFor(page: PageMap): string {
+  return RouteMap[page]!.toString()
+    .replace(":projectId", "project-one")
+    .replace(":id", "conversation-one");
+}
+
+beforeEach(() => {
+  // Each test starts with a cold module cache, like a fresh dashboard document.
+  jest.resetModules();
+  jest.clearAllMocks();
+  loadedPages.length = 0;
+  eagerPages.length = 0;
+  pageProps.clear();
+  failingModule = undefined;
+  currentPath = homePath;
+  getListMock.mockResolvedValue({ data: [project], count: 1 });
+  sessionStorage.clear();
+
+  // Keep the renderer and router on the same React instance after resetting.
+  jest.doMock("react", () => {
+    return React;
+  });
+  jest.doMock("react-router-dom", () => {
+    return Router;
+  });
+
+  for (const module of new Set(
+    secondaryPages.map((page: PageCase): string => {
+      return page.module;
+    }),
+  )) {
+    jest.doMock(`${dashboardSource}/Pages/${module}`, () => {
+      loadedPages.push(module);
+      if (module === failingModule) {
+        throw new Error("Failed to fetch dynamically imported module");
+      }
+      return {
+        __esModule: true,
+        default: (props: PageComponentProps): React.ReactElement => {
+          pageProps.set(module, props);
+          return <div data-testid="secondary-page">{module}</div>;
+        },
+      };
+    });
+  }
+
+  for (const module of [
+    "Home/Home",
+    "Onboarding/Welcome",
+    "Logout/Logout",
+    "PageNotFound/PageNotFound",
+  ]) {
+    jest.doMock(`${dashboardSource}/Pages/${module}`, () => {
+      eagerPages.push(module);
+      return {
+        __esModule: true,
+        default: (props: PageComponentProps): React.ReactElement => {
+          pageProps.set(module, props);
+          return <div data-testid="eager-page">{module}</div>;
+        },
+      };
+    });
+  }
+
+  for (const module of [
+    "AIChat/AIChatPanel",
+    "CommandPalette/DashboardCommandPalette",
+    "KeyboardShortcuts/DashboardKeyboardShortcuts",
+    "UserTimezone/UserTimezoneInit",
+  ]) {
+    jest.doMock(`${dashboardSource}/Components/${module}`, () => {
+      return {
+        __esModule: true,
+        default: () => {
+          return null;
+        },
+      };
+    });
+  }
+
+  jest.doMock(`${dashboardSource}/Components/MasterPage/MasterPage`, () => {
+    return {
+      __esModule: true,
+      default: (props: MasterPageProps): React.ReactElement => {
+        return (
+          <div>
+            <header>Dashboard shell</header>
+            <button
+              onClick={() => {
+                props.onProjectSelected(project);
+              }}
+            >
+              Select project
+            </button>
+            <div data-testid="project-count">{props.projects.length}</div>
+            {props.children}
+          </div>
+        );
+      },
+    };
+  });
+
+  jest.doMock(`${dashboardSource}/Routes/InitRoutes`, () => {
+    return {
+      __esModule: true,
+      default: () => {
+        return <div>Project selection</div>;
+      },
+    };
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  jest.restoreAllMocks();
+  sessionStorage.clear();
+});
+
+function renderApp(path: string): void {
+  const App: React.FunctionComponent = jest.requireActual<{
+    default: React.FunctionComponent;
+  }>(`${dashboardSource}/App`).default;
+  render(
+    <Router.MemoryRouter
+      initialEntries={[path]}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <App />
+    </Router.MemoryRouter>,
+  );
+}
+
+describe("dashboard secondary page loading", () => {
+  test("renders Home without loading any secondary page modules", async () => {
+    renderApp(homePath);
+
+    expect(screen.getByTestId("eager-page")).toHaveTextContent("Home/Home");
+    expect(screen.queryByTestId("page-loader")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId("project-count")).toHaveTextContent("1");
+    });
+    expect(loadedPages).toEqual([]);
+    expect(eagerPages).toEqual([
+      "Onboarding/Welcome",
+      "Home/Home",
+      "Logout/Logout",
+      "PageNotFound/PageNotFound",
+    ]);
+    expect(pageProps.get("Home/Home")).toMatchObject({
+      projects: [project],
+      isLoadingProjects: false,
+    });
+  });
+
+  test.each(secondaryPages)(
+    "loads only $module for a direct $page navigation and keeps its props",
+    async (page: PageCase) => {
+      renderApp(pathFor(page.page));
+
+      expect(screen.getByTestId("page-loader")).toBeInTheDocument();
+      expect(screen.getByText("Dashboard shell")).toBeInTheDocument();
+      expect(await screen.findByTestId("secondary-page")).toHaveTextContent(
+        page.module,
+      );
+      expect(screen.queryByTestId("page-loader")).not.toBeInTheDocument();
+      expect(loadedPages).toEqual([page.module]);
+      expect(pageProps.get(page.module)).toMatchObject({
+        currentProject: null,
+        hasPaymentMethod: true,
+      });
+      expect(pageProps.get(page.module)!.pageRoute.toString()).toBe(
+        RouteMap[page.page]!.toString(),
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Select project" }));
+      await waitFor(() => {
+        expect(pageProps.get(page.module)!.currentProject).toBe(project);
+      });
+      expect(pageProps.get(page.module)!.pageRoute.toString()).toBe(
+        RouteMap[page.page]!.toString(),
+      );
+      expect(loadedPages).toEqual([page.module]);
+      expect(navigateMock).not.toHaveBeenCalled();
+    },
+  );
+
+  test("loads pages when navigating from Home and reuses them on return", async () => {
+    renderApp(homePath);
+    await waitFor(() => {
+      expect(screen.getByTestId("project-count")).toHaveTextContent("1");
+    });
+    expect(loadedPages).toEqual([]);
+
+    await act(async () => {
+      navigateHook(pathFor(PageMap.USER_PROFILE_OVERVIEW));
+    });
+    expect(await screen.findByTestId("secondary-page")).toHaveTextContent(
+      "Global/UserProfile/Index",
+    );
+    await act(async () => {
+      navigateHook(pathFor(PageMap.ACTIVE_ALERTS));
+    });
+    expect(await screen.findByTestId("secondary-page")).toHaveTextContent(
+      "Global/ActiveAlerts",
+    );
+    await act(async () => {
+      navigateHook(pathFor(PageMap.USER_PROFILE_OVERVIEW));
+    });
+    expect(screen.getByTestId("secondary-page")).toHaveTextContent(
+      "Global/UserProfile/Index",
+    );
+    expect(loadedPages).toEqual([
+      "Global/UserProfile/Index",
+      "Global/ActiveAlerts",
+    ]);
+  });
+
+  test("preserves the project-deleted callback on the deferred danger zone page", async () => {
+    renderApp(pathFor(PageMap.SETTINGS_DANGERZONE));
+    await screen.findByTestId("secondary-page");
+    fireEvent.click(screen.getByRole("button", { name: "Select project" }));
+    expect(pageProps.get("Settings/DangerZone")!.currentProject).toBe(project);
+    getListMock.mockResolvedValueOnce({ data: [], count: 0 });
+
+    await act(async () => {
+      await pageProps.get("Settings/DangerZone")!.onProjectDeleted!();
+    });
+
+    expect(await screen.findByText("Project selection")).toBeInTheDocument();
+    expect(getListMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId("project-count")).toHaveTextContent("0");
+    expect(navigateMock.mock.calls[0]![0].toString()).toBe(
+      RouteMap[PageMap.INIT]!.toString(),
+    );
+  });
+
+  test("contains a failed page import and recovers when navigating Home", async () => {
+    failingModule = "Global/UserProfile/Index";
+    // Exercise fallback after the existing one-reload chunk recovery is exhausted.
+    sessionStorage.setItem(
+      CHUNK_LOAD_RELOAD_STORAGE_KEY,
+      Date.now().toString(),
+    );
+    jest.spyOn(console, "error").mockImplementation(() => {
+      return;
+    });
+    renderApp(pathFor(PageMap.USER_PROFILE_OVERVIEW));
+
+    expect(
+      await screen.findByTestId("error-boundary-fallback"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Dashboard shell")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("error-boundary-error-message"),
+    ).toHaveTextContent("Failed to fetch dynamically imported module");
+    expect(loadedPages).toEqual(["Global/UserProfile/Index"]);
+
+    await act(async () => {
+      navigateHook(homePath);
+    });
+
+    expect(screen.getByTestId("eager-page")).toHaveTextContent("Home/Home");
+    expect(
+      screen.queryByTestId("error-boundary-fallback"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Dashboard shell")).toBeInTheDocument();
+  });
+});

--- a/Common/Tests/App/Dashboard/DashboardLazyPages.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardLazyPages.test.tsx
@@ -188,6 +188,22 @@ function pathFor(page: PageMap): string {
     .replace(":id", "conversation-one");
 }
 
+function mockSecondaryPage(module: string): void {
+  jest.doMock(`${dashboardSource}/Pages/${module}`, () => {
+    loadedPages.push(module);
+    if (module === failingModule) {
+      throw new Error("Failed to fetch dynamically imported module");
+    }
+    return {
+      __esModule: true,
+      default: (props: PageComponentProps): React.ReactElement => {
+        pageProps.set(module, props);
+        return <div data-testid="secondary-page">{module}</div>;
+      },
+    };
+  });
+}
+
 beforeEach(() => {
   // Each test starts with a cold module cache, like a fresh dashboard document.
   jest.resetModules();
@@ -213,19 +229,7 @@ beforeEach(() => {
       return page.module;
     }),
   )) {
-    jest.doMock(`${dashboardSource}/Pages/${module}`, () => {
-      loadedPages.push(module);
-      if (module === failingModule) {
-        throw new Error("Failed to fetch dynamically imported module");
-      }
-      return {
-        __esModule: true,
-        default: (props: PageComponentProps): React.ReactElement => {
-          pageProps.set(module, props);
-          return <div data-testid="secondary-page">{module}</div>;
-        },
-      };
-    });
+    mockSecondaryPage(module);
   }
 
   for (const module of [

--- a/Common/Tests/UI/ColorPickerBuild.test.ts
+++ b/Common/Tests/UI/ColorPickerBuild.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "@jest/globals";
+import childProcess from "child_process";
+import path from "path";
+
+const COMMON_ROOT: string = path.resolve(__dirname, "..", "..");
+const PICKER_SOURCE: string = path.join(
+  COMMON_ROOT,
+  "UI/Components/Forms/Fields/ColorPicker.tsx",
+);
+const COLOR_CONTROL_MODULE: RegExp =
+  /^(lib|es)\/(components\/(chrome|common)\/|helpers\/)/;
+
+/*
+ * FormField reaches this component even on pages without a color field. The
+ * react-color barrel included every picker implementation in those pages'
+ * bundles. Build the actual component with the frontend configuration and
+ * inspect emitted modules, so tree-shaking and type-only imports are accounted
+ * for. A subprocess supplies the native Node environment esbuild requires.
+ */
+function bundledColorModules(nodeEnv: string): Array<string> {
+  const script: string = `
+    const path = require("path");
+    const commonRoot = ${JSON.stringify(COMMON_ROOT)};
+    const esbuild = require(require.resolve("esbuild", { paths: [commonRoot] }));
+    const { createConfig } = require(path.join(commonRoot, "UI/esbuild-config.js"));
+    const config = createConfig({
+      serviceName: "Dashboard",
+      publicPath: "/dashboard/dist/",
+      entryPoint: ${JSON.stringify(PICKER_SOURCE)},
+    });
+
+    esbuild.build({
+      ...config,
+      write: false,
+      sourcemap: false,
+      metafile: true,
+      logLevel: "silent",
+    }).then((result) => {
+      const included = new Set();
+      for (const output of Object.values(result.metafile.outputs)) {
+        for (const [input, contribution] of Object.entries(output.inputs)) {
+          if (contribution.bytesInOutput > 0 && input.includes("/react-color/")) {
+            included.add(input.split("/react-color/")[1]);
+          }
+        }
+      }
+      console.log(JSON.stringify([...included].sort()));
+    }).catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+  `;
+
+  return JSON.parse(
+    childProcess.execFileSync(process.execPath, ["-e", script], {
+      cwd: COMMON_ROOT,
+      env: { ...process.env, NODE_ENV: nodeEnv },
+      encoding: "utf8",
+      timeout: 60000,
+      maxBuffer: 1024 * 1024,
+    }),
+  ) as Array<string>;
+}
+
+describe("color picker frontend bundle", () => {
+  test.each(["production", "development"])(
+    "includes Chrome and shared controls without the other pickers in %s",
+    (nodeEnv: string) => {
+      const modules: Array<string> = bundledColorModules(nodeEnv);
+
+      expect(modules).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^(lib|es)\/components\/chrome\/Chrome\.js$/),
+          expect.stringMatching(
+            /^(lib|es)\/components\/common\/ColorWrap\.js$/,
+          ),
+        ]),
+      );
+      expect(
+        modules.filter((modulePath: string) => {
+          return !COLOR_CONTROL_MODULE.test(modulePath);
+        }),
+      ).toEqual([]);
+    },
+  );
+});

--- a/Common/Tests/UI/ReactDomBuild.test.ts
+++ b/Common/Tests/UI/ReactDomBuild.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "@jest/globals";
+import childProcess from "child_process";
+import path from "path";
+
+const COMMON_ROOT: string = path.resolve(__dirname, "..", "..");
+
+interface RendererBuild {
+  rendererFiles: Array<string>;
+  clientFiles: Array<string>;
+  foreignRendererFiles: Array<string>;
+  outputBytes: number;
+}
+
+describe("frontend renderer deduplication", () => {
+  test.each(["production", "development"])(
+    "bundles one renderer for the entry point and shared portals in %s",
+    (environment: string) => {
+      // Use a subprocess because esbuild requires Node's native Uint8Array.
+      // Separate physical installs reproduce the app/Common package layout;
+      // symlinking both to one install would hide the original duplication.
+      const result: RendererBuild = JSON.parse(
+        childProcess.execFileSync(
+          process.execPath,
+          [
+            "-e",
+            String.raw`
+              const fs = require("fs");
+              const os = require("os");
+              const path = require("path");
+              const esbuild = require("esbuild");
+              const { createConfig } = require("./UI/esbuild-config");
+              const reactDomRoot = path.dirname(require.resolve("react-dom/package.json"));
+              const root = fs.mkdtempSync(path.join(os.tmpdir(), "oneuptime-renderer-"));
+
+              async function run() {
+                try {
+                  for (const name of ["app", "shared"]) {
+                    const destination = path.join(root, name, "node_modules/react-dom");
+                    fs.cpSync(reactDomRoot, destination, { recursive: true });
+                  }
+
+                  const entry = path.join(root, "app/index.js");
+                  fs.writeFileSync(entry, [
+                    'import { createRoot } from "react-dom/client";',
+                    'export { createRoot };',
+                    'export { createPortal, flushSync } from "../shared/index.js";',
+                  ].join("\n"));
+                  fs.writeFileSync(path.join(root, "shared/index.js"),
+                    'export { createPortal, flushSync } from "react-dom";');
+
+                  const config = createConfig({
+                    serviceName: "Dashboard",
+                    publicPath: "/dashboard/dist/",
+                    entryPoint: entry,
+                    outdir: path.join(root, "dist"),
+                  });
+                  const built = await esbuild.build({
+                    ...config,
+                    nodePaths: [path.resolve("node_modules")],
+                    metafile: true,
+                    write: false,
+                    logLevel: "silent",
+                  });
+                  const inputs = Object.keys(built.metafile.inputs);
+                  const rendererFiles = inputs.filter((file) =>
+                    /react-dom[/\\]cjs[/\\]react-dom\.(production\.min|development)\.js$/.test(file));
+                  const clientFiles = inputs.filter((file) => /react-dom[/\\]client\.js$/.test(file));
+                  const foreignRendererFiles = inputs.filter((file) =>
+                    path.resolve(file).startsWith(root) && file.includes("react-dom"));
+                  console.log(JSON.stringify({
+                    rendererFiles,
+                    clientFiles,
+                    foreignRendererFiles,
+                    outputBytes: built.outputFiles.reduce((sum, file) => sum + file.contents.length, 0),
+                  }));
+                } finally {
+                  fs.rmSync(root, { recursive: true, force: true });
+                }
+              }
+              run().catch((error) => { console.error(error); process.exitCode = 1; });
+            `,
+          ],
+          {
+            cwd: COMMON_ROOT,
+            env: { ...process.env, NODE_ENV: environment },
+            encoding: "utf8",
+          },
+        ),
+      ) as RendererBuild;
+
+      expect(result.outputBytes).toBeGreaterThan(0);
+      expect(result.rendererFiles).toHaveLength(1);
+      expect(result.rendererFiles[0]).toContain(
+        environment === "production"
+          ? "react-dom.production.min.js"
+          : "react-dom.development.js",
+      );
+      expect(result.clientFiles).toHaveLength(1);
+      expect(result.foreignRendererFiles).toEqual([]);
+    },
+  );
+});

--- a/Common/Tests/UI/ReactDomBuild.test.ts
+++ b/Common/Tests/UI/ReactDomBuild.test.ts
@@ -15,9 +15,11 @@ describe("frontend renderer deduplication", () => {
   test.each(["production", "development"])(
     "bundles one renderer for the entry point and shared portals in %s",
     (environment: string) => {
-      // Use a subprocess because esbuild requires Node's native Uint8Array.
-      // Separate physical installs reproduce the app/Common package layout;
-      // symlinking both to one install would hide the original duplication.
+      /*
+       * Use a subprocess because esbuild requires Node's native Uint8Array.
+       * Separate physical installs reproduce the app/Common package layout;
+       * symlinking both to one install would hide the original duplication.
+       */
       const result: RendererBuild = JSON.parse(
         childProcess.execFileSync(
           process.execPath,

--- a/Common/UI/Components/Forms/Fields/ColorPicker.tsx
+++ b/Common/UI/Components/Forms/Fields/ColorPicker.tsx
@@ -14,7 +14,8 @@ import React, {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
-import { ChromePicker, ColorResult } from "react-color";
+import ChromePicker from "react-color/lib/components/chrome/Chrome";
+import type { ColorResult } from "react-color";
 
 // ChromePicker renders at a fixed intrinsic width.
 const COLOR_PICKER_POPUP_WIDTH_PX: number = 225;

--- a/Common/UI/esbuild-config.js
+++ b/Common/UI/esbuild-config.js
@@ -304,6 +304,7 @@ function createConfig(options) {
   const isDev = process.env.NODE_ENV !== "production";
   const isAnalyze = process.env.analyze === "true";
   const reactRoot = resolvePackageRoot("react");
+  const reactDomRoot = resolvePackageRoot("react-dom");
   const reactRouterRoot = resolvePackageRoot("react-router");
   const reactRouterDomRoot = resolvePackageRoot("react-router-dom");
   const reactI18nextRoot = resolvePackageRoot("react-i18next");
@@ -356,6 +357,9 @@ function createConfig(options) {
     external: ["react-native-sqlite-storage", ...additionalExternal],
     alias: {
       react: reactRoot,
+      // Shared controls use portals while the entry point uses react-dom/client.
+      // Resolve both to one renderer even when each package installs its own copy.
+      "react-dom": reactDomRoot,
       "react/jsx-runtime": path.join(reactRoot, "jsx-runtime.js"),
       "react/jsx-dev-runtime": path.join(reactRoot, "jsx-dev-runtime.js"),
       // Public dashboards reuse widgets from the private dashboard package.


### PR DESCRIPTION
### Title of this pull request?

Speed up dashboard startup with smaller bundles and fewer requests

### Small Description?

Dashboard startup eagerly loaded secondary pages, two React DOM renderers, and every color-picker implementation. It also repeated the on-call lookup when a cached project was replaced by a fresh object with the same ID.

- Load 19 secondary pages on demand through the existing Suspense and error boundary, preserving routes and props.
- Share one React DOM renderer across the frontend and shared controls; import only the Chrome color picker.
- Key the on-call lookup by project ID and ignore responses belonging to a previous project.

Production build measurement with the same installed dependencies: **7,347,708 → 6,803,812 bytes of initial JavaScript (-543,896 bytes / 7.4%)**, and **101 → 93 initial JS files**. This counts the entry point and transitive static imports from esbuild's production metafile; it is a bundle measurement, not a load-time benchmark.

Validation:
- **140 targeted tests passed across 12 suites**, including 41 new tests for route loading/error recovery, request deduplication/stale responses, and production/development bundle contents.
- Existing picker interactions, header layouts, and frontend build configuration tests passed. Most runtime suites used a temporary ts-jest isolatedModules CLI override; the repository test configuration is unchanged.
- Production dashboard build passed.
- Browser smoke against the production frontend with a stubbed API: Home and password-page direct links, then in-app navigation to two-factor authentication; no JavaScript errors, deferred chunks loaded on navigation, and one on-call startup lookup. The configured Docker development host was unreachable.
- Strict TypeScript checking of all four new Common test files passed with zero diagnostics.
- Common, App, and Dashboard compilation passed in CI on the final commit.
- Full CI lint passed on the final commit. Local root `npm run fix` terminated before completion (SIGTERM), and a focused recheck reached the Node heap limit; local formatting checks passed for all changed files.

### Pull Request Checklist:

- [ ] Please make sure all jobs pass before requesting a review.
- [ ] Have you lint your code locally before submission? (Attempted locally; full CI lint passed. See validation above.)
- [x] Did you write tests where appropriate?

### Related Issue?

None; dashboard loading performance investigation.
