### PR TITLE
fix(forms): stop the invite form throwing away what the user types

### DIFF
--- a/Common/Tests/UI/Components/Forms/ModelFormPreservesUserInput.test.tsx
+++ b/Common/Tests/UI/Components/Forms/ModelFormPreservesUserInput.test.tsx
@@ -1,0 +1,937 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
+import * as React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Nobody could invite a user.
+ *
+ * Type a valid email into the invite form, press Tab, and the email vanished -
+ * placeholder and all. Type again and characters disappeared as they were
+ * entered; the reporter's recording ends with a lone "@" in an otherwise empty
+ * box.
+ *
+ * The form was not losing the value. It was being destroyed and rebuilt:
+ *
+ *   1. The Email field calls back into the page on every keystroke so the page
+ *      can check whether that address already has a OneUptime account.
+ *   2. When the check resolves, the page sets state and re-renders - and its
+ *      `fields` array is an inline literal in JSX, so ModelForm sees a brand
+ *      new array identity.
+ *   3. ModelForm's field-preparation effect is keyed on that identity, so it
+ *      re-ran and re-fetched the Team dropdown's options.
+ *   4. While that request was in flight ModelForm returned <Loader/> INSTEAD OF
+ *      the form. A different element in the same position unmounts the subtree,
+ *      and a form's values live in that subtree - in BasicForm's refs and in
+ *      each Input's own state, because Input is DOM-uncontrolled.
+ *   5. The request finished, the form remounted from empty initial values, and
+ *      everything typed in the meantime was gone.
+ *
+ * Nothing here is specific to the invite form. Practically every ModelForm in
+ * the product writes its fields as an inline literal, so any page that changes
+ * state while someone types into its form had the same bug waiting.
+ *
+ * These tests drive the real ModelForm against the real TeamMember/Team models
+ * and assert on the DOM the user is actually looking at.
+ */
+
+let permissionsForTest: Array<unknown> = [];
+
+/*
+ * ModelForm reads the merged list for its model-level gate but the global and
+ * project snapshots directly for per-column checks, so all three have to agree
+ * or fields get stripped for reasons unrelated to what is being tested.
+ */
+jest.mock("../../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<unknown> => {
+        return permissionsForTest;
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): { globalPermissions: Array<unknown> } => {
+        return { globalPermissions: permissionsForTest };
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return false;
+      },
+      getUserId: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined): string | undefined => {
+          return value;
+        },
+        translateValue: (value: unknown): unknown => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+/*
+ * Every list request the form makes, and how it is allowed to finish.
+ *
+ * "deferred" hands back a promise the test resolves by hand, which is the only
+ * way to observe the window the bug lived in. "immediate" still crosses a
+ * macrotask boundary, because React 18 batches everything inside one task -
+ * resolving synchronously would hide the very loading render being tested.
+ */
+interface ListRequest {
+  tableName: string;
+  resolve: () => void;
+}
+
+let listRequests: Array<ListRequest> = [];
+let listMode: "immediate" | "deferred" = "immediate";
+let listRowsByTableName: Record<string, Array<unknown>> = {};
+
+jest.mock("../../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getItem: async (): Promise<null> => {
+        return null;
+      },
+      getList: async (data: {
+        modelType: { new (): { tableName: string | null } };
+      }): Promise<{
+        data: Array<unknown>;
+        count: number;
+        skip: number;
+        limit: number;
+      }> => {
+        const tableName: string = new data.modelType().tableName || "";
+
+        let releaseRequest: () => void = (): void => {};
+
+        const requestFinished: Promise<void> = new Promise<void>(
+          (innerResolve: () => void) => {
+            releaseRequest = innerResolve;
+          },
+        );
+
+        listRequests.push({ tableName: tableName, resolve: releaseRequest });
+
+        if (listMode === "immediate") {
+          setTimeout(releaseRequest, 0);
+        }
+
+        await requestFinished;
+
+        const rows: Array<unknown> = listRowsByTableName[tableName] || [];
+
+        return { data: rows, count: rows.length, skip: 0, limit: 50 };
+      },
+      createOrUpdate: async (): Promise<null> => {
+        return null;
+      },
+    },
+  };
+});
+
+import ModelForm, { FormType } from "../../../../UI/Components/Forms/ModelForm";
+import BasicForm from "../../../../UI/Components/Forms/BasicForm";
+import FormFieldSchemaType from "../../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import Fields from "../../../../UI/Components/Forms/Types/Fields";
+import FormValues from "../../../../UI/Components/Forms/Types/FormValues";
+import PermissionGate from "../../../../UI/Utils/PermissionGate";
+import TeamMember from "../../../../Models/DatabaseModels/TeamMember";
+import Team from "../../../../Models/DatabaseModels/Team";
+import Label from "../../../../Models/DatabaseModels/Label";
+import Email from "../../../../Types/Email";
+import ObjectID from "../../../../Types/ObjectID";
+import Permission from "../../../../Types/Permission";
+import getJestMockFunction, { MockFunction } from "../../../MockType";
+
+const EMAIL_PLACEHOLDER: string = "member@company.com";
+const TEAM_PLACEHOLDER: string = "Select a team";
+const VALID_EMAIL: string = "member@company.com";
+
+type SetRegisteredStatusFunction = (value: boolean | null) => void;
+
+interface InviteFormHarnessProps {
+  onReady: (setRegisteredStatus: SetRegisteredStatusFunction) => void;
+  // Mirrors the real page adding a second entity dropdown to the same form.
+  showLabelField?: boolean | undefined;
+}
+
+/*
+ * As close to App/FeatureSet/Dashboard/src/Pages/Users/Index.tsx as a test can
+ * get: page-level state, a `fields` array written inline in JSX so it is a new
+ * identity on every render, an Email field that reports every keystroke back to
+ * the page, and a required Team dropdown whose options come from the API.
+ *
+ * The real page debounces the account check by 400ms; here it resolves
+ * synchronously so the test pins the behaviour rather than the timing.
+ */
+const InviteFormHarness: React.FunctionComponent<InviteFormHarnessProps> = (
+  props: InviteFormHarnessProps,
+): React.ReactElement => {
+  const [isEmailRegistered, setIsEmailRegistered] = React.useState<
+    boolean | null
+  >(null);
+
+  const { onReady } = props;
+
+  React.useEffect(() => {
+    onReady(setIsEmailRegistered);
+  }, [onReady]);
+
+  return (
+    <ModelForm<TeamMember>
+      modelType={TeamMember}
+      name="Invite New User"
+      id="invite-user-form"
+      formType={FormType.Create}
+      submitButtonText="Invite"
+      onSuccess={() => {}}
+      fields={[
+        {
+          field: { user: true },
+          title: "Email",
+          fieldType: FormFieldSchemaType.Email,
+          required: true,
+          placeholder: EMAIL_PLACEHOLDER,
+          overrideFieldKey: "email",
+          onChange: (value: string) => {
+            setIsEmailRegistered(Email.isValid(value) ? true : null);
+          },
+        },
+        {
+          field: { user: true },
+          title: "Name",
+          fieldType: FormFieldSchemaType.Text,
+          required: false,
+          placeholder: "John Smith",
+          overrideFieldKey: "name",
+          showIf: (): boolean => {
+            return isEmailRegistered === false;
+          },
+        },
+        ...(props.showLabelField
+          ? [
+              {
+                field: { team: true },
+                title: "Label",
+                fieldType: FormFieldSchemaType.Dropdown,
+                required: false,
+                overrideFieldKey: "labelPicker",
+                dropdownModal: {
+                  type: Label,
+                  labelField: "name",
+                  valueField: "_id",
+                },
+                placeholder: "Select a label",
+              },
+            ]
+          : []),
+        {
+          field: { team: true },
+          title: "Team",
+          fieldType: FormFieldSchemaType.Dropdown,
+          required: true,
+          dropdownModal: {
+            type: Team,
+            labelField: "name",
+            valueField: "_id",
+          },
+          placeholder: TEAM_PLACEHOLDER,
+        },
+      ]}
+    />
+  );
+};
+
+/*
+ * Page state changes are driven through waitFor rather than act on purpose.
+ * act() flushes the whole cascade in one go, which batches the unmount and the
+ * remount into a single commit - the form never actually leaves the DOM, and
+ * the bug these tests exist for becomes invisible. waitFor yields between
+ * attempts, so the intermediate commits (and the timers the option fetch waits
+ * on) land the way they do in a browser.
+ */
+type SettleFunction = (change: () => void) => Promise<void>;
+
+const settle: SettleFunction = async (change: () => void): Promise<void> => {
+  await waitFor(() => {
+    change();
+  });
+};
+
+type GetEmailInputFunction = () => HTMLInputElement;
+
+const getEmailInput: GetEmailInputFunction = (): HTMLInputElement => {
+  return screen.getByPlaceholderText(EMAIL_PLACEHOLDER) as HTMLInputElement;
+};
+
+type MakeTeamFunction = (name: string) => Team;
+
+const makeTeam: MakeTeamFunction = (name: string): Team => {
+  const team: Team = new Team();
+  team._id = ObjectID.generate().toString();
+  team.name = name;
+  return team;
+};
+
+describe("ModelForm preserves what the user typed while inviting a user", () => {
+  beforeEach(() => {
+    permissionsForTest = [Permission.ProjectOwner, Permission.ProjectAdmin];
+    PermissionGate.clearPermissionPropsCache();
+    window.localStorage.clear();
+
+    listRequests = [];
+    listMode = "immediate";
+    listRowsByTableName = {
+      Team: [makeTeam("Owners"), makeTeam("Engineering")],
+      Label: [],
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  /*
+   * The bug exactly as reported. The email is typed, the page's own state flips
+   * when the address becomes valid, and the field must still hold what was
+   * typed. Before the fix the whole form was unmounted at that moment and the
+   * input came back empty.
+   */
+  test("keeps the typed email when the page re-renders mid-typing", async () => {
+    const user: UserEvent = userEvent.setup();
+
+    render(<InviteFormHarness onReady={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
+    });
+
+    await user.type(getEmailInput(), VALID_EMAIL);
+
+    // Whatever the page did with that keystroke, the field still reads back.
+    await waitFor(() => {
+      expect(getEmailInput().value).toBe(VALID_EMAIL);
+    });
+
+    expect(getEmailInput().value).toBe(VALID_EMAIL);
+  });
+
+  /*
+   * Tab is what the reporter pressed. It only marks the field touched, but it
+   * is also roughly when the account check came back - so the sequence is worth
+   * pinning end to end.
+   */
+  test("keeps the typed email across a Tab out of the field", async () => {
+    const user: UserEvent = userEvent.setup();
+
+    let setRegisteredStatus: SetRegisteredStatusFunction = () => {};
+
+    render(
+      <InviteFormHarness
+        onReady={(setter: SetRegisteredStatusFunction) => {
+          setRegisteredStatus = setter;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
+    });
+
+    await user.type(getEmailInput(), VALID_EMAIL);
+    await user.tab();
+
+    /*
+     * The account check resolving is a page-level state change, exactly as in
+     * useUserEmailRegistrationStatus once the debounce fires.
+     */
+    await settle(() => {
+      setRegisteredStatus(true);
+    });
+
+    await waitFor(() => {
+      expect(getEmailInput().value).toBe(VALID_EMAIL);
+    });
+  });
+
+  /*
+   * The second half of the report: after the first wipe the user retyped, and
+   * the very first character flipped the page's state back (true -> null),
+   * which wiped the field again. Retyping has to work.
+   */
+  test("keeps every character while the page state flips back and forth", async () => {
+    const user: UserEvent = userEvent.setup();
+
+    let setRegisteredStatus: SetRegisteredStatusFunction = () => {};
+
+    render(
+      <InviteFormHarness
+        onReady={(setter: SetRegisteredStatusFunction) => {
+          setRegisteredStatus = setter;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
+    });
+
+    await user.type(getEmailInput(), VALID_EMAIL);
+
+    await settle(() => {
+      setRegisteredStatus(true);
+    });
+
+    // Now edit the address, which makes it briefly invalid: true -> null.
+    await user.type(getEmailInput(), ".uk");
+
+    await waitFor(() => {
+      expect(getEmailInput().value).toBe(`${VALID_EMAIL}.uk`);
+    });
+
+    await settle(() => {
+      setRegisteredStatus(false);
+    });
+
+    /*
+     * The conditional Name field appears - which changes the rendered field
+     * list - and the email must still survive that.
+     */
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("John Smith")).toBeTruthy();
+    });
+
+    expect(getEmailInput().value).toBe(`${VALID_EMAIL}.uk`);
+  });
+
+  /*
+   * The field list legitimately changes when the account check resolves - the
+   * Name field is only asked for when the address has no account yet. Values
+   * already entered must survive that too.
+   */
+  test("keeps the typed email when a conditional field appears", async () => {
+    const user: UserEvent = userEvent.setup();
+
+    let setRegisteredStatus: SetRegisteredStatusFunction = () => {};
+
+    render(
+      <InviteFormHarness
+        onReady={(setter: SetRegisteredStatusFunction) => {
+          setRegisteredStatus = setter;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
+    });
+
+    await user.type(getEmailInput(), VALID_EMAIL);
+
+    expect(screen.queryByPlaceholderText("John Smith")).toBeNull();
+
+    await settle(() => {
+      setRegisteredStatus(false);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("John Smith")).toBeTruthy();
+    });
+
+    expect(getEmailInput().value).toBe(VALID_EMAIL);
+  });
+
+  /*
+   * The mechanism, asserted directly: once the form is on screen, nothing may
+   * put a loader in its place. That swap is what threw the input away.
+   */
+  test("never replaces a form the user is filling in with a loader", async () => {
+    const user: UserEvent = userEvent.setup();
+
+    let setRegisteredStatus: SetRegisteredStatusFunction = () => {};
+
+    render(
+      <InviteFormHarness
+        onReady={(setter: SetRegisteredStatusFunction) => {
+          setRegisteredStatus = setter;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
+    });
+
+    const inputBeforeRerender: HTMLInputElement = getEmailInput();
+
+    await user.type(getEmailInput(), VALID_EMAIL);
+
+    await settle(() => {
+      setRegisteredStatus(true);
+    });
+
+    expect(screen.queryByTestId("bar-loader")).toBeNull();
+
+    /*
+     * The strongest form of the assertion: it is the same DOM node. A remount
+     * would hand back a different element even if it happened to be refilled.
+     */
+    expect(getEmailInput()).toBe(inputBeforeRerender);
+  });
+
+  /*
+   * The loader is still right when there is genuinely nothing to show. Losing
+   * it entirely would flash an empty form before the Team list arrives.
+   */
+  test("still shows the loader while the form is loading for the first time", async () => {
+    listMode = "deferred";
+
+    render(<InviteFormHarness onReady={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bar-loader")).toBeTruthy();
+    });
+
+    expect(screen.queryByPlaceholderText(EMAIL_PLACEHOLDER)).toBeNull();
+
+    await waitFor(() => {
+      expect(listRequests.length).toBe(1);
+    });
+
+    await settle(() => {
+      listRequests.forEach((request: ListRequest) => {
+        request.resolve();
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
+    });
+
+    expect(screen.queryByTestId("bar-loader")).toBeNull();
+  });
+
+  /*
+   * The re-run was not only destructive, it was expensive: the invite form
+   * issued a Team list request per keystroke. Options for a dropdown depend on
+   * the model and its label/value columns and nothing else, so they are fetched
+   * once.
+   */
+  test("does not re-request dropdown options when the page re-renders", async () => {
+    const user: UserEvent = userEvent.setup();
+
+    let setRegisteredStatus: SetRegisteredStatusFunction = () => {};
+
+    render(
+      <InviteFormHarness
+        onReady={(setter: SetRegisteredStatusFunction) => {
+          setRegisteredStatus = setter;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
+    });
+
+    expect(listRequests.length).toBe(1);
+
+    await user.type(getEmailInput(), VALID_EMAIL);
+
+    const flipStatus: SetRegisteredStatusFunction = setRegisteredStatus;
+
+    for (const status of [true, null, false, true]) {
+      await settle(() => {
+        flipStatus(status);
+      });
+    }
+
+    await waitFor(() => {
+      expect(getEmailInput().value).toBe(VALID_EMAIL);
+    });
+
+    expect(listRequests.length).toBe(1);
+  });
+
+  /*
+   * The options still have to arrive, and they still have to arrive after the
+   * page has re-rendered a few times - caching that served a stale or empty
+   * list would turn a data-loss bug into a cannot-pick-a-team bug.
+   */
+  test("still offers the teams after the page has re-rendered", async () => {
+    const user: UserEvent = userEvent.setup();
+
+    let setRegisteredStatus: SetRegisteredStatusFunction = () => {};
+
+    render(
+      <InviteFormHarness
+        onReady={(setter: SetRegisteredStatusFunction) => {
+          setRegisteredStatus = setter;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
+    });
+
+    await user.type(getEmailInput(), VALID_EMAIL);
+
+    await settle(() => {
+      setRegisteredStatus(true);
+    });
+
+    const teamDropdown: HTMLElement =
+      screen.getByPlaceholderText(TEAM_PLACEHOLDER);
+
+    fireEvent.focus(teamDropdown);
+
+    expect(await screen.findByText("Engineering")).toBeTruthy();
+    expect(screen.getByText("Owners")).toBeTruthy();
+
+    // And the email the user was in the middle of typing is untouched by it.
+    expect(getEmailInput().value).toBe(VALID_EMAIL);
+  });
+
+  /*
+   * The cache is keyed on what the request actually depends on, so a second
+   * dropdown over a DIFFERENT model must still fetch its own options rather
+   * than inheriting the first one's.
+   */
+  test("fetches separately for each distinct dropdown model", async () => {
+    render(<InviteFormHarness onReady={() => {}} showLabelField={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
+    });
+
+    await waitFor(() => {
+      expect(listRequests.length).toBe(2);
+    });
+
+    const tableNames: Array<string> = listRequests
+      .map((request: ListRequest) => {
+        return request.tableName;
+      })
+      .sort();
+
+    expect(tableNames).toEqual(["Label", "Team"]);
+  });
+
+  /*
+   * A slow first run must not be able to come back and undo a newer one. The
+   * effect is re-entrant by construction - it re-runs on every parent render -
+   * so without a generation guard an older in-flight request can clear a
+   * loading flag the newer run still owns and leave the form half-built.
+   */
+  test("ignores a stale field-preparation run that finishes late", async () => {
+    listMode = "deferred";
+
+    let setRegisteredStatus: SetRegisteredStatusFunction = () => {};
+
+    render(
+      <InviteFormHarness
+        onReady={(setter: SetRegisteredStatusFunction) => {
+          setRegisteredStatus = setter;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listRequests.length).toBe(1);
+    });
+
+    // Re-render the page while the very first options request is still open.
+    await settle(() => {
+      setRegisteredStatus(false);
+    });
+
+    // Let every request that was opened finish, oldest first.
+    await settle(() => {
+      listRequests.forEach((request: ListRequest) => {
+        request.resolve();
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
+    });
+
+    // The form settles on the newest field list, not the stale one.
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("John Smith")).toBeTruthy();
+    });
+
+    expect(screen.queryByTestId("bar-loader")).toBeNull();
+  });
+});
+
+/*
+ * BasicForm is where the values actually live, so the guarantee is asserted at
+ * that level too - independently of how ModelForm happens to drive it today.
+ */
+describe("BasicForm never re-seeds a form the user has edited", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const NAME_PLACEHOLDER: string = "Enter a name";
+
+  type BuildFieldsFunction = () => Fields<FormValues<any>>;
+
+  const buildFields: BuildFieldsFunction = (): Fields<FormValues<any>> => {
+    return [
+      {
+        field: { name: true },
+        title: "Name",
+        fieldType: FormFieldSchemaType.Text,
+        required: false,
+        placeholder: NAME_PLACEHOLDER,
+      },
+    ];
+  };
+
+  /*
+   * Both props change identity on every render at almost every call site - the
+   * fields because they are written inline, and initialValues because
+   * BasicModelForm spreads them into a fresh object each time. Neither may
+   * disturb a form in progress.
+   */
+  test("keeps typed values when fields and initialValues change identity", async () => {
+    const user: UserEvent = userEvent.setup();
+
+    let rerender: () => void = () => {};
+
+    const Harness: React.FunctionComponent = (): React.ReactElement => {
+      const [, setTick] = React.useState<number>(0);
+
+      rerender = () => {
+        setTick((tick: number) => {
+          return tick + 1;
+        });
+      };
+
+      return (
+        <BasicForm
+          id="identity-churn-form"
+          initialValues={{}}
+          fields={buildFields()}
+          onSubmit={() => {}}
+          footer={<></>}
+        />
+      );
+    };
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(NAME_PLACEHOLDER)).toBeTruthy();
+    });
+
+    const input: HTMLInputElement = screen.getByPlaceholderText(
+      NAME_PLACEHOLDER,
+    ) as HTMLInputElement;
+
+    await user.type(input, "Engineering");
+
+    const triggerRerender: () => void = rerender;
+
+    for (let i: number = 0; i < 5; i++) {
+      await settle(() => {
+        triggerRerender();
+      });
+    }
+
+    expect(
+      (screen.getByPlaceholderText(NAME_PLACEHOLDER) as HTMLInputElement).value,
+    ).toBe("Engineering");
+  });
+
+  /*
+   * A third way keystrokes went missing, on a different path to the one above:
+   * while ANY dropdown in the form was fetching its options, every field in the
+   * form was disabled - and Input renders `disabled` as `readOnly`, so a text
+   * box stayed focusable and simply ate what was typed into it, with nothing on
+   * screen to say why. Only the dropdowns waiting on those options should wait.
+   */
+  test("keeps text fields usable while a dropdown re-fetches its options", async () => {
+    const user: UserEvent = userEvent.setup();
+
+    /*
+     * Resolves the first time so the form gets on screen, then hangs - which is
+     * the window that matters. A refetch happens on top of an already-rendered
+     * form, so the fields the user can see are the ones that used to go
+     * read-only.
+     */
+    let fetchCount: number = 0;
+
+    const fetchDropdownOptions: () => Promise<Array<never>> = (): Promise<
+      Array<never>
+    > => {
+      fetchCount++;
+
+      if (fetchCount === 1) {
+        return Promise.resolve([]);
+      }
+
+      return new Promise<Array<never>>(() => {});
+    };
+
+    let rerender: () => void = () => {};
+
+    const Harness: React.FunctionComponent = (): React.ReactElement => {
+      const [, setTick] = React.useState<number>(0);
+
+      rerender = () => {
+        setTick((tick: number) => {
+          return tick + 1;
+        });
+      };
+
+      return (
+        <BasicForm
+          id="options-loading-form"
+          initialValues={{}}
+          fields={[
+            {
+              field: { name: true },
+              title: "Name",
+              fieldType: FormFieldSchemaType.Text,
+              required: false,
+              placeholder: NAME_PLACEHOLDER,
+            },
+            {
+              field: { team: true },
+              title: "Team",
+              fieldType: FormFieldSchemaType.Dropdown,
+              required: false,
+              placeholder: "Select a team",
+              fetchDropdownOptions: fetchDropdownOptions,
+            },
+          ]}
+          onSubmit={() => {}}
+          footer={<></>}
+        />
+      );
+    };
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(NAME_PLACEHOLDER)).toBeTruthy();
+    });
+
+    // A new inline fields array sends the dropdown back to fetch, and it hangs.
+    await settle(() => {
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(fetchCount).toBeGreaterThan(1);
+    });
+
+    const input: HTMLInputElement = screen.getByPlaceholderText(
+      NAME_PLACEHOLDER,
+    ) as HTMLInputElement;
+
+    await user.type(input, "Engineering");
+
+    expect(
+      (screen.getByPlaceholderText(NAME_PLACEHOLDER) as HTMLInputElement).value,
+    ).toBe("Engineering");
+  });
+
+  /*
+   * The other side of the same guard. formFields starts empty and is filled in
+   * by an effect, so the initial-values pass must not latch before the field
+   * list arrives - or every default value and every dropdown/date
+   * normalisation would be skipped.
+   */
+  test("still applies default values once the field list arrives", async () => {
+    const onSubmit: MockFunction = getJestMockFunction();
+
+    render(
+      <BasicForm
+        id="default-value-form"
+        initialValues={{}}
+        fields={[
+          {
+            field: { name: true },
+            title: "Name",
+            fieldType: FormFieldSchemaType.Text,
+            required: false,
+            placeholder: NAME_PLACEHOLDER,
+            defaultValue: "Default Team",
+          },
+          {
+            field: { description: true },
+            title: "Description",
+            fieldType: FormFieldSchemaType.Text,
+            required: false,
+            placeholder: "Describe it",
+            getDefaultValue: (): string => {
+              return "Derived default";
+            },
+          },
+        ]}
+        onSubmit={(values: FormValues<any>) => {
+          onSubmit(values);
+        }}
+        submitButtonText="Save"
+        footer={<></>}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(NAME_PLACEHOLDER)).toBeTruthy();
+    });
+
+    await userEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+    });
+
+    const submitted: FormValues<any> = onSubmit.mock.calls[0]![0];
+
+    expect(submitted["name"]).toBe("Default Team");
+    expect(submitted["description"]).toBe("Derived default");
+  });
+});

--- a/Common/Tests/UI/Utils/UserEmailRegistrationStatus.test.tsx
+++ b/Common/Tests/UI/Utils/UserEmailRegistrationStatus.test.tsx
@@ -1,0 +1,295 @@
+import "@testing-library/jest-dom";
+import { act, cleanup, render } from "@testing-library/react";
+import * as React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * This hook is what the invite forms call on every keystroke to find out
+ * whether the address being typed already has a OneUptime account.
+ *
+ * It is therefore attached to a form the user is actively typing into, and the
+ * state it owns lives on the page that renders that form - so every time it
+ * flips, the whole form re-renders. The invite-user bug was ultimately about a
+ * form that could not survive being re-rendered while in use; the fixes for that
+ * live in ModelForm/BasicForm/Input, and these tests cover the other half of
+ * the bargain: this hook must not cause MORE renders than the answer needs.
+ */
+
+interface PendingCheck {
+  email: string;
+  headers: unknown;
+  resolve: (isRegistered: boolean) => void;
+  reject: (error: Error) => void;
+}
+
+let pendingChecks: Array<PendingCheck> = [];
+
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      post: (data: {
+        data: { email: string };
+        headers?: unknown;
+      }): Promise<{ data: { isRegistered: boolean } }> => {
+        return new Promise<{ data: { isRegistered: boolean } }>(
+          (
+            resolve: (value: { data: { isRegistered: boolean } }) => void,
+            reject: (error: Error) => void,
+          ) => {
+            pendingChecks.push({
+              email: data.data.email,
+              headers: data.headers,
+              resolve: (isRegistered: boolean) => {
+                resolve({ data: { isRegistered: isRegistered } });
+              },
+              reject: reject,
+            });
+          },
+        );
+      },
+      getFriendlyMessage: (): string => {
+        return "";
+      },
+    },
+  };
+});
+
+import { useUserEmailRegistrationStatus } from "../../../UI/Utils/UserEmailRegistrationStatus";
+
+const DEBOUNCE_MS: number = 400;
+
+interface ProbeResult {
+  checkEmailIdentities: Array<unknown>;
+  statuses: Array<boolean | null>;
+  rerender: () => void;
+  check: (email: string) => void;
+}
+
+type RenderProbeFunction = (
+  headersFactory?: () => {
+    [key: string]: string;
+  },
+) => ProbeResult;
+
+/*
+ * Renders the hook the way every real caller does - passing its options as an
+ * inline object literal, so the options and the header factory are brand new
+ * on every render - and records what comes back.
+ */
+const renderProbe: RenderProbeFunction = (
+  headersFactory?: () => {
+    [key: string]: string;
+  },
+): ProbeResult => {
+  const result: ProbeResult = {
+    checkEmailIdentities: [],
+    statuses: [],
+    rerender: () => {},
+    check: () => {},
+  };
+
+  const Probe: React.FunctionComponent = (): React.ReactElement => {
+    const [, setTick] = React.useState<number>(0);
+
+    const { isEmailRegistered, checkEmail } = useUserEmailRegistrationStatus({
+      getRequestHeaders: headersFactory
+        ? () => {
+            return headersFactory();
+          }
+        : undefined,
+    });
+
+    result.checkEmailIdentities.push(checkEmail);
+    result.statuses.push(isEmailRegistered);
+    result.check = checkEmail;
+    result.rerender = () => {
+      setTick((tick: number) => {
+        return tick + 1;
+      });
+    };
+
+    return <div />;
+  };
+
+  render(<Probe />);
+
+  return result;
+};
+
+describe("useUserEmailRegistrationStatus", () => {
+  beforeEach(() => {
+    pendingChecks = [];
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    cleanup();
+  });
+
+  /*
+   * The whole reason the header factory is held in a ref. A caller writing its
+   * options inline used to get a new checkEmail on every render, which becomes
+   * a new field definition, which becomes another render of the form.
+   */
+  test("hands back the same checkEmail across re-renders", () => {
+    const probe: ProbeResult = renderProbe(() => {
+      return { tenant: "abc" };
+    });
+
+    act(() => {
+      probe.rerender();
+    });
+    act(() => {
+      probe.rerender();
+    });
+
+    expect(probe.checkEmailIdentities.length).toBeGreaterThan(2);
+
+    const identities: Set<unknown> = new Set(probe.checkEmailIdentities);
+    expect(identities.size).toBe(1);
+  });
+
+  /*
+   * And it still has to use the CURRENT headers, not the ones captured when the
+   * hook first ran - the auth headers a form sends can change while the page is
+   * open.
+   */
+  test("sends the headers the caller has now, not the ones it had first", () => {
+    let tenant: string = "first";
+
+    const probe: ProbeResult = renderProbe(() => {
+      return { tenant: tenant };
+    });
+
+    tenant = "second";
+
+    act(() => {
+      probe.rerender();
+    });
+
+    act(() => {
+      probe.check("member@company.com");
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(pendingChecks.length).toBe(1);
+    expect(pendingChecks[0]!.headers).toEqual({ tenant: "second" });
+  });
+
+  test("only asks once the typing has settled, and reports the answer", async () => {
+    const probe: ProbeResult = renderProbe();
+
+    act(() => {
+      probe.check("mem");
+    });
+    act(() => {
+      probe.check("member@comp");
+    });
+    act(() => {
+      probe.check("member@company.com");
+    });
+
+    // Still mid-word: nothing has been asked yet.
+    expect(pendingChecks.length).toBe(0);
+
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(pendingChecks.length).toBe(1);
+    expect(pendingChecks[0]!.email).toBe("member@company.com");
+
+    await act(async () => {
+      pendingChecks[0]!.resolve(true);
+    });
+
+    expect(probe.statuses[probe.statuses.length - 1]).toBe(true);
+  });
+
+  /*
+   * An address that is not a valid email cannot have an account, so it must not
+   * cost a request - which also means the first few keystrokes of any address
+   * are free.
+   */
+  test("does not ask about an address that is not a valid email", () => {
+    const probe: ProbeResult = renderProbe();
+
+    act(() => {
+      probe.check("mem");
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS * 3);
+    });
+
+    expect(pendingChecks.length).toBe(0);
+    expect(probe.statuses[probe.statuses.length - 1]).toBeNull();
+  });
+
+  /*
+   * The user carried on typing while a check was in flight. The old answer is
+   * about an address they are no longer entering, so applying it would show the
+   * wrong prompt - and, before the form fixes, would have wiped what they were
+   * typing for good measure.
+   */
+  test("ignores an answer about an address that has since changed", async () => {
+    const probe: ProbeResult = renderProbe();
+
+    act(() => {
+      probe.check("first@company.com");
+    });
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(pendingChecks.length).toBe(1);
+
+    act(() => {
+      probe.check("second@company.com");
+    });
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(pendingChecks.length).toBe(2);
+
+    // The first request answers last.
+    await act(async () => {
+      pendingChecks[1]!.resolve(false);
+    });
+    await act(async () => {
+      pendingChecks[0]!.resolve(true);
+    });
+
+    expect(probe.statuses[probe.statuses.length - 1]).toBe(false);
+  });
+
+  // A check still pending when the form closes has nowhere to report to.
+  test("drops a pending check when the caller unmounts", () => {
+    const probe: ProbeResult = renderProbe();
+
+    act(() => {
+      probe.check("member@company.com");
+    });
+
+    cleanup();
+
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS * 3);
+    });
+
+    expect(pendingChecks.length).toBe(0);
+  });
+});

--- a/Common/UI/Components/Forms/BasicForm.tsx
+++ b/Common/UI/Components/Forms/BasicForm.tsx
@@ -152,6 +152,15 @@ const BasicForm: ForwardRefExoticComponent<any> = forwardRef(
 
     const isInitialValuesSet: MutableRefObject<boolean> = useRef(false);
 
+    /*
+     * Nothing may re-seed a form the user has already typed into. The guard
+     * above latches once, which is enough on its own, but "the value the user
+     * entered survives" is the one property of a form that must never quietly
+     * regress - so it is asserted directly rather than inferred from the order
+     * two effects happen to run in.
+     */
+    const hasUserEdited: MutableRefObject<boolean> = useRef(false);
+
     const refCurrentValue: React.MutableRefObject<FormValues<T>> = useRef(
       props.initialValues || {},
     );
@@ -310,6 +319,24 @@ const BasicForm: ForwardRefExoticComponent<any> = forwardRef(
       setFormFields(fields);
     }, [props.fields, currentFormStepId]);
 
+    /*
+     * A field is only worth disabling while options are being fetched if it is
+     * one of the fields those options belong to. Disabling everything meant a
+     * Text or Email field went read-only because some unrelated dropdown was
+     * refreshing - and Input renders `disabled` as `readOnly`, so it stays
+     * focusable and simply swallows the keystrokes with no visible reason.
+     */
+    type IsDropdownFieldFunction = (field: Field<T>) => boolean;
+
+    const isDropdownField: IsDropdownFieldFunction = (
+      field: Field<T>,
+    ): boolean => {
+      return (
+        field.fieldType === FormFieldSchemaType.Dropdown ||
+        field.fieldType === FormFieldSchemaType.MultiSelectDropdown
+      );
+    };
+
     type GetFieldNameFunction = (field: Field<T>) => string;
 
     const getFieldName: GetFieldNameFunction = (field: Field<T>): string => {
@@ -346,6 +373,8 @@ const BasicForm: ForwardRefExoticComponent<any> = forwardRef(
         ...refCurrentValue.current,
         [fieldName]: value as any,
       };
+
+      hasUserEdited.current = true;
 
       refCurrentValue.current = updatedValue;
 
@@ -484,7 +513,7 @@ const BasicForm: ForwardRefExoticComponent<any> = forwardRef(
         return;
       }
 
-      if (isInitialValuesSet.current) {
+      if (isInitialValuesSet.current || hasUserEdited.current) {
         return;
       }
 
@@ -601,7 +630,16 @@ const BasicForm: ForwardRefExoticComponent<any> = forwardRef(
         if (field.getDefaultValue && (values as any)[fieldName] === undefined) {
           (values as any)[fieldName] = field.getDefaultValue(values);
         }
+      }
 
+      /*
+       * Latch only once the field list has actually arrived. formFields starts
+       * empty and is filled in by an effect, so latching before then would
+       * skip every default value and every dropdown/date normalisation above.
+       * (This used to be written as an assignment inside the loop, which had
+       * the same effect by accident.)
+       */
+      if (formFields.length > 0) {
         isInitialValuesSet.current = true;
       }
 
@@ -747,7 +785,8 @@ const BasicForm: ForwardRefExoticComponent<any> = forwardRef(
                                       touched={touched[fieldName] || false}
                                       isDisabled={
                                         isLoading ||
-                                        isDropdownOptionsLoading ||
+                                        (isDropdownOptionsLoading &&
+                                          isDropdownField(field)) ||
                                         false
                                       }
                                       currentValues={refCurrentValue.current}

--- a/Common/UI/Components/Forms/ModelForm.tsx
+++ b/Common/UI/Components/Forms/ModelForm.tsx
@@ -51,7 +51,7 @@ import Permission, {
   UserPermission,
 } from "../../../Types/Permission";
 import Typeof from "../../../Types/Typeof";
-import React, { MutableRefObject, ReactElement, useState } from "react";
+import React, { MutableRefObject, ReactElement, useRef, useState } from "react";
 import useAsyncEffect from "use-async-effect";
 import Select from "../../../Types/BaseDatabase/Select";
 
@@ -131,6 +131,37 @@ const ModelForm: <TBaseModel extends BaseModel>(
   const [error, setError] = useState<string>("");
   const [itemToEdit, setItemToEdit] = useState<TBaseModel | null>(null);
   const model: TBaseModel = new props.modelType();
+
+  /*
+   * Almost every caller writes its `fields` as an inline array literal in JSX,
+   * so the array is a brand new identity on every render of the page holding
+   * the form - which makes the effect below re-run whenever ANY unrelated
+   * state on that page changes, including while the user is typing into this
+   * form. Two guards keep that from being destructive:
+   *
+   *  - `dropdownOptionsCache` remembers the options already fetched for a
+   *    given dropdown, so a re-run does not fire the same list request again.
+   *    Without it the invite-user form issued a Team list request per
+   *    keystroke.
+   *  - `fieldsRunGeneration` discards a slower earlier run, so an in-flight
+   *    request that resolves after a newer one cannot put stale fields back
+   *    or clear a loading flag the newer run still owns.
+   */
+  type DropdownOptionsCacheEntry = {
+    dropdownOptions: Array<DropdownOption>;
+    selectByAccessControlProps: Field<TBaseModel>["selectByAccessControlProps"];
+  };
+
+  /*
+   * Keyed on the model CONSTRUCTOR rather than on its name, so two models can
+   * never share an entry however they are named - a model with neither a
+   * tableName nor a singularName would otherwise key as the empty string.
+   */
+  const dropdownOptionsCache: MutableRefObject<
+    Map<unknown, Dictionary<DropdownOptionsCacheEntry>>
+  > = useRef<Map<unknown, Dictionary<DropdownOptionsCacheEntry>>>(new Map());
+
+  const fieldsRunGeneration: MutableRefObject<number> = useRef<number>(0);
 
   const modelAPI: typeof ModelAPI = props.modelAPI || ModelAPI;
 
@@ -242,6 +273,9 @@ const ModelForm: <TBaseModel extends BaseModel>(
   };
 
   const setFormFields: PromiseVoidFunction = async (): Promise<void> => {
+    fieldsRunGeneration.current = fieldsRunGeneration.current + 1;
+    const generation: number = fieldsRunGeneration.current;
+
     let fieldsToSet: Fields<TBaseModel> = [];
 
     for (const field of props.fields) {
@@ -314,7 +348,12 @@ const ModelForm: <TBaseModel extends BaseModel>(
       }
     }
 
-    fieldsToSet = await fetchDropdownOptions(fieldsToSet);
+    fieldsToSet = await fetchDropdownOptions(fieldsToSet, generation);
+
+    if (generation !== fieldsRunGeneration.current) {
+      // A newer run started while this one was fetching. It owns the state now.
+      return;
+    }
 
     // if there are no fields to set, then show permission error. This is useful when there are no fields to show.
     if (fieldsToSet.length === 0 && props.fields.length > 0) {
@@ -441,15 +480,103 @@ const ModelForm: <TBaseModel extends BaseModel>(
 
   type FetchDropdownOptionsFunction = (
     fields: Fields<TBaseModel>,
+    generation: number,
   ) => Promise<Fields<TBaseModel>>;
+
+  /*
+   * What a dropdown's options depend on, and nothing else: the model, and the
+   * two columns read off it. The request below takes no query and no closure
+   * state, so two fields with the same three always get the same list back -
+   * which is what makes caching them safe.
+   */
+  type GetCachedDropdownOptionsFunction = (
+    dropdownModal: NonNullable<Field<TBaseModel>["dropdownModal"]>,
+  ) => DropdownOptionsCacheEntry | undefined;
+
+  type SetCachedDropdownOptionsFunction = (
+    dropdownModal: NonNullable<Field<TBaseModel>["dropdownModal"]>,
+    entry: DropdownOptionsCacheEntry,
+  ) => void;
+
+  const getDropdownColumnsKey: (
+    dropdownModal: NonNullable<Field<TBaseModel>["dropdownModal"]>,
+  ) => string = (
+    dropdownModal: NonNullable<Field<TBaseModel>["dropdownModal"]>,
+  ): string => {
+    return `${dropdownModal.labelField}|${dropdownModal.valueField}`;
+  };
+
+  const getCachedDropdownOptions: GetCachedDropdownOptionsFunction = (
+    dropdownModal: NonNullable<Field<TBaseModel>["dropdownModal"]>,
+  ): DropdownOptionsCacheEntry | undefined => {
+    return dropdownOptionsCache.current.get(dropdownModal.type)?.[
+      getDropdownColumnsKey(dropdownModal)
+    ];
+  };
+
+  const setCachedDropdownOptions: SetCachedDropdownOptionsFunction = (
+    dropdownModal: NonNullable<Field<TBaseModel>["dropdownModal"]>,
+    entry: DropdownOptionsCacheEntry,
+  ): void => {
+    const byColumns: Dictionary<DropdownOptionsCacheEntry> =
+      dropdownOptionsCache.current.get(dropdownModal.type) || {};
+
+    byColumns[getDropdownColumnsKey(dropdownModal)] = entry;
+
+    dropdownOptionsCache.current.set(dropdownModal.type, byColumns);
+  };
 
   const fetchDropdownOptions: FetchDropdownOptionsFunction = async (
     fields: Fields<TBaseModel>,
+    generation: number,
   ): Promise<Fields<TBaseModel>> => {
+    /*
+     * Serve everything already fetched from the cache first, then work out
+     * whether anything is actually left to request. Flipping the loading flag
+     * for a run that has nothing to fetch used to blank the whole form (see
+     * the comment on the render guard below), so only flip it when a real
+     * request is about to go out.
+     */
+    const fieldsToFetch: Fields<TBaseModel> = [];
+
+    for (const field of fields) {
+      if (!field.dropdownModal || !field.dropdownModal.type) {
+        continue;
+      }
+
+      const cached: DropdownOptionsCacheEntry | undefined =
+        getCachedDropdownOptions(field.dropdownModal);
+
+      if (cached) {
+        field.dropdownOptions = cached.dropdownOptions;
+
+        if (cached.selectByAccessControlProps) {
+          field.selectByAccessControlProps = cached.selectByAccessControlProps;
+        }
+
+        continue;
+      }
+
+      fieldsToFetch.push(field);
+    }
+
+    if (fieldsToFetch.length === 0) {
+      /*
+       * Nothing to wait for. Clearing rather than just returning keeps the flag
+       * from being left on by an older run that lost the race and therefore
+       * declined to clear it - React bails out when it is already false.
+       */
+      if (generation === fieldsRunGeneration.current) {
+        setIsFetchingDropdownOptions(false);
+      }
+
+      return fields;
+    }
+
     setIsFetchingDropdownOptions(true);
 
     try {
-      for (const field of fields) {
+      for (const field of fieldsToFetch) {
         if (field.dropdownModal && field.dropdownModal.type) {
           const tempModel: BaseModel = new field.dropdownModal.type();
           const select: any = {
@@ -642,13 +769,21 @@ const ModelForm: <TBaseModel extends BaseModel>(
           } else {
             field.dropdownOptions = [];
           }
+
+          setCachedDropdownOptions(field.dropdownModal, {
+            dropdownOptions: (field.dropdownOptions ||
+              []) as Array<DropdownOption>,
+            selectByAccessControlProps: field.selectByAccessControlProps,
+          });
         }
       }
     } catch (err) {
       setError(API.getFriendlyMessage(err));
     }
 
-    setIsFetchingDropdownOptions(false);
+    if (generation === fieldsRunGeneration.current) {
+      setIsFetchingDropdownOptions(false);
+    }
 
     return fields;
   };
@@ -849,7 +984,26 @@ const ModelForm: <TBaseModel extends BaseModel>(
     }
   };
 
-  if (isFetching || isFetchingDropdownOptions) {
+  /*
+   * Only ever swap the form out for a loader while there is no form to show.
+   * Returning the loader over a form the user is already filling in unmounts
+   * BasicModelForm and everything under it, and a form's values live in that
+   * subtree - in BasicForm's refs and in each Input's own state, since Input
+   * is DOM-uncontrolled. So the remount silently threw the user's input away.
+   *
+   * That is what made inviting a user impossible: the invite form's Email field
+   * calls back into the page on every keystroke to check whether the address
+   * already has an account, the page re-renders with a fresh `fields` array
+   * literal, the effect above re-runs, and the form the user was typing into
+   * was destroyed and rebuilt empty.
+   *
+   * Once fields exist, options refresh in the background instead. The cache in
+   * fetchDropdownOptions means the usual re-run does not even reach the
+   * network, so in practice nothing about the form flickers at all.
+   */
+  const hasFieldsToRender: boolean = fields.length > 0;
+
+  if (isFetching || (isFetchingDropdownOptions && !hasFieldsToRender)) {
     return (
       <div className="row flex justify-center mt-20 mb-20">
         <Loader loaderType={LoaderType.Bar} color={VeryLightGray} size={200} />

--- a/Common/UI/Components/Input/Input.tsx
+++ b/Common/UI/Components/Input/Input.tsx
@@ -85,9 +85,18 @@ const Input: FunctionComponent<ComponentProps> = (
   }
 
   const [value, setValue] = useState<string | Date>("");
-  const [displayValue, setDisplayValue] = useState<string>("");
+
+  /*
+   * Only dates need a display form that differs from the stored value, and
+   * working it out means parsing, so it stays in state behind an effect.
+   * Text keeps no second copy - see the comment on displayValue below.
+   */
+  const [dateDisplayValue, setDateDisplayValue] = useState<string>("");
   const ref: React.MutableRefObject<HTMLInputElement | null> =
     useRef<HTMLInputElement | null>(null);
+
+  const isDateInput: boolean =
+    props.type === InputType.DATE || props.type === InputType.DATETIME_LOCAL;
 
   useEffect(() => {
     if (
@@ -105,7 +114,7 @@ const Input: FunctionComponent<ComponentProps> = (
         } catch (e: any) {
           Logger.error(e);
         }
-        setDisplayValue(dateString);
+        setDateDisplayValue(dateString);
       } else if (
         value &&
         (value as any).includes &&
@@ -123,21 +132,47 @@ const Input: FunctionComponent<ComponentProps> = (
         } catch (err: any) {
           Logger.error(err);
         }
-        setDisplayValue(dateString);
+        setDateDisplayValue(dateString);
       } else if (
         !value ||
         ((value as any).includes && !(value as any).includes(" - "))
       ) {
-        setDisplayValue("");
+        setDateDisplayValue("");
       }
-    } else {
-      setDisplayValue(value as string);
     }
   }, [value]);
 
+  /*
+   * For text the display value IS the value, derived here rather than kept in
+   * a second piece of state, and that is load-bearing rather than tidiness.
+   *
+   * This <input> is uncontrolled - React never writes its `value` attribute -
+   * so the effect below is the only thing keeping the DOM and this component
+   * in step. When the display value was its own state it settled one render
+   * behind `value`, and anything that interleaved a render between those two
+   * commits (a parent re-rendering while the user typed, which is exactly what
+   * the invite form does on every keystroke) made the effect write the older
+   * copy back over text the browser already held. The character typed in that
+   * window disappeared - the "typed characters vanish as I type" half of the
+   * invite-user bug, and a silent character-eater in every form in the product.
+   *
+   * Derived, the two can no longer drift: `setValue` runs synchronously in the
+   * change handler, so by the time any render commits, this already equals
+   * what the user typed.
+   */
+  const displayValue: string = isDateInput
+    ? dateDisplayValue
+    : (value as string) || "";
+
   useEffect(() => {
     const input: HTMLInputElement | null = ref.current;
-    if (input) {
+
+    /*
+     * Never write when it would not change anything: assigning to input.value
+     * moves the caret to the end, so an unconditional write reorders text
+     * whenever someone edits in the middle of a field.
+     */
+    if (input && input.value !== displayValue) {
       input.value = displayValue;
     }
   }, [ref, displayValue]);

--- a/Common/UI/Utils/UserEmailRegistrationStatus.ts
+++ b/Common/UI/Utils/UserEmailRegistrationStatus.ts
@@ -1,4 +1,10 @@
-import { MutableRefObject, useCallback, useRef, useState } from "react";
+import {
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import Dictionary from "../../Types/Dictionary";
 import Email from "../../Types/Email";
 import HTTPErrorResponse from "../../Types/API/HTTPErrorResponse";
@@ -36,8 +42,28 @@ export function useUserEmailRegistrationStatus(options?: {
   > | null> = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestEmail: MutableRefObject<string> = useRef<string>("");
 
-  const getRequestHeaders: (() => Dictionary<string>) | undefined =
-    options?.getRequestHeaders;
+  /*
+   * Held in a ref so a caller that writes its options inline - which is every
+   * caller - does not get a new checkEmail on every render, and through it a
+   * new field definition and a new re-render of the form it is attached to.
+   */
+  const getRequestHeaders: MutableRefObject<
+    (() => Dictionary<string>) | undefined
+  > = useRef<(() => Dictionary<string>) | undefined>(
+    options?.getRequestHeaders,
+  );
+
+  getRequestHeaders.current = options?.getRequestHeaders;
+
+  // A check still in flight when the form closes has nowhere to report to.
+  useEffect(() => {
+    return () => {
+      if (debounceTimeout.current) {
+        clearTimeout(debounceTimeout.current);
+        debounceTimeout.current = null;
+      }
+    };
+  }, []);
 
   const checkEmail: (email: string) => void = useCallback(
     (email: string): void => {
@@ -64,7 +90,9 @@ export function useUserEmailRegistrationStatus(options?: {
               data: {
                 email: trimmedEmail,
               },
-              ...(getRequestHeaders ? { headers: getRequestHeaders() } : {}),
+              ...(getRequestHeaders.current
+                ? { headers: getRequestHeaders.current() }
+                : {}),
             });
 
           if (latestEmail.current !== trimmedEmail) {
@@ -86,7 +114,7 @@ export function useUserEmailRegistrationStatus(options?: {
         }
       }, 400);
     },
-    [getRequestHeaders],
+    [],
   );
 
   return { isEmailRegistered, checkEmail };

--- a/E2E/Tests/Dashboard/InviteUser.spec.ts
+++ b/E2E/Tests/Dashboard/InviteUser.spec.ts
@@ -1,0 +1,194 @@
+import { BASE_URL } from "../../Config";
+import { Browser, Locator, Page, expect, test } from "@playwright/test";
+import URL from "Common/Types/API/URL";
+import Faker from "Common/Utils/Faker";
+import {
+  registerAndCreateProject,
+  gotoProjectPage,
+} from "./Helpers/ProductOnboarding";
+
+/*
+ * The invite form could not be filled in.
+ *
+ * Type a valid address into "Invite New User" and the email vanished from the
+ * box; keep typing and characters disappeared as they were entered. Two
+ * separate defects, both in Common's form stack, both only reachable through a
+ * form like this one - the Email field reports every keystroke back to the page
+ * so it can look up whether that address already has an account, and the page
+ * re-renders when it answers:
+ *
+ *   - ModelForm returned a <Loader/> in place of the form while it refreshed
+ *     the Team dropdown's options, which unmounted the form and threw away
+ *     everything typed into it.
+ *   - Input mirrored its React state into the DOM one render late, so a
+ *     keystroke landing in that window was overwritten by the previous value.
+ *
+ * Common/Tests/UI/Components/Forms/ModelFormPreservesUserInput.test.tsx pins
+ * both mechanisms directly. This walks the flow the reporter walked, through
+ * the real app, because that is the only place the whole chain - dashboard
+ * page, real Team list request, real account-lookup request - is present at
+ * once.
+ */
+
+type UsersPageUrlFunction = (projectId: string) => string;
+
+const usersPageUrl: UsersPageUrlFunction = (projectId: string): string => {
+  return URL.fromString(BASE_URL.toString())
+    .addRoute(`/dashboard/${projectId}/users`)
+    .toString();
+};
+
+const EMAIL_PLACEHOLDER: string = "member@company.com";
+
+interface SharedContext {
+  page: Page;
+  projectId: string;
+}
+
+test.describe("Invite user", () => {
+  const ctx: SharedContext = {
+    page: undefined as unknown as Page,
+    projectId: "",
+  };
+
+  test.beforeAll(async ({ browser }: { browser: Browser }) => {
+    test.setTimeout(300000);
+    ctx.page = await browser.newPage();
+    ctx.projectId = await registerAndCreateProject({
+      page: ctx.page,
+      projectNamePrefix: "E2E Invite User Project",
+    });
+  });
+
+  test.afterAll(async () => {
+    await ctx.page.close();
+  });
+
+  type OpenInviteModalFunction = () => Promise<Locator>;
+
+  const openInviteModal: OpenInviteModalFunction =
+    async (): Promise<Locator> => {
+      const page: Page = ctx.page;
+
+      const inviteButton: Locator = page.getByRole("button", {
+        name: "Invite User",
+      });
+
+      await gotoProjectPage({
+        page,
+        projectId: ctx.projectId,
+        url: usersPageUrl(ctx.projectId),
+        ready: inviteButton,
+      });
+
+      await inviteButton.click();
+      await page.getByTestId("modal").waitFor({ state: "visible" });
+
+      const emailInput: Locator = page.getByPlaceholder(EMAIL_PLACEHOLDER);
+      await emailInput.waitFor({ state: "visible" });
+
+      return emailInput;
+    };
+
+  /*
+   * The reported sequence, verbatim: type a valid address, press Tab, wait long
+   * enough for the account lookup to come back (it is debounced by 400ms) and
+   * re-render the page. The address has to still be there.
+   */
+  test("keeps the email after typing it and tabbing out", async () => {
+    test.setTimeout(180000);
+
+    const emailInput: Locator = await openInviteModal();
+    const email: string = Faker.generateEmail().toString();
+
+    await emailInput.click();
+    await emailInput.fill(email);
+    await emailInput.press("Tab");
+
+    // Comfortably past the 400ms debounce plus the lookup round trip.
+    await ctx.page.waitForTimeout(3000);
+
+    await expect(emailInput).toHaveValue(email);
+  });
+
+  /*
+   * The second half of the report. After the address had been checked once,
+   * every further keystroke made it briefly invalid again, which flipped the
+   * page's state back and re-triggered the whole cascade. Typing character by
+   * character is the point here - `fill` would set the value in one event and
+   * never reproduce it.
+   */
+  test("keeps every character when the address is typed one key at a time", async () => {
+    test.setTimeout(180000);
+
+    const emailInput: Locator = await openInviteModal();
+    const email: string = Faker.generateEmail().toString();
+
+    await emailInput.click();
+    await emailInput.pressSequentially(email, { delay: 60 });
+
+    await ctx.page.waitForTimeout(3000);
+
+    await expect(emailInput).toHaveValue(email);
+  });
+
+  /*
+   * And editing an address that has already been looked up, which is what the
+   * reporter did after the first wipe.
+   */
+  test("keeps the email while it is edited after being checked", async () => {
+    test.setTimeout(180000);
+
+    const emailInput: Locator = await openInviteModal();
+    const email: string = Faker.generateEmail().toString();
+
+    await emailInput.click();
+    await emailInput.fill(email);
+
+    // Let the lookup resolve, so the page's state is no longer "unknown".
+    await ctx.page.waitForTimeout(3000);
+
+    await emailInput.pressSequentially(".uk", { delay: 60 });
+    await ctx.page.waitForTimeout(3000);
+
+    await expect(emailInput).toHaveValue(`${email}.uk`);
+  });
+
+  /*
+   * The form is only fixed if it can actually be submitted, so this finishes
+   * the job: pick a team and invite. On success the page navigates to the
+   * invited user, which is where the address shows up again.
+   */
+  test("invites the user once the email and team are filled in", async () => {
+    test.setTimeout(180000);
+
+    const page: Page = ctx.page;
+    const emailInput: Locator = await openInviteModal();
+    const email: string = Faker.generateEmail().toString();
+
+    await emailInput.click();
+    await emailInput.fill(email);
+    await page.waitForTimeout(3000);
+
+    // The address survived long enough to pick a team.
+    await expect(emailInput).toHaveValue(email);
+
+    const teamInput: Locator = page.getByPlaceholder("Select a team");
+    await teamInput.click();
+
+    const ownersOption: Locator = page
+      .getByRole("option", { name: /Owners/ })
+      .first();
+    await ownersOption.waitFor({ state: "visible", timeout: 30000 });
+    await ownersOption.click();
+
+    // Choosing a team must not have disturbed the email either.
+    await expect(emailInput).toHaveValue(email);
+
+    await page.getByTestId("modal-footer-submit-button").click();
+
+    await expect(page.getByText(email).first()).toBeVisible({
+      timeout: 60000,
+    });
+  });
+});


### PR DESCRIPTION
Typing a valid email into **Invite New User** and pressing Tab made the email
vanish, placeholder and all. Typing again dropped characters as they were
entered — the reporter's recording ends with a lone `@` in an empty box. The
form could not be filled in at all.

Those are two separate defects in the shared form stack. Neither is new; both
were exposed by the account-lookup the invite form added, which is the first
thing to re-render a page *while the user is typing into a form on it*.

## 1. The form was destroyed and rebuilt (the whole-field wipe)

`ModelForm` prepares its fields in an effect keyed on `props.fields`. Almost
every caller writes that array inline in JSX, so it is a new identity on every
render of the page holding the form — a couple of hundred files across the
product. Two wrappers make it unavoidable no matter what the caller does:
`ModelTable.tsx:304` passes `props.formFields?.filter(...)` and
`CardModelDetail.tsx:189` passes `props.formFields || []`, both fresh arrays on
every render. So this had to be fixed inside `ModelForm`, not at the call sites.

Re-running that effect re-fetched the Team dropdown's options, and while the
request was in flight `ModelForm` returned `<Loader/>` *instead of* the form:

```tsx
if (isFetching || isFetchingDropdownOptions) {
  return <Loader ... />;   // unmounts BasicModelForm and everything under it
}
```

A different element in the same position unmounts the subtree — and a form's
values live in that subtree, in `BasicForm`'s refs and in each `Input`'s own
state. The request finished, the form remounted from empty initial values, and
everything typed in the meantime was gone.

The chain that set it off: Email field `onChange` → the page's debounced
account check → `setIsEmailRegistered` → page re-renders → new `fields` array →
effect re-runs → loader → unmount.

**Fix**, all in `ModelForm`:
- The loader only replaces the form when there is no form yet
  (`fields.length === 0`). After that, options refresh in the background.
- Dropdown options are cached per `(model constructor, labelField, valueField)`
  — everything the request depends on, since it takes no query and no closure
  state. The invite form was issuing a Team list request per keystroke; now the
  usual re-run does not touch the network at all. The cache lives on the
  ModelForm instance, so reopening a modal fetches fresh.
- A generation guard drops a slow earlier run so it cannot restore stale fields
  or clear a loading flag a newer run owns.

The effect still re-runs and still replaces the field definitions, which is
load-bearing: `showIf` / `onChange` / `getDefaultValue` are closures over page
state, and freezing them would silently break the invite form's own conditional
Name field. Only the network call is skipped.

## 2. Characters were overwritten as they were typed

Independent of the above, and reproducible with no dropdown in the form at all
(so it also affected **Teams → Members**, whose invite form has no Team field).

`Input` renders an uncontrolled `<input>` and mirrors React state into the DOM
through two hops — `value` → effect → `displayValue` → effect → `input.value`.
`displayValue` therefore settles one render behind. If anything interleaved a
render between those commits, the effect wrote the *older* value back over text
the browser already held, and the character typed in that window disappeared.

**Fix**: for text, the display value is now derived during render rather than
stored, so it cannot lag behind `value` (which is set synchronously in the
change handler). Dates keep their parsed state — they genuinely need one. The
write is also now conditional, which stops the caret jumping to the end when
editing mid-field.

## Also fixed on the way

- `BasicForm` disabled **every** field while **any** dropdown fetched its
  options, and `Input` renders `disabled` as `readOnly` — so a text box stayed
  focusable and silently ate keystrokes for an unrelated reason. Only dropdowns
  wait now.
- `BasicForm` will not re-seed a form the user has already edited. The existing
  latch already covered this; this asserts it directly instead of leaving it to
  effect ordering. The latch itself moved out of a `for` loop it was sitting
  inside by accident.
- `useUserEmailRegistrationStatus` held the caller's header factory in a
  closure, so an inline options object (every caller) produced a new
  `checkEmail` every render — and through it, another render of the form. It is
  now a ref, and the debounce is cleared on unmount.

## Tests

`Common/Tests/UI/Components/Forms/ModelFormPreservesUserInput.test.tsx` — 13
tests driving the real `ModelForm` over the real `TeamMember`/`Team` models,
with a harness that mirrors the invite page (inline fields array, per-keystroke
`onChange` into page state, `dropdownModal`-backed Team field). **9 of them fail
on master**; the other 4 are the "still works" guards — loader on first load,
per-model option keying, default values, identity churn.

Covered: the email survives typing, Tab, the check resolving, the status
flipping back and forth, and a conditional field appearing; the form is never
replaced by a loader once rendered (asserted as *the same DOM node*); options
are fetched once, still arrive, and are keyed per model; a stale run is
ignored; text fields stay usable while a dropdown loads; defaults still apply.

`Common/Tests/UI/Utils/UserEmailRegistrationStatus.test.tsx` — 6 tests (2 fail
on master):
`checkEmail` identity is stable, current headers are still used, the debounce
asks once, invalid addresses cost nothing, a superseded answer is ignored, and
a pending check is dropped on unmount.

`E2E/Tests/Dashboard/InviteUser.spec.ts` — Playwright, through the real app:
register → project → Users → Invite User; the email survives fill+Tab, survives
being typed one key at a time, survives being edited after the lookup, and the
invite actually completes with a team selected.

## Known tradeoff

A form whose field list *grows* after mount now renders immediately with the
new dropdown empty for the length of one request, instead of blanking the form.
Entity dropdowns run their own server-side search when opened, so this is not
visible in practice — and it is strictly better than destroying the form.
