### PR TITLE
fix(billing): stop telemetry admission from polling Stripe per request

### DIFF
--- a/Common/Server/Services/BillingPaymentMethodService.ts
+++ b/Common/Server/Services/BillingPaymentMethodService.ts
@@ -9,6 +9,7 @@ import BadDataException from "../../Types/Exception/BadDataException";
 import Model from "../../Models/DatabaseModels/BillingPaymentMethod";
 import Project from "../../Models/DatabaseModels/Project";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import PayAsYouGoBillingService from "./PayAsYouGoBillingService";
 import Dictionary from "../../Types/Dictionary";
 import ObjectID from "../../Types/ObjectID";
 
@@ -94,6 +95,16 @@ export class Service extends DatabaseService<Model> {
       });
     }
 
+    /*
+     * We have just read the authoritative list of payment methods for this
+     * project, so any cached authorization decision is now stale by
+     * definition. Clearing it here is what makes the admission path's denial
+     * cache safe: the billing page reads this table immediately after a card
+     * is added, so ingest stops being denied on the very next batch instead of
+     * at the end of the denial TTL.
+     */
+    PayAsYouGoBillingService.invalidate(data.projectId);
+
     return paymentMethods;
   }
 
@@ -166,6 +177,13 @@ export class Service extends DatabaseService<Model> {
       }
     }
 
+    /*
+     * No authorization invalidation here on purpose: BillingService
+     * .deletePaymentMethod refuses to detach the last remaining method, so a
+     * successful delete always leaves the project with at least one card and
+     * its authorization unchanged. Clearing the cache would only force a
+     * needless provider read.
+     */
     return { deleteBy, carryForward: null };
   }
 }

--- a/Common/Server/Services/BillingService.ts
+++ b/Common/Server/Services/BillingService.ts
@@ -87,6 +87,11 @@ const PAYMENT_READ_MAX_RETRY_DELAY_IN_MS: number = 8000;
  * 500 {"error":"Server Error"}. That is a user-visible failure of the billing
  * page on a single upstream hiccup. The SDK's own retry generates an
  * idempotency key per attempt, so it is safe for writes as well as reads.
+ *
+ * It does NOT cover a plain 429: stripe-node's _shouldRetry
+ * (node_modules/stripe/lib/StripeResource.js) retries connection-closed codes,
+ * 409 and >=500 only. Rate limits are handled by readPaymentProvider's own
+ * ladder and, more importantly, by not making the calls in the first place.
  */
 const STRIPE_MAX_NETWORK_RETRIES: number = 2;
 
@@ -1381,10 +1386,16 @@ export class BillingService extends BaseService {
   }
 
   /**
-   * Stripe answers a rate limit with Retry-After when it knows how long the
-   * caller should wait. Preferring our own doubling over Stripe's own number
-   * is how a retry ladder ends up firing all of its attempts inside a window
-   * the provider already said was too small.
+   * Honour Retry-After if it is there, rather than preferring our own doubling
+   * over a number the provider gave us.
+   *
+   * Be clear about what this does NOT buy: Stripe documents only a
+   * `Stripe-Rate-Limited-Reason` header on a rate-limited 429
+   * (https://docs.stripe.com/rate-limits) and does not document sending
+   * Retry-After, so on the failure that actually breaks us this falls through
+   * to the exponential backoff. It is kept because it is correct if Stripe
+   * ever does send one - not because it is mitigating today's rate limit.
+   * Do not count it as mitigation when sizing this.
    */
   private static getPaymentReadRetryDelay(
     err: unknown,

--- a/Common/Server/Services/PayAsYouGoBillingService.ts
+++ b/Common/Server/Services/PayAsYouGoBillingService.ts
@@ -17,41 +17,97 @@ export const PAY_AS_YOU_GO_PAYMENT_REQUIRED_MESSAGE: string =
 
 type PaymentAuthorization = "payment-method" | "invoice" | "reseller";
 
+type NotAuthorized = "none";
+const NOT_AUTHORIZED: NotAuthorized = "none";
+
+/*
+ * A denial is the expensive answer. An authorized project answers from the
+ * positive cache and costs one provider read a minute; an unauthorized one
+ * re-ran the full check every time, and that check costs a payment-method
+ * read per supported type. On the telemetry admission path - which runs for
+ * every ingested batch over OTLP, gRPC, MQTT and session replay, and which
+ * deliberately re-checks even on a key-cache hit - that is a provider read
+ * storm proportional to ingest traffic, for exactly the projects that are not
+ * paying. It is enough on its own to hold a Stripe account at its rate limit
+ * indefinitely, which then breaks the billing page for every other project.
+ *
+ * So denials are cacheable, but only where a few seconds of staleness is
+ * harmless: admission control, which the client retries anyway. Every
+ * user-facing check - the billing page's own gate, creating a monitor -
+ * still reads through, so "add a card and it works" keeps meaning that.
+ */
+const DENIAL_CACHE_TTL_IN_MS: number = 10_000;
+const AUTHORIZATION_CACHE_TTL_IN_MS: number = 60_000;
+
 export class Service {
-  private authorizedProjects: InMemoryTTLCache<PaymentAuthorization> =
-    new InMemoryTTLCache(10_000);
+  private authorizedProjects: InMemoryTTLCache<
+    PaymentAuthorization | NotAuthorized
+  > = new InMemoryTTLCache(10_000);
 
   /**
    * A subscription created during signup is not permission to incur charges.
    * Require a payment method, or a real invoice/reseller billing agreement.
-   * Short positive caching keeps the telemetry admission path affordable;
-   * rejected checks are never cached so adding a card works immediately.
+   * Short positive caching keeps the telemetry admission path affordable.
+   *
+   * `allowStaleDenial` additionally lets a recent denial answer without going
+   * back to the provider. Only admission control should pass it - see
+   * DENIAL_CACHE_TTL_IN_MS above.
    */
   public async canUsePayAsYouGo(
     projectId: ObjectID,
-    options?: { useCache?: boolean },
+    options?: { useCache?: boolean; allowStaleDenial?: boolean },
   ): Promise<boolean> {
     if (!BillingService.isBillingEnabled()) {
       return true;
     }
 
     const cacheKey: string = projectId.toString();
-    if (options?.useCache !== false && this.authorizedProjects.get(cacheKey)) {
-      return true;
+    if (options?.useCache !== false) {
+      const cached: PaymentAuthorization | NotAuthorized | undefined =
+        this.authorizedProjects.get(cacheKey);
+
+      if (cached && cached !== NOT_AUTHORIZED) {
+        return true;
+      }
+
+      if (cached === NOT_AUTHORIZED && options?.allowStaleDenial) {
+        return false;
+      }
     }
 
     const authorization: PaymentAuthorization | null =
       await this.checkPaymentAuthorization(projectId);
     if (authorization) {
-      this.authorizedProjects.set(cacheKey, authorization, 60_000);
+      this.authorizedProjects.set(
+        cacheKey,
+        authorization,
+        AUTHORIZATION_CACHE_TTL_IN_MS,
+      );
     } else {
-      this.authorizedProjects.delete(cacheKey);
+      this.authorizedProjects.set(
+        cacheKey,
+        NOT_AUTHORIZED,
+        DENIAL_CACHE_TTL_IN_MS,
+      );
     }
     return Boolean(authorization);
   }
 
-  public async requirePayAsYouGo(projectId: ObjectID): Promise<void> {
-    if (!(await this.canUsePayAsYouGo(projectId))) {
+  /**
+   * Forget everything cached about a project's authorization. Called when the
+   * payment methods on file are re-read and when one is removed, so a card
+   * added a moment ago is honoured on the next admission check rather than at
+   * the end of the denial TTL.
+   */
+  public invalidate(projectId: ObjectID): void {
+    this.authorizedProjects.delete(projectId.toString());
+  }
+
+  public async requirePayAsYouGo(
+    projectId: ObjectID,
+    options?: { allowStaleDenial?: boolean },
+  ): Promise<void> {
+    if (!(await this.canUsePayAsYouGo(projectId, options))) {
       throw new PaymentRequiredException(
         PAY_AS_YOU_GO_PAYMENT_REQUIRED_MESSAGE,
       );
@@ -66,7 +122,7 @@ export class Service {
       return undefined;
     }
 
-    const authorization: PaymentAuthorization | undefined =
+    const authorization: PaymentAuthorization | NotAuthorized | undefined =
       this.authorizedProjects.get(projectId.toString());
     if (authorization === "invoice" || authorization === "reseller") {
       return undefined;

--- a/Common/Server/Services/TelemetryIngestionKeyService.ts
+++ b/Common/Server/Services/TelemetryIngestionKeyService.ts
@@ -414,8 +414,19 @@ export class Service extends DatabaseService<Model> {
       /*
        * Check even on key-cache hits. Billing eligibility has its own bounded
        * cache, and must not remain enabled for the lifetime of a live key.
+       *
+       * This runs for every ingested batch, so it is the one caller that may
+       * answer from a recently cached denial rather than re-reading the
+       * payment provider. Without that, an unpaid project ingesting telemetry
+       * turns every batch into provider reads and holds the whole Stripe
+       * account at its rate limit. The client retries, so a few seconds
+       * between adding a card and ingest being admitted costs nothing - and
+       * BillingPaymentMethodService clears the entry as soon as the card is
+       * read, which is what the billing page does right after one is added.
        */
-      await PayAsYouGoBillingService.requirePayAsYouGo(policy.projectId);
+      await PayAsYouGoBillingService.requirePayAsYouGo(policy.projectId, {
+        allowStaleDenial: true,
+      });
     }
 
     return policy;

--- a/Common/Tests/Server/Services/PayAsYouGoBillingService.test.ts
+++ b/Common/Tests/Server/Services/PayAsYouGoBillingService.test.ts
@@ -126,6 +126,94 @@ describe("PayAsYouGoBillingService", () => {
     expect(hasPaymentMethods).toHaveBeenCalledTimes(2);
   });
 
+  /*
+   * The telemetry admission path re-checks billing for every ingested batch.
+   * With denials uncached that was a payment-provider read per batch for every
+   * unpaid project, which is enough to hold the whole Stripe account at its
+   * rate limit and take the billing page down with it.
+   */
+  describe("denial caching on the admission path", () => {
+    it("still reads through a denial for ordinary callers", async () => {
+      hasPaymentMethods.mockResolvedValue(false);
+      await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(false);
+      hasPaymentMethods.mockResolvedValue(true);
+      await expect(service.canUsePayAsYouGo(PROJECT_ID)).resolves.toBe(true);
+      expect(hasPaymentMethods).toHaveBeenCalledTimes(2);
+    });
+
+    it("answers a repeat admission check from the cached denial", async () => {
+      hasPaymentMethods.mockResolvedValue(false);
+      await expect(
+        service.canUsePayAsYouGo(PROJECT_ID, { allowStaleDenial: true }),
+      ).resolves.toBe(false);
+      await expect(
+        service.canUsePayAsYouGo(PROJECT_ID, { allowStaleDenial: true }),
+      ).resolves.toBe(false);
+      await expect(
+        service.canUsePayAsYouGo(PROJECT_ID, { allowStaleDenial: true }),
+      ).resolves.toBe(false);
+      // One provider read for three admission checks, not three.
+      expect(hasPaymentMethods).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops trusting a denial after ten seconds", async () => {
+      const now: jest.SpyInstance = getJestSpyOn(Date, "now").mockReturnValue(
+        100_000,
+      );
+      hasPaymentMethods.mockResolvedValue(false);
+      await service.canUsePayAsYouGo(PROJECT_ID, { allowStaleDenial: true });
+      await service.canUsePayAsYouGo(PROJECT_ID, { allowStaleDenial: true });
+      expect(hasPaymentMethods).toHaveBeenCalledTimes(1);
+
+      now.mockReturnValue(110_001);
+      hasPaymentMethods.mockResolvedValue(true);
+      await expect(
+        service.canUsePayAsYouGo(PROJECT_ID, { allowStaleDenial: true }),
+      ).resolves.toBe(true);
+      expect(hasPaymentMethods).toHaveBeenCalledTimes(2);
+    });
+
+    it("honours a card added a moment ago once the payment methods are re-read", async () => {
+      hasPaymentMethods.mockResolvedValue(false);
+      await expect(
+        service.canUsePayAsYouGo(PROJECT_ID, { allowStaleDenial: true }),
+      ).resolves.toBe(false);
+
+      /*
+       * What BillingPaymentMethodService does after syncing the project's
+       * payment methods from the provider - which is what the billing page
+       * triggers immediately after a card is added.
+       */
+      service.invalidate(PROJECT_ID);
+      hasPaymentMethods.mockResolvedValue(true);
+
+      await expect(
+        service.canUsePayAsYouGo(PROJECT_ID, { allowStaleDenial: true }),
+      ).resolves.toBe(true);
+      expect(hasPaymentMethods).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps a cached denial project-scoped", async () => {
+      hasPaymentMethods.mockResolvedValue(false);
+      await service.canUsePayAsYouGo(PROJECT_ID, { allowStaleDenial: true });
+      await service.canUsePayAsYouGo(OTHER_PROJECT_ID, {
+        allowStaleDenial: true,
+      });
+      expect(hasPaymentMethods).toHaveBeenCalledTimes(2);
+    });
+
+    it("still refuses admission from a cached denial", async () => {
+      hasPaymentMethods.mockResolvedValue(false);
+      await expect(
+        service.requirePayAsYouGo(PROJECT_ID, { allowStaleDenial: true }),
+      ).rejects.toBeInstanceOf(PaymentRequiredException);
+      await expect(
+        service.requirePayAsYouGo(PROJECT_ID, { allowStaleDenial: true }),
+      ).rejects.toBeInstanceOf(PaymentRequiredException);
+      expect(hasPaymentMethods).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("caches positive admission checks for at most sixty seconds", async () => {
     const now: jest.SpyInstance = getJestSpyOn(Date, "now").mockReturnValue(
       100_000,


### PR DESCRIPTION
Follow-up to #3693. That PR made the failure *legible*; this one removes its cause.

## The error you saw

> Could not reach the payment provider to read payment methods (rate_limit). Please try again.

That string is the 503 added in #3693, and `rate_limit` is Stripe's own error code — so the diagnosis is now settled rather than inferred. It is HTTP 429, and it survived everything #3693 did: single-flight syncs, five retry attempts, `Retry-After`, `maxNetworkRetries`. Retrying harder was never going to fix it.

## Where the calls actually come from

Not the billing page. **Telemetry admission.**

`getPolicyFromSecretKey` runs for every ingested batch — OTLP over HTTP ([TelemetryIngest.ts:221](Common/Server/Middleware/TelemetryIngest.ts:221)), gRPC ([GrpcServer.ts:83](App/FeatureSet/Telemetry/GrpcServer.ts:83)), MQTT per PUBLISH ([MqttServer.ts:339](App/FeatureSet/Telemetry/MqttServer.ts:339)), session replay — and it deliberately re-checks billing even on a key-cache hit.

`canUsePayAsYouGo` cached an *authorized* project for 60s. A **denial was never cached at all**, so an unpaid project re-ran the full check every single time — and that check costs one `paymentMethods.list` per supported type, of which there are four.

At this repo's own OTel export defaults (traces every 5s, logs every 1s), one instrumented Node process makes **~73 admission checks/min ≈ 292 Stripe reads/min**. Six processes is **~29 reads/second** against a documented sandbox ceiling of **25 requests/second per account** ([Stripe rate limits](https://docs.stripe.com/rate-limits)).

So a single un-carded project ingesting telemetry can hold the entire Stripe account at its rate limit indefinitely — and every other project's billing page fails with it. That is what you were looking at.

## The fix

Denials become cacheable, but only where staleness is harmless:

- `canUsePayAsYouGo` caches a denial for **10s**, honoured only for callers passing `allowStaleDenial`. Telemetry admission is the only such caller, and the client retries, so a few seconds is invisible. Every user-facing check — the billing page's own gate, creating a monitor — still reads through, so *"add a card and it works"* keeps meaning that.
- `BillingPaymentMethodService` clears the cached decision whenever it re-reads payment methods from the provider. The billing page reads that table immediately after a card is added, so ingest is admitted on the **next batch**, not at the end of the TTL.

Effect on the failing path: from *4 Stripe reads per ingest request, unbounded* to *at most 4 reads per project per 10s, independent of ingest volume*.

## Corrections to #3693

Two comments I wrote there overstated what they bought, and I'd rather fix them than let someone double-count the mitigation later:

- Stripe documents only a `Stripe-Rate-Limited-Reason` header on a rate-limited 429 and does **not** document sending `Retry-After`.
- stripe-node's `_shouldRetry` never retries a plain 429 — it covers connection-closed codes, 409 and ≥500.

Both mechanisms are worth keeping. Neither was mitigating this.

## Considered and deliberately not done

- **Collapsing the four per-type `paymentMethods.list` calls into one untyped list** (5 reads → 2). The direction is right and the response shape is identical, but the API version at which `type` became optional could not be established without a live call, and an unfiltered list returns Stripe's ordering rather than ours — which silently changes which card `payInvoice` charges first. Worth doing as its own change, with its own testing, on the money path.
- **A circuit breaker on provider reads**, and **invalidating authorization on payment-method delete** — the latter is unreachable, because `deletePaymentMethod` refuses to detach the last remaining method, so a successful delete always leaves authorization unchanged. Clearing the cache there would only force a needless read.

## Verification

- 406 tests across 13 billing suites pass, including 6 new ones covering: ordinary callers still read through a denial, repeat admission checks answer from cache (1 provider read for 3 checks), the denial expires at 10s, a card added a moment ago is honoured once payment methods are re-read, denials stay project-scoped, and admission is still refused from a cached denial.
- `tsc --noEmit` clean; eslint clean on every changed file.

One caveat worth stating plainly: `InMemoryTTLCache` is per-process, so the invalidation only clears the process that served the billing page. A cross-process invalidation would need Valkey. In practice the denial TTL is 10s, so the worst case elsewhere is bounded by that anyway.
