### PR TITLE
fix(probe): stop a stalled synthetic bootstrap from failing the monitor

### DIFF
--- a/HelmChart/Public/oneuptime/templates/probe.yaml
+++ b/HelmChart/Public/oneuptime/templates/probe.yaml
@@ -106,6 +106,14 @@ spec:
           volumeMounts:
             - name: synthetic-runtime-tmp
               mountPath: /tmp
+            # Chromium keeps its shared-memory segments here, and a container
+            # gets 64Mi of /dev/shm by default. Several concurrent browsers at
+            # a desktop viewport exhaust that, and a browser that cannot
+            # allocate shared memory does not fail cleanly -- its renderer or
+            # network service wedges, and the synthetic runtime's first
+            # navigation simply never completes.
+            - name: dshm
+              mountPath: /dev/shm
             {{- with (default $.Values.extraVolumeMounts $val.extraVolumeMounts) }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -220,6 +228,10 @@ spec:
         - name: synthetic-runtime-tmp
           emptyDir:
             sizeLimit: {{ default "2Gi" $val.syntheticMonitorTempStorageSizeLimit | quote }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ default "512Mi" $val.syntheticMonitorSharedMemorySizeLimit | quote }}
         {{- with (default $.Values.extraVolumes $val.extraVolumes) }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/HelmChart/Public/oneuptime/tests/extra-env-volumes_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/extra-env-volumes_test.yaml
@@ -136,6 +136,9 @@ tests:
 
   # The four workloads that already carry volumes keep exactly the ones they
   # shipped with — a count, so an accidental extra entry fails too.
+  # Two of the probe's own: the synthetic-runtime scratch space at /tmp, and
+  # the memory-backed /dev/shm that Chromium needs to be bigger than a
+  # container's 64Mi default.
   - it: leaves the probe's own volumes alone when nothing is set
     templates:
       - templates/probe.yaml
@@ -145,16 +148,23 @@ tests:
     asserts:
       - lengthEqual:
           path: spec.template.spec.volumes
-          count: 1
+          count: 2
       - lengthEqual:
           path: spec.template.spec.containers[0].volumeMounts
-          count: 1
+          count: 2
       - contains:
           path: spec.template.spec.volumes
           content:
             name: synthetic-runtime-tmp
             emptyDir:
               sizeLimit: "2Gi"
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 512Mi
 
   - it: leaves nginx's own volumes alone when nothing is set
     templates:
@@ -396,13 +406,20 @@ tests:
     asserts:
       - lengthEqual:
           path: spec.template.spec.volumes
-          count: 2
+          count: 3
       - contains:
           path: spec.template.spec.volumes
           content:
             name: synthetic-runtime-tmp
             emptyDir:
               sizeLimit: "2Gi"
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 512Mi
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:

--- a/HelmChart/Public/oneuptime/tests/probe-shared-memory_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/probe-shared-memory_test.yaml
@@ -1,0 +1,110 @@
+# Chromium keeps its shared-memory segments in /dev/shm. A container gets 64Mi
+# of it by default, which is not enough for syntheticMonitorMaxConcurrency
+# browsers at a 1920x1080 viewport -- and running out of it does not surface as
+# a clean browser error. The browser process starts, launchPersistentContext
+# resolves, pages open, and then the synthetic runtime's first navigation
+# simply never completes, which reaches the customer as a 30-second page.goto
+# timeout on an internal URL.
+#
+# These render assertions exist because that failure is invisible in a
+# deployment that "works": the volume is either there or the probe is one busy
+# night away from the bug.
+suite: probe shared memory
+templates:
+  - templates/probe.yaml
+release:
+  name: oneuptime
+  namespace: oneuptime
+tests:
+  - it: gives every probe a memory-backed /dev/shm larger than the 64Mi default
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: dshm
+            mountPath: /dev/shm
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 512Mi
+
+  - it: keeps the temporary-storage volume alongside it
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: synthetic-runtime-tmp
+            mountPath: /tmp
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: synthetic-runtime-tmp
+            emptyDir:
+              sizeLimit: "2Gi"
+
+  - it: honours a per-probe shared-memory override
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      probes.one.syntheticMonitorSharedMemorySizeLimit: 1Gi
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 1Gi
+
+  - it: keeps shared memory sized independently of the temporary-storage limit
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      probes.one.syntheticMonitorTempStorageSizeLimit: 8Gi
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 512Mi
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: synthetic-runtime-tmp
+            emptyDir:
+              sizeLimit: "8Gi"
+
+  - it: keeps extra volumes from displacing either of them
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      probes.one.extraVolumes:
+        - name: custom
+          emptyDir: {}
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 512Mi
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: custom
+            emptyDir: {}

--- a/HelmChart/Public/oneuptime/values.schema.json
+++ b/HelmChart/Public/oneuptime/values.schema.json
@@ -2191,6 +2191,10 @@
                             "type": "string",
                             "pattern": "^[0-9]+(?:Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K)?$"
                         },
+                        "syntheticMonitorSharedMemorySizeLimit": {
+                            "type": "string",
+                            "pattern": "^[0-9]+(?:Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K)?$"
+                        },
                         "syntheticMonitorChromiumSandboxEnabled": {
                             "type": "boolean"
                         },

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -1295,6 +1295,13 @@ probes:
     # watchdog is the primary limit; this emptyDir ceiling contains failures
     # across all concurrent executions and other temporary Probe data.
     syntheticMonitorTempStorageSizeLimit: 2Gi
+    # Size of /dev/shm, which Chromium uses for shared memory between its
+    # browser, renderer and network processes. A container gets 64Mi by
+    # default -- not enough for syntheticMonitorMaxConcurrency browsers at a
+    # 1920x1080 viewport, and running out does not produce a clean error: the
+    # browser starts, then its first navigation never completes. This is
+    # memory-backed, so it counts against the pod's memory limit.
+    syntheticMonitorSharedMemorySizeLimit: 512Mi
     # RuntimeDefault is available on every conforming cluster but commonly
     # blocks the user-namespace creation Chromium's OS sandbox needs. Leave the
     # Chromium sandbox disabled with RuntimeDefault. Set this to true together
@@ -1392,6 +1399,7 @@ probes:
 #   syntheticMonitorMaxProcessTreeRssBytes: 1610612736
 #   syntheticMonitorMaxDiskBytes: 268435456
 #   syntheticMonitorTempStorageSizeLimit: 2Gi
+#   syntheticMonitorSharedMemorySizeLimit: 512Mi
 #   syntheticMonitorChromiumSandboxEnabled: false
 #   customCodeMonitorScriptTimeoutInMs: 60000
 #   # DNS override for this probe (otherwise inherits the chart-wide dnsConfig default).

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SyntheticMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SyntheticMonitor.test.ts
@@ -1,4 +1,7 @@
-import ProcessRunner from "../../../../Utils/Monitors/SyntheticRuntime/ProcessRunner";
+import ProcessRunner, {
+  SyntheticProcessRunnerError,
+} from "../../../../Utils/Monitors/SyntheticRuntime/ProcessRunner";
+import { SYNTHETIC_RUNTIME_FAULT_KIND } from "../../../../Utils/Monitors/SyntheticRuntime/SyntheticRuntimeFault";
 import {
   SyntheticMonitorWorkerConfig,
   SyntheticMonitorWorkerResult,
@@ -267,7 +270,13 @@ describe("SyntheticMonitor secure worker orchestration", () => {
         .payload as SyntheticMonitorWorkerConfig;
       expect(payload.proxy).toEqual({
         server: "http://proxy.internal:8080",
-        bypass: "localhost,127.0.0.1,.internal.example",
+        /*
+         * The sandbox's own controller origin leads the list, ahead of the
+         * operator's entries: the internal bootstrap navigation must never
+         * depend on their proxy being reachable.
+         */
+        bypass:
+          "synthetic-runtime.oneuptime.invalid,localhost,127.0.0.1,.internal.example",
       });
     } finally {
       noProxy.splice(0, noProxy.length, ...originalNoProxy);
@@ -455,6 +464,201 @@ describe("SyntheticMonitor secure worker orchestration", () => {
       scriptError: "worker launch failed",
       totalAttempts: 1,
     });
+  });
+
+  /*
+   * A probe that cannot start its own browser has not learned anything about
+   * the customer's site. Everything below is about keeping those two apart:
+   * the customer who reported this was handed a Playwright timeout on an
+   * internal `.invalid` URL as though their script had failed, on the first
+   * and only attempt, because Retry Count On Error defaults to zero.
+   */
+  function runtimeFault(message: string): SyntheticProcessRunnerError {
+    const error: SyntheticProcessRunnerError = Object.create(
+      SyntheticProcessRunnerError.prototype,
+    ) as SyntheticProcessRunnerError;
+    Object.assign(error, {
+      name: "SyntheticProcessRunnerError",
+      message,
+      stdout: "",
+      stderr: "",
+      stdoutTruncated: false,
+      stderrTruncated: false,
+      kind: SYNTHETIC_RUNTIME_FAULT_KIND,
+      remoteStack: `${message}\n    at WorkerController.execute (/usr/src/app/Utils/Monitors/SyntheticRuntime/WorkerController.ts:148:28)`,
+    });
+    return error;
+  }
+
+  test("retries a probe runtime fault even when the tenant asked for no retries", async () => {
+    const timeoutSpy: jest.SpyInstance = jest
+      .spyOn(global, "setTimeout")
+      .mockImplementation(((callback: () => void): NodeJS.Timeout => {
+        callback();
+        return {} as NodeJS.Timeout;
+      }) as typeof setTimeout);
+    runSpy
+      .mockRejectedValueOnce(
+        runtimeFault("Synthetic monitor could not start on this probe: ..."),
+      )
+      .mockResolvedValueOnce(
+        workerRunResult({
+          returnValue: { data: "recovered" },
+          logMessages: [],
+          capturedMetrics: [],
+          screenshots: {},
+        }),
+      );
+
+    try {
+      const responses: SyntheticMonitorResponse[] | null =
+        await SyntheticMonitor.execute({
+          script: "return { data: 'recovered' };",
+          browserTypes: [BrowserType.Chromium],
+          screenSizeTypes: [ScreenSizeType.Desktop],
+          // Deliberately absent: this is the default every monitor ships with.
+        });
+
+      expect(runSpy).toHaveBeenCalledTimes(2);
+      expect(responses?.[0]).toMatchObject({
+        result: "recovered",
+        scriptError: undefined,
+        totalAttempts: 2,
+      });
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
+  test("does not retry a tenant script error the tenant chose not to retry", async () => {
+    runSpy.mockResolvedValue(
+      workerRunResult({
+        logMessages: [],
+        capturedMetrics: [],
+        screenshots: {},
+        scriptError: "TypeError: page.clickk is not a function",
+      }),
+    );
+
+    const responses: SyntheticMonitorResponse[] | null =
+      await SyntheticMonitor.execute({
+        script: "await page.clickk('#buy');",
+        browserTypes: [BrowserType.Chromium],
+        screenSizeTypes: [ScreenSizeType.Desktop],
+      });
+
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(responses?.[0]?.totalAttempts).toBe(1);
+  });
+
+  test("stops after one extra attempt when the runtime fault persists", async () => {
+    const timeoutSpy: jest.SpyInstance = jest
+      .spyOn(global, "setTimeout")
+      .mockImplementation(((callback: () => void): NodeJS.Timeout => {
+        callback();
+        return {} as NodeJS.Timeout;
+      }) as typeof setTimeout);
+    runSpy.mockRejectedValue(
+      runtimeFault(
+        "Synthetic monitor could not start on this probe: the browser runtime did not finish starting up after 3 attempt(s) of 30000 ms. The monitored page was never opened, so this does not reflect the health of the monitored site.",
+      ),
+    );
+
+    try {
+      const responses: SyntheticMonitorResponse[] | null =
+        await SyntheticMonitor.execute({
+          script: "return { data: true };",
+          browserTypes: [BrowserType.Chromium],
+          screenSizeTypes: [ScreenSizeType.Desktop],
+        });
+
+      expect(runSpy).toHaveBeenCalledTimes(2);
+      expect(responses?.[0]?.totalAttempts).toBe(2);
+      /*
+       * A persistent fault still has to be reported -- silently reporting a
+       * monitor as healthy would be worse than a confusing message.
+       */
+      expect(responses?.[0]?.scriptError).toContain(
+        "could not start on this probe",
+      );
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
+  test("keeps OneUptime internals out of the error the tenant is shown", async () => {
+    const timeoutSpy: jest.SpyInstance = jest
+      .spyOn(global, "setTimeout")
+      .mockImplementation(((callback: () => void): NodeJS.Timeout => {
+        callback();
+        return {} as NodeJS.Timeout;
+      }) as typeof setTimeout);
+    runSpy.mockRejectedValue(
+      runtimeFault(
+        "Synthetic monitor could not start on this probe: the browser runtime did not finish starting up after 3 attempt(s) of 30000 ms. The monitored page was never opened, so this does not reflect the health of the monitored site.",
+      ),
+    );
+
+    try {
+      const responses: SyntheticMonitorResponse[] | null =
+        await SyntheticMonitor.execute({
+          script: "return { data: true };",
+          browserTypes: [BrowserType.Chromium],
+          screenSizeTypes: [ScreenSizeType.Desktop],
+        });
+
+      const scriptError: string = responses?.[0]?.scriptError as string;
+      expect(scriptError).not.toContain("synthetic-runtime.oneuptime.invalid");
+      expect(scriptError).not.toContain("WorkerController.ts");
+      expect(scriptError).not.toContain("page.goto");
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
+  test("retries the runtime fault per browser and screen-size combination", async () => {
+    const timeoutSpy: jest.SpyInstance = jest
+      .spyOn(global, "setTimeout")
+      .mockImplementation(((callback: () => void): NodeJS.Timeout => {
+        callback();
+        return {} as NodeJS.Timeout;
+      }) as typeof setTimeout);
+    runSpy
+      .mockRejectedValueOnce(runtimeFault("probe runtime fault"))
+      .mockResolvedValueOnce(
+        workerRunResult({
+          returnValue: { data: "chromium-desktop" },
+          logMessages: [],
+          capturedMetrics: [],
+          screenshots: {},
+        }),
+      )
+      .mockResolvedValueOnce(
+        workerRunResult({
+          returnValue: { data: "firefox-desktop" },
+          logMessages: [],
+          capturedMetrics: [],
+          screenshots: {},
+        }),
+      );
+
+    try {
+      const responses: SyntheticMonitorResponse[] | null =
+        await SyntheticMonitor.execute({
+          script: "return { data: true };",
+          browserTypes: [BrowserType.Chromium, BrowserType.Firefox],
+          screenSizeTypes: [ScreenSizeType.Desktop],
+        });
+
+      expect(runSpy).toHaveBeenCalledTimes(3);
+      expect(
+        responses?.map((response: SyntheticMonitorResponse) => {
+          return response.result;
+        }),
+      ).toEqual(["chromium-desktop", "firefox-desktop"]);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
   });
 });
 

--- a/Probe/Tests/Utils/Monitors/SyntheticRuntime/ProcessRunner.test.ts
+++ b/Probe/Tests/Utils/Monitors/SyntheticRuntime/ProcessRunner.test.ts
@@ -12,9 +12,13 @@ import ProcessRunner, {
 } from "../../../../Utils/Monitors/SyntheticRuntime/ProcessRunner";
 import {
   SyntheticWorkerStartEnvelope,
+  createWorkerFailureEnvelope,
   createWorkerNonce,
   createWorkerSuccessEnvelope,
 } from "../../../../Utils/Monitors/SyntheticRuntime/WorkerProtocol";
+import SyntheticRuntimeFault, {
+  SYNTHETIC_RUNTIME_FAULT_KIND,
+} from "../../../../Utils/Monitors/SyntheticRuntime/SyntheticRuntimeFault";
 
 jest.mock("child_process", () => {
   const actual: typeof import("child_process") =
@@ -172,6 +176,18 @@ function emitSuccess(child: FakeChildProcess, result: TestResult): void {
     createWorkerSuccessEnvelope({
       nonce: startEnvelope.nonce,
       result,
+    }),
+  );
+}
+
+function emitFailure(child: FakeChildProcess, error: unknown): void {
+  const startEnvelope: SyntheticWorkerStartEnvelope<TestConfig> =
+    startEnvelopeFrom(child);
+  child.emit(
+    "message",
+    createWorkerFailureEnvelope({
+      nonce: startEnvelope.nonce,
+      error,
     }),
   );
 }
@@ -851,8 +867,17 @@ describe("SyntheticRuntime ProcessRunner", () => {
     expect(environment?.["HTTPS_PROXY_URL"]).toBe(httpsProxyUrl);
     expect(environment?.["HTTPS_PROXY"]).toBe(httpsProxyUrl);
     expect(environment?.["https_proxy"]).toBe(httpsProxyUrl);
-    expect(environment?.["NO_PROXY"]).toBe("localhost,127.0.0.1");
-    expect(environment?.["no_proxy"]).toBe(".svc.internal");
+    /*
+     * The sandbox's own controller host is prepended to whatever the operator
+     * configured: the internal bootstrap navigation must never be routed at a
+     * proxy, whichever spelling of the variable the browser happens to read.
+     */
+    expect(environment?.["NO_PROXY"]).toBe(
+      "synthetic-runtime.oneuptime.invalid,localhost,127.0.0.1",
+    );
+    expect(environment?.["no_proxy"]).toBe(
+      "synthetic-runtime.oneuptime.invalid,.svc.internal",
+    );
     expect(environment?.["HTTP_PROXY_USERNAME"]).toBeUndefined();
     expect(environment?.["HTTPS_PROXY_PASSWORD"]).toBeUndefined();
     expect(environment?.["AWS_SECRET_ACCESS_KEY"]).toBeUndefined();
@@ -903,7 +928,189 @@ describe("SyntheticRuntime ProcessRunner", () => {
     expect(environment?.["https_proxy"]).toBe(
       "http://lower-https-proxy.internal:8443",
     );
-    expect(environment?.["NO_PROXY"]).toBe("localhost");
+    expect(environment?.["NO_PROXY"]).toBe(
+      "synthetic-runtime.oneuptime.invalid,localhost",
+    );
+  });
+
+  test("carries a worker runtime fault up as a fault, with its stack kept off the message", async () => {
+    /*
+     * The worker already wrote a message for whoever reads the monitor.
+     * Appending its Playwright stack -- as every other worker failure gets --
+     * would bury that message under exactly the internals it replaces, which
+     * is what the customer saw: the same timeout paragraph twice, then a path
+     * inside /usr/src/app.
+     */
+    const child: FakeChildProcess = new FakeChildProcess(41_201);
+    getForkMock().mockImplementation(() => {
+      return asChildProcess(child);
+    });
+    child.onSend = (): void => {
+      global.setImmediate(() => {
+        emitFailure(
+          child,
+          new SyntheticRuntimeFault({
+            message: "Synthetic monitor could not start on this probe.",
+            internalDetail: "unused on this side of the fork",
+          }),
+        );
+        emitExit(child, null);
+      });
+    };
+
+    const runner: ProcessRunner = new ProcessRunner({
+      workerEntryPath: "Workers/SyntheticMonitorWorker.ts",
+      concurrencyLimit: 1,
+    });
+
+    const error: SyntheticProcessRunnerError = await runner
+      .run<TestConfig, TestResult>({
+        payload: { monitorId: "monitor-1" },
+        timeoutInMs: 1000,
+        validateResult: isTestResult,
+      })
+      .then(
+        (): never => {
+          throw new Error("Expected the run to fail.");
+        },
+        (caught: SyntheticProcessRunnerError): SyntheticProcessRunnerError => {
+          return caught;
+        },
+      );
+
+    expect(error).toBeInstanceOf(SyntheticProcessRunnerError);
+    expect(error.kind).toBe(SYNTHETIC_RUNTIME_FAULT_KIND);
+    expect(error.message).toBe(
+      "Synthetic monitor could not start on this probe.",
+    );
+    expect(error.message).not.toContain("SyntheticRuntimeFault");
+    expect(error.remoteStack).toContain("SyntheticRuntimeFault");
+  });
+
+  test("still folds the stack into the message for an ordinary worker failure", async () => {
+    const child: FakeChildProcess = new FakeChildProcess(41_202);
+    getForkMock().mockImplementation(() => {
+      return asChildProcess(child);
+    });
+    child.onSend = (): void => {
+      global.setImmediate(() => {
+        emitFailure(
+          child,
+          new Error("TypeError: page.clickk is not a function"),
+        );
+        emitExit(child, null);
+      });
+    };
+
+    const runner: ProcessRunner = new ProcessRunner({
+      workerEntryPath: "Workers/SyntheticMonitorWorker.ts",
+      concurrencyLimit: 1,
+    });
+
+    const error: SyntheticProcessRunnerError = await runner
+      .run<TestConfig, TestResult>({
+        payload: { monitorId: "monitor-1" },
+        timeoutInMs: 1000,
+        validateResult: isTestResult,
+      })
+      .then(
+        (): never => {
+          throw new Error("Expected the run to fail.");
+        },
+        (caught: SyntheticProcessRunnerError): SyntheticProcessRunnerError => {
+          return caught;
+        },
+      );
+
+    expect(error.kind).toBeUndefined();
+    expect(error.remoteStack).toBeUndefined();
+    expect(error.message).toContain("TypeError: page.clickk is not a function");
+    expect(error.message).toContain("ProcessRunner.test.ts");
+  });
+
+  test("keeps the synthetic runtime's own host out of every proxy, configured or not", async () => {
+    /*
+     * The controller document is fulfilled from memory, so it should never
+     * reach a proxy in the first place -- but that is an ordering guarantee
+     * inside Chromium's network stack, and a corporate proxy asked for a host
+     * that cannot resolve hangs rather than failing fast. The bootstrap is the
+     * least affordable place to find that out.
+     */
+    jest.spyOn(process, "getuid").mockReturnValue(501);
+    const child: FakeChildProcess = new FakeChildProcess(41_103);
+    const forkSpy: jest.Mock = getForkMock().mockImplementation(() => {
+      return asChildProcess(child);
+    });
+    child.onSend = (): void => {
+      global.setImmediate(() => {
+        emitSuccess(child, { value: "complete" });
+        emitExit(child, null);
+      });
+    };
+
+    const runner: ProcessRunner = new ProcessRunner({
+      workerEntryPath: "Workers/SyntheticMonitorWorker.ts",
+      concurrencyLimit: 1,
+      // No proxy configured at all, and no NO_PROXY of any kind.
+      environment: {},
+    });
+
+    await expect(
+      runner.run<TestConfig, TestResult>({
+        payload: { monitorId: "monitor-1" },
+        timeoutInMs: 1000,
+        validateResult: isTestResult,
+      }),
+    ).resolves.toMatchObject({ result: { value: "complete" } });
+
+    const environment: NodeJS.ProcessEnv | undefined = forkOptionsAt(
+      forkSpy,
+      0,
+    ).env;
+    expect(environment?.["NO_PROXY"]).toBe(
+      "synthetic-runtime.oneuptime.invalid",
+    );
+    expect(environment?.["no_proxy"]).toBe(
+      "synthetic-runtime.oneuptime.invalid",
+    );
+  });
+
+  test("does not list the synthetic runtime host twice when it is already bypassed", async () => {
+    jest.spyOn(process, "getuid").mockReturnValue(501);
+    const child: FakeChildProcess = new FakeChildProcess(41_104);
+    const forkSpy: jest.Mock = getForkMock().mockImplementation(() => {
+      return asChildProcess(child);
+    });
+    child.onSend = (): void => {
+      global.setImmediate(() => {
+        emitSuccess(child, { value: "complete" });
+        emitExit(child, null);
+      });
+    };
+
+    const runner: ProcessRunner = new ProcessRunner({
+      workerEntryPath: "Workers/SyntheticMonitorWorker.ts",
+      concurrencyLimit: 1,
+      environment: {
+        NO_PROXY: "synthetic-runtime.oneuptime.invalid, localhost",
+      },
+    });
+
+    await expect(
+      runner.run<TestConfig, TestResult>({
+        payload: { monitorId: "monitor-1" },
+        timeoutInMs: 1000,
+        validateResult: isTestResult,
+      }),
+    ).resolves.toMatchObject({ result: { value: "complete" } });
+
+    const environment: NodeJS.ProcessEnv | undefined = forkOptionsAt(
+      forkSpy,
+      0,
+    ).env;
+    expect(environment?.["NO_PROXY"]).toBe(
+      "synthetic-runtime.oneuptime.invalid, localhost",
+    );
   });
 
   test("allocates distinct rotating identities for concurrent root children", async () => {

--- a/Probe/Tests/Utils/Monitors/SyntheticRuntime/WorkerController.test.ts
+++ b/Probe/Tests/Utils/Monitors/SyntheticRuntime/WorkerController.test.ts
@@ -946,6 +946,179 @@ describe("SyntheticRuntime WorkerController", () => {
     expect(result.returnValue).toEqual({ data: [1, 2, 3] });
   });
 
+  test("recovers in a real browser when the first bootstrap navigation stalls", async () => {
+    /*
+     * The customer-reported failure, reproduced against a real Chromium: the
+     * controller page's navigation never comes back, and the check dies with
+     *
+     *   page.goto: Timeout 30000ms exceeded.
+     *   Call log: - navigating to "https://synthetic-runtime.oneuptime.invalid/<id>",
+     *             waiting until "domcontentloaded"
+     *
+     * The stall is injected rather than provoked -- a healthy browser will not
+     * wedge on demand -- but everything after it is real: a real second page
+     * in the same real context, and the tenant's script actually running.
+     */
+    const browserContext: BrowserContext = await browser.newContext({
+      viewport: { width: 800, height: 600 },
+    });
+    await browserContext.route(`${TARGET_URL}**`, async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: "<!doctype html><title>Synthetic target</title><main>ready</main>",
+      });
+    });
+    const page: Page = await browserContext.newPage();
+
+    const openedPages: Page[] = [];
+    const realNewPage: () => Promise<Page> =
+      browserContext.newPage.bind(browserContext);
+    let stalledOnce: boolean = false;
+
+    const contextWithOneStall: BrowserContext = new Proxy(browserContext, {
+      get(
+        target: BrowserContext,
+        property: string | symbol,
+        receiver: unknown,
+      ) {
+        if (property !== "newPage") {
+          return Reflect.get(target, property, receiver);
+        }
+
+        return async (): Promise<Page> => {
+          const created: Page = await realNewPage();
+          openedPages.push(created);
+
+          if (stalledOnce) {
+            return created;
+          }
+          stalledOnce = true;
+
+          return new Proxy(created, {
+            get(
+              pageTarget: Page,
+              pageProperty: string | symbol,
+              pageReceiver: unknown,
+            ) {
+              if (pageProperty !== "goto") {
+                return Reflect.get(pageTarget, pageProperty, pageReceiver);
+              }
+
+              return async (url: string): Promise<never> => {
+                const error: Error = new Error(
+                  [
+                    "page.goto: Timeout 30000ms exceeded.",
+                    "Call log:",
+                    `  - navigating to "${url}", waiting until "domcontentloaded"`,
+                  ].join("\n"),
+                );
+                error.name = "TimeoutError";
+                throw error;
+              };
+            },
+          });
+        };
+      },
+    }) as BrowserContext;
+
+    try {
+      const result: SandboxExecutionResult = await WorkerController.execute({
+        browserContext: contextWithOneStall,
+        page,
+        code: `
+          await page.goto(${JSON.stringify(TARGET_URL)});
+          const text = await page.locator("main").innerText();
+          return { data: { text } };
+        `,
+        browserType: "Chromium",
+        screenSizeType: "Desktop",
+        args: {},
+        timeoutInMs: 10_000,
+      });
+
+      expect(result.scriptError).toBeUndefined();
+      expect(result.returnValue).toEqual({ data: { text: "ready" } });
+      // One page for the stalled attempt, one for the attempt that worked.
+      expect(openedPages).toHaveLength(2);
+      expect(openedPages[0]!.isClosed()).toBe(true);
+    } finally {
+      await browserContext.close();
+    }
+  });
+
+  test("reports a probe-side fault, not a script error, when every bootstrap attempt stalls", async () => {
+    const browserContext: BrowserContext = await browser.newContext({
+      viewport: { width: 800, height: 600 },
+    });
+    const page: Page = await browserContext.newPage();
+    const realNewPage: () => Promise<Page> =
+      browserContext.newPage.bind(browserContext);
+
+    const alwaysStalling: BrowserContext = new Proxy(browserContext, {
+      get(
+        target: BrowserContext,
+        property: string | symbol,
+        receiver: unknown,
+      ) {
+        if (property !== "newPage") {
+          return Reflect.get(target, property, receiver);
+        }
+
+        return async (): Promise<Page> => {
+          const created: Page = await realNewPage();
+          return new Proxy(created, {
+            get(
+              pageTarget: Page,
+              pageProperty: string | symbol,
+              pageReceiver: unknown,
+            ) {
+              if (pageProperty !== "goto") {
+                return Reflect.get(pageTarget, pageProperty, pageReceiver);
+              }
+              return async (): Promise<never> => {
+                const error: Error = new Error(
+                  "page.goto: Timeout 30000ms exceeded.",
+                );
+                error.name = "TimeoutError";
+                throw error;
+              };
+            },
+          });
+        };
+      },
+    }) as BrowserContext;
+
+    try {
+      const error: Error = await WorkerController.execute({
+        browserContext: alwaysStalling,
+        page,
+        code: "return { data: true };",
+        browserType: "Chromium",
+        screenSizeType: "Desktop",
+        args: {},
+        timeoutInMs: 10_000,
+        bootstrapAttempts: 2,
+        bootstrapTimeoutInMs: 1000,
+      }).then(
+        (): never => {
+          throw new Error("Expected the bootstrap to fail.");
+        },
+        (caught: Error): Error => {
+          return caught;
+        },
+      );
+
+      expect((error as { kind?: string }).kind).toBe("probe-runtime");
+      expect(error.message).not.toContain(
+        "synthetic-runtime.oneuptime.invalid",
+      );
+      expect(error.message).toContain("could not start on this probe");
+    } finally {
+      await browserContext.close();
+    }
+  });
+
   test("uses the same copy-only runtime in Firefox", async () => {
     const firefoxBrowser: Browser = await firefox.launch({ headless: true });
     const firefoxContext: BrowserContext = await firefoxBrowser.newContext();

--- a/Probe/Tests/Utils/Monitors/SyntheticRuntime/WorkerControllerBootstrap.test.ts
+++ b/Probe/Tests/Utils/Monitors/SyntheticRuntime/WorkerControllerBootstrap.test.ts
@@ -1,0 +1,534 @@
+import { BrowserContext, Page, Route } from "playwright";
+import WorkerController from "../../../../Utils/Monitors/SyntheticRuntime/WorkerController";
+import { SYNTHETIC_RUNTIME_CONTROLLER_ORIGIN } from "../../../../Utils/Monitors/SyntheticRuntime/ControllerOrigin";
+import { SYNTHETIC_RUNTIME_FAULT_KIND } from "../../../../Utils/Monitors/SyntheticRuntime/SyntheticRuntimeFault";
+import { SandboxExecutionResult } from "../../../../Utils/Monitors/SyntheticRuntime/RpcProtocol";
+
+/*
+ * These cover the sandbox's own start-up, not the tenant's script, so they run
+ * against fakes rather than a real browser: the point is what happens when the
+ * controller page's navigation never comes back, which is not something a
+ * healthy Chromium will do on demand.
+ *
+ * The failure being pinned here is the one a customer reported --
+ *
+ *   page.goto: Timeout 30000ms exceeded.
+ *   Call log: - navigating to "https://synthetic-runtime.oneuptime.invalid/<id>",
+ *             waiting until "domcontentloaded"
+ *       at WorkerController.execute (.../WorkerController.ts)
+ *
+ * -- which reached them as their monitor's script error, on an internal URL
+ * they had no way to recognise, after a single attempt.
+ */
+
+type BindingHandler = (
+  source: { page: Page; frame: unknown },
+  request: unknown,
+) => Promise<unknown>;
+
+type RouteHandler = (route: Route) => Promise<void>;
+
+interface FakePageRecord {
+  page: FakePage;
+  gotoUrls: string[];
+  gotoTimeouts: Array<number | undefined>;
+  routePatterns: string[];
+  bindingNames: string[];
+}
+
+const WORKER_COMPLETION: Record<string, unknown> = {
+  returnValue: { data: { ok: true } },
+  logMessages: [],
+  capturedMetrics: [],
+  screenshotAssignments: {},
+};
+
+class FakePage {
+  public closeCount: number = 0;
+  public readonly gotoUrls: string[] = [];
+  public readonly gotoTimeouts: Array<number | undefined> = [];
+  public readonly routePatterns: string[] = [];
+  public readonly routeHandlers: RouteHandler[] = [];
+  public readonly bindingNames: string[] = [];
+  public readonly bindingHandlers: BindingHandler[] = [];
+
+  private isPageClosed: boolean = false;
+  private readonly frame: Record<string, unknown> = { name: "main" };
+
+  public constructor(
+    private readonly context: FakeBrowserContext,
+    private readonly index: number,
+  ) {}
+
+  public async route(pattern: string, handler: RouteHandler): Promise<void> {
+    this.routePatterns.push(pattern);
+    this.routeHandlers.push(handler);
+  }
+
+  public async exposeBinding(
+    name: string,
+    handler: BindingHandler,
+  ): Promise<void> {
+    this.bindingNames.push(name);
+    this.bindingHandlers.push(handler);
+  }
+
+  public async goto(
+    url: string,
+    options?: { waitUntil?: string; timeout?: number },
+  ): Promise<null> {
+    this.gotoUrls.push(url);
+    this.gotoTimeouts.push(options?.timeout);
+
+    const failure: Error | undefined = this.context.gotoFailureFor(this.index);
+    if (failure) {
+      throw failure;
+    }
+
+    return null;
+  }
+
+  public mainFrame(): unknown {
+    return this.frame;
+  }
+
+  public async evaluate(
+    _callback: unknown,
+    argument?: unknown,
+  ): Promise<unknown> {
+    /*
+     * WorkerController drives the page with exactly two evaluate calls: one to
+     * start the sandbox (an object payload) and one to stop it (the control
+     * key, a bare string).
+     */
+    if (typeof argument === "string") {
+      return undefined;
+    }
+
+    if (this.context.onStartWorker) {
+      await this.context.onStartWorker(this);
+    }
+
+    return WORKER_COMPLETION;
+  }
+
+  public isClosed(): boolean {
+    return this.isPageClosed;
+  }
+
+  public async close(): Promise<void> {
+    this.closeCount++;
+    this.isPageClosed = true;
+  }
+}
+
+class FakeBrowserContext {
+  public readonly pages: FakePage[] = [];
+  public readonly listenerEvents: string[] = [];
+  public onStartWorker?: ((page: FakePage) => Promise<void>) | undefined;
+
+  /*
+   * How many of the first navigations fail, and with what. A zero here is a
+   * probe that is behaving; anything else is a probe under the load it
+   * predictably sees whenever monitor intervals line up on a wall clock.
+   */
+  public constructor(
+    private readonly failingNavigations: number = 0,
+    private readonly failure: Error = timeoutError(),
+  ) {}
+
+  public async newPage(): Promise<Page> {
+    const page: FakePage = new FakePage(this, this.pages.length);
+    this.pages.push(page);
+    return page as unknown as Page;
+  }
+
+  public on(event: string, _listener: unknown): void {
+    this.listenerEvents.push(event);
+  }
+
+  public gotoFailureFor(pageIndex: number): Error | undefined {
+    return pageIndex < this.failingNavigations ? this.failure : undefined;
+  }
+}
+
+/*
+ * Playwright's real shape for this: the message carries the call log, and the
+ * stack repeats it. Both halves matter -- the supervisor concatenates them,
+ * which is why the customer saw the same paragraph twice.
+ */
+function timeoutError(): Error {
+  const message: string = [
+    "page.goto: Timeout 30000ms exceeded.",
+    "Call log:",
+    `  - navigating to "${SYNTHETIC_RUNTIME_CONTROLLER_ORIGIN}/6f0d1f6e-1f0a-4d0e-9d0e-6f0d1f6e1f0a", waiting until "domcontentloaded"`,
+  ].join("\n");
+  const error: Error = new Error(message);
+  error.name = "TimeoutError";
+  error.stack = `${message}\n    at WorkerController.execute (/usr/src/app/Utils/Monitors/SyntheticRuntime/WorkerController.ts:148:28)`;
+  return error;
+}
+
+function execute(
+  context: FakeBrowserContext,
+  overrides: {
+    bootstrapAttempts?: number;
+    bootstrapTimeoutInMs?: number;
+  } = {},
+): Promise<SandboxExecutionResult> {
+  return WorkerController.execute({
+    browserContext: context as unknown as BrowserContext,
+    page: { name: "monitored-page" } as unknown as Page,
+    code: "return { data: { ok: true } };",
+    browserType: "Chromium",
+    screenSizeType: "Desktop",
+    args: {},
+    timeoutInMs: 10_000,
+    bootstrapAttempts: overrides.bootstrapAttempts ?? 3,
+    /*
+     * Small enough to keep the suite fast, large enough that the retry delays
+     * do not themselves exhaust the total bootstrap budget -- which is derived
+     * from this number, so a 50ms budget would leave no room to retry at all.
+     */
+    bootstrapTimeoutInMs: overrides.bootstrapTimeoutInMs ?? 500,
+  });
+}
+
+function describeFakePages(context: FakeBrowserContext): FakePageRecord[] {
+  return context.pages.map((page: FakePage) => {
+    return {
+      page,
+      gotoUrls: page.gotoUrls,
+      gotoTimeouts: page.gotoTimeouts,
+      routePatterns: page.routePatterns,
+      bindingNames: page.bindingNames,
+    };
+  });
+}
+
+describe("SyntheticRuntime WorkerController bootstrap", () => {
+  test("opens exactly one controller page when the first navigation lands", async () => {
+    const context: FakeBrowserContext = new FakeBrowserContext(0);
+
+    const result: SandboxExecutionResult = await execute(context);
+
+    expect(result.returnValue).toEqual({ data: { ok: true } });
+    expect(context.pages).toHaveLength(1);
+    expect(context.pages[0]!.gotoUrls).toHaveLength(1);
+    expect(context.pages[0]!.gotoUrls[0]).toContain(
+      SYNTHETIC_RUNTIME_CONTROLLER_ORIGIN,
+    );
+  });
+
+  test("recovers from a stalled bootstrap navigation by retrying on a fresh page", async () => {
+    const context: FakeBrowserContext = new FakeBrowserContext(1);
+
+    const result: SandboxExecutionResult = await execute(context);
+
+    expect(result.returnValue).toEqual({ data: { ok: true } });
+    expect(context.pages).toHaveLength(2);
+    // The stalled page is abandoned, not reused: its request is still paused.
+    expect(context.pages[0]!.gotoUrls).toHaveLength(1);
+    expect(context.pages[1]!.gotoUrls).toHaveLength(1);
+  });
+
+  test("closes the page from every abandoned attempt", async () => {
+    const context: FakeBrowserContext = new FakeBrowserContext(2);
+
+    await execute(context);
+
+    expect(context.pages).toHaveLength(3);
+    expect(context.pages[0]!.closeCount).toBe(1);
+    expect(context.pages[1]!.closeCount).toBe(1);
+  });
+
+  test("navigates every attempt to the same execution's sentinel URL", async () => {
+    const context: FakeBrowserContext = new FakeBrowserContext(2);
+
+    await execute(context);
+
+    const urls: string[] = context.pages.flatMap((page: FakePage) => {
+      return page.gotoUrls;
+    });
+    expect(urls).toHaveLength(3);
+    expect(new Set(urls).size).toBe(1);
+  });
+
+  test("re-installs the route and the RPC binding on each fresh attempt", async () => {
+    const context: FakeBrowserContext = new FakeBrowserContext(1);
+
+    await execute(context);
+
+    for (const record of describeFakePages(context)) {
+      expect(record.routePatterns).toEqual(["**/*"]);
+      expect(record.bindingNames).toHaveLength(1);
+      expect(record.bindingNames[0]).toMatch(/^__oneuptimeRpc_[0-9a-f]{32}$/);
+    }
+  });
+
+  test("subscribes to the browser context once, however many attempts it takes", async () => {
+    /*
+     * A broker per attempt would be the obvious way to write the retry, and
+     * would leak a "page" listener onto the shared context for every attempt
+     * that failed.
+     */
+    const context: FakeBrowserContext = new FakeBrowserContext(2);
+
+    await execute(context);
+
+    expect(context.listenerEvents).toEqual(["page"]);
+  });
+
+  test("gives each attempt the configured bootstrap budget", async () => {
+    const context: FakeBrowserContext = new FakeBrowserContext(1);
+
+    await execute(context, { bootstrapTimeoutInMs: 1234 });
+
+    expect(context.pages[0]!.gotoTimeouts).toEqual([1234]);
+    expect(context.pages[1]!.gotoTimeouts).toEqual([1234]);
+  });
+
+  test("reports a probe-side runtime fault once the attempts are spent", async () => {
+    const context: FakeBrowserContext = new FakeBrowserContext(99);
+
+    await expect(
+      execute(context, { bootstrapAttempts: 2 }),
+    ).rejects.toMatchObject({
+      kind: SYNTHETIC_RUNTIME_FAULT_KIND,
+      name: "SyntheticRuntimeFault",
+    });
+    expect(context.pages).toHaveLength(2);
+  });
+
+  test("keeps the sentinel URL and the Playwright stack out of the tenant-facing message", async () => {
+    const context: FakeBrowserContext = new FakeBrowserContext(99);
+
+    const error: Error = await execute(context, {
+      bootstrapAttempts: 1,
+    }).then(
+      (): Error => {
+        throw new Error("Expected the bootstrap to fail.");
+      },
+      (caught: Error): Error => {
+        return caught;
+      },
+    );
+
+    // What the customer reads must not be OneUptime's internals.
+    expect(error.message).not.toContain("synthetic-runtime.oneuptime.invalid");
+    expect(error.message).not.toContain("WorkerController.ts");
+    expect(error.message).not.toContain("page.goto");
+    expect(error.message).toContain("could not start on this probe");
+    expect(error.message).toContain(
+      "does not reflect the health of the monitored site",
+    );
+
+    // ...while the probe's own logs keep every bit of it.
+    const detail: string = (error as { internalDetail?: string })
+      .internalDetail as string;
+    expect(detail).toContain("page.goto: Timeout 30000ms exceeded.");
+    expect(detail).toContain("WorkerController.ts:148:28");
+  });
+
+  test("reports the number of attempts and the budget it spent on each", async () => {
+    const context: FakeBrowserContext = new FakeBrowserContext(99);
+
+    await expect(
+      execute(context, { bootstrapAttempts: 3, bootstrapTimeoutInMs: 250 }),
+    ).rejects.toThrow(/3 attempt\(s\) of up to 250 ms/);
+  });
+
+  test("stops retrying once the whole bootstrap budget is spent", async () => {
+    /*
+     * Retrying has to fit inside the startup allowance the supervisor already
+     * reserved. Past it, the supervisor's own deadline fires first and the
+     * check dies as a bare execution timeout that explains nothing.
+     */
+    const context: FakeBrowserContext = new FakeBrowserContext(99);
+
+    /*
+     * Ten attempts are allowed, but each one burns its full 40ms budget
+     * against a total of 10 x 40ms, so the elapsed retry delays (250ms each)
+     * exhaust it well before the tenth.
+     */
+    await expect(
+      execute(context, { bootstrapAttempts: 10, bootstrapTimeoutInMs: 40 }),
+    ).rejects.toThrow(/could not start on this probe/);
+
+    expect(context.pages.length).toBeGreaterThan(1);
+    expect(context.pages.length).toBeLessThan(10);
+  });
+
+  test("binds the RPC guard to the page of its own attempt", async () => {
+    /*
+     * The binding installed on a page that was later abandoned must not accept
+     * calls, and the surviving page's binding must not reject its own.
+     */
+    const context: FakeBrowserContext = new FakeBrowserContext(1);
+    const outcomes: string[] = [];
+
+    context.onStartWorker = async (page: FakePage): Promise<void> => {
+      const stale: BindingHandler = context.pages[0]!.bindingHandlers[0]!;
+      const live: BindingHandler = page.bindingHandlers[0]!;
+      const source: { page: Page; frame: unknown } = {
+        page: page as unknown as Page,
+        frame: page.mainFrame(),
+      };
+
+      await stale(source, {}).then(
+        (): void => {
+          outcomes.push("stale-accepted");
+        },
+        (error: Error): void => {
+          outcomes.push(`stale-rejected:${error.message}`);
+        },
+      );
+
+      await live(source, {}).then(
+        (): void => {
+          outcomes.push("live-accepted");
+        },
+        (error: Error): void => {
+          outcomes.push(`live-rejected:${error.message}`);
+        },
+      );
+    };
+
+    await execute(context);
+
+    expect(outcomes[0]).toBe(
+      "stale-rejected:Rejected synthetic runtime RPC source.",
+    );
+    /*
+     * The live binding reaches the broker, which rejects the empty request on
+     * its own terms -- never as a bad source.
+     */
+    expect(outcomes[1]).not.toBe(
+      "live-rejected:Rejected synthetic runtime RPC source.",
+    );
+    expect(outcomes[1]).not.toBe("live-accepted");
+  });
+
+  test("rejects a bootstrap attempt count that is not a usable number", async () => {
+    const context: FakeBrowserContext = new FakeBrowserContext(0);
+
+    await expect(execute(context, { bootstrapAttempts: 0 })).rejects.toThrow(
+      "Synthetic runtime bootstrap attempt count is invalid.",
+    );
+    await expect(execute(context, { bootstrapAttempts: 99 })).rejects.toThrow(
+      "Synthetic runtime bootstrap attempt count is invalid.",
+    );
+    expect(context.pages).toHaveLength(0);
+  });
+
+  test("rejects a bootstrap timeout that is not a usable number", async () => {
+    const context: FakeBrowserContext = new FakeBrowserContext(0);
+
+    await expect(execute(context, { bootstrapTimeoutInMs: 0 })).rejects.toThrow(
+      "Synthetic runtime bootstrap timeout is invalid.",
+    );
+    await expect(
+      execute(context, { bootstrapTimeoutInMs: 1.5 }),
+    ).rejects.toThrow("Synthetic runtime bootstrap timeout is invalid.");
+  });
+});
+
+describe("SyntheticRuntime WorkerController sentinel route", () => {
+  async function captureRouteHandler(): Promise<{
+    handler: RouteHandler;
+    url: string;
+  }> {
+    const context: FakeBrowserContext = new FakeBrowserContext(0);
+    await execute(context);
+    return {
+      handler: context.pages[0]!.routeHandlers[0]!,
+      url: context.pages[0]!.gotoUrls[0]!,
+    };
+  }
+
+  function fakeRoute(data: {
+    url: string;
+    resourceType: string;
+    fulfill?: () => Promise<void>;
+  }): { route: Route; fulfilled: string[]; aborted: string[] } {
+    const fulfilled: string[] = [];
+    const aborted: string[] = [];
+    const route: Route = {
+      request: (): { url: () => string; resourceType: () => string } => {
+        return {
+          url: (): string => {
+            return data.url;
+          },
+          resourceType: (): string => {
+            return data.resourceType;
+          },
+        };
+      },
+      fulfill: async (): Promise<void> => {
+        if (data.fulfill) {
+          await data.fulfill();
+        }
+        fulfilled.push(data.url);
+      },
+      abort: async (errorCode?: string): Promise<void> => {
+        aborted.push(errorCode || "");
+      },
+    } as unknown as Route;
+
+    return { route, fulfilled, aborted };
+  }
+
+  test("serves the sentinel document from memory and blocks everything else", async () => {
+    const { handler, url } = await captureRouteHandler();
+
+    const sentinel: ReturnType<typeof fakeRoute> = fakeRoute({
+      url,
+      resourceType: "document",
+    });
+    await handler(sentinel.route);
+    expect(sentinel.fulfilled).toEqual([url]);
+    expect(sentinel.aborted).toEqual([]);
+
+    const other: ReturnType<typeof fakeRoute> = fakeRoute({
+      url: "https://example.com/tracker.js",
+      resourceType: "script",
+    });
+    await handler(other.route);
+    expect(other.fulfilled).toEqual([]);
+    expect(other.aborted).toEqual(["blockedbyclient"]);
+  });
+
+  test("blocks a non-document request even on the sentinel URL", async () => {
+    const { handler, url } = await captureRouteHandler();
+
+    const disguised: ReturnType<typeof fakeRoute> = fakeRoute({
+      url,
+      resourceType: "fetch",
+    });
+    await handler(disguised.route);
+
+    expect(disguised.fulfilled).toEqual([]);
+    expect(disguised.aborted).toEqual(["blockedbyclient"]);
+  });
+
+  test("always settles the route, so a failed fulfil cannot strand the navigation", async () => {
+    /*
+     * A handler that returns without fulfilling, aborting, or continuing leaves
+     * the request paused in the browser with nothing to end it but the
+     * navigation timeout -- the 30-second stall this whole file is about.
+     */
+    const { handler, url } = await captureRouteHandler();
+
+    const broken: ReturnType<typeof fakeRoute> = fakeRoute({
+      url,
+      resourceType: "document",
+      fulfill: async (): Promise<void> => {
+        throw new Error("Target page, context or browser has been closed");
+      },
+    });
+
+    await expect(handler(broken.route)).resolves.toBeUndefined();
+    expect(broken.fulfilled).toEqual([]);
+    expect(broken.aborted).toEqual(["failed"]);
+  });
+});

--- a/Probe/Tests/Utils/Monitors/SyntheticRuntime/WorkerProtocol.test.ts
+++ b/Probe/Tests/Utils/Monitors/SyntheticRuntime/WorkerProtocol.test.ts
@@ -9,6 +9,9 @@ import {
   isWorkerResultEnvelope,
   isWorkerStartEnvelope,
 } from "../../../../Utils/Monitors/SyntheticRuntime/WorkerProtocol";
+import SyntheticRuntimeFault, {
+  SYNTHETIC_RUNTIME_FAULT_KIND,
+} from "../../../../Utils/Monitors/SyntheticRuntime/SyntheticRuntimeFault";
 
 interface TestConfig {
   readonly monitorId: string;
@@ -165,5 +168,95 @@ describe("SyntheticRuntime WorkerProtocol", () => {
         result: {},
       });
     }).toThrow("nonce is invalid");
+  });
+
+  /*
+   * The worker raises the fault; the supervisor has to be able to tell it
+   * apart from the tenant's script failing. The Error object does not survive
+   * the fork, so the marker travels on the envelope.
+   */
+  test("marks a probe runtime fault on the failure envelope", () => {
+    const nonce: string = createWorkerNonce();
+    const envelope: ReturnType<typeof createWorkerFailureEnvelope> =
+      createWorkerFailureEnvelope({
+        nonce,
+        error: new SyntheticRuntimeFault({
+          message: "Synthetic monitor could not start on this probe.",
+          internalDetail: new Error("page.goto: Timeout 30000ms exceeded."),
+        }),
+      });
+
+    expect(envelope.ok).toBe(false);
+    expect(envelope.error.kind).toBe(SYNTHETIC_RUNTIME_FAULT_KIND);
+    expect(envelope.error.message).toBe(
+      "Synthetic monitor could not start on this probe.",
+    );
+    expect(
+      isWorkerResultEnvelope({ value: envelope, expectedNonce: nonce }),
+    ).toBe(true);
+  });
+
+  test("leaves the marker off a tenant script failure", () => {
+    const nonce: string = createWorkerNonce();
+    const envelope: ReturnType<typeof createWorkerFailureEnvelope> =
+      createWorkerFailureEnvelope({
+        nonce,
+        error: new Error("TypeError: page.clickk is not a function"),
+      });
+
+    expect(envelope.error.kind).toBeUndefined();
+    expect(Object.keys(envelope.error).sort()).toEqual(["message", "stack"]);
+    expect(
+      isWorkerResultEnvelope({ value: envelope, expectedNonce: nonce }),
+    ).toBe(true);
+  });
+
+  test("does not carry the fault's internal detail across the boundary", () => {
+    /*
+     * internalDetail is for the probe's own logs on this side of the fork.
+     * The envelope carries only what the supervisor needs.
+     */
+    const nonce: string = createWorkerNonce();
+    const envelope: ReturnType<typeof createWorkerFailureEnvelope> =
+      createWorkerFailureEnvelope({
+        nonce,
+        error: new SyntheticRuntimeFault({
+          message: "Synthetic monitor could not start on this probe.",
+          internalDetail: "a very long playwright call log",
+        }),
+      });
+
+    expect(Object.keys(envelope.error).sort()).toEqual([
+      "kind",
+      "message",
+      "stack",
+    ]);
+  });
+
+  test("rejects an envelope carrying an unknown error kind", () => {
+    const nonce: string = createWorkerNonce();
+    const forged: unknown = {
+      ...createWorkerFailureEnvelope({ nonce, error: new Error("boom") }),
+      error: { message: "boom", kind: "tenant-fault" },
+    };
+
+    expect(
+      isWorkerResultEnvelope({ value: forged, expectedNonce: nonce }),
+    ).toBe(false);
+  });
+
+  test("accepts a marked envelope that has no stack", () => {
+    const nonce: string = createWorkerNonce();
+    const envelope: unknown = {
+      ...createWorkerFailureEnvelope({ nonce, error: new Error("boom") }),
+      error: {
+        message: "Synthetic monitor could not start on this probe.",
+        kind: SYNTHETIC_RUNTIME_FAULT_KIND,
+      },
+    };
+
+    expect(
+      isWorkerResultEnvelope({ value: envelope, expectedNonce: nonce }),
+    ).toBe(true);
   });
 });

--- a/Probe/Utils/Monitors/MonitorTypes/SyntheticMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/SyntheticMonitor.ts
@@ -21,13 +21,38 @@ import LocalFile from "Common/Server/Utils/LocalFile";
 import os from "os";
 import path from "path";
 import { SYNTHETIC_MONITOR_WORKER_STARTUP_ALLOWANCE_IN_MS } from "../SyntheticRuntime/Limits";
-import ProcessRunner from "../SyntheticRuntime/ProcessRunner";
+import ProcessRunner, {
+  SyntheticProcessRunnerError,
+} from "../SyntheticRuntime/ProcessRunner";
+import { isSyntheticRuntimeFault } from "../SyntheticRuntime/SyntheticRuntimeFault";
+import { SYNTHETIC_RUNTIME_CONTROLLER_HOST } from "../SyntheticRuntime/ControllerOrigin";
 import {
   SyntheticMonitorWorkerConfig,
   SyntheticMonitorWorkerProxy,
   SyntheticMonitorWorkerResult,
   isSyntheticMonitorWorkerResult,
 } from "../SyntheticRuntime/SyntheticMonitorWorkerTypes";
+
+/*
+ * A failure of the probe's own runtime is not the tenant's failure, so it is
+ * retried whatever the tenant set Retry Count On Error to -- that setting is
+ * about their script, and they should not have to raise it to absorb our
+ * browser failing to start. One extra attempt is enough: the stall this
+ * covers is transient by nature (a saturated probe, a wedged page), and the
+ * retry runs a whole fresh worker process and browser, so it is not free.
+ */
+const SYNTHETIC_RUNTIME_FAULT_RETRY_ATTEMPTS: number = 1;
+const SYNTHETIC_RUNTIME_FAULT_RETRY_DELAY_IN_MS: number = 2000;
+const RETRY_DELAY_IN_MS: number = 1000;
+
+interface SyntheticMonitorAttempt {
+  response: SyntheticMonitorResponse;
+  /*
+   * True when the check never got as far as the tenant's script: the browser,
+   * the controller page, or the sandbox failed to start.
+   */
+  isRuntimeFault: boolean;
+}
 
 export interface SyntheticMonitorOptions {
   monitorId?: ObjectID | undefined;
@@ -89,54 +114,70 @@ export default class SyntheticMonitor {
     attemptHistory?: Array<RetryAttempt>;
   }): Promise<SyntheticMonitorResponse | null> {
     const currentRetry: number = options.currentRetry || 0;
-    const maxRetries: number = options.retryCountOnError;
     const attemptHistory: Array<RetryAttempt> = options.attemptHistory || [];
 
-    const result: SyntheticMonitorResponse | null =
+    const attempt: SyntheticMonitorAttempt =
       await this.executeByBrowserAndScreenSize({
         script: options.script,
         browserType: options.browserType,
         screenSizeType: options.screenSizeType,
       });
+    const result: SyntheticMonitorResponse = attempt.response;
 
-    if (result) {
-      attemptHistory.push({
-        attemptNumber: currentRetry + 1,
-        scriptError: result.scriptError,
-        executionTimeInMS: result.executionTimeInMS,
-      });
-    }
+    /*
+     * Two different budgets, and the larger wins: what the tenant asked for
+     * when THEIR script fails, and our own floor when the probe's runtime is
+     * what failed. Without the second one, the customer-visible failure this
+     * whole path exists to prevent -- a transient bootstrap stall reported as
+     * their script erroring -- reaches them on the very first attempt,
+     * because Retry Count On Error defaults to zero.
+     */
+    const maxRetries: number = attempt.isRuntimeFault
+      ? Math.max(
+          options.retryCountOnError,
+          SYNTHETIC_RUNTIME_FAULT_RETRY_ATTEMPTS,
+        )
+      : options.retryCountOnError;
+
+    attemptHistory.push({
+      attemptNumber: currentRetry + 1,
+      scriptError: result.scriptError,
+      executionTimeInMS: result.executionTimeInMS,
+    });
 
     // If there's an error and we haven't exceeded retry count, retry
-    if (result?.scriptError && currentRetry < maxRetries) {
+    if (result.scriptError && currentRetry < maxRetries) {
       logger.debug(
-        `Synthetic Monitor script error, retrying (${currentRetry + 1}/${maxRetries}): ${result.scriptError}`,
+        `Synthetic Monitor ${attempt.isRuntimeFault ? "runtime fault" : "script error"}, retrying (${currentRetry + 1}/${maxRetries}): ${result.scriptError}`,
       );
 
       // Wait a bit before retrying
       await new Promise((resolve: (value: void) => void) => {
-        setTimeout(resolve, 1000);
+        setTimeout(
+          resolve,
+          attempt.isRuntimeFault
+            ? SYNTHETIC_RUNTIME_FAULT_RETRY_DELAY_IN_MS
+            : RETRY_DELAY_IN_MS,
+        );
       });
 
       return this.executeWithRetry({
         script: options.script,
         browserType: options.browserType,
         screenSizeType: options.screenSizeType,
-        retryCountOnError: maxRetries,
+        retryCountOnError: options.retryCountOnError,
         currentRetry: currentRetry + 1,
         attemptHistory: attemptHistory,
       });
     }
 
-    if (result) {
-      result.totalAttempts = attemptHistory.length;
-      /*
-       * Per-attempt history is only useful when more than one attempt occurred.
-       * Skip populating it for clean single-attempt runs to keep the log payload small.
-       */
-      if (attemptHistory.length > 1) {
-        result.retryAttempts = attemptHistory;
-      }
+    result.totalAttempts = attemptHistory.length;
+    /*
+     * Per-attempt history is only useful when more than one attempt occurred.
+     * Skip populating it for clean single-attempt runs to keep the log payload small.
+     */
+    if (attemptHistory.length > 1) {
+      result.retryAttempts = attemptHistory;
     }
 
     return result;
@@ -146,7 +187,7 @@ export default class SyntheticMonitor {
     script: string;
     browserType: BrowserType;
     screenSizeType: ScreenSizeType;
-  }): Promise<SyntheticMonitorResponse | null> {
+  }): Promise<SyntheticMonitorAttempt> {
     if (!options) {
       // this should never happen
       options = {
@@ -234,12 +275,57 @@ export default class SyntheticMonitor {
         scriptResult.scriptError = result.scriptError;
       }
     } catch (err: unknown) {
+      if (this.isRuntimeFault(err)) {
+        /*
+         * Ours, not theirs: no EXTERNAL_FAULT here, and the worker-side stack
+         * is logged separately so the probe operator still gets the Playwright
+         * detail that the tenant-facing message deliberately leaves out.
+         */
+        logger.error(
+          `Synthetic Monitor runtime fault (browser: ${options.browserType}, screen size: ${options.screenSizeType}): ${(err as Error).message}`,
+        );
+        const detail: string | undefined = this.getRuntimeFaultDetail(err);
+        if (detail) {
+          logger.error(detail);
+        }
+
+        scriptResult.scriptError = (err as Error).message;
+        return { response: scriptResult, isRuntimeFault: true };
+      }
+
       logger.error(err);
       scriptResult.scriptError =
         (err as Error)?.message || (err as Error).toString();
     }
 
-    return scriptResult;
+    return { response: scriptResult, isRuntimeFault: false };
+  }
+
+  /**
+   * Did the check fail before the tenant's script ever ran?
+   *
+   * The fault is raised inside the worker process, so by the time it gets
+   * here the Error object itself is gone -- the supervisor rebuilt it from
+   * the IPC failure envelope, which carries the marker across (see
+   * WorkerProtocol). Both shapes are accepted because a fault raised on this
+   * side of the fork never crosses that boundary at all.
+   */
+  private static isRuntimeFault(error: unknown): boolean {
+    if (isSyntheticRuntimeFault(error)) {
+      return true;
+    }
+
+    return error instanceof SyntheticProcessRunnerError && Boolean(error.kind);
+  }
+
+  private static getRuntimeFaultDetail(error: unknown): string | undefined {
+    if (error instanceof SyntheticProcessRunnerError) {
+      return error.remoteStack;
+    }
+    if (isSyntheticRuntimeFault(error)) {
+      return error.internalDetail;
+    }
+    return undefined;
   }
 
   private static getViewportHeightAndWidth(options: {
@@ -423,9 +509,19 @@ export default class SyntheticMonitor {
           server: proxyUrl,
         };
 
-        if (NO_PROXY.length > 0) {
-          proxy.bypass = NO_PROXY.join(",");
-        }
+        /*
+         * The sentinel controller origin is always bypassed, ahead of whatever
+         * the operator configured. Interception fulfils that navigation before
+         * the network stack is reached, so in practice the proxy never sees it
+         * -- but "in practice" is an ordering assumption inside Chromium, and
+         * the cost of not relying on it is one entry in a list. A corporate
+         * proxy asked to reach a host that cannot resolve does not fail fast;
+         * it hangs, and the runtime bootstrap is exactly where that is least
+         * affordable.
+         */
+        proxy.bypass = [SYNTHETIC_RUNTIME_CONTROLLER_HOST, ...NO_PROXY].join(
+          ",",
+        );
 
         // Extract username and password if present in proxy URL
         try {

--- a/Probe/Utils/Monitors/SyntheticRuntime/ControllerOrigin.ts
+++ b/Probe/Utils/Monitors/SyntheticRuntime/ControllerOrigin.ts
@@ -1,0 +1,18 @@
+/*
+ * The origin of the sandbox's internal controller document.
+ *
+ * `.invalid` is reserved by RFC 2606 so that it can never resolve, which is
+ * exactly what is wanted here: the origin is unspoofable, it is distinct from
+ * anything the tenant's script can reach, and nothing ever leaves the process
+ * for it -- WorkerController fulfils the navigation from memory with
+ * page.route.
+ *
+ * It lives in its own module rather than beside the controller because the
+ * supervisor process needs the host name (to keep it out of every proxy) and
+ * must not pay for Playwright's client library to learn it. Nothing may be
+ * imported here.
+ */
+export const SYNTHETIC_RUNTIME_CONTROLLER_HOST: string =
+  "synthetic-runtime.oneuptime.invalid";
+
+export const SYNTHETIC_RUNTIME_CONTROLLER_ORIGIN: string = `https://${SYNTHETIC_RUNTIME_CONTROLLER_HOST}`;

--- a/Probe/Utils/Monitors/SyntheticRuntime/ProcessRunner.ts
+++ b/Probe/Utils/Monitors/SyntheticRuntime/ProcessRunner.ts
@@ -4,6 +4,8 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import ConcurrencyLimiter from "./ConcurrencyLimiter";
+import { SyntheticRuntimeFaultKind } from "./SyntheticRuntimeFault";
+import { SYNTHETIC_RUNTIME_CONTROLLER_HOST } from "./ControllerOrigin";
 import {
   SyntheticWorkerResultEnvelope,
   createWorkerNonce,
@@ -216,11 +218,28 @@ export class SyntheticProcessRunnerError extends Error {
   public readonly stderr: string;
   public readonly stdoutTruncated: boolean;
   public readonly stderrTruncated: boolean;
+  /*
+   * Set when the worker reported that it could not start ITSELF -- browser
+   * launch, controller page, sandbox boot -- rather than that the tenant's
+   * script failed. Carried up from the worker's failure envelope so the
+   * monitor can log it as our fault and retry it instead of reporting it to
+   * the tenant as a script error.
+   */
+  public readonly kind: SyntheticRuntimeFaultKind | undefined;
+  /*
+   * The worker-side stack for a `kind` failure. Kept off `message` on purpose:
+   * `message` for those is written to be read by the tenant, and a Playwright
+   * stack naming internal files and an internal URL is exactly what made this
+   * failure mode unreadable before.
+   */
+  public readonly remoteStack: string | undefined;
 
   public constructor(data: {
     message: string;
     stdout: BoundedOutput;
     stderr: BoundedOutput;
+    kind?: SyntheticRuntimeFaultKind | undefined;
+    remoteStack?: string | undefined;
   }) {
     super(data.message);
     this.name = "SyntheticProcessRunnerError";
@@ -228,6 +247,8 @@ export class SyntheticProcessRunnerError extends Error {
     this.stderr = data.stderr.toString();
     this.stdoutTruncated = data.stdout.isTruncated;
     this.stderrTruncated = data.stderr.isTruncated;
+    this.kind = data.kind;
+    this.remoteStack = data.remoteStack;
   }
 }
 
@@ -980,6 +1001,24 @@ export default class ProcessRunner {
       }
 
       if (!envelope.ok) {
+        /*
+         * A worker that could not start itself already produced a message
+         * written for whoever reads the monitor. Appending its stack would
+         * bury that message under the internals it was written to replace, so
+         * the stack travels beside it instead.
+         */
+        if (envelope.error.kind) {
+          throw this.createRunnerError({
+            message: envelope.error.message,
+            stdout,
+            stderr,
+            kind: envelope.error.kind,
+            ...(envelope.error.stack
+              ? { remoteStack: envelope.error.stack }
+              : {}),
+          });
+        }
+
         const remoteStack: string = envelope.error.stack
           ? `\n${envelope.error.stack}`
           : "";
@@ -1033,6 +1072,14 @@ export default class ProcessRunner {
       conventionalKeys: ["HTTPS_PROXY", "https_proxy"],
     });
 
+    /*
+     * Chromium reads these too, so the sentinel controller host is pinned into
+     * the child's bypass list for the same reason it is pinned into the
+     * Playwright proxy option: the internal bootstrap navigation must never
+     * depend on an operator's proxy being reachable.
+     */
+    this.addSyntheticRuntimeHostToNoProxy(environment);
+
     environment["PATH"] = environment["PATH"] || DEFAULT_PATH;
     environment["HOME"] = runDirectory;
     environment["TMPDIR"] = runDirectory;
@@ -1048,6 +1095,30 @@ export default class ProcessRunner {
     environment["LOCALAPPDATA"] = runDirectory;
     environment["APPDATA"] = runDirectory;
     return environment;
+  }
+
+  private addSyntheticRuntimeHostToNoProxy(
+    environment: NodeJS.ProcessEnv,
+  ): void {
+    for (const key of ["NO_PROXY", "no_proxy"] as const) {
+      const existing: string | undefined = environment[key];
+      const entries: string[] = (existing || "")
+        .split(",")
+        .map((entry: string): string => {
+          return entry.trim();
+        })
+        .filter((entry: string): boolean => {
+          return entry.length > 0;
+        });
+
+      if (entries.includes(SYNTHETIC_RUNTIME_CONTROLLER_HOST)) {
+        continue;
+      }
+
+      environment[key] = [SYNTHETIC_RUNTIME_CONTROLLER_HOST, ...entries].join(
+        ",",
+      );
+    }
   }
 
   private mapProxyUrlToConventionalEnvironment(data: {
@@ -1997,6 +2068,8 @@ export default class ProcessRunner {
     message: string;
     stdout: BoundedOutput;
     stderr: BoundedOutput;
+    kind?: SyntheticRuntimeFaultKind | undefined;
+    remoteStack?: string | undefined;
   }): SyntheticProcessRunnerError {
     return new SyntheticProcessRunnerError(data);
   }

--- a/Probe/Utils/Monitors/SyntheticRuntime/SyntheticRuntimeFault.ts
+++ b/Probe/Utils/Monitors/SyntheticRuntime/SyntheticRuntimeFault.ts
@@ -1,0 +1,68 @@
+/*
+ * A synthetic check has three places it can fail, and only one of them is the
+ * tenant's:
+ *
+ *   1. The probe's own runtime -- launching the browser, opening the internal
+ *      controller page, booting the sandbox. Nothing tenant-authored has run
+ *      yet and the monitored site has not been contacted.
+ *   2. The tenant's script -- it threw, timed out, or returned too much data.
+ *   3. The monitored site -- reachable through (2) as a Playwright error.
+ *
+ * Only (2) and (3) say anything about the tenant's service. (1) is ours, and
+ * reporting it as a script error is what makes a probe hiccup look like the
+ * customer's page failing: the monitor goes down, an incident opens, and the
+ * message they are handed is a Playwright stack trace pointing at an internal
+ * `synthetic-runtime.oneuptime.invalid` URL they have never heard of.
+ *
+ * This error marks case (1) so it can survive the worker IPC boundary (see
+ * WorkerProtocol's failure envelope), be logged as our fault rather than
+ * theirs, and be retried once before anyone is paged.
+ */
+export const SYNTHETIC_RUNTIME_FAULT_KIND: "probe-runtime" =
+  "probe-runtime" as const;
+
+export type SyntheticRuntimeFaultKind = typeof SYNTHETIC_RUNTIME_FAULT_KIND;
+
+export default class SyntheticRuntimeFault extends Error {
+  public readonly kind: SyntheticRuntimeFaultKind =
+    SYNTHETIC_RUNTIME_FAULT_KIND;
+
+  /*
+   * The underlying Playwright/browser error, kept for the probe's own logs.
+   * It is deliberately NOT folded into `message`: `message` is what the tenant
+   * reads on their monitor, and it must stay free of internal URLs and
+   * internal file paths.
+   */
+  public readonly internalDetail: string | undefined;
+
+  public constructor(data: { message: string; internalDetail?: unknown }) {
+    super(data.message);
+    this.name = "SyntheticRuntimeFault";
+    this.internalDetail = describeInternalDetail(data.internalDetail);
+  }
+}
+
+function describeInternalDetail(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (value instanceof Error) {
+    return value.stack || value.message;
+  }
+  return String(value);
+}
+
+export function isSyntheticRuntimeFault(
+  value: unknown,
+): value is SyntheticRuntimeFault {
+  /*
+   * Structural rather than `instanceof`: the fault is re-created from the IPC
+   * failure envelope in the parent process, so the constructor identity that
+   * threw it in the child is long gone by the time anyone asks.
+   */
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    (value as { kind?: unknown }).kind === SYNTHETIC_RUNTIME_FAULT_KIND
+  );
+}

--- a/Probe/Utils/Monitors/SyntheticRuntime/WorkerController.ts
+++ b/Probe/Utils/Monitors/SyntheticRuntime/WorkerController.ts
@@ -14,11 +14,47 @@ import {
   isRecord,
 } from "./RpcProtocol";
 import { getSyntheticMonitorWorkerBootstrapSource } from "./WorkerBootstrap";
+import SyntheticRuntimeFault from "./SyntheticRuntimeFault";
+import { SYNTHETIC_RUNTIME_CONTROLLER_ORIGIN } from "./ControllerOrigin";
+import { SYNTHETIC_MONITOR_WORKER_STARTUP_ALLOWANCE_IN_MS } from "./Limits";
 
-const CONTROLLER_ORIGIN: string = "https://synthetic-runtime.oneuptime.invalid";
 const MAX_SCRIPT_BYTES: number = 1_000_000;
 const MAX_SCRIPT_ERROR_BYTES: number = 4_000;
 const RUNTIME_STARTUP_TIMEOUT_IN_MS: number = 30_000;
+/*
+ * The controller document never touches the network: page.route fulfils it
+ * from memory, with no socket, no DNS lookup, and no proxy hop. On an idle
+ * probe the navigation completes in about a tenth of a second. The per-attempt
+ * budget is in seconds only to absorb a probe that is briefly saturated --
+ * which it is, predictably, whenever monitor intervals align on a wall-clock
+ * boundary.
+ *
+ * When even that is not enough, the answer is another attempt, not a bigger
+ * number. A navigation that stalls leaves its request paused inside a page
+ * that will never recover, but the browser around it is healthy: a fresh page
+ * navigates in roughly a hundred milliseconds. Without this retry a single
+ * stalled bootstrap discarded a check that still had minutes of its deadline
+ * unspent, and handed the tenant a Playwright timeout naming an internal URL
+ * as though their own script had failed.
+ */
+const CONTROLLER_BOOTSTRAP_TIMEOUT_IN_MS: number = 20_000;
+const CONTROLLER_BOOTSTRAP_ATTEMPTS: number = 3;
+const CONTROLLER_BOOTSTRAP_RETRY_DELAY_IN_MS: number = 250;
+const MAX_CONTROLLER_BOOTSTRAP_ATTEMPTS: number = 10;
+/*
+ * Retrying has to stay inside the budget the supervisor already set aside for
+ * starting a worker, or a bootstrap that keeps stalling stops being reported
+ * as a bootstrap failure at all: the supervisor's own deadline fires first and
+ * the check dies as a bare execution timeout, which says nothing about why.
+ *
+ * The startup allowance covers everything before the tenant's script -- fork,
+ * ts-node, browser launch, this navigation, sandbox init. Half of it is this
+ * step's share; the rest belongs to the browser launch and the sandbox, which
+ * carry their own 30-second budgets on either side of it.
+ */
+const CONTROLLER_BOOTSTRAP_TOTAL_BUDGET_IN_MS: number = Math.floor(
+  SYNTHETIC_MONITOR_WORKER_STARTUP_ALLOWANCE_IN_MS / 2,
+);
 
 interface WorkerCompletionResult {
   returnValue?: unknown;
@@ -36,6 +72,13 @@ export interface WorkerControllerOptions {
   screenSizeType: string;
   args?: Record<string, unknown> | undefined;
   timeoutInMs: number;
+  /*
+   * Bootstrap budget for the internal controller page, separate from the
+   * tenant's script deadline above. Exposed so tests can drive the retry path
+   * without spending half a minute per attempt.
+   */
+  bootstrapTimeoutInMs?: number | undefined;
+  bootstrapAttempts?: number | undefined;
 }
 
 interface ControllerPayload {
@@ -74,43 +117,7 @@ export default class WorkerController {
     let startupTimeout: NodeJS.Timeout | null = null;
 
     try {
-      const controllerUrl: string = `${CONTROLLER_ORIGIN}/${executionId}`;
-      controllerPage = await options.browserContext.newPage();
-      await controllerPage.route("**/*", async (route: Route) => {
-        if (
-          route.request().url() === controllerUrl &&
-          route.request().resourceType() === "document"
-        ) {
-          await route.fulfill({
-            status: 200,
-            contentType: "text/html; charset=utf-8",
-            headers: {
-              "Cache-Control": "no-store",
-              "Content-Security-Policy": [
-                "default-src 'none'",
-                "base-uri 'none'",
-                "connect-src 'none'",
-                "form-action 'none'",
-                "frame-src 'none'",
-                "img-src data:",
-                "object-src 'none'",
-                "script-src 'unsafe-eval' blob:",
-                "worker-src blob:",
-              ].join("; "),
-              "Cross-Origin-Opener-Policy": "same-origin",
-              "Cross-Origin-Resource-Policy": "same-origin",
-              "Permissions-Policy":
-                "camera=(), geolocation=(), microphone=(), payment=(), usb=()",
-              "Referrer-Policy": "no-referrer",
-              "X-Content-Type-Options": "nosniff",
-            },
-            body: "<!doctype html><meta charset=utf-8><title>Synthetic Runtime</title>",
-          });
-          return;
-        }
-
-        await route.abort("blockedbyclient");
-      });
+      const controllerUrl: string = `${SYNTHETIC_RUNTIME_CONTROLLER_ORIGIN}/${executionId}`;
 
       let resolveRuntimeReady: (() => void) | null = null;
       const runtimeReadyPromise: Promise<void> = new Promise<void>(
@@ -118,36 +125,48 @@ export default class WorkerController {
           resolveRuntimeReady = resolve;
         },
       );
-      const broker: PlaywrightCapabilityBroker = new PlaywrightCapabilityBroker(
-        {
-          executionId,
-          page: options.page,
-          browserContext: options.browserContext,
-          controllerPage,
-          signal: abortController.signal,
-          onRuntimeReady: (): void => {
-            resolveRuntimeReady?.();
-          },
-        },
-      );
 
-      await controllerPage.exposeBinding(
+      /*
+       * The broker is built from the page that the bootstrap finally settles
+       * on, so it cannot exist yet -- but the RPC binding has to be installed
+       * on every attempt, before that page navigates. The binding therefore
+       * closes over the broker slot rather than the broker, and reads it at
+       * call time. Nothing can call it before the sandbox starts, which is
+       * strictly after the assignment below.
+       *
+       * Constructing a broker per attempt would be the obvious alternative and
+       * is wrong: each one subscribes to the shared browser context's "page"
+       * event, so discarded attempts would leave their listeners behind.
+       */
+      let broker: PlaywrightCapabilityBroker | null = null;
+
+      controllerPage = await this.openControllerPage({
+        browserContext: options.browserContext,
+        controllerUrl,
         bindingName,
-        async (source: { page: Page; frame: unknown }, request: unknown) => {
-          if (
-            source.page !== controllerPage ||
-            source.frame !== controllerPage?.mainFrame() ||
-            abortController.signal.aborted
-          ) {
-            throw new Error("Rejected synthetic runtime RPC source.");
+        abortSignal: abortController.signal,
+        timeoutInMs: this.getBootstrapTimeoutInMs(options),
+        attempts: this.getBootstrapAttempts(options),
+        totalBudgetInMs: this.getBootstrapTotalBudgetInMs(options),
+        dispatch: async (request: unknown): Promise<unknown> => {
+          if (!broker) {
+            throw new Error(
+              "Synthetic runtime RPC arrived before the sandbox was ready.",
+            );
           }
           return await broker.dispatch(request);
         },
-      );
+      });
 
-      await controllerPage.goto(controllerUrl, {
-        waitUntil: "domcontentloaded",
-        timeout: 30_000,
+      broker = new PlaywrightCapabilityBroker({
+        executionId,
+        page: options.page,
+        browserContext: options.browserContext,
+        controllerPage,
+        signal: abortController.signal,
+        onRuntimeReady: (): void => {
+          resolveRuntimeReady?.();
+        },
       });
 
       const payload: ControllerPayload = {
@@ -189,7 +208,14 @@ export default class WorkerController {
         startupTimeout = null;
       }
       if (startupResult === startupTimeoutMarker) {
-        throw new Error("Synthetic runtime failed to initialize in time.");
+        /*
+         * The controller page loaded, so the browser is alive, but the sandbox
+         * never signalled ready. Nothing tenant-authored has run and the
+         * monitored page has not been opened -- this is the probe's failure.
+         */
+        throw new SyntheticRuntimeFault({
+          message: `Synthetic monitor could not start on this probe: the sandbox did not finish initializing within ${RUNTIME_STARTUP_TIMEOUT_IN_MS} ms. The monitored page was never opened, so this does not reflect the health of the monitored site.`,
+        });
       }
 
       let rawResult: unknown = startupResult;
@@ -273,6 +299,186 @@ export default class WorkerController {
     if (byteLengthOfJson(options.args || {}) > MAX_RPC_RESULT_BYTES) {
       throw new Error("Synthetic monitor arguments exceeded the size limit.");
     }
+    if (
+      options.bootstrapTimeoutInMs !== undefined &&
+      (!Number.isSafeInteger(options.bootstrapTimeoutInMs) ||
+        options.bootstrapTimeoutInMs <= 0)
+    ) {
+      throw new Error("Synthetic runtime bootstrap timeout is invalid.");
+    }
+    if (
+      options.bootstrapAttempts !== undefined &&
+      (!Number.isSafeInteger(options.bootstrapAttempts) ||
+        options.bootstrapAttempts < 1 ||
+        options.bootstrapAttempts > MAX_CONTROLLER_BOOTSTRAP_ATTEMPTS)
+    ) {
+      throw new Error("Synthetic runtime bootstrap attempt count is invalid.");
+    }
+  }
+
+  /**
+   * Opens the internal controller page and navigates it to the sentinel
+   * document, retrying on a fresh page when an attempt stalls.
+   *
+   * Every attempt gets its own page on purpose. The two ways this step fails
+   * -- an interception round-trip that never comes back, and a renderer that
+   * has wedged -- both leave the page unusable while the browser around it is
+   * still fine, and a fresh page costs about a hundred milliseconds.
+   */
+  private static async openControllerPage(data: {
+    browserContext: BrowserContext;
+    controllerUrl: string;
+    bindingName: string;
+    abortSignal: AbortSignal;
+    timeoutInMs: number;
+    attempts: number;
+    totalBudgetInMs: number;
+    dispatch: (request: unknown) => Promise<unknown>;
+  }): Promise<Page> {
+    let lastError: unknown;
+    let attemptsMade: number = 0;
+    const startedAtInMs: number = Date.now();
+
+    for (let attempt: number = 1; attempt <= data.attempts; attempt++) {
+      const remainingBudgetInMs: number =
+        data.totalBudgetInMs - (Date.now() - startedAtInMs);
+      if (attempt > 1 && remainingBudgetInMs <= 0) {
+        break;
+      }
+
+      const attemptTimeoutInMs: number = Math.max(
+        1,
+        Math.min(data.timeoutInMs, remainingBudgetInMs),
+      );
+      attemptsMade++;
+      const page: Page = await data.browserContext.newPage();
+
+      try {
+        await page.route("**/*", async (route: Route) => {
+          try {
+            if (
+              route.request().url() === data.controllerUrl &&
+              route.request().resourceType() === "document"
+            ) {
+              await route.fulfill({
+                status: 200,
+                contentType: "text/html; charset=utf-8",
+                headers: {
+                  "Cache-Control": "no-store",
+                  "Content-Security-Policy": [
+                    "default-src 'none'",
+                    "base-uri 'none'",
+                    "connect-src 'none'",
+                    "form-action 'none'",
+                    "frame-src 'none'",
+                    "img-src data:",
+                    "object-src 'none'",
+                    "script-src 'unsafe-eval' blob:",
+                    "worker-src blob:",
+                  ].join("; "),
+                  "Cross-Origin-Opener-Policy": "same-origin",
+                  "Cross-Origin-Resource-Policy": "same-origin",
+                  "Permissions-Policy":
+                    "camera=(), geolocation=(), microphone=(), payment=(), usb=()",
+                  "Referrer-Policy": "no-referrer",
+                  "X-Content-Type-Options": "nosniff",
+                },
+                body: "<!doctype html><meta charset=utf-8><title>Synthetic Runtime</title>",
+              });
+              return;
+            }
+
+            await route.abort("blockedbyclient");
+          } catch {
+            /*
+             * A handler that returns without settling its route leaves the
+             * request paused in the browser with nothing to end it but the
+             * navigation timeout -- the exact stall this retry exists for.
+             * Abort so the navigation fails fast instead; a route belonging to
+             * a page that has already gone away ignores this too.
+             */
+            await route.abort("failed").catch((): void => {
+              // The attempt is abandoned either way.
+            });
+          }
+        });
+
+        await page.exposeBinding(
+          data.bindingName,
+          async (source: { page: Page; frame: unknown }, request: unknown) => {
+            if (
+              source.page !== page ||
+              source.frame !== page.mainFrame() ||
+              data.abortSignal.aborted
+            ) {
+              throw new Error("Rejected synthetic runtime RPC source.");
+            }
+            return await data.dispatch(request);
+          },
+        );
+
+        await page.goto(data.controllerUrl, {
+          waitUntil: "domcontentloaded",
+          timeout: attemptTimeoutInMs,
+        });
+
+        return page;
+      } catch (error: unknown) {
+        lastError = error;
+
+        try {
+          await page.close();
+        } catch {
+          // The context teardown in the worker is the final cleanup boundary.
+        }
+
+        if (attempt < data.attempts) {
+          await this.delay(CONTROLLER_BOOTSTRAP_RETRY_DELAY_IN_MS);
+        }
+      }
+    }
+
+    /*
+     * Deliberately free of the sentinel URL and of internal file paths: this
+     * string is what the tenant reads on their monitor. The Playwright error
+     * travels separately, in internalDetail, for the probe's own logs.
+     */
+    throw new SyntheticRuntimeFault({
+      message: `Synthetic monitor could not start on this probe: the browser runtime did not finish starting up after ${attemptsMade} attempt(s) of up to ${data.timeoutInMs} ms. The monitored page was never opened, so this does not reflect the health of the monitored site.`,
+      internalDetail: lastError,
+    });
+  }
+
+  private static getBootstrapTimeoutInMs(
+    options: WorkerControllerOptions,
+  ): number {
+    return options.bootstrapTimeoutInMs ?? CONTROLLER_BOOTSTRAP_TIMEOUT_IN_MS;
+  }
+
+  private static getBootstrapAttempts(
+    options: WorkerControllerOptions,
+  ): number {
+    return options.bootstrapAttempts ?? CONTROLLER_BOOTSTRAP_ATTEMPTS;
+  }
+
+  private static getBootstrapTotalBudgetInMs(
+    options: WorkerControllerOptions,
+  ): number {
+    /*
+     * A caller that shortens the per-attempt budget (tests do) means the whole
+     * retry to be shorter too, not to keep the production ceiling.
+     */
+    return Math.min(
+      CONTROLLER_BOOTSTRAP_TOTAL_BUDGET_IN_MS,
+      this.getBootstrapTimeoutInMs(options) * this.getBootstrapAttempts(options),
+    );
+  }
+
+  private static async delay(delayInMs: number): Promise<void> {
+    await new Promise<void>((resolve: () => void): void => {
+      const timer: NodeJS.Timeout = setTimeout(resolve, delayInMs);
+      timer.unref?.();
+    });
   }
 
   private static async startWorker(data: {

--- a/Probe/Utils/Monitors/SyntheticRuntime/WorkerProtocol.ts
+++ b/Probe/Utils/Monitors/SyntheticRuntime/WorkerProtocol.ts
@@ -1,4 +1,9 @@
 import crypto from "crypto";
+import {
+  SYNTHETIC_RUNTIME_FAULT_KIND,
+  SyntheticRuntimeFaultKind,
+  isSyntheticRuntimeFault,
+} from "./SyntheticRuntimeFault";
 
 export const SYNTHETIC_WORKER_PROTOCOL_VERSION: 1 = 1 as const;
 export const SYNTHETIC_WORKER_START_MESSAGE_TYPE: "oneuptime.synthetic.start" =
@@ -35,6 +40,12 @@ export interface SyntheticWorkerFailureEnvelope {
   readonly error: {
     readonly message: string;
     readonly stack?: string | undefined;
+    /*
+     * Present only when the worker failed to start itself, as opposed to the
+     * tenant's script failing. The supervisor needs to tell the two apart
+     * after the Error object itself has been flattened for IPC.
+     */
+    readonly kind?: SyntheticRuntimeFaultKind | undefined;
   };
 }
 
@@ -160,6 +171,9 @@ export function createWorkerFailureEnvelope(data: {
         MAX_ERROR_MESSAGE_LENGTH,
       ),
       ...(stack ? { stack } : {}),
+      ...(isSyntheticRuntimeFault(data.error)
+        ? { kind: SYNTHETIC_RUNTIME_FAULT_KIND }
+        : {}),
     },
   };
 }
@@ -210,8 +224,13 @@ export function isWorkerResultEnvelope<Result>(data: {
   }
 
   const error: Record<string, unknown> = data.value["error"];
-  const expectedErrorKeys: string[] =
-    error["stack"] === undefined ? ["message"] : ["message", "stack"];
+  const expectedErrorKeys: string[] = ["message"];
+  if (error["stack"] !== undefined) {
+    expectedErrorKeys.push("stack");
+  }
+  if (error["kind"] !== undefined) {
+    expectedErrorKeys.push("kind");
+  }
 
   return (
     hasExactKeys(error, expectedErrorKeys) &&
@@ -220,6 +239,8 @@ export function isWorkerResultEnvelope<Result>(data: {
     error["message"].length <= MAX_ERROR_MESSAGE_LENGTH &&
     (error["stack"] === undefined ||
       (typeof error["stack"] === "string" &&
-        error["stack"].length <= MAX_ERROR_STACK_LENGTH))
+        error["stack"].length <= MAX_ERROR_STACK_LENGTH)) &&
+    (error["kind"] === undefined ||
+      error["kind"] === SYNTHETIC_RUNTIME_FAULT_KIND)
   );
 }

--- a/config.example.env
+++ b/config.example.env
@@ -199,6 +199,12 @@ GLOBAL_PROBE_1_SYNTHETIC_MONITOR_SCRIPT_TIMEOUT_IN_MS=60000
 GLOBAL_PROBE_1_SYNTHETIC_MONITOR_MAX_CONCURRENCY=4
 GLOBAL_PROBE_1_SYNTHETIC_MONITOR_MAX_PROCESS_TREE_RSS_BYTES=1610612736
 GLOBAL_PROBE_1_SYNTHETIC_MONITOR_MAX_DISK_BYTES=268435456
+# Size of /dev/shm for this probe's container. Chromium keeps shared memory
+# between its browser, renderer and network processes there, and Docker's 64MB
+# default is not enough for SYNTHETIC_MONITOR_MAX_CONCURRENCY browsers at a
+# desktop viewport. Running out of it does not fail cleanly: the browser
+# starts and its first navigation then never completes.
+GLOBAL_PROBE_1_SHM_SIZE=512m
 GLOBAL_PROBE_1_CUSTOM_CODE_MONITOR_SCRIPT_TIMEOUT_IN_MS=60000
 GLOBAL_PROBE_1_PORT=3874
 # (Optional) Configure HTTP and HTTPS proxy URLs independently. The legacy
@@ -217,6 +223,12 @@ GLOBAL_PROBE_2_SYNTHETIC_MONITOR_SCRIPT_TIMEOUT_IN_MS=60000
 GLOBAL_PROBE_2_SYNTHETIC_MONITOR_MAX_CONCURRENCY=4
 GLOBAL_PROBE_2_SYNTHETIC_MONITOR_MAX_PROCESS_TREE_RSS_BYTES=1610612736
 GLOBAL_PROBE_2_SYNTHETIC_MONITOR_MAX_DISK_BYTES=268435456
+# Size of /dev/shm for this probe's container. Chromium keeps shared memory
+# between its browser, renderer and network processes there, and Docker's 64MB
+# default is not enough for SYNTHETIC_MONITOR_MAX_CONCURRENCY browsers at a
+# desktop viewport. Running out of it does not fail cleanly: the browser
+# starts and its first navigation then never completes.
+GLOBAL_PROBE_2_SHM_SIZE=512m
 GLOBAL_PROBE_2_CUSTOM_CODE_MONITOR_SCRIPT_TIMEOUT_IN_MS=60000
 GLOBAL_PROBE_2_PORT=3875
 # (Optional) Configure HTTP and HTTPS proxy URLs independently. The legacy

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -388,6 +388,12 @@ services:
   probe-1:
     restart: always
     network_mode: host
+    # Chromium keeps its shared-memory segments in /dev/shm, and Docker gives a
+    # container 64MB of it by default. Several concurrent synthetic browsers at
+    # a desktop viewport exhaust that, and a browser that cannot allocate
+    # shared memory does not fail cleanly -- its renderer or network service
+    # wedges, and the synthetic runtime's first navigation never completes.
+    shm_size: ${GLOBAL_PROBE_1_SHM_SIZE:-512m}
     # The probe remains root so its trusted supervisor can assign a unique UID
     # to every synthetic execution. Drop everything except the capabilities it
     # needs to prepare, terminate, and clean up those workers (plus NET_RAW for
@@ -447,6 +453,12 @@ services:
   probe-2:
     restart: always
     network_mode: host
+    # Chromium keeps its shared-memory segments in /dev/shm, and Docker gives a
+    # container 64MB of it by default. Several concurrent synthetic browsers at
+    # a desktop viewport exhaust that, and a browser that cannot allocate
+    # shared memory does not fail cleanly -- its renderer or network service
+    # wedges, and the synthetic runtime's first navigation never completes.
+    shm_size: ${GLOBAL_PROBE_2_SHM_SIZE:-512m}
     cap_drop:
       - ALL
     cap_add:


### PR DESCRIPTION
## What the customer saw

A customer's synthetic monitors intermittently failed overnight, several at a time. What reached them was:

```
page.goto: Timeout 30000ms exceeded.
Call log:
  - navigating to "https://synthetic-runtime.oneuptime.invalid/c2ca7948-…", waiting until "domcontentloaded"
    at WorkerController.execute (/usr/src/app/Utils/Monitors/SyntheticRuntime/WorkerController.ts:148:28)
```

They read it correctly without any access to our logs: *"This looks more like the monitor isn't firing up properly."*

## Root cause

That URL is **ours**. `synthetic-runtime.oneuptime.invalid` is the sandbox's internal controller document, and `page.route` fulfils it from memory — no socket, no DNS lookup, no proxy hop. Measured against a real Chromium, that navigation completes in ~170 ms, and still does with four browsers launching at once. A 30-second timeout on it means the browser was wedged, not slow.

The tenant's script never ran and their site was never opened. But the Playwright timeout was written into `scriptError`, which the default synthetic criteria turns straight into an incident.

Three defects turned a transient stall into a customer-visible monitor failure:

1. **The bootstrap navigation had a hardcoded 30 s budget and no retry**, sitting inside a 180 s run deadline. One stall discarded a check with roughly 2.5 minutes of its budget unspent. A stalled navigation leaves its request paused in a page that will never recover — but the browser around it is healthy, and a fresh page navigates in ~100 ms (verified: 302 ms on a real Chromium, same context, same execution id).
2. **The failure was attributed to the tenant**, `scriptError` and all, complete with an internal `.invalid` URL and a file path inside `/usr/src/app`.
3. **Nothing retried it.** Synthetic is the only monitor type that defaults to zero retries, so a probe-side hiccup reached the customer on the first attempt.

### Why at night

Nothing in the probe runs nightly. `nextPingAt` is a **cron expression evaluated against the wall clock** ([MonitorProbeService.ts:216](Common/Server/Services/MonitorProbeService.ts#L216)) with no jitter, so every monitor sharing an interval becomes due in the same second — and midnight is where every interval coincides at once. The probe then fans an entire claimed batch out through `Promise.allSettled` with no per-batch cap ([FetchList.ts:222](Probe/Jobs/Monitor/FetchList.ts#L222)), on top of up to four cold Chromium launches. That burst is what the 30-second budget had to survive, once, with no second chance.

## What this changes

**Recovery** — `WorkerController` retries the controller-page bootstrap on a fresh page, up to 3 attempts, bounded in total by half the worker startup allowance so it cannot push the run past the supervisor's own deadline (which would report a bare execution timeout that explains nothing). Per-attempt budget drops 30 s → 20 s: three chances beat one long wait when the healthy path takes 170 ms.

**Attribution** — a typed `SyntheticRuntimeFault` marks failures that happen before the tenant's script runs. It survives the worker IPC boundary via a `kind` field on the failure envelope, so the supervisor can still tell probe faults from script faults after the `Error` object is gone. Those are logged as ours (no `EXTERNAL_FAULT`), and the tenant-facing message carries no internal URL and no internal path — the Playwright stack travels separately for the probe's own logs.

**Retry policy** — a runtime fault is always retried once, whatever Retry Count On Error is set to. That setting is about the tenant's script; they should not have to raise it to absorb our browser failing to start. Tenant script errors keep exactly the retry behaviour they have today.

**Route handler settles its route** — a handler that returns without fulfilling, aborting or continuing leaves the request paused in the browser forever, with only the navigation timeout to end it. If `fulfill` throws (a page closing mid-flight), it now aborts.

### Hardening for the conditions that make the stall likely

- **`/dev/shm`**: Chromium keeps shared memory between its browser, renderer and network processes there, and a container gets 64 MB by default. That is not enough for `syntheticMonitorMaxConcurrency` browsers at 1920×1080, and exhausting it does not fail cleanly — the browser starts and its first navigation never completes. The Helm chart now mounts a memory-backed `/dev/shm` (512Mi default, per-probe override) and compose sets `shm_size`. Postgres and vLLM already get one; the probe, which runs the browsers, did not.
- **Proxy bypass**: the sentinel host is pinned into the browser's proxy bypass and the child's `NO_PROXY`. I verified empirically that interception beats the proxy — a black-holed proxy does not affect the sentinel navigation — but that is an ordering assumption inside Chromium, and a corporate proxy asked for a host that cannot resolve hangs rather than failing fast.

## Testing

`Probe`: 786 tests across 40 suites pass, including the real-browser suites. Helm: 254 tests pass.

**12 of the new tests fail without the fix**, including two that drive a real Chromium through a stalled first navigation and assert the sandbox still runs the tenant's script end to end. Verified by disabling the retry and re-running.

New coverage:
- `WorkerControllerBootstrap.test.ts` (17 tests) — retry on a fresh page, closing every abandoned page, one browser-context listener however many attempts it takes, the RPC binding bound to its own attempt's page, the total budget stopping the retry, and the tenant-facing message being free of internals.
- `WorkerController.test.ts` — two real-Chromium integration tests: recovery from a stalled first navigation, and a probe-side fault (not a script error) when every attempt stalls.
- `WorkerProtocol.test.ts` — the fault marker crossing the IPC boundary, and not being forgeable.
- `ProcessRunner.test.ts` — the fault surfacing with its stack kept off the message, ordinary failures unchanged, and the sentinel host in `NO_PROXY` with and without an operator proxy.
- `SyntheticMonitor.test.ts` — a runtime fault retried at the default zero retries, a script error not retried, one extra attempt only, and no internals in what the tenant is shown.
- `probe-shared-memory_test.yaml` — render assertions for the `/dev/shm` volume.

## Deliberately not in this PR

Real problems found while investigating, each its own change:

- **Scheduling has no jitter**, which is what concentrates load at wall-clock boundaries. Spreading `nextPingAt` would reduce the burst for every monitor type, not just synthetic — but it changes check timing product-wide.
- **The probe fans out a whole claimed batch at once** with no global concurrency cap.
- **The disk watchdog recursively `lstat`s every live browser profile four times a second** from the probe's own libuv threadpool, on the same volume the browsers are writing to.
- **Per-run resource ceilings do not compose**: four concurrent runs may collectively permit ~6 GB RSS with no aggregate limit.
- **A `faultDomain` on `SyntheticMonitorResponse`** so criteria could leave monitor status unchanged on a probe fault instead of reporting a script error at all. That changes the monitor-state contract and deserves a product decision — this PR keeps `scriptError` so a persistent fault is still reported rather than silently passing.
