### PR TITLE
test(billing): cover the two seams the Stripe rate-limit fix hangs on

### DIFF
--- a/Common/Tests/Server/Services/BillingPaymentMethodServiceSync.test.ts
+++ b/Common/Tests/Server/Services/BillingPaymentMethodServiceSync.test.ts
@@ -3,6 +3,7 @@ import BillingService, {
   PaymentMethod,
 } from "../../../Server/Services/BillingService";
 import ProjectService from "../../../Server/Services/ProjectService";
+import PayAsYouGoBillingService from "../../../Server/Services/PayAsYouGoBillingService";
 import ObjectID from "../../../Types/ObjectID";
 import { getJestSpyOn } from "../../Spy";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
@@ -122,6 +123,43 @@ describe("BillingPaymentMethodService provider sync", () => {
      */
     await find();
     expect(getPaymentMethods).toHaveBeenCalledTimes(2);
+  });
+
+  /*
+   * This is what makes the admission path's denial cache safe to have at all.
+   * The billing page reads this table immediately after a card is added, so
+   * clearing the authorization here is what lets ingest be admitted on the
+   * next batch instead of at the end of the denial TTL. Nothing else asserts
+   * it, and dropping it would reintroduce a delay nobody would connect back
+   * to this line.
+   */
+  it("clears the project's cached authorization once the provider has been read", async () => {
+    const invalidate: jest.SpiedFunction<
+      typeof PayAsYouGoBillingService.invalidate
+    > = getJestSpyOn(PayAsYouGoBillingService, "invalidate").mockReturnValue(
+      undefined,
+    );
+
+    await find();
+
+    expect(invalidate).toHaveBeenCalledTimes(1);
+    expect(invalidate.mock.calls[0]![0]!.toString()).toBe(
+      PROJECT_ID.toString(),
+    );
+  });
+
+  it("does not clear the cached authorization when the provider read fails", async () => {
+    const invalidate: jest.SpiedFunction<
+      typeof PayAsYouGoBillingService.invalidate
+    > = getJestSpyOn(PayAsYouGoBillingService, "invalidate").mockReturnValue(
+      undefined,
+    );
+    getPaymentMethods.mockRejectedValueOnce(new Error("provider unreachable"));
+
+    await expect(find()).rejects.toThrow("provider unreachable");
+
+    // A failed read learned nothing, so it must not claim the cache is stale.
+    expect(invalidate).not.toHaveBeenCalled();
   });
 
   it("does not strand later callers when a provider read fails", async () => {

--- a/Common/Tests/Server/Services/TelemetryIngestionKeyPolicyResolution.test.ts
+++ b/Common/Tests/Server/Services/TelemetryIngestionKeyPolicyResolution.test.ts
@@ -4,6 +4,7 @@ import ObjectID from "../../../Types/ObjectID";
 import TelemetryIngestionKeyPolicy from "../../../Types/Telemetry/TelemetryIngestionKeyPolicy";
 import TelemetryIngestionKeyType from "../../../Types/Telemetry/TelemetryIngestionKeyType";
 import TelemetryIngestionKeyService from "../../../Server/Services/TelemetryIngestionKeyService";
+import PayAsYouGoBillingService from "../../../Server/Services/PayAsYouGoBillingService";
 
 // Payment eligibility is covered by the billing admission suites.
 jest.mock("../../../Server/Services/PayAsYouGoBillingService", () => {
@@ -817,6 +818,69 @@ describe("TelemetryIngestionKeyService policy resolution", () => {
       expect(hookedUpdateOneById).not.toHaveBeenCalled();
       expect(hookedUpdateBy).not.toHaveBeenCalled();
       expect(findOneByMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /*
+   * This path runs for every ingested batch, and it is the only caller
+   * allowed to answer from a cached denial. Without the flag, an unpaid
+   * project re-reads the payment provider once per batch - which is what held
+   * the whole Stripe account at its rate limit and took the billing page down
+   * with it. Nothing else asserts the flag is passed, so removing it here
+   * would be a silent regression back to that behaviour.
+   */
+  describe("billing admission", () => {
+    test("admits ingest with a denial that may be a few seconds stale", async () => {
+      const requirePayAsYouGo: jest.Mock =
+        PayAsYouGoBillingService.requirePayAsYouGo as unknown as jest.Mock;
+      requirePayAsYouGo.mockClear();
+
+      const token: string = ObjectID.generate().toString();
+      const projectId: ObjectID = ObjectID.generate();
+      installRows({
+        [token]: {
+          _id: ObjectID.generate(),
+          projectId: projectId,
+          isEnabled: true,
+        },
+      });
+
+      await TelemetryIngestionKeyService.getPolicyFromSecretKey(token);
+
+      expect(requirePayAsYouGo).toHaveBeenCalledTimes(1);
+      expect(requirePayAsYouGo).toHaveBeenCalledWith(
+        expect.objectContaining({ value: projectId.value }),
+        expect.objectContaining({ allowStaleDenial: true }),
+      );
+    });
+
+    test("re-checks billing on a policy cache hit, still allowing a stale denial", async () => {
+      const requirePayAsYouGo: jest.Mock =
+        PayAsYouGoBillingService.requirePayAsYouGo as unknown as jest.Mock;
+      requirePayAsYouGo.mockClear();
+
+      const token: string = ObjectID.generate().toString();
+      installRows({
+        [token]: {
+          _id: ObjectID.generate(),
+          projectId: ObjectID.generate(),
+          isEnabled: true,
+        },
+      });
+
+      await TelemetryIngestionKeyService.getPolicyFromSecretKey(token);
+      await TelemetryIngestionKeyService.getPolicyFromSecretKey(token);
+
+      /*
+       * A live key must not outlive billing eligibility, so the check runs on
+       * the cache hit too - which is exactly why it has to be cheap.
+       */
+      expect(requirePayAsYouGo).toHaveBeenCalledTimes(2);
+      for (const call of requirePayAsYouGo.mock.calls) {
+        expect(call[1]).toEqual(
+          expect.objectContaining({ allowStaleDenial: true }),
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
Follow-up to #3702. You asked whether that change had extensive tests — it had six, on the cache semantics, and I went back and looked properly. The cache itself was covered. **The two wiring seams that make the fix correct were not**, and each is a single argument that a refactor could drop without anything going red.

## 1. Admission must keep asking for the stale-denial path

`TelemetryIngestionKeyService` is the *only* caller allowed to answer from a cached denial. If `allowStaleDenial` stops being passed there, admission silently reverts to a payment-provider read per ingested batch — precisely the behaviour that held the Stripe account at its rate limit and took the billing page down.

Now asserted on **both** paths, because the billing check deliberately runs on policy-cache hits too (a live key must not outlive billing eligibility):

- `admits ingest with a denial that may be a few seconds stale`
- `re-checks billing on a policy cache hit, still allowing a stale denial`

## 2. The sync must clear the cached authorization

`BillingPaymentMethodService` clearing the cached decision after re-reading payment methods is what makes the denial cache *safe*: the billing page reads that table immediately after a card is added, so this is the thing that admits ingest on the next batch rather than at the end of the TTL. Without it, "add a card and it works" quietly becomes "add a card and wait".

- `clears the project's cached authorization once the provider has been read`
- `does not clear the cached authorization when the provider read fails` — the negative matters: a failed read learned nothing and must not claim the cache is stale.

## Verification

`TelemetryIngestionKeyPolicyResolution` 30/30, `BillingPaymentMethodServiceSync` 6/6, `tsc --noEmit` clean, eslint clean. Tests only — no production code changes.

---

Worth stating plainly since it bears on all three PRs: **no CI run containing any of these fixes has completed.** Every "Push Test Images" run since #3693 merged has been cancelled — including all of its docker image build jobs — so the `-test` images were never rebuilt and test.oneuptime.com is still running pre-fix code. The billing page there will still show the `rate_limit` error until a run survives to publish new images.
