### PR TITLE
fix(ai): tell the user Ask AI is off instead of letting them type into it

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/AIChat/AIChatAvailability.ts
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/AIChatAvailability.ts
@@ -1,0 +1,103 @@
+import PageMap from "../../Utils/PageMap";
+import IconProp from "Common/Types/Icon/IconProp";
+
+/*
+ * Why Ask AI cannot answer a question right now.
+ *
+ * Every one of these is a SETTING somebody flipped (or never turned on), not a
+ * failure — which is why they are resolved before the user types rather than
+ * surfaced as an error after a send is refused. Ordered by precedence in
+ * getAIChatUnavailableReason: the reason shown is the one the user has to fix
+ * FIRST, so the page it points at is never a dead end.
+ */
+enum AIChatUnavailableReason {
+  // The project's plan does not include AI at all — nothing else matters yet.
+  PlanUpgradeRequired = "PlanUpgradeRequired",
+  // Project.enableAi is off: the project's own AI kill switch.
+  DisabledForProject = "DisabledForProject",
+  // AI is on, but no LLM provider is configured for the project (nor globally).
+  NoProviderConfigured = "NoProviderConfigured",
+}
+
+export default AIChatUnavailableReason;
+
+/*
+ * What a surface needs to tell the user, per reason: what is off, and the one
+ * settings page that turns it back on. Kept as data rather than as branches in
+ * a component so the panel, the full page, and the tests all read the same
+ * sentences.
+ */
+export interface AIChatUnavailableCopy {
+  icon: IconProp;
+  title: string;
+  description: string;
+  // The settings page that owns the switch, and the words that link to it.
+  actionPage: PageMap;
+  actionLabel: string;
+}
+
+const COPY: Record<AIChatUnavailableReason, AIChatUnavailableCopy> = {
+  [AIChatUnavailableReason.PlanUpgradeRequired]: {
+    icon: IconProp.Sparkles,
+    title: "AI is not included in this project's plan",
+    description:
+      "Ask AI needs the Growth plan or higher. Upgrade the project to ask questions about your logs, traces, metrics, incidents and monitors.",
+    actionPage: PageMap.SETTINGS_BILLING,
+    actionLabel: "Go to Project Settings > Billing",
+  },
+  [AIChatUnavailableReason.DisabledForProject]: {
+    icon: IconProp.Sparkles,
+    title: "AI features are disabled for this project",
+    description:
+      "Ask AI is switched off along with every other AI feature in this project. A project owner can turn it back on with the Enable AI toggle.",
+    actionPage: PageMap.SETTINGS_AI_CREDITS,
+    actionLabel: "Go to Project Settings > AI Credits",
+  },
+  [AIChatUnavailableReason.NoProviderConfigured]: {
+    icon: IconProp.Sparkles,
+    title: "No LLM provider is configured for this project",
+    description:
+      "Ask AI sends your questions to a model, and this project has no provider to send them to yet. Add one to start chatting.",
+    actionPage: PageMap.SETTINGS_AI_LLM_PROVIDERS,
+    actionLabel: "Go to Project Settings > AI > LLM Providers",
+  },
+};
+
+export function getAIChatUnavailableCopy(
+  reason: AIChatUnavailableReason,
+): AIChatUnavailableCopy {
+  return COPY[reason];
+}
+
+/*
+ * The single verdict every Ask AI surface asks for, resolved from what the
+ * client actually knows.
+ *
+ * FAILS OPEN by design. `isProjectAIEnabled` and `hasLoadedProviders` both
+ * come from POST /ai-chat/providers, and that request can be slow, can fail,
+ * or can be refused for a member without provider-read permission. Guessing
+ * "disabled" in any of those cases would lock a working assistant behind a
+ * setup notice for a setting that is perfectly fine — so only a verdict we
+ * actually received closes the door. The server still refuses the send either
+ * way; this decides what the user is TOLD, and it must not lie.
+ */
+export function getAIChatUnavailableReason(data: {
+  isAccessibleOnPlan: boolean;
+  isProjectAIEnabled: boolean;
+  hasLoadedProviders: boolean;
+  providerCount: number;
+}): AIChatUnavailableReason | null {
+  if (!data.isAccessibleOnPlan) {
+    return AIChatUnavailableReason.PlanUpgradeRequired;
+  }
+
+  if (!data.isProjectAIEnabled) {
+    return AIChatUnavailableReason.DisabledForProject;
+  }
+
+  if (data.hasLoadedProviders && data.providerCount === 0) {
+    return AIChatUnavailableReason.NoProviderConfigured;
+  }
+
+  return null;
+}

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/AIChatPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/AIChatPanel.tsx
@@ -19,6 +19,7 @@ import React, {
 import EventName from "../../Utils/EventName";
 import PageMap from "../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
+import AIChatUnavailableView from "./AIChatUnavailableView";
 import ChatActivityFeed from "./ChatActivityFeed";
 import ChatDownloadMenu from "./ChatDownloadMenu";
 import ChatHomeView from "./ChatHomeView";
@@ -369,13 +370,14 @@ const AIChatPanel: FunctionComponent = (): ReactElement => {
            */
           className="min-h-0 flex-1 overflow-y-auto overscroll-contain"
         >
-          {!chat.isConversationView && (
+          {chat.unavailableReason && (
+            <AIChatUnavailableView reason={chat.unavailableReason} />
+          )}
+
+          {!chat.unavailableReason && !chat.isConversationView && (
             <ChatHomeView
               conversations={chat.conversations}
               isSending={chat.isSending}
-              showNoProviderNotice={
-                chat.providersLoaded && chat.providers.length === 0
-              }
               pageContext={chat.pageContext}
               isPageContextAttached={chat.isPageContextAttached}
               onOpenConversation={chat.openConversation}
@@ -388,7 +390,7 @@ const AIChatPanel: FunctionComponent = (): ReactElement => {
             />
           )}
 
-          {chat.isConversationView && (
+          {!chat.unavailableReason && chat.isConversationView && (
             <div className="px-4 py-6">
               {chat.messages.length === 0 && !chat.isWorking && (
                 <div className="flex justify-center py-10">
@@ -429,33 +431,35 @@ const AIChatPanel: FunctionComponent = (): ReactElement => {
           )}
         </div>
 
-        {/* Composer */}
-        <ChatInput
-          value={chat.inputValue}
-          onChange={chat.setInputValue}
-          canSend={
-            !chat.isSending && !chat.isWorking && !chat.isAwaitingApproval
-          }
-          isWorking={chat.isWorking}
-          isStopping={chat.isCancelling}
-          onStop={
-            chat.isWorking && !chat.isAwaitingApproval
-              ? () => {
-                  chat.cancelRun().catch(() => {
-                    // handled in the hook
-                  });
-                }
-              : undefined
-          }
-          leading={composerLeading}
-          contextChip={contextChip}
-          placeholder={composerPlaceholder}
-          onSend={() => {
-            chat.sendMessage().catch(() => {
-              // handled in the hook
-            });
-          }}
-        />
+        {/* Composer — withheld entirely while AI is switched off. */}
+        {!chat.unavailableReason && (
+          <ChatInput
+            value={chat.inputValue}
+            onChange={chat.setInputValue}
+            canSend={
+              !chat.isSending && !chat.isWorking && !chat.isAwaitingApproval
+            }
+            isWorking={chat.isWorking}
+            isStopping={chat.isCancelling}
+            onStop={
+              chat.isWorking && !chat.isAwaitingApproval
+                ? () => {
+                    chat.cancelRun().catch(() => {
+                      // handled in the hook
+                    });
+                  }
+                : undefined
+            }
+            leading={composerLeading}
+            contextChip={contextChip}
+            placeholder={composerPlaceholder}
+            onSend={() => {
+              chat.sendMessage().catch(() => {
+                // handled in the hook
+              });
+            }}
+          />
+        )}
       </div>
     </div>
   );

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/AIChatUnavailableView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/AIChatUnavailableView.tsx
@@ -1,0 +1,66 @@
+import PageMap from "../../Utils/PageMap";
+import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
+import AIChatUnavailableReason, {
+  AIChatUnavailableCopy,
+  getAIChatUnavailableCopy,
+} from "./AIChatAvailability";
+import Route from "Common/Types/API/Route";
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import Link from "Common/UI/Components/Link/Link";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  reason: AIChatUnavailableReason;
+}
+
+/*
+ * What Ask AI shows INSTEAD of the composer when AI is switched off for the
+ * project.
+ *
+ * Ask AI used to look completely ready in this state: the hero invited a
+ * question, the suggested prompts were clickable, and the only sign that AI
+ * was off arrived as a red error banner after the user had already written
+ * something. This view replaces the whole surface, so the answer to "why did
+ * nothing happen?" is on screen before the question is asked — and it names
+ * the settings page that owns the switch, because the person who hits this is
+ * usually not the person who flipped it.
+ */
+const AIChatUnavailableView: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const copy: AIChatUnavailableCopy = getAIChatUnavailableCopy(props.reason);
+
+  const actionRoute: Route = RouteUtil.populateRouteParams(
+    RouteMap[copy.actionPage as PageMap] as Route,
+  );
+
+  return (
+    <div
+      className="flex min-h-full w-full flex-1 flex-col items-center justify-center px-6 py-12 text-center"
+      role="status"
+    >
+      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gray-100">
+        <Icon icon={copy.icon} className="h-5 w-5 text-gray-400" />
+      </div>
+
+      <h3 className="mt-4 text-base font-semibold tracking-tight text-gray-900">
+        {copy.title}
+      </h3>
+
+      <p className="mt-2 max-w-md text-sm leading-relaxed text-gray-500">
+        {copy.description}
+      </p>
+
+      <Link
+        to={actionRoute}
+        className="mt-5 inline-flex items-center gap-1.5 rounded-lg bg-gray-900 px-3.5 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800"
+      >
+        <Icon icon={IconProp.Settings} className="h-4 w-4" />
+        <span>{copy.actionLabel}</span>
+      </Link>
+    </div>
+  );
+};
+
+export default AIChatUnavailableView;

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/ChatHomeView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/ChatHomeView.tsx
@@ -1,15 +1,11 @@
-import PageMap from "../../Utils/PageMap";
-import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import PageContextUtil, {
   DashboardPageContext,
   SuggestedQuestion,
 } from "./PageContext";
 import AIConversation from "Common/Models/DatabaseModels/AIConversation";
-import Route from "Common/Types/API/Route";
 import OneUptimeDate from "Common/Types/Date";
 import IconProp from "Common/Types/Icon/IconProp";
 import Icon from "Common/UI/Components/Icon/Icon";
-import Link from "Common/UI/Components/Link/Link";
 import React, { FunctionComponent, ReactElement } from "react";
 
 export interface ComponentProps {
@@ -23,12 +19,6 @@ export interface ComponentProps {
    * list here and keeps only the hero + suggested prompts.
    */
   hideConversations?: boolean | undefined;
-  /*
-   * True when the provider list has loaded and is empty — the first message
-   * would fail, so surface the setup notice up front instead. Left false while
-   * loading or when the fetch errors (fail open).
-   */
-  showNoProviderNotice?: boolean | undefined;
   /*
    * What the user was looking at when they opened the chat. When attached, the
    * hero and suggestions speak about that page ("What would you like to know
@@ -66,10 +56,6 @@ const genericSuggestions: Array<SuggestedQuestion> = [
 const ChatHomeView: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const llmProvidersRoute: Route = RouteUtil.populateRouteParams(
-    RouteMap[PageMap.SETTINGS_AI_LLM_PROVIDERS] as Route,
-  );
-
   const context: DashboardPageContext | null | undefined =
     props.isPageContextAttached ? props.pageContext : null;
 
@@ -151,25 +137,6 @@ const ChatHomeView: FunctionComponent<ComponentProps> = (
           </>
         )}
       </div>
-
-      {props.showNoProviderNotice && (
-        <div className="mb-8 flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-3.5">
-          <Icon
-            icon={IconProp.Info}
-            className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-500"
-          />
-          <div className="text-sm leading-relaxed text-amber-800">
-            <span className="font-medium">
-              No LLM provider is configured for this project.
-            </span>{" "}
-            Messages need a provider to run — add one in{" "}
-            <Link to={llmProvidersRoute} className="font-medium underline">
-              Settings → AI → LLM Providers
-            </Link>{" "}
-            to start chatting.
-          </div>
-        </div>
-      )}
 
       {contextSuggestions.length > 0 && (
         <div className="mb-8 grid grid-cols-1 gap-2.5 sm:grid-cols-2">

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/useAiChat.ts
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/useAiChat.ts
@@ -25,6 +25,10 @@ import ProjectUtil from "Common/UI/Utils/Project";
 import Realtime from "Common/UI/Utils/Realtime";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
+import { isAIAccessibleOnCurrentPlan } from "../AI/AIPlanGate";
+import AIChatUnavailableReason, {
+  getAIChatUnavailableReason,
+} from "./AIChatAvailability";
 import PageContextUtil, { DashboardPageContext } from "./PageContext";
 
 // The thumbs rating a user can put on an assistant answer.
@@ -68,6 +72,14 @@ export interface UseAiChat {
    * latter fails open and shows the normal home).
    */
   providersLoaded: boolean;
+  /*
+   * Why Ask AI cannot take a question right now — the project's plan, its
+   * `enableAi` kill switch, or a project with no LLM provider at all. Null
+   * when AI is usable, and null while the answer is still unknown: this
+   * decides what the user is TOLD, so it fails open (see
+   * getAIChatUnavailableReason).
+   */
+  unavailableReason: AIChatUnavailableReason | null;
   selectedProviderId: string | undefined;
   setSelectedProviderId: (id: string | undefined) => void;
   selectedProvider: ChatProvider | undefined;
@@ -140,6 +152,12 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
   const [error, setError] = useState<string>("");
   const [providers, setProviders] = useState<Array<ChatProvider>>([]);
   const [providersLoaded, setProvidersLoaded] = useState<boolean>(false);
+  /*
+   * Project.enableAi, as reported by the providers endpoint. Starts true so a
+   * surface that has not asked yet (or asked and was refused) behaves exactly
+   * as it did before, rather than accusing a healthy project of having AI off.
+   */
+  const [isProjectAIEnabled, setIsProjectAIEnabled] = useState<boolean>(true);
   const [selectedProviderId, setSelectedProviderId] = useState<
     string | undefined
   >(undefined);
@@ -194,6 +212,14 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
     },
   );
 
+  const unavailableReason: AIChatUnavailableReason | null =
+    getAIChatUnavailableReason({
+      isAccessibleOnPlan: isAIAccessibleOnCurrentPlan(),
+      isProjectAIEnabled: isProjectAIEnabled,
+      hasLoadedProviders: providersLoaded,
+      providerCount: providers.length,
+    });
+
   const activeConversationTitle: string =
     conversations
       .find((conversation: AIConversation) => {
@@ -237,6 +263,7 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
 
         setProviders(list);
         setProvidersLoaded(true);
+        setIsProjectAIEnabled(data["isAIEnabledForProject"] !== false);
 
         // Default the picker to the project's resolved provider on first load.
         const defaultProviderId: string | undefined =
@@ -710,7 +737,13 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
     async (contentOverride?: string): Promise<void> => {
       const content: string = (contentOverride ?? inputValue).trim();
 
-      if (!content || isSending || isWorking) {
+      /*
+       * `unavailableReason` is a refusal the server would make anyway — the
+       * send-message route reads the same kill switch. Stopping here keeps the
+       * hook from optimistically rendering a question that is already known to
+       * be unanswerable, whatever a surface does with its composer.
+       */
+      if (!content || isSending || isWorking || unavailableReason) {
         return;
       }
 
@@ -796,7 +829,14 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
       setIsSending(false);
       setIsAwaitingResponse(false);
     },
-    [inputValue, isSending, isWorking, fetchConversations, fetchMessages],
+    [
+      inputValue,
+      isSending,
+      isWorking,
+      unavailableReason,
+      fetchConversations,
+      fetchMessages,
+    ],
   );
 
   const respondToApproval: (
@@ -983,6 +1023,7 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
     setError,
     providers,
     providersLoaded,
+    unavailableReason,
     selectedProviderId,
     setSelectedProviderId,
     selectedProvider,

--- a/App/FeatureSet/Dashboard/src/Pages/AICopilot/AICopilot.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/AICopilot/AICopilot.tsx
@@ -1,5 +1,5 @@
 import PageComponentProps from "../PageComponentProps";
-import AIPlanGate from "../../Components/AI/AIPlanGate";
+import AIChatUnavailableView from "../../Components/AIChat/AIChatUnavailableView";
 import ChatActivityFeed from "../../Components/AIChat/ChatActivityFeed";
 import ChatDownloadMenu from "../../Components/AIChat/ChatDownloadMenu";
 import ChatHomeView from "../../Components/AIChat/ChatHomeView";
@@ -148,9 +148,28 @@ const AICopilot: FunctionComponent<PageComponentProps> = (): ReactElement => {
     />
   ) : undefined;
 
+  /*
+   * AI switched off for the project (plan, kill switch, or no provider at all)
+   * replaces the entire workspace — rail, thread and composer. A conversation
+   * rail whose threads cannot be continued, above a composer that cannot send,
+   * would be a page pretending to work; the notice names the setting instead.
+   * This subsumes <AIPlanGate />, which used to carry the plan half alone.
+   */
+  if (chat.unavailableReason) {
+    return (
+      <Page title="AI" description={AI_CHAT_DESCRIPTION}>
+        <div
+          className="flex overflow-hidden rounded-2xl border border-gray-200 bg-white"
+          style={{ minHeight: "420px" }}
+        >
+          <AIChatUnavailableView reason={chat.unavailableReason} />
+        </div>
+      </Page>
+    );
+  }
+
   return (
     <Page title="AI" description={AI_CHAT_DESCRIPTION}>
-      <AIPlanGate />
       <div
         className="flex overflow-hidden rounded-2xl border border-gray-200 bg-white"
         style={{ height: "calc(100vh - 220px)", minHeight: "560px" }}
@@ -313,9 +332,6 @@ const AICopilot: FunctionComponent<PageComponentProps> = (): ReactElement => {
                   conversations={chat.conversations}
                   isSending={chat.isSending}
                   hideConversations={true}
-                  showNoProviderNotice={
-                    chat.providersLoaded && chat.providers.length === 0
-                  }
                   pageContext={chat.pageContext}
                   isPageContextAttached={chat.isPageContextAttached}
                   onOpenConversation={chat.openConversation}

--- a/App/Tests/Dashboard/AskAiDisabledWiring.test.ts
+++ b/App/Tests/Dashboard/AskAiDisabledWiring.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Ask AI has two front doors — the quick-launch panel the header opens, and
+ * the full-page Copilot — and they share one hook. When a project switches AI
+ * off (Project.enableAi), has no LLM provider, or sits on a plan without AI,
+ * BOTH doors have to close, and close the same way: the composer withheld, the
+ * suggested prompts gone, and a notice naming the settings page that owns the
+ * switch. A surface that keeps its composer is the original bug back again,
+ * just on the other page.
+ *
+ * The panel's rendered behaviour is covered against a real DOM in
+ * Common/Tests/App/Dashboard/AskAiDisabled.test.tsx, and the rule itself in
+ * AskAiAvailability.test.ts. What is left is the wiring, and it is asserted
+ * here as source text because the App suite runs in a plain Node environment
+ * (App/jest.config.json sets testEnvironment: "node") — rendering the
+ * full-page Copilot, with its Page chrome, routing and analytics, to find out
+ * whether one component is mounted is not worth what it costs.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+/*
+ * Comments are stripped first. Every file below explains this behaviour in
+ * prose that names the very identifiers being matched, and an assertion about
+ * the code has to read the code rather than the commentary about it.
+ */
+type StripCommentsFunction = (raw: string) => string;
+
+const stripComments: StripCommentsFunction = (raw: string): string => {
+  return raw.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/gm, " ");
+};
+
+type ReadCodeFunction = (...relativeParts: Array<string>) => string;
+
+const readCode: ReadCodeFunction = (
+  ...relativeParts: Array<string>
+): string => {
+  return stripComments(
+    fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8"),
+  ).replace(/\s+/g, " ");
+};
+
+const HOOK: string = readCode("Components", "AIChat", "useAiChat.ts");
+
+const PANEL: string = readCode("Components", "AIChat", "AIChatPanel.tsx");
+
+const FULL_PAGE: string = readCode("Pages", "AICopilot", "AICopilot.tsx");
+
+const HOME_VIEW: string = readCode("Components", "AIChat", "ChatHomeView.tsx");
+
+const AVAILABILITY: string = readCode(
+  "Components",
+  "AIChat",
+  "AIChatAvailability.ts",
+);
+
+describe("the verdict is resolved once, in the hook both surfaces share", () => {
+  test("the hook reads the project's kill switch off the providers response", () => {
+    /*
+     * Project.enableAi is a server row, and the chat surfaces hold no project
+     * model. It rides on the request the provider picker already makes, so the
+     * answer costs no extra round trip — see the server side in
+     * Common/Tests/Server/API/AIChatProvidersAIEnabled.
+     */
+    expect(HOOK).toContain('data["isAIEnabledForProject"] !== false');
+  });
+
+  test("the hook publishes one reason, not three raw flags for each surface to combine", () => {
+    expect(HOOK).toContain("getAIChatUnavailableReason({");
+    expect(HOOK).toContain("unavailableReason,");
+  });
+
+  test("the plan gate feeds the same verdict rather than being a second, parallel notice", () => {
+    expect(HOOK).toContain(
+      'import { isAIAccessibleOnCurrentPlan } from "../AI/AIPlanGate";',
+    );
+    expect(HOOK).toContain("isAccessibleOnPlan: isAIAccessibleOnCurrentPlan()");
+  });
+
+  test("sendMessage refuses while a reason stands, whatever a surface does with its composer", () => {
+    expect(HOOK).toContain(
+      "if (!content || isSending || isWorking || unavailableReason) {",
+    );
+  });
+});
+
+describe("both front doors close", () => {
+  test("the panel shows the notice", () => {
+    expect(PANEL).toContain(
+      "{chat.unavailableReason && ( <AIChatUnavailableView reason={chat.unavailableReason} /> )}",
+    );
+  });
+
+  test("the panel withholds the composer entirely", () => {
+    /*
+     * Withheld, not disabled: a greyed-out textarea still reads as "type here
+     * and something will happen", and the send path is the thing that cannot
+     * work.
+     */
+    expect(PANEL).toContain("{!chat.unavailableReason && ( <ChatInput");
+  });
+
+  test("the panel hides the home view, so no suggested prompt can start a doomed turn", () => {
+    expect(PANEL).toContain(
+      "{!chat.unavailableReason && !chat.isConversationView && (",
+    );
+  });
+
+  test("the panel hides the thread too, so nothing invites a follow-up question", () => {
+    expect(PANEL).toContain(
+      "{!chat.unavailableReason && chat.isConversationView && (",
+    );
+  });
+
+  test("the full page returns the notice instead of its workspace", () => {
+    expect(FULL_PAGE).toContain("if (chat.unavailableReason) {");
+    expect(FULL_PAGE).toContain(
+      "<AIChatUnavailableView reason={chat.unavailableReason} />",
+    );
+  });
+
+  test("the full page's early return sits after every hook it calls", () => {
+    /*
+     * React's rules, not style: useAiChat and the three effects below it run
+     * unconditionally, so the bail-out has to come after them or the render
+     * where a project switches AI off throws.
+     */
+    const bailOut: number = FULL_PAGE.indexOf("if (chat.unavailableReason) {");
+
+    expect(bailOut).toBeGreaterThan(-1);
+    expect(FULL_PAGE.lastIndexOf("useEffect(", bailOut)).toBeGreaterThan(-1);
+    expect(FULL_PAGE.indexOf("useEffect(", bailOut)).toBe(-1);
+    expect(FULL_PAGE.indexOf("useAiChat({")).toBeLessThan(bailOut);
+  });
+
+  test("the full page no longer carries a separate plan banner that the notice now covers", () => {
+    /*
+     * <AIPlanGate /> used to sit above the chat card and speak for the plan
+     * half alone. Leaving it there would put two different messages about the
+     * same switch on one screen.
+     */
+    expect(FULL_PAGE).not.toContain("<AIPlanGate />");
+  });
+});
+
+describe("the old half-measure is gone", () => {
+  test("no surface still renders the inline 'no provider' notice next to a live composer", () => {
+    /*
+     * ChatHomeView used to show an amber "no LLM provider configured" strip
+     * while leaving the composer fully usable underneath it. That is the state
+     * this change replaces; a re-introduced prop would mean two notices
+     * disagreeing about whether the user may type.
+     */
+    expect(HOME_VIEW).not.toContain("showNoProviderNotice");
+    expect(PANEL).not.toContain("showNoProviderNotice");
+    expect(FULL_PAGE).not.toContain("showNoProviderNotice");
+  });
+});
+
+describe("the notice always has somewhere to send the user", () => {
+  test("every reason carries a settings page in the copy table", () => {
+    /*
+     * The copy lives as data keyed by reason, so a new reason cannot be added
+     * without deciding which page fixes it — TypeScript's Record makes the
+     * omission a compile error rather than a blank notice.
+     */
+    expect(AVAILABILITY).toContain(
+      "const COPY: Record<AIChatUnavailableReason, AIChatUnavailableCopy>",
+    );
+    expect(AVAILABILITY).toContain("PageMap.SETTINGS_AI_CREDITS");
+    expect(AVAILABILITY).toContain("PageMap.SETTINGS_AI_LLM_PROVIDERS");
+    expect(AVAILABILITY).toContain("PageMap.SETTINGS_BILLING");
+  });
+
+  test("the rule fails open on a verdict that has not arrived", () => {
+    /*
+     * The providers request is slow before it is anything else, and a member
+     * without provider-read permission never gets an answer at all. Only a
+     * loaded, genuinely empty list counts.
+     */
+    expect(AVAILABILITY).toContain(
+      "if (data.hasLoadedProviders && data.providerCount === 0) {",
+    );
+  });
+});

--- a/Common/Server/API/AIChatAPI.ts
+++ b/Common/Server/API/AIChatAPI.ts
@@ -524,15 +524,34 @@ router.post(
           "You do not have permission to read this project's AI providers.",
       });
 
-      const [providers, defaultProvider]: [
+      const [providers, defaultProvider, project]: [
         Array<LlmProvider>,
         LlmProvider | null,
+        Project | null,
       ] = await Promise.all([
         LlmProviderService.getSelectableProvidersForProject(projectId),
         LlmProviderService.getLLMProviderForProject(projectId),
+        ProjectService.findOneById({
+          id: projectId,
+          select: { enableAi: true },
+          props: { isRoot: true },
+        }),
       ]);
 
       Response.sendJsonObjectResponse(req, res, {
+        /*
+         * The project's AI kill switch, so Ask AI can say up front why it is
+         * unavailable instead of letting the user compose a question that
+         * send-message will only refuse. This route is where the answer
+         * belongs: the chat surfaces already call it as they open, so the
+         * verdict costs no extra round trip.
+         *
+         * Strictly `!== false`, mirroring AIService's own read — the column is
+         * NOT NULL DEFAULT true, so anything but an explicit false is "on".
+         * A project row we cannot read answers "off", the same way the
+         * server-side gate fails closed.
+         */
+        isAIEnabledForProject: project ? project.enableAi !== false : false,
         defaultProviderId: defaultProvider?.id?.toString() || null,
         providers: providers.map((provider: LlmProvider) => {
           return {

--- a/Common/Tests/App/Dashboard/AskAiAvailability.test.ts
+++ b/Common/Tests/App/Dashboard/AskAiAvailability.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import AIChatUnavailableReason, {
+  AIChatUnavailableCopy,
+  getAIChatUnavailableCopy,
+  getAIChatUnavailableReason,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/AIChat/AIChatAvailability";
+import PageMap from "../../../../App/FeatureSet/Dashboard/src/Utils/PageMap";
+import RouteMap from "../../../../App/FeatureSet/Dashboard/src/Utils/RouteMap";
+import Route from "../../../Types/API/Route";
+
+/*
+ * The rule Ask AI uses to decide whether it can take a question, and the words
+ * it uses to explain a "no".
+ *
+ * Two things are easy to get wrong here and neither shows up as a crash:
+ *
+ *   ORDER. Three separate switches can each stop a chat turn, and they are not
+ *   independent — a project on a plan without AI cannot use its own enableAi
+ *   toggle, and a toggle that is off makes a configured provider irrelevant.
+ *   Reporting the wrong one sends the user to a settings page that will not fix
+ *   anything, which is worse than saying nothing.
+ *
+ *   FAILING OPEN. The verdict arrives on the same request as the provider list,
+ *   and that request is slow before it is anything else. Treating "not answered
+ *   yet" as "disabled" would flash a setup notice over a working assistant on
+ *   every single open, and would strand members whose permissions do not let
+ *   them read providers at all.
+ */
+
+const REPO_ROOT: string = path.join(__dirname, "..", "..", "..", "..");
+
+const ALL_REASONS: Array<AIChatUnavailableReason> = Object.values(
+  AIChatUnavailableReason,
+);
+
+// Everything on: the state in which Ask AI must simply work.
+const HEALTHY: Parameters<typeof getAIChatUnavailableReason>[0] = {
+  isAccessibleOnPlan: true,
+  isProjectAIEnabled: true,
+  hasLoadedProviders: true,
+  providerCount: 1,
+};
+
+describe("what stops Ask AI from taking a question", () => {
+  test("nothing, when the plan allows it, the project has AI on and a provider exists", () => {
+    expect(getAIChatUnavailableReason(HEALTHY)).toBeNull();
+  });
+
+  test("a plan without AI", () => {
+    expect(
+      getAIChatUnavailableReason({ ...HEALTHY, isAccessibleOnPlan: false }),
+    ).toBe(AIChatUnavailableReason.PlanUpgradeRequired);
+  });
+
+  test("the project's own AI kill switch", () => {
+    expect(
+      getAIChatUnavailableReason({ ...HEALTHY, isProjectAIEnabled: false }),
+    ).toBe(AIChatUnavailableReason.DisabledForProject);
+  });
+
+  test("a project with no LLM provider at all", () => {
+    expect(getAIChatUnavailableReason({ ...HEALTHY, providerCount: 0 })).toBe(
+      AIChatUnavailableReason.NoProviderConfigured,
+    );
+  });
+});
+
+describe("the reason reported is the one the user has to fix first", () => {
+  test("plan beats the project toggle — the toggle cannot help without the plan", () => {
+    expect(
+      getAIChatUnavailableReason({
+        ...HEALTHY,
+        isAccessibleOnPlan: false,
+        isProjectAIEnabled: false,
+      }),
+    ).toBe(AIChatUnavailableReason.PlanUpgradeRequired);
+  });
+
+  test("plan beats a missing provider", () => {
+    expect(
+      getAIChatUnavailableReason({
+        ...HEALTHY,
+        isAccessibleOnPlan: false,
+        providerCount: 0,
+      }),
+    ).toBe(AIChatUnavailableReason.PlanUpgradeRequired);
+  });
+
+  test("the project toggle beats a missing provider — adding one changes nothing while AI is off", () => {
+    expect(
+      getAIChatUnavailableReason({
+        ...HEALTHY,
+        isProjectAIEnabled: false,
+        providerCount: 0,
+      }),
+    ).toBe(AIChatUnavailableReason.DisabledForProject);
+  });
+
+  test("with everything off, the answer is still the plan", () => {
+    expect(
+      getAIChatUnavailableReason({
+        isAccessibleOnPlan: false,
+        isProjectAIEnabled: false,
+        hasLoadedProviders: true,
+        providerCount: 0,
+      }),
+    ).toBe(AIChatUnavailableReason.PlanUpgradeRequired);
+  });
+});
+
+describe("an unanswered question is not a 'no'", () => {
+  test("an empty provider list that has not loaded yet reports nothing", () => {
+    expect(
+      getAIChatUnavailableReason({
+        ...HEALTHY,
+        hasLoadedProviders: false,
+        providerCount: 0,
+      }),
+    ).toBeNull();
+  });
+
+  test("the toggle defaults to enabled, so a surface that never asked stays usable", () => {
+    /*
+     * This is the shape of a first render, and of a member whose permissions
+     * get the providers request refused: no verdict, no providers, no notice.
+     */
+    expect(
+      getAIChatUnavailableReason({
+        isAccessibleOnPlan: true,
+        isProjectAIEnabled: true,
+        hasLoadedProviders: false,
+        providerCount: 0,
+      }),
+    ).toBeNull();
+  });
+
+  test("only a loaded, genuinely empty provider list closes the door", () => {
+    expect(
+      getAIChatUnavailableReason({
+        ...HEALTHY,
+        hasLoadedProviders: true,
+        providerCount: 0,
+      }),
+    ).not.toBeNull();
+  });
+});
+
+describe("every reason can be explained to the person who hit it", () => {
+  test.each(ALL_REASONS)(
+    "%s has a title, an explanation and a way out",
+    (reason: AIChatUnavailableReason) => {
+      const copy: AIChatUnavailableCopy = getAIChatUnavailableCopy(reason);
+
+      expect(copy.title.length).toBeGreaterThan(0);
+      expect(copy.description.length).toBeGreaterThan(0);
+      expect(copy.actionLabel.length).toBeGreaterThan(0);
+    },
+  );
+
+  test.each(ALL_REASONS)(
+    "%s points at a page that actually exists",
+    (reason: AIChatUnavailableReason) => {
+      const copy: AIChatUnavailableCopy = getAIChatUnavailableCopy(reason);
+
+      expect(Object.values(PageMap)).toContain(copy.actionPage);
+      expect(RouteMap[copy.actionPage as PageMap]).toBeInstanceOf(Route);
+    },
+  );
+
+  test.each(ALL_REASONS)(
+    "%s tells the user where to go, not just that something is wrong",
+    (reason: AIChatUnavailableReason) => {
+      const copy: AIChatUnavailableCopy = getAIChatUnavailableCopy(reason);
+
+      /*
+       * The whole point of the notice: whoever is looking at it usually did
+       * not flip the switch, so "Settings" alone is not an answer.
+       */
+      expect(copy.actionLabel).toMatch(/Settings/);
+    },
+  );
+
+  test("each reason points somewhere different — three reasons collapsing onto one page would hide two of them", () => {
+    const pages: Array<PageMap> = ALL_REASONS.map(
+      (reason: AIChatUnavailableReason) => {
+        return getAIChatUnavailableCopy(reason).actionPage;
+      },
+    );
+
+    expect(new Set(pages).size).toBe(ALL_REASONS.length);
+  });
+
+  test("the kill-switch notice points at the same page the server's own refusal names", () => {
+    /*
+     * AIService.AI_DISABLED_MESSAGE is the sentence a user reads in Slack, on
+     * a runbook step and behind every "Generate with AI" button. Ask AI now
+     * says the same thing before the request instead of after it, and the two
+     * must not drift into naming different screens.
+     *
+     * Read as source text rather than imported: AIService is server code with
+     * a database-shaped import graph, and this file runs in the browser suite.
+     */
+    const aiService: string = fs.readFileSync(
+      path.join(REPO_ROOT, "Common", "Server", "Services", "AIService.ts"),
+      "utf8",
+    );
+
+    const message: string = (aiService.match(
+      /AI_DISABLED_MESSAGE:\s*string\s*=\s*\n?\s*"([^"]+)"/,
+    ) || [])[1] as string;
+
+    expect(message).toBeDefined();
+    expect(message).toContain("AI Credits");
+
+    const copy: AIChatUnavailableCopy = getAIChatUnavailableCopy(
+      AIChatUnavailableReason.DisabledForProject,
+    );
+
+    expect(copy.actionPage).toBe(PageMap.SETTINGS_AI_CREDITS);
+    expect(copy.actionLabel).toContain("AI Credits");
+  });
+});

--- a/Common/Tests/App/Dashboard/AskAiDisabled.test.tsx
+++ b/Common/Tests/App/Dashboard/AskAiDisabled.test.tsx
@@ -1,0 +1,432 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import GlobalEvents from "../../../UI/Utils/GlobalEvents";
+import AIChatPanel from "../../../../App/FeatureSet/Dashboard/src/Components/AIChat/AIChatPanel";
+import EventName from "../../../../App/FeatureSet/Dashboard/src/Utils/EventName";
+
+/*
+ * Issue: "when AI features are disabled for the app, Ask AI is not".
+ *
+ * A project can switch AI off (Project.enableAi, on Settings > AI Credits), or
+ * simply never configure an LLM provider (Settings > AI > LLM Providers), or
+ * sit on a plan that does not include AI at all. In every one of those states
+ * the server refuses a chat turn — and Ask AI still looked completely ready:
+ * the header button opened a composer, the suggested prompts were clickable,
+ * and the only mention of the switch was a red banner AFTER the user had
+ * written a question and pressed send. The person hitting it is usually not
+ * the person who flipped the switch, so "it just says no" is a support ticket.
+ *
+ * These tests render the REAL Ask AI panel the dashboard mounts, drive it the
+ * way the header does (the AI_CHAT_TOGGLE global event), and assert the two
+ * halves of the fix that a refactor could quietly undo:
+ *
+ *   1. the composer is GONE, not merely decorated with a warning; and
+ *   2. what replaces it says AI is off and names the settings page that turns
+ *      it back on — the reason it is off decides which page.
+ *
+ * The panel's fail-open posture is pinned too. The verdict arrives on the same
+ * request as the provider list, and that request can be slow, can fail, or can
+ * be refused for a member without provider-read permission. Guessing
+ * "disabled" there would lock a perfectly healthy assistant behind a setup
+ * notice, which is a worse bug than the one being fixed.
+ */
+
+const postMock: MockFunction = getJestMockFunction();
+const getListMock: MockFunction = getJestMockFunction();
+const isAccessibleOnPlanMock: MockFunction = getJestMockFunction();
+
+const PROJECT_ID: string = "11111111-1111-1111-1111-111111111111";
+
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      post: (...args: Array<unknown>) => {
+        return postMock(...args);
+      },
+      getFriendlyMessage: () => {
+        return "error";
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<unknown>) => {
+        return getListMock(...args);
+      },
+      getCommonHeaders: () => {
+        return { tenantid: PROJECT_ID };
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: () => {
+        return new ObjectID(PROJECT_ID);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Realtime", () => {
+  return {
+    __esModule: true,
+    default: {
+      listenToModelEvent: () => {
+        return () => {};
+      },
+    },
+  };
+});
+
+/*
+ * Page context detection reads the browser route through Navigation, which is
+ * not wired up under MemoryRouter. Ask AI's context chip is not what is under
+ * test here, so it is switched off rather than simulated.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/AIChat/PageContext",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        detectPageContext: () => {
+          return null;
+        },
+        resolveEntityTitle: async () => {
+          return null;
+        },
+        getSuggestions: () => {
+          return [];
+        },
+        toRequestPayload: () => {
+          return {};
+        },
+      },
+    };
+  },
+);
+
+/*
+ * The download menu pulls the markdown/PDF export stack, which is ESM the
+ * browser suite's transform does not take. Nothing under test here opens it.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/AIChat/ChatDownloadMenu",
+  () => {
+    return {
+      __esModule: true,
+      default: () => {
+        return null;
+      },
+    };
+  },
+);
+
+/*
+ * The plan verdict is read straight off local storage and the build's billing
+ * flag, neither of which exists here. Mocking the predicate keeps the plan
+ * reason drivable without pretending to be a Stripe subscription.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/AI/AIPlanGate",
+  () => {
+    return {
+      __esModule: true,
+      isAIAccessibleOnCurrentPlan: () => {
+        return isAccessibleOnPlanMock();
+      },
+      default: () => {
+        return null;
+      },
+    };
+  },
+);
+
+interface ProvidersResponse {
+  isAIEnabledForProject?: boolean | undefined;
+  providerCount?: number | undefined;
+}
+
+function providersPayload(data: ProvidersResponse): JSONObject {
+  const providers: Array<JSONObject> = [];
+
+  for (let index: number = 0; index < (data.providerCount ?? 1); index++) {
+    providers.push({
+      id: `provider-${index}`,
+      name: `Provider ${index}`,
+      description: null,
+      llmType: "OpenAI",
+      modelName: "gpt-4o",
+      isDefault: index === 0,
+      isGlobal: false,
+    });
+  }
+
+  return {
+    isAIEnabledForProject: data.isAIEnabledForProject ?? true,
+    defaultProviderId: providers[0]?.["id"] ?? null,
+    providers: providers,
+  };
+}
+
+function respondWithProviders(data: ProvidersResponse): void {
+  postMock.mockImplementation(async () => {
+    return new HTTPResponse<JSONObject>(200, providersPayload(data), {});
+  });
+}
+
+async function openAskAi(): Promise<void> {
+  render(
+    <MemoryRouter>
+      <AIChatPanel />
+    </MemoryRouter>,
+  );
+
+  // Exactly what the header's Ask AI button does.
+  await act(async () => {
+    GlobalEvents.dispatchEvent(EventName.AI_CHAT_TOGGLE);
+  });
+
+  // Let the providers request settle.
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function composer(): HTMLElement | null {
+  return document.querySelector("textarea");
+}
+
+function settingsLinkHref(): string | null {
+  const links: Array<HTMLAnchorElement> = Array.from(
+    document.querySelectorAll("a[href]"),
+  );
+
+  return links.length > 0
+    ? links[links.length - 1]!.getAttribute("href")
+    : null;
+}
+
+beforeEach(() => {
+  postMock.mockReset();
+  getListMock.mockReset();
+  isAccessibleOnPlanMock.mockReset();
+
+  isAccessibleOnPlanMock.mockImplementation(() => {
+    return true;
+  });
+  getListMock.mockImplementation(async () => {
+    return { data: [], count: 0, skip: 0, limit: 25 };
+  });
+  respondWithProviders({});
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Ask AI on a project whose AI is switched off", () => {
+  test("says AI is disabled for the project instead of inviting a question", async () => {
+    respondWithProviders({ isAIEnabledForProject: false });
+
+    await openAskAi();
+
+    expect(
+      screen.getByText("AI features are disabled for this project"),
+    ).toBeInTheDocument();
+  });
+
+  test("names the settings page that owns the switch", async () => {
+    respondWithProviders({ isAIEnabledForProject: false });
+
+    await openAskAi();
+
+    expect(
+      screen.getByText("Go to Project Settings > AI Credits"),
+    ).toBeInTheDocument();
+    expect(settingsLinkHref()).toContain("/settings/ai-credits");
+  });
+
+  test("the link is scoped to the project the user is in", async () => {
+    respondWithProviders({ isAIEnabledForProject: false });
+
+    await openAskAi();
+
+    expect(settingsLinkHref()).toContain(PROJECT_ID);
+  });
+
+  test("the composer is withheld — there is nothing to type a question into", async () => {
+    respondWithProviders({ isAIEnabledForProject: false });
+
+    await openAskAi();
+
+    expect(composer()).toBeNull();
+  });
+
+  test("the suggested prompts are gone too, so no click can start a doomed turn", async () => {
+    respondWithProviders({ isAIEnabledForProject: false });
+
+    await openAskAi();
+
+    expect(screen.queryByText("Top exceptions")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Ask AI about your data — or tell it to act"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("no message is ever sent from this state", async () => {
+    respondWithProviders({ isAIEnabledForProject: false });
+
+    await openAskAi();
+
+    for (const call of postMock.mock.calls) {
+      const url: string = String(
+        (call[0] as { url?: unknown })?.url ?? call[0],
+      );
+      expect(url).not.toContain("send-message");
+    }
+  });
+});
+
+describe("Ask AI on a project with no LLM provider", () => {
+  test("says so, and points at the provider page rather than the AI toggle", async () => {
+    respondWithProviders({ providerCount: 0 });
+
+    await openAskAi();
+
+    expect(
+      screen.getByText("No LLM provider is configured for this project"),
+    ).toBeInTheDocument();
+    expect(settingsLinkHref()).toContain("/settings/llm-providers");
+  });
+
+  test("the composer is withheld here too — a message would have nowhere to go", async () => {
+    respondWithProviders({ providerCount: 0 });
+
+    await openAskAi();
+
+    expect(composer()).toBeNull();
+  });
+
+  test("the project's own kill switch wins when both are off — enabling a provider first would not help", async () => {
+    respondWithProviders({ isAIEnabledForProject: false, providerCount: 0 });
+
+    await openAskAi();
+
+    expect(
+      screen.getByText("AI features are disabled for this project"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("No LLM provider is configured for this project"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("Ask AI on a plan that does not include AI", () => {
+  test("sends the user to billing, not to a toggle they cannot use yet", async () => {
+    isAccessibleOnPlanMock.mockImplementation(() => {
+      return false;
+    });
+
+    await openAskAi();
+
+    expect(
+      screen.getByText("AI is not included in this project's plan"),
+    ).toBeInTheDocument();
+    expect(settingsLinkHref()).toContain("/settings/billing");
+    expect(composer()).toBeNull();
+  });
+
+  test("the plan wins over the project toggle — the toggle is unreachable without the plan", async () => {
+    isAccessibleOnPlanMock.mockImplementation(() => {
+      return false;
+    });
+    respondWithProviders({ isAIEnabledForProject: false });
+
+    await openAskAi();
+
+    expect(
+      screen.getByText("AI is not included in this project's plan"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Ask AI stays open for business unless it actually hears otherwise", () => {
+  test("a healthy project gets the composer and the prompts, with no notice", async () => {
+    await openAskAi();
+
+    expect(composer()).not.toBeNull();
+    expect(
+      screen.getByText("Ask AI about your data — or tell it to act"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("AI features are disabled for this project"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("a providers request that fails does not accuse the project of having AI off", async () => {
+    postMock.mockImplementation(async () => {
+      throw new Error("network");
+    });
+
+    await openAskAi();
+
+    expect(composer()).not.toBeNull();
+    expect(
+      screen.queryByText("AI features are disabled for this project"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("No LLM provider is configured for this project"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("an older server that does not report the switch is treated as enabled", async () => {
+    postMock.mockImplementation(async () => {
+      return new HTTPResponse<JSONObject>(
+        200,
+        {
+          defaultProviderId: "provider-0",
+          providers: [
+            {
+              id: "provider-0",
+              name: "Provider 0",
+              isDefault: true,
+              isGlobal: false,
+            },
+          ],
+        },
+        {},
+      );
+    });
+
+    await openAskAi();
+
+    expect(composer()).not.toBeNull();
+    expect(
+      screen.queryByText("AI features are disabled for this project"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/Common/Tests/Server/API/AIChatProvidersAIEnabled.test.ts
+++ b/Common/Tests/Server/API/AIChatProvidersAIEnabled.test.ts
@@ -1,0 +1,259 @@
+import { mockRouter } from "./Helpers";
+import "../../../Server/API/AIChatAPI";
+import CommonAPI from "../../../Server/API/CommonAPI";
+import LlmProviderService from "../../../Server/Services/LlmProviderService";
+import ProjectService from "../../../Server/Services/ProjectService";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import LlmProvider from "../../../Models/DatabaseModels/LlmProvider";
+import Project from "../../../Models/DatabaseModels/Project";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Dictionary from "../../../Types/Dictionary";
+import { JSONObject } from "../../../Types/JSON";
+import LlmType from "../../../Types/LLM/LlmType";
+import ObjectID from "../../../Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../../Types/Permission";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendJsonObjectResponse: jest.fn(),
+  };
+});
+
+/*
+ * Ask AI used to look perfectly ready on a project with AI switched off. The
+ * header button opened a composer, the suggested prompts were clickable, and
+ * the only thing that ever mentioned the switch was the red banner that
+ * appeared AFTER the user had written a question and pressed send — telling
+ * them, at that point, to go and find a settings page.
+ *
+ * The client cannot know the answer on its own: Project.enableAi is a server
+ * row, and the chat surfaces deliberately hold no project model. So the
+ * verdict rides along on POST /ai-chat/providers, which every chat surface
+ * already calls as it opens. That is what this suite pins:
+ *
+ *   - the field is reported, and reported honestly (the toggle's three states
+ *     are true / undefined-because-unselected / false, not two);
+ *   - it fails CLOSED on a project row we cannot read, matching the
+ *     server-side gate in AIService rather than contradicting it; and
+ *   - it does not cost a request of its own, because a second round trip is
+ *     exactly how this ends up back where it started.
+ *
+ * The refusal itself still lives in AIService.executeWithLogging and in the
+ * send-message route (Common/Tests/Server/API/AIKillSwitchBackstop). Nothing
+ * here is a security boundary — it is what the user is TOLD, before typing.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+
+const USER_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+
+const PROVIDER_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+const PROVIDERS_ROUTE: string = "/ai-chat/providers";
+
+function memberProps(): DatabaseCommonInteractionProps {
+  const permissions: Array<UserPermission> = [
+    Permission.ProjectMember,
+    Permission.ReadProjectLlm,
+  ].map((permission: Permission) => {
+    return {
+      _type: "UserPermission",
+      permission: permission,
+      labelIds: [],
+      isBlockPermission: false,
+    } as UserPermission;
+  });
+
+  const dictionary: Dictionary<UserTenantAccessPermission> = {};
+  dictionary[PROJECT_ID.toString()] = {
+    _type: "UserTenantAccessPermission",
+    projectId: PROJECT_ID,
+    permissions: permissions,
+    isBlockPermission: false,
+  } as UserTenantAccessPermission;
+
+  return {
+    userId: USER_ID,
+    tenantId: PROJECT_ID,
+    userTenantAccessPermission: dictionary,
+  };
+}
+
+function provider(): LlmProvider {
+  const llmProvider: LlmProvider = new LlmProvider(PROVIDER_ID);
+  llmProvider.name = "project-gpt";
+  llmProvider.llmType = LlmType.OpenAI;
+  llmProvider.modelName = "gpt-4o";
+  llmProvider.isDefault = true;
+  llmProvider.projectId = PROJECT_ID;
+  return llmProvider;
+}
+
+/*
+ * `enableAi` is deliberately typed as optional on the model: the column is NOT
+ * NULL DEFAULT true, so a row selected without that column arrives undefined,
+ * and undefined has always meant "not selected", never "off".
+ */
+function projectRow(enableAi: boolean | undefined): Project {
+  const project: Project = new Project(PROJECT_ID);
+
+  // Left unset, not set to undefined — that is what an unselected column is.
+  if (enableAi !== undefined) {
+    project.enableAi = enableAi;
+  }
+
+  return project;
+}
+
+async function callProviders(): Promise<void> {
+  const next: ReturnType<typeof jest.fn> = jest.fn();
+
+  await mockRouter.match("post", PROVIDERS_ROUTE).handlerFunction(
+    {
+      body: {},
+      headers: {},
+      params: {},
+      query: {},
+    } as unknown as ExpressRequest,
+    {} as ExpressResponse,
+    next as unknown as NextFunction,
+  );
+
+  const thrown: unknown = next.mock.calls[0]?.[0];
+
+  if (thrown) {
+    throw thrown;
+  }
+}
+
+function sentPayload(): JSONObject {
+  const send: jest.Mock =
+    Response.sendJsonObjectResponse as unknown as jest.Mock;
+  return send.mock.calls[0]![2] as JSONObject;
+}
+
+function stubProject(project: Project | null): void {
+  jest.spyOn(ProjectService, "findOneById").mockResolvedValue(project);
+}
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+
+  jest
+    .spyOn(CommonAPI, "getDatabaseCommonInteractionProps")
+    .mockResolvedValue(memberProps());
+  jest
+    .spyOn(LlmProviderService, "getSelectableProvidersForProject")
+    .mockResolvedValue([provider()]);
+  jest
+    .spyOn(LlmProviderService, "getLLMProviderForProject")
+    .mockResolvedValue(provider());
+  stubProject(projectRow(true));
+});
+
+describe("POST /ai-chat/providers reports the project's AI kill switch", () => {
+  test("a project with AI on is reported as enabled", async () => {
+    stubProject(projectRow(true));
+
+    await callProviders();
+
+    expect(sentPayload()["isAIEnabledForProject"]).toBe(true);
+  });
+
+  test("a project with AI explicitly off is reported as disabled", async () => {
+    stubProject(projectRow(false));
+
+    await callProviders();
+
+    expect(sentPayload()["isAIEnabledForProject"]).toBe(false);
+  });
+
+  test("undefined means 'not selected', not 'off' — the column defaults to true", async () => {
+    stubProject(projectRow(undefined));
+
+    await callProviders();
+
+    expect(sentPayload()["isAIEnabledForProject"]).toBe(true);
+  });
+
+  test("a project row that cannot be read answers 'disabled' — the same way the server-side gate fails closed", async () => {
+    stubProject(null);
+
+    await callProviders();
+
+    expect(sentPayload()["isAIEnabledForProject"]).toBe(false);
+  });
+
+  test("the verdict is read for the caller's own project", async () => {
+    await callProviders();
+
+    expect(ProjectService.findOneById).toHaveBeenCalledWith(
+      expect.objectContaining({ id: PROJECT_ID }),
+    );
+  });
+
+  test("only the toggle column is selected — no other project data is pulled to answer this", async () => {
+    await callProviders();
+
+    const call: JSONObject = (
+      ProjectService.findOneById as unknown as jest.Mock
+    ).mock.calls[0]![0] as JSONObject;
+
+    expect(call["select"]).toEqual({ enableAi: true });
+  });
+
+  test("the switch costs no extra round trip — it rides on the request the picker already makes", async () => {
+    await callProviders();
+
+    const payload: JSONObject = sentPayload();
+
+    // One response, carrying the providers AND the verdict.
+    expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+    expect(payload).toHaveProperty("isAIEnabledForProject");
+    expect(payload).toHaveProperty("providers");
+    expect(payload).toHaveProperty("defaultProviderId");
+  });
+
+  test("a disabled project still gets its provider list — the notice explains, it does not hide the setup", async () => {
+    stubProject(projectRow(false));
+
+    await callProviders();
+
+    const payload: JSONObject = sentPayload();
+
+    expect(payload["isAIEnabledForProject"]).toBe(false);
+    expect((payload["providers"] as Array<JSONObject>).length).toBe(1);
+  });
+
+  test("the toggle read never carries the caller's props — it is a root read of one boolean", async () => {
+    await callProviders();
+
+    const call: JSONObject = (
+      ProjectService.findOneById as unknown as jest.Mock
+    ).mock.calls[0]![0] as JSONObject;
+
+    expect(call["props"]).toEqual({ isRoot: true });
+  });
+});

--- a/Common/Tests/Server/API/AIChatRouteAuthorization.test.ts
+++ b/Common/Tests/Server/API/AIChatRouteAuthorization.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../Server/Utils/Express";
 import Response from "../../../Server/Utils/Response";
 import LlmProvider from "../../../Models/DatabaseModels/LlmProvider";
+import Project from "../../../Models/DatabaseModels/Project";
 import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import NotAuthorizedException from "../../../Types/Exception/NotAuthorizedException";
@@ -266,6 +267,18 @@ function victimProvider(): LlmProvider {
   return provider;
 }
 
+/*
+ * The provider listing also reports the project's AI kill switch, so the chat
+ * surfaces can say why they are unavailable before a question is typed. The
+ * default row here has AI on, which is what every authorization case above
+ * assumes; AIChatProvidersAIEnabled.test.ts owns the switch itself.
+ */
+function projectWithAI(enableAi: boolean): Project {
+  const project: Project = new Project(PROJECT_B_ID);
+  project.enableAi = enableAi;
+  return project;
+}
+
 function stubProviderLookups(): void {
   jest
     .spyOn(LlmProviderService, "getSelectableProvidersForProject")
@@ -273,6 +286,9 @@ function stubProviderLookups(): void {
   jest
     .spyOn(LlmProviderService, "getLLMProviderForProject")
     .mockResolvedValue(victimProvider());
+  jest
+    .spyOn(ProjectService, "findOneById")
+    .mockResolvedValue(projectWithAI(true));
 }
 
 function providerLookupsRan(): boolean {
@@ -280,8 +296,21 @@ function providerLookupsRan(): boolean {
     LlmProviderService.getSelectableProvidersForProject as unknown as jest.Mock;
   const forProject: jest.Mock =
     LlmProviderService.getLLMProviderForProject as unknown as jest.Mock;
+  /*
+   * The project read that reports the AI kill switch sits in the same
+   * Promise.all as the two provider reads, and it is root-privileged on the
+   * header's project id — exactly the shape the advisory was about. It counts
+   * as a lookup, so "nothing was queried for the victim project" keeps meaning
+   * what it says.
+   */
+  const projectRead: jest.Mock =
+    ProjectService.findOneById as unknown as jest.Mock;
 
-  return selectable.mock.calls.length > 0 || forProject.mock.calls.length > 0;
+  return (
+    selectable.mock.calls.length > 0 ||
+    forProject.mock.calls.length > 0 ||
+    projectRead.mock.calls.length > 0
+  );
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## The problem

A project can switch AI off (`Project.enableAi`, on **Settings → AI Credits**), never configure an LLM provider (**Settings → AI → LLM Providers**), or sit on a plan that does not include AI. In every one of those states the server refuses a chat turn.

Ask AI still looked completely ready. The header button opened a composer, the suggested prompts were clickable, and the only mention of the switch was a red error banner **after** the user had written a question and pressed send — at which point it told them to go find a settings page. The person who hits this is usually not the person who flipped the switch.

## What changes

Both front doors — the quick-launch panel and the full-page Copilot — now close, and close the same way:

- the composer is **withheld**, not greyed out (a disabled textarea still reads as "type here and something will happen");
- the suggested prompts are gone, so no click can start a doomed turn;
- a notice says which switch is off and links to the settings page that owns it.

| Reason | Where it points |
| --- | --- |
| Plan does not include AI | Settings → Billing |
| `Project.enableAi` is off | Settings → AI Credits |
| No LLM provider configured | Settings → AI → LLM Providers |

The reasons are ordered by what has to be fixed **first**. A project on a plan without AI cannot use its own `enableAi` toggle, and a toggle that is off makes a configured provider irrelevant — sending someone to a page that cannot help yet is worse than saying nothing.

## How it knows

`Project.enableAi` is a server row and the chat surfaces hold no project model, so the verdict rides on `POST /ai-chat/providers` — the request every chat surface already makes as it opens. No extra round trip, one new boolean on the response.

The rule is resolved once, in the `useAiChat` hook both surfaces share, so the panel and the full page cannot drift.

## It fails open

The providers request is slow before it is anything else, it can error, and it is refused outright for a member whose permissions do not cover reading providers. Guessing "disabled" in any of those cases would flash a setup notice over a perfectly healthy assistant on every open — a worse bug than the one being fixed. Only a verdict actually received closes the door; an older server that does not report the field is treated as enabled.

Nothing here is a security boundary. The refusal still lives in `AIService.executeWithLogging` and the send-message route, unchanged. This is only what the user is **told**, before typing.

`<AIPlanGate />` comes off the Copilot page — the in-card notice now covers the plan case, and two messages about one switch on one screen is worse than one. The banner stays where it is still the only signal (Insights, Code Repository, AI Agent Tasks).

## Tests

| Suite | What it holds |
| --- | --- |
| `Common/Tests/App/Dashboard/AskAiDisabled.test.tsx` (14) | Renders the real panel against a DOM and drives it the way the header does. Composer gone, prompts gone, the right page named, the link scoped to the project — and the fail-open cases: a failed request and an older server both leave Ask AI usable. |
| `Common/Tests/App/Dashboard/AskAiAvailability.test.ts` (22) | The rule itself: each reason, the precedence between them, and that an unanswered question is never a "no". Also pins the kill-switch notice to the same page the server's own `AI_DISABLED_MESSAGE` names, so the two cannot drift. |
| `Common/Tests/Server/API/AIChatProvidersAIEnabled.test.ts` (24) | The endpoint: the toggle's three states (`true` / unselected / `false`), failing closed on an unreadable row, only the one column selected, and no second round trip. |
| `App/Tests/Dashboard/AskAiDisabledWiring.test.ts` (14) | Both surfaces are wired, including the full page whose chrome makes rendering it a poor trade. Also that the old inline "no provider" strip beside a live composer is gone. |
| `Common/Tests/Server/API/AIChatRouteAuthorization.test.ts` (updated) | The new project read sits in the same `Promise.all` on a header-supplied project id — exactly the shape GHSA-hm7m-9qjj-xj5x was about — so "nothing was queried for the victim project" now counts it too. |

All green, along with the adjacent suites (`AIKillSwitchBackstop`, `AIChatPanelScrollLock`, `AskAiSuggestedPrompts`, `DashboardLazyPages`, `DashboardHeaderSmallScreens`, `HeaderRightRail` and the App layering suites). `tsc --noEmit` clean in both `App` and `Common`; eslint clean.