### PR TITLE
fix(mcp): negotiate the MCP protocol version instead of rejecting the client

### DIFF
--- a/App/FeatureSet/MCP/Handlers/RouteHandler.ts
+++ b/App/FeatureSet/MCP/Handlers/RouteHandler.ts
@@ -18,6 +18,14 @@
  * state: `tools/list` is derived from the tool list bound at route setup and
  * every `tools/call` authenticates with the API key supplied on that same
  * request (x-api-key / Authorization header).
+ *
+ * Before a request reaches the SDK transport it goes through the compatibility
+ * negotiation in Utils/TransportNegotiation: the protocol version is negotiated
+ * down to the best mutually supported one and the response format is chosen
+ * from the client's Accept header. Without that, clients newer than the bundled
+ * SDK — or clients that send a wildcard Accept — were turned away at the
+ * transport layer with an error the user could only see in container logs
+ * (GitHub issue #3695).
  */
 
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -32,6 +40,25 @@ import { createMCPServerInstance, McpServer } from "../Server/MCPServer";
 import { registerToolHandlers } from "./ToolHandler";
 import { McpToolInfo } from "../Types/McpTypes";
 import { ROUTE_PREFIXES, API_KEY_HEADERS } from "../Config/ServerConfig";
+import {
+  ACCEPT_HEADER,
+  AcceptNegotiationResult,
+  KNOWN_PROTOCOL_VERSIONS,
+  MCP_PROTOCOL_VERSION_HEADER,
+  NORMALIZED_ACCEPT_HEADER,
+  ProtocolNegotiationOutcome,
+  ProtocolNegotiationResult,
+  ResponseFormat,
+  HeaderMutableRequest,
+  getLatestSupportedProtocolVersion,
+  isInitializeRequestBody,
+  negotiateProtocolVersion,
+  negotiateResponseFormat,
+  readHeaderValue,
+  removeRequestHeader,
+  sanitizeForLog,
+  setRequestHeader,
+} from "../Utils/TransportNegotiation";
 import logger from "Common/Server/Utils/Logger";
 
 // Type for MCP handler function
@@ -142,13 +169,19 @@ function createMCPHandler(tools: McpToolInfo[]): McpHandlerFunction {
       if (req.method === "GET") {
         const acceptHeader: string = (req.headers["accept"] as string) || "";
 
-        // Non-SSE GET (browser / probe): return a friendly discovery payload.
+        /*
+         * Non-SSE GET (browser / probe): return a friendly discovery payload.
+         * It advertises the protocol versions this build speaks so a failing
+         * handshake can be diagnosed from outside the container logs.
+         */
         if (!acceptHeader.includes("text/event-stream")) {
           res.status(200).json({
             name: "oneuptime-mcp",
             status: "running",
             message:
               "This is a Model Context Protocol (MCP) server endpoint. Use an MCP client to connect.",
+            protocolVersions: KNOWN_PROTOCOL_VERSIONS,
+            latestProtocolVersion: getLatestSupportedProtocolVersion(),
           });
           return;
         }
@@ -205,6 +238,29 @@ async function handleStatelessRequest(
   // API key is read fresh from this request's headers (optional for public tools).
   const apiKey: string = extractApiKey(req) || "";
 
+  /*
+   * Record what the client sent before either negotiation overwrites it — the
+   * diagnostics below are only useful if they describe the caller rather than
+   * this server's own normalized headers.
+   */
+  const snapshot: McpRequestSnapshot = snapshotMcpRequest(req);
+
+  /*
+   * Settle the protocol version and the response format BEFORE the SDK sees the
+   * request. Both negotiations rewrite the corresponding request header so the
+   * SDK's own (stricter) validation passes on values we have already accepted.
+   */
+  if (!negotiateProtocolVersionForRequest(req, res, snapshot)) {
+    return;
+  }
+
+  const acceptNegotiation: AcceptNegotiationResult | null =
+    negotiateResponseFormatForRequest(req, res, snapshot);
+
+  if (!acceptNegotiation) {
+    return;
+  }
+
   const mcpServer: McpServer = createMCPServerInstance();
 
   /*
@@ -213,17 +269,45 @@ async function handleStatelessRequest(
    * no `mcp-session-id` is emitted and every request is self-contained. (We omit
    * rather than pass `undefined` explicitly because the tsconfig enables
    * exactOptionalPropertyTypes.)
+   *
+   * `enableJsonResponse` makes the transport answer with a single
+   * `application/json` body instead of an SSE stream. Both are valid replies to
+   * a POST per the spec, so we use whichever one the client said it accepts.
    */
   const transport: StreamableHTTPServerTransport =
-    new StreamableHTTPServerTransport({});
+    new StreamableHTTPServerTransport(
+      acceptNegotiation.format === ResponseFormat.Json
+        ? { enableJsonResponse: true }
+        : {},
+    );
 
   registerToolHandlers(mcpServer, tools, apiKey);
 
   transport.onerror = (error: Error): void => {
-    logger.error(`MCP transport error: ${error.message}`);
+    /*
+     * Transport-level failures never reach the tool layer, so without this
+     * context the only symptom a user sees is an unrelated-looking tool error.
+     * Log enough to identify the offending client and header.
+     */
+    logger.error(
+      `MCP transport error: ${error.message} ${describeMcpRequest(snapshot)}`,
+    );
   };
 
-  // Tear down the ephemeral server + transport once the response is finished.
+  /*
+   * Tear down the ephemeral server + transport once the response is finished,
+   * and settle `responseClosed` so the await below can never outlive the
+   * request (see the Promise.race).
+   */
+  let releaseOnClose: () => void = (): void => {
+    // Replaced synchronously below; a no-op only if `close` somehow beats it.
+  };
+  const responseClosed: Promise<void> = new Promise<void>(
+    (resolve: () => void) => {
+      releaseOnClose = resolve;
+    },
+  );
+
   res.on("close", () => {
     transport.close().catch((error: Error) => {
       logger.error(`Error closing MCP transport: ${error.message}`);
@@ -231,10 +315,221 @@ async function handleStatelessRequest(
     mcpServer.close().catch((error: Error) => {
       logger.error(`Error closing MCP server: ${error.message}`);
     });
+    releaseOnClose();
   });
 
   await mcpServer.connect(transport as Parameters<typeof mcpServer.connect>[0]);
-  await transport.handleRequest(req, res, req.body);
+
+  /*
+   * In JSON-response mode the SDK answers with a promise that only settles once
+   * every response is ready, and its own `close()` deletes the pending entry
+   * WITHOUT resolving it. So a client that disconnects mid-request would leave
+   * this await pending forever, pinning the request, response, server and
+   * transport for the life of the process. Racing the close event lets this
+   * frame unwind; teardown has already run in the handler above.
+   */
+  await Promise.race([
+    transport.handleRequest(req, res, req.body),
+    responseClosed,
+  ]);
+}
+
+/**
+ * What the client actually sent, captured BEFORE negotiation rewrites anything.
+ *
+ * The negotiation deliberately overwrites the protocol-version and Accept
+ * headers in place, so reading them back later would report this server's own
+ * values. A diagnostic that echoes what we wrote is worse than none at all —
+ * the whole point of these logs is to identify the offending client.
+ */
+interface McpRequestSnapshot {
+  jsonrpcMethod: string;
+  protocolVersion: string;
+  accept: string;
+  userAgent: string;
+}
+
+function snapshotMcpRequest(req: ExpressRequest): McpRequestSnapshot {
+  const body: { method?: unknown } | undefined = req.body as
+    | { method?: unknown }
+    | undefined;
+
+  return {
+    jsonrpcMethod:
+      typeof body?.method === "string"
+        ? sanitizeForLog(body.method)
+        : "unknown",
+    protocolVersion:
+      sanitizeForLog(
+        readHeaderValue(req.headers[MCP_PROTOCOL_VERSION_HEADER]),
+      ) || "none",
+    accept:
+      sanitizeForLog(readHeaderValue(req.headers[ACCEPT_HEADER])) || "none",
+    userAgent:
+      sanitizeForLog(readHeaderValue(req.headers["user-agent"])) || "unknown",
+  };
+}
+
+/**
+ * Short, log-safe description of an MCP request. Never includes the API key:
+ * only the JSON-RPC method, the negotiated headers and the user agent are
+ * reported, and every one of them is sanitized and length-capped first.
+ */
+function describeMcpRequest(snapshot: McpRequestSnapshot): string {
+  const parts: string[] = [
+    `jsonrpcMethod=${snapshot.jsonrpcMethod}`,
+    `protocolVersion=${snapshot.protocolVersion}`,
+    `accept=${snapshot.accept}`,
+    `userAgent=${snapshot.userAgent}`,
+  ];
+
+  return `(${parts.join(", ")})`;
+}
+
+/**
+ * Negotiate the MCP protocol version for this request.
+ *
+ * Returns true when the request may continue. When it returns false a response
+ * has already been written.
+ *
+ * The SDK rejects any `MCP-Protocol-Version` header it does not recognize, so a
+ * client on a newer revision of the spec than the bundled SDK could never get
+ * past the transport. We negotiate down to the best mutually supported version
+ * and rewrite the header, which is what the MCP lifecycle calls for.
+ */
+function negotiateProtocolVersionForRequest(
+  req: ExpressRequest,
+  res: ExpressResponse,
+  snapshot: McpRequestSnapshot,
+): boolean {
+  const negotiation: ProtocolNegotiationResult = negotiateProtocolVersion(
+    req.headers[MCP_PROTOCOL_VERSION_HEADER],
+  );
+
+  if (negotiation.outcome === ProtocolNegotiationOutcome.NotRequested) {
+    /*
+     * "Not requested" covers a header that is absent AND one that is present
+     * but blank. Those are not the same thing to the SDK: an empty string is
+     * not null, so it fails the SDK's membership check and produces the very
+     * 400 this negotiation exists to prevent. Drop the header so the request
+     * really does look header-less by the time the SDK sees it.
+     */
+    removeRequestHeader(asHeaderMutable(req), MCP_PROTOCOL_VERSION_HEADER);
+    return true;
+  }
+
+  if (negotiation.outcome === ProtocolNegotiationOutcome.Supported) {
+    return true;
+  }
+
+  if (negotiation.outcome === ProtocolNegotiationOutcome.Unsupported) {
+    /*
+     * `initialize` negotiates the version in the JSON-RPC body, where the SDK
+     * already answers an unknown version with the newest one it supports. Drop
+     * the unusable header and let the handshake do its job rather than failing
+     * the very request whose purpose is to agree on a version.
+     */
+    if (isInitializeRequestBody(req.body)) {
+      logger.warn(
+        `MCP: dropping unsupported MCP-Protocol-Version header "${negotiation.requestedVersion}" on an initialize request; negotiating in the handshake instead ${describeMcpRequest(snapshot)}`,
+      );
+      removeRequestHeader(asHeaderMutable(req), MCP_PROTOCOL_VERSION_HEADER);
+      return true;
+    }
+
+    const message: string = `Unsupported MCP protocol version: ${negotiation.requestedVersion}. This server supports ${KNOWN_PROTOCOL_VERSIONS.join(", ")}. Send an MCP-Protocol-Version header with one of those versions, or omit the header to use the version agreed during initialize.`;
+
+    logger.warn(`MCP: ${message} ${describeMcpRequest(snapshot)}`);
+
+    res.status(400).json({
+      jsonrpc: "2.0",
+      error: {
+        code: -32000,
+        message: `Bad Request: ${message}`,
+        data: {
+          requestedProtocolVersion: negotiation.requestedVersion,
+          supportedProtocolVersions: KNOWN_PROTOCOL_VERSIONS,
+        },
+      },
+      id: null,
+    });
+    return false;
+  }
+
+  // Downgraded: the client is newer than us, so answer on the newest shared version.
+  logger.info(
+    `MCP: client requested protocol version ${negotiation.requestedVersion}; negotiated down to ${negotiation.negotiatedVersion} ${describeMcpRequest(snapshot)}`,
+  );
+  setRequestHeader(
+    asHeaderMutable(req),
+    MCP_PROTOCOL_VERSION_HEADER,
+    negotiation.negotiatedVersion as string,
+  );
+  return true;
+}
+
+/**
+ * Decide whether to answer with SSE or a plain JSON body.
+ *
+ * Returns the negotiation result when the request may continue, or null when a
+ * 406 response has already been written.
+ *
+ * The SDK insists a POST list BOTH `application/json` and `text/event-stream`,
+ * matched by substring — so a wildcard Accept or a missing Accept header was a 406
+ * even though the spec lets the server answer with either media type.
+ */
+function negotiateResponseFormatForRequest(
+  req: ExpressRequest,
+  res: ExpressResponse,
+  snapshot: McpRequestSnapshot,
+): AcceptNegotiationResult | null {
+  const negotiation: AcceptNegotiationResult = negotiateResponseFormat(
+    req.headers[ACCEPT_HEADER],
+  );
+
+  if (negotiation.format === ResponseFormat.Unacceptable) {
+    const message: string = `This endpoint responds with application/json or text/event-stream, but the request's Accept header ("${negotiation.requestedAccept}") allows neither.`;
+
+    logger.warn(`MCP: ${message} ${describeMcpRequest(snapshot)}`);
+
+    res.status(406).json({
+      jsonrpc: "2.0",
+      error: {
+        code: -32000,
+        message: `Not Acceptable: ${message}`,
+        data: {
+          requestedAccept: negotiation.requestedAccept,
+          supportedContentTypes: ["application/json", "text/event-stream"],
+        },
+      },
+      id: null,
+    });
+    return null;
+  }
+
+  /*
+   * The SDK re-checks the Accept header itself with a naive substring match.
+   * We have already decided what to send, so normalize the header to the value
+   * that check expects.
+   */
+  setRequestHeader(
+    asHeaderMutable(req),
+    ACCEPT_HEADER,
+    NORMALIZED_ACCEPT_HEADER,
+  );
+
+  return negotiation;
+}
+
+/**
+ * Narrow an Express request to the header views the negotiation helpers rewrite.
+ *
+ * The MCP SDK rebuilds the request it validates from Node's `rawHeaders` array
+ * rather than from Express's parsed `headers` map, so a negotiated value has to
+ * land in both.
+ */
+function asHeaderMutable(req: ExpressRequest): HeaderMutableRequest {
+  return req as unknown as HeaderMutableRequest;
 }
 
 /**
@@ -278,6 +573,12 @@ function setupHealthEndpoint(
       tools: tools.length,
       // Stateless mode keeps no sessions in memory; retained for response-shape compatibility.
       activeSessions: 0,
+      /*
+       * Advertised so an operator debugging a failed handshake can see which
+       * protocol versions this build speaks without reading container logs.
+       */
+      protocolVersions: KNOWN_PROTOCOL_VERSIONS,
+      latestProtocolVersion: getLatestSupportedProtocolVersion(),
     });
   });
 }

--- a/App/FeatureSet/MCP/README.md
+++ b/App/FeatureSet/MCP/README.md
@@ -183,7 +183,50 @@ A typical incident-response loop an agent can run:
 | `/mcp`        | GET    | Without an SSE `Accept` header: friendly JSON discovery payload. With one: `405` (no standalone SSE stream in stateless mode). |
 | `/mcp`        | DELETE | No-op (stateless — nothing to terminate)                                  |
 | `/mcp/tools`  | GET    | REST listing of available tools                                           |
-| `/mcp/health` | GET    | Health check                                                              |
+| `/mcp/health` | GET    | Health check, including the protocol versions this build speaks           |
+
+## Protocol compatibility
+
+The server negotiates rather than rejects, so a client does not have to match the
+MCP SDK bundled in the App container exactly.
+
+**Protocol version.** The `MCP-Protocol-Version` request header is negotiated down
+to the highest version both sides support. A header sent twice is read as its
+first value — Node collapses repeated headers into one comma-joined string, and
+a version never contains a comma:
+
+- a version the server supports is used as-is;
+- a version *newer* than anything the server knows about (for example a client on
+  a newer revision of the spec) is negotiated down to the server's latest — the
+  same answer `initialize` gives;
+- a version *older* than everything the server supports, or one that is not a
+  `YYYY-MM-DD` version at all, has no common ground. The request is answered with
+  `400` and a JSON-RPC error that names the requested version and lists the
+  supported ones, instead of failing silently at the transport layer.
+
+An unusable header on an `initialize` request is dropped rather than rejected,
+because that request negotiates the version in its body. A header that is
+present but *blank* is dropped too: an empty string is not the same as an absent
+header to the SDK, which would otherwise reject it like any other unknown
+version.
+
+`GET /mcp` and `GET /mcp/health` both list the supported versions, so a failing
+handshake can be diagnosed without reading container logs.
+
+**Response format.** A POST is answered with whatever the client's `Accept` header
+allows: `text/event-stream` when the client asks for it by name or via the
+`text/*` range (what spec-compliant MCP clients do), and a plain
+`application/json` body otherwise — including for `Accept: application/json`, an
+`application/*` or `*/*` wildcard, or no `Accept` header at all. Both are valid
+replies to a POST under the MCP spec. A client that accepts neither gets a `406`
+naming the media types the endpoint can produce.
+
+**Diagnostics.** Negotiation logs describe the *client*: they are built from a
+snapshot taken before the headers are rewritten, so they report what was
+actually sent rather than the values this server normalised them to. Every field
+in them — header values and the JSON-RPC method alike — is stripped of control
+characters and length-capped, so a caller cannot forge log lines or flood the
+log through them. The API key is never logged.
 
 ## Self-hosting
 

--- a/App/FeatureSet/MCP/Tests/RouteHandler.test.ts
+++ b/App/FeatureSet/MCP/Tests/RouteHandler.test.ts
@@ -6,6 +6,12 @@
  * the server keeps no in-memory session state, so it issues no `mcp-session-id`
  * and every request is self-contained — which is what makes it safe behind a
  * multi-replica deployment with no session affinity.
+ *
+ * They also lock in the transport compatibility fixes for GitHub issue #3695:
+ * protocol versions newer than the bundled SDK are negotiated down instead of
+ * rejected, the response format follows the client's Accept header, and any
+ * negotiation that genuinely cannot succeed answers with a precise error
+ * instead of a silent transport-level rejection.
  */
 
 import {
@@ -35,7 +41,9 @@ jest.mock("Common/Server/Utils/Logger", () => {
   };
 });
 
+import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js";
 import { createExpressApp } from "Common/Server/Utils/Express";
+import logger from "Common/Server/Utils/Logger";
 import { setupMCPRoutes } from "../Handlers/RouteHandler";
 import OneUptimeApiService from "../Services/OneUptimeApiService";
 import { McpToolInfo } from "../Types/McpTypes";
@@ -62,9 +70,17 @@ const TOOLS: McpToolInfo[] = [
 
 const A_RANDOM_SESSION_ID: string = "11111111-2222-3333-4444-555555555555";
 
+/*
+ * The protocol version Claude's MCP client declared in issue #3695. It is newer
+ * than anything the bundled SDK knows about, which is the whole point: the
+ * server has to negotiate down to a shared version rather than reject it.
+ */
+const CLIENT_VERSION_FROM_ISSUE: string = "2026-07-28";
+
 interface McpResult {
   status: number;
   sessionId: string | null;
+  contentType: string;
   json: any;
   text: string;
 }
@@ -109,7 +125,11 @@ async function readBody(res: Response): Promise<{ json: any; text: string }> {
     } catch {
       json = null;
     }
-  } else if (text.trim().startsWith("{")) {
+  } else if (
+    text.trim().startsWith("{") ||
+    // A JSON-RPC batch response is an array, not an object.
+    text.trim().startsWith("[")
+  ) {
     try {
       json = JSON.parse(text);
     } catch {
@@ -137,9 +157,89 @@ function postMcp(
     return {
       status: res.status,
       sessionId: res.headers.get("mcp-session-id"),
+      contentType: res.headers.get("content-type") || "",
       json,
       text,
     };
+  });
+}
+
+/**
+ * POST with full control over the request headers — including sending none at
+ * all. `fetch` always fills in an `Accept` header, so the "client sent no
+ * Accept header" case has to go through the raw http client.
+ */
+function postMcpRaw(
+  port: number,
+  body: unknown,
+  headers: Record<string, string>,
+  repeatedHeaders: Array<[string, string]> = [],
+): Promise<McpResult> {
+  const payload: string = JSON.stringify(body);
+  const merged: Record<string, string | string[] | number> = {
+    "Content-Length": Buffer.byteLength(payload),
+    ...headers,
+  };
+
+  /*
+   * Node sends an array header value as repeated header lines, which is the
+   * only way to reproduce a client that sends the same header twice.
+   */
+  for (const [name, value] of repeatedHeaders) {
+    const existing: string | string[] | number | undefined = merged[name];
+    if (Array.isArray(existing)) {
+      existing.push(value);
+    } else if (typeof existing === "string") {
+      merged[name] = [existing, value];
+    } else {
+      merged[name] = [value];
+    }
+  }
+
+  return new Promise((resolve: (value: McpResult) => void, reject: any) => {
+    const request: http.ClientRequest = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: "/mcp",
+        method: "POST",
+        headers: merged,
+      },
+      (res: http.IncomingMessage) => {
+        let text: string = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk: string) => {
+          text += chunk;
+        });
+        res.on("end", () => {
+          const dataLine: string | undefined = text
+            .split(/\r?\n/)
+            .find((line: string) => {
+              return line.startsWith("data:");
+            });
+          let json: any = null;
+          const candidate: string = dataLine
+            ? dataLine.slice("data:".length).trim()
+            : text.trim();
+          if (candidate.startsWith("{") || candidate.startsWith("[")) {
+            try {
+              json = JSON.parse(candidate);
+            } catch {
+              json = null;
+            }
+          }
+          resolve({
+            status: res.statusCode || 0,
+            sessionId: (res.headers["mcp-session-id"] as string) || null,
+            contentType: (res.headers["content-type"] as string) || "",
+            json,
+            text,
+          });
+        });
+      },
+    );
+    request.on("error", reject);
+    request.end(payload);
   });
 }
 
@@ -252,6 +352,757 @@ describe("MCP RouteHandler (stateless mode)", () => {
       });
       expect(list.status).toBe(200);
       expect((list.json?.result?.tools || []).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("protocol version negotiation (issue #3695)", () => {
+    it("negotiates a client newer than the SDK down instead of returning 400", async () => {
+      /*
+       * This is the exact header from the issue. Before the fix the SDK
+       * transport answered 400 "Unsupported protocol version: 2026-07-28" and
+       * the rejection was only visible in the container logs.
+       */
+      const res: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 20, method: "tools/list" },
+        { "mcp-protocol-version": CLIENT_VERSION_FROM_ISSUE },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.text).not.toContain("Unsupported protocol version");
+      const names: string[] = (res.json?.result?.tools || []).map(
+        (t: { name: string }) => {
+          return t.name;
+        },
+      );
+      expect(names).toContain("create_project");
+    });
+
+    it("runs a tools/call from a newer client end to end", async () => {
+      /*
+       * The user-visible symptom in the issue was that every tool call looked
+       * like an API-key permissions problem. Prove the call now reaches the
+       * tool layer with the request's API key.
+       */
+      (OneUptimeApiService.executeOperation as jest.Mock).mockResolvedValue({
+        _id: "proj_3",
+        name: "Gamma",
+      } as never);
+
+      const res: McpResult = await postMcp(
+        portA,
+        {
+          jsonrpc: "2.0",
+          id: 21,
+          method: "tools/call",
+          params: { name: "create_project", arguments: { name: "Gamma" } },
+        },
+        {
+          "mcp-protocol-version": CLIENT_VERSION_FROM_ISSUE,
+          "x-api-key": "key-from-newer-client",
+        },
+      );
+
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.json.result.content[0].text).success).toBe(true);
+      expect(
+        OneUptimeApiService.executeOperation as jest.Mock,
+      ).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        "key-from-newer-client",
+      );
+    });
+
+    it("still accepts every protocol version the SDK supports", async () => {
+      for (const version of SUPPORTED_PROTOCOL_VERSIONS) {
+        const res: McpResult = await postMcp(
+          portA,
+          { jsonrpc: "2.0", id: 22, method: "tools/list" },
+          { "mcp-protocol-version": version },
+        );
+
+        expect(res.status).toBe(200);
+        expect((res.json?.result?.tools || []).length).toBeGreaterThan(0);
+      }
+    });
+
+    it("initialize with a future protocol version answers with a version we support", async () => {
+      const res: McpResult = await postMcp(portA, {
+        jsonrpc: "2.0",
+        id: 23,
+        method: "initialize",
+        params: {
+          protocolVersion: CLIENT_VERSION_FROM_ISSUE,
+          capabilities: {},
+          clientInfo: { name: "claude", version: "1.0" },
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(
+        res.json?.result?.protocolVersion,
+      );
+    });
+
+    it("initialize survives an unusable protocol version header", async () => {
+      /*
+       * `initialize` is where the two sides are supposed to agree on a version,
+       * so an unusable header is dropped rather than failing the handshake.
+       */
+      const res: McpResult = await postMcp(
+        portA,
+        {
+          jsonrpc: "2.0",
+          id: 24,
+          method: "initialize",
+          params: {
+            protocolVersion: "2026-07-28",
+            capabilities: {},
+            clientInfo: { name: "claude", version: "1.0" },
+          },
+        },
+        { "mcp-protocol-version": "not-a-version" },
+      );
+
+      expect(res.status).toBe(200);
+      expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(
+        res.json?.result?.protocolVersion,
+      );
+    });
+
+    it("returns an explicit, actionable 400 when no version can be agreed on", async () => {
+      const res: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 25, method: "tools/list" },
+        { "mcp-protocol-version": "2000-01-01" },
+      );
+
+      expect(res.status).toBe(400);
+      // The client gets the real reason in-band, not just in the server logs.
+      expect(res.json?.error?.message).toMatch(
+        /Unsupported MCP protocol version: 2000-01-01/,
+      );
+      expect(res.json?.error?.data?.requestedProtocolVersion).toBe(
+        "2000-01-01",
+      );
+      expect(res.json?.error?.data?.supportedProtocolVersions).toEqual(
+        expect.arrayContaining([...SUPPORTED_PROTOCOL_VERSIONS]),
+      );
+    });
+
+    it("returns the same explicit 400 for a malformed version", async () => {
+      const res: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 26, method: "tools/list" },
+        { "mcp-protocol-version": "banana" },
+      );
+
+      expect(res.status).toBe(400);
+      expect(res.json?.error?.message).toMatch(/banana/);
+      expect(res.json?.error?.code).toBe(-32000);
+    });
+
+    it("works with no protocol version header at all", async () => {
+      const res: McpResult = await postMcp(portA, {
+        jsonrpc: "2.0",
+        id: 27,
+        method: "tools/list",
+      });
+
+      expect(res.status).toBe(200);
+      expect((res.json?.result?.tools || []).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Accept header negotiation (issue #3695)", () => {
+    it("answers a JSON-only client with JSON instead of 406", async () => {
+      // Before the fix: 406 "Client must accept both application/json and text/event-stream".
+      const res: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 30, method: "tools/list" },
+        { Accept: "application/json" },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.contentType).toContain("application/json");
+      expect((res.json?.result?.tools || []).length).toBeGreaterThan(0);
+    });
+
+    it("answers a wildcard Accept with JSON instead of 406", async () => {
+      const res: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 31, method: "tools/list" },
+        { Accept: "*/*" },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.contentType).toContain("application/json");
+      expect((res.json?.result?.tools || []).length).toBeGreaterThan(0);
+    });
+
+    it("answers a request with no Accept header at all", async () => {
+      const res: McpResult = await postMcpRaw(
+        portA,
+        { jsonrpc: "2.0", id: 32, method: "tools/list" },
+        { "Content-Type": "application/json" },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.contentType).toContain("application/json");
+      expect((res.json?.result?.tools || []).length).toBeGreaterThan(0);
+    });
+
+    it("keeps streaming SSE for clients that ask for text/event-stream", async () => {
+      const res: McpResult = await postMcp(portA, {
+        jsonrpc: "2.0",
+        id: 33,
+        method: "tools/list",
+      });
+
+      expect(res.status).toBe(200);
+      // Unchanged behavior for spec-compliant clients.
+      expect(res.contentType).toContain("text/event-stream");
+      expect(res.text).toContain("data:");
+    });
+
+    it("runs a tools/call for a JSON-only client", async () => {
+      (OneUptimeApiService.executeOperation as jest.Mock).mockResolvedValue({
+        _id: "proj_4",
+        name: "Delta",
+      } as never);
+
+      const res: McpResult = await postMcp(
+        portA,
+        {
+          jsonrpc: "2.0",
+          id: 34,
+          method: "tools/call",
+          params: { name: "create_project", arguments: { name: "Delta" } },
+        },
+        { Accept: "application/json", "x-api-key": "json-client-key" },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.contentType).toContain("application/json");
+      expect(JSON.parse(res.json.result.content[0].text).success).toBe(true);
+    });
+
+    it("accepts notifications from a JSON-only client (202)", async () => {
+      const res: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", method: "notifications/initialized" },
+        { Accept: "application/json" },
+      );
+
+      expect(res.status).toBe(202);
+    });
+
+    it("returns an explicit 406 when the client accepts neither media type", async () => {
+      const res: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 35, method: "tools/list" },
+        { Accept: "text/html" },
+      );
+
+      expect(res.status).toBe(406);
+      expect(res.json?.error?.message).toMatch(/Not Acceptable/);
+      expect(res.json?.error?.data?.requestedAccept).toBe("text/html");
+      expect(res.json?.error?.data?.supportedContentTypes).toEqual([
+        "application/json",
+        "text/event-stream",
+      ]);
+    });
+  });
+
+  describe("full handshake from a client newer than the SDK (issue #3695)", () => {
+    it("initialize, initialized, tools/list and tools/call all succeed", async () => {
+      (OneUptimeApiService.executeOperation as jest.Mock).mockResolvedValue({
+        _id: "proj_5",
+      } as never);
+
+      // 1. initialize — the client announces a version the SDK has never heard of.
+      const init: McpResult = await postMcp(portA, {
+        jsonrpc: "2.0",
+        id: 40,
+        method: "initialize",
+        params: {
+          protocolVersion: CLIENT_VERSION_FROM_ISSUE,
+          capabilities: {},
+          clientInfo: { name: "claude", version: "1.0" },
+        },
+      });
+      expect(init.status).toBe(200);
+
+      /*
+       * 2. Every following request carries the client's own version in the
+       * header. That is what used to break the connection at the transport
+       * layer, one request after a successful handshake.
+       */
+      const versionHeader: Record<string, string> = {
+        "mcp-protocol-version": CLIENT_VERSION_FROM_ISSUE,
+      };
+
+      const initialized: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", method: "notifications/initialized" },
+        versionHeader,
+      );
+      expect(initialized.status).toBe(202);
+
+      const list: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 41, method: "tools/list" },
+        versionHeader,
+      );
+      expect(list.status).toBe(200);
+      expect((list.json?.result?.tools || []).length).toBeGreaterThan(0);
+
+      const call: McpResult = await postMcp(
+        portA,
+        {
+          jsonrpc: "2.0",
+          id: 42,
+          method: "tools/call",
+          params: { name: "create_project", arguments: { name: "Epsilon" } },
+        },
+        { ...versionHeader, "x-api-key": "handshake-key" },
+      );
+      expect(call.status).toBe(200);
+      /*
+       * Assert the result EXISTS before asserting it is not an error: on a
+       * JSON-RPC error response `result` is undefined, and `undefined?.isError`
+       * is falsy — so checking isError alone would pass on the very failure
+       * this test exists to catch.
+       */
+      expect(call.json?.error).toBeUndefined();
+      expect(call.json?.result).toBeDefined();
+      expect(call.json?.result?.isError).toBeFalsy();
+      expect(JSON.parse(call.json.result.content[0].text).success).toBe(true);
+    });
+
+    it("works the same on a different replica (no session affinity)", async () => {
+      const res: McpResult = await postMcp(
+        portB,
+        { jsonrpc: "2.0", id: 43, method: "tools/list" },
+        {
+          "mcp-protocol-version": CLIENT_VERSION_FROM_ISSUE,
+          Accept: "application/json",
+        },
+      );
+
+      expect(res.status).toBe(200);
+      expect((res.json?.result?.tools || []).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("negotiation hardening (issue #3695 audit)", () => {
+    it("an empty MCP-Protocol-Version header is dropped, not rejected", async () => {
+      /*
+       * Confirmed defect from the audit. A blank header classifies as "not
+       * requested", but an empty string is not null to the SDK, so leaving it
+       * in place reproduced the exact 400 this fix exists to eliminate. The
+       * header has to actually be removed before the SDK sees the request.
+       */
+      const res: McpResult = await postMcpRaw(
+        portA,
+        { jsonrpc: "2.0", id: 50, method: "tools/list" },
+        {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          "MCP-Protocol-Version": "",
+        },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.text).not.toContain("Unsupported protocol version");
+      expect((res.json?.result?.tools || []).length).toBeGreaterThan(0);
+    });
+
+    it("a whitespace-only MCP-Protocol-Version header is dropped too", async () => {
+      const res: McpResult = await postMcpRaw(
+        portA,
+        { jsonrpc: "2.0", id: 51, method: "tools/list" },
+        {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          "MCP-Protocol-Version": "   ",
+        },
+      );
+
+      expect(res.status).toBe(200);
+      expect((res.json?.result?.tools || []).length).toBeGreaterThan(0);
+    });
+
+    it("serves a text/* client the event stream rather than a 406", async () => {
+      // Confirmed defect: text/* is a range covering text/event-stream.
+      const res: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 52, method: "tools/list" },
+        { Accept: "text/*" },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.contentType).toContain("text/event-stream");
+      expect((res.json?.result?.tools || []).length).toBeGreaterThan(0);
+    });
+
+    it("a downgraded client still receives a real SSE data frame", async () => {
+      /*
+       * Distinguishes "negotiated down and streamed a response" from "the
+       * header was dropped and the stream came back empty".
+       */
+      const res: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 53, method: "tools/list" },
+        { "mcp-protocol-version": CLIENT_VERSION_FROM_ISSUE },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.contentType).toContain("text/event-stream");
+      expect(res.text).toContain("data:");
+      expect(res.json?.id).toBe(53);
+    });
+
+    it("negotiates an intermediate version down to the next one below it", async () => {
+      /*
+       * 2025-08-01 sits between two supported versions, so this proves the
+       * downgrade picks the highest version at-or-below the request rather
+       * than always falling back to the newest one.
+       */
+      const res: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 54, method: "tools/list" },
+        { "mcp-protocol-version": "2025-08-01" },
+      );
+
+      expect(res.status).toBe(200);
+      expect((res.json?.result?.tools || []).length).toBeGreaterThan(0);
+    });
+
+    it("answers a JSON-RPC batch from a future client", async () => {
+      const res: McpResult = await postMcp(
+        portA,
+        [
+          { jsonrpc: "2.0", id: 55, method: "tools/list" },
+          { jsonrpc: "2.0", id: 56, method: "tools/list" },
+        ],
+        { "mcp-protocol-version": CLIENT_VERSION_FROM_ISSUE },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.text).not.toContain("Unsupported protocol version");
+    });
+
+    it("does not reject GET, DELETE or OPTIONS carrying a bad version header", async () => {
+      /*
+       * Those methods never reach the SDK transport, so the version check must
+       * not fire for them — a browser probe with a stale header should not 400.
+       */
+      const headers: Record<string, string> = {
+        "mcp-protocol-version": "not-a-version",
+      };
+
+      const get: Response = await fetch(`http://127.0.0.1:${portA}/mcp`, {
+        headers,
+      });
+      expect(get.status).toBe(200);
+
+      const del: Response = await fetch(`http://127.0.0.1:${portA}/mcp`, {
+        method: "DELETE",
+        headers,
+      });
+      expect(del.status).toBe(200);
+
+      const options: Response = await fetch(`http://127.0.0.1:${portA}/mcp`, {
+        method: "OPTIONS",
+        headers,
+      });
+      expect(options.status).toBe(200);
+    });
+
+    it("the 400 rejection is a structurally valid JSON-RPC error envelope", async () => {
+      const res: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 57, method: "tools/list" },
+        { "mcp-protocol-version": "1999-01-01" },
+      );
+
+      expect(res.status).toBe(400);
+      expect(res.json?.jsonrpc).toBe("2.0");
+      expect(typeof res.json?.error?.code).toBe("number");
+      expect(typeof res.json?.error?.message).toBe("string");
+      expect("id" in (res.json || {})).toBe(true);
+    });
+
+    it("the 406 rejection is a structurally valid JSON-RPC error envelope", async () => {
+      const res: McpResult = await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 58, method: "tools/list" },
+        { Accept: "image/png" },
+      );
+
+      expect(res.status).toBe(406);
+      expect(res.json?.jsonrpc).toBe("2.0");
+      expect(typeof res.json?.error?.code).toBe("number");
+      expect(typeof res.json?.error?.message).toBe("string");
+      expect("id" in (res.json || {})).toBe(true);
+    });
+
+    it("the rejections still carry the MCP CORS headers", async () => {
+      /*
+       * A browser-based client has to be able to READ the rejection, otherwise
+       * the error is invisible again — which is the whole complaint in #3695.
+       */
+      const res: Response = await fetch(`http://127.0.0.1:${portA}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          "mcp-protocol-version": "1999-01-01",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 59, method: "tools/list" }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(
+        (res.headers.get("access-control-allow-headers") || "").toLowerCase(),
+      ).toContain("mcp-protocol-version");
+    });
+
+    it("a repeated mcp-protocol-version header over the wire is negotiated", async () => {
+      const res: McpResult = await postMcpRaw(
+        portA,
+        { jsonrpc: "2.0", id: 60, method: "tools/list" },
+        {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        [
+          ["MCP-Protocol-Version", CLIENT_VERSION_FROM_ISSUE],
+          ["MCP-Protocol-Version", "2025-06-18"],
+        ],
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.text).not.toContain("Unsupported protocol version");
+    });
+  });
+
+  describe("JSON response mode (issue #3695)", () => {
+    it("initialize works over the JSON path", async () => {
+      const res: McpResult = await postMcp(
+        portA,
+        {
+          jsonrpc: "2.0",
+          id: 61,
+          method: "initialize",
+          params: {
+            protocolVersion: CLIENT_VERSION_FROM_ISSUE,
+            capabilities: {},
+            clientInfo: { name: "json-only-client", version: "1.0" },
+          },
+        },
+        { Accept: "application/json" },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.contentType).toContain("application/json");
+      expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(
+        res.json?.result?.protocolVersion,
+      );
+    });
+
+    it("surfaces a failing tool as an in-band isError result, not a transport error", async () => {
+      (OneUptimeApiService.executeOperation as jest.Mock).mockRejectedValue(
+        new Error("upstream exploded") as never,
+      );
+
+      const res: McpResult = await postMcp(
+        portA,
+        {
+          jsonrpc: "2.0",
+          id: 62,
+          method: "tools/call",
+          params: { name: "create_project", arguments: { name: "Boom" } },
+        },
+        { Accept: "application/json", "x-api-key": "some-key" },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.contentType).toContain("application/json");
+      expect(res.json?.result?.isError).toBe(true);
+      expect(res.json?.result?.content?.[0]?.text).toMatch(
+        /upstream exploded/i,
+      );
+    });
+
+    it("answers a JSON-RPC batch in JSON mode", async () => {
+      const res: McpResult = await postMcp(
+        portA,
+        [
+          { jsonrpc: "2.0", id: 63, method: "tools/list" },
+          { jsonrpc: "2.0", id: 64, method: "tools/list" },
+        ],
+        { Accept: "application/json" },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.contentType).toContain("application/json");
+      expect(Array.isArray(res.json)).toBe(true);
+      expect(res.json).toHaveLength(2);
+    });
+
+    it("concurrent requests with different Accept headers each get their own format", async () => {
+      /*
+       * A fresh transport is built per request, so two in-flight callers must
+       * not be able to see each other's response format. A shared transport
+       * would make one of these come back in the wrong content type.
+       */
+      const both: [McpResult, McpResult] = await Promise.all([
+        postMcp(
+          portA,
+          { jsonrpc: "2.0", id: 65, method: "tools/list" },
+          { Accept: "application/json" },
+        ),
+        postMcp(portA, { jsonrpc: "2.0", id: 66, method: "tools/list" }),
+      ]);
+      const json: McpResult = both[0];
+      const sse: McpResult = both[1];
+
+      expect(json.status).toBe(200);
+      expect(json.contentType).toContain("application/json");
+      expect(json.json?.id).toBe(65);
+
+      expect(sse.status).toBe(200);
+      expect(sse.contentType).toContain("text/event-stream");
+      expect(sse.json?.id).toBe(66);
+    });
+
+    it("a wrong Content-Type is still rejected with a readable message", async () => {
+      const res: McpResult = await postMcpRaw(
+        portA,
+        { jsonrpc: "2.0", id: 67, method: "tools/list" },
+        { "Content-Type": "text/plain", Accept: "application/json" },
+      );
+
+      expect(res.status).toBe(415);
+      expect(res.text).toMatch(/content-type/i);
+    });
+  });
+
+  describe("diagnostics never leak the API key (issue #3695)", () => {
+    it("no log line contains the API key, on the happy path or a rejection", async () => {
+      const secret: string = "super-secret-key-do-not-log";
+
+      await postMcp(
+        portA,
+        {
+          jsonrpc: "2.0",
+          id: 68,
+          method: "tools/call",
+          params: { name: "create_project", arguments: { name: "Acme" } },
+        },
+        {
+          "x-api-key": secret,
+          "mcp-protocol-version": CLIENT_VERSION_FROM_ISSUE,
+        },
+      );
+
+      await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 69, method: "tools/list" },
+        {
+          Authorization: `Bearer ${secret}`,
+          "mcp-protocol-version": "1999-01-01",
+        },
+      );
+
+      const everythingLogged: string = (
+        ["info", "warn", "error", "debug"] as const
+      )
+        .flatMap((level: "info" | "warn" | "error" | "debug") => {
+          return ((logger[level] as jest.Mock).mock.calls || []).flat();
+        })
+        .map((entry: unknown) => {
+          return typeof entry === "string" ? entry : JSON.stringify(entry);
+        })
+        .join("\n");
+
+      expect(everythingLogged.length).toBeGreaterThan(0);
+      expect(everythingLogged).not.toContain(secret);
+    });
+
+    it("reports the client's own headers, not the values negotiation rewrote", async () => {
+      /*
+       * The diagnostic exists to identify the offending client. Reading the
+       * headers back after the rewrite would echo this server's normalized
+       * values and describe nothing.
+       */
+      await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 70, method: "tools/list" },
+        {
+          "mcp-protocol-version": CLIENT_VERSION_FROM_ISSUE,
+          Accept: "application/json",
+          "User-Agent": "claude-mcp-test/9.9",
+        },
+      );
+
+      const negotiationLogs: string = (
+        (logger.info as jest.Mock).mock.calls || []
+      )
+        .flat()
+        .map((entry: unknown) => {
+          return typeof entry === "string" ? entry : JSON.stringify(entry);
+        })
+        .filter((line: string) => {
+          return line.includes("negotiated down");
+        })
+        .join("\n");
+
+      expect(negotiationLogs).toContain(CLIENT_VERSION_FROM_ISSUE);
+      // The client asked for JSON only; the log must not claim it sent both.
+      expect(negotiationLogs).toContain("accept=application/json");
+      expect(negotiationLogs).toContain("claude-mcp-test/9.9");
+    });
+
+    it("the JSON-RPC method cannot forge extra log lines or flood the log", async () => {
+      /*
+       * Node refuses to put a newline in a header value, so the body is the
+       * real injection surface: `method` is attacker-controlled, unbounded,
+       * and lands in the negotiation diagnostics. The version header here is
+       * what makes those diagnostics fire at all.
+       */
+      const forgedMethod: string = `tools/list\nFAKE-LOG-LINE${"z".repeat(4000)}`;
+
+      await postMcp(
+        portA,
+        { jsonrpc: "2.0", id: 71, method: forgedMethod },
+        { "mcp-protocol-version": CLIENT_VERSION_FROM_ISSUE },
+      );
+
+      const lines: string[] = (["info", "warn", "error"] as const)
+        .flatMap((level: "info" | "warn" | "error") => {
+          return ((logger[level] as jest.Mock).mock.calls || []).flat();
+        })
+        .map((entry: unknown) => {
+          return typeof entry === "string" ? entry : JSON.stringify(entry);
+        });
+
+      const negotiationLines: string[] = lines.filter((line: string) => {
+        return line.includes("jsonrpcMethod=");
+      });
+
+      expect(negotiationLines.length).toBeGreaterThan(0);
+      for (const line of negotiationLines) {
+        expect(line).not.toContain("\nFAKE-LOG-LINE");
+        expect(line).toContain("truncated");
+        expect(line.length).toBeLessThan(1500);
+      }
     });
   });
 
@@ -399,6 +1250,36 @@ describe("MCP RouteHandler (stateless mode)", () => {
       expect(json.mode).toBe("stateless");
       expect(json.activeSessions).toBe(0);
       expect(json.tools).toBe(TOOLS.length);
+    });
+
+    it("GET /mcp/health advertises the supported protocol versions", () => {
+      /*
+       * Issue #3695: the only place the supported versions used to appear was
+       * an error in the container logs. Publishing them makes a failing
+       * handshake diagnosable from outside the container.
+       */
+      return fetch(`http://127.0.0.1:${portA}/mcp/health`)
+        .then((res: Response) => {
+          return res.json();
+        })
+        .then((json: any) => {
+          expect(json.protocolVersions).toEqual(
+            expect.arrayContaining([...SUPPORTED_PROTOCOL_VERSIONS]),
+          );
+          expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(
+            json.latestProtocolVersion,
+          );
+        });
+    });
+
+    it("GET /mcp discovery payload advertises the supported protocol versions", async () => {
+      const res: Response = await fetch(`http://127.0.0.1:${portA}/mcp`);
+      const json: any = await res.json();
+
+      expect(json.protocolVersions).toEqual(
+        expect.arrayContaining([...SUPPORTED_PROTOCOL_VERSIONS]),
+      );
+      expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(json.latestProtocolVersion);
     });
 
     it("GET /mcp/tools lists the registered tools", async () => {

--- a/App/FeatureSet/MCP/Tests/TransportNegotiation.test.ts
+++ b/App/FeatureSet/MCP/Tests/TransportNegotiation.test.ts
@@ -1,0 +1,962 @@
+/**
+ * Unit tests for the MCP transport compatibility layer (GitHub issue #3695).
+ *
+ * These cover the pure negotiation helpers. The HTTP-level regressions they
+ * protect against are exercised end-to-end in RouteHandler.test.ts.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  LATEST_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  KNOWN_PROTOCOL_VERSIONS,
+  NORMALIZED_ACCEPT_HEADER,
+  ProtocolNegotiationOutcome,
+  ProtocolNegotiationResult,
+  ResponseFormat,
+  AcceptNegotiationResult,
+  HeaderMutableRequest,
+  getLatestSupportedProtocolVersion,
+  isInitializeRequestBody,
+  negotiateProtocolVersion,
+  negotiateResponseFormat,
+  readHeaderValue,
+  readSingleValueHeader,
+  removeRequestHeader,
+  sanitizeForLog,
+  setRequestHeader,
+} from "../Utils/TransportNegotiation";
+
+/** The exact version Claude's MCP client sent in the bug report. */
+const CLIENT_VERSION_FROM_ISSUE: string = "2026-07-28";
+
+describe("KNOWN_PROTOCOL_VERSIONS", () => {
+  it("mirrors the SDK's supported list", () => {
+    expect([...KNOWN_PROTOCOL_VERSIONS].sort()).toEqual(
+      [...SUPPORTED_PROTOCOL_VERSIONS].sort(),
+    );
+  });
+
+  it("is sorted oldest first so lexicographic comparison is chronological", () => {
+    const sorted: string[] = [...KNOWN_PROTOCOL_VERSIONS].sort();
+    expect(KNOWN_PROTOCOL_VERSIONS).toEqual(sorted);
+  });
+
+  it("ends at the SDK's latest protocol version", () => {
+    expect(KNOWN_PROTOCOL_VERSIONS[KNOWN_PROTOCOL_VERSIONS.length - 1]).toBe(
+      LATEST_PROTOCOL_VERSION,
+    );
+    expect(getLatestSupportedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+  });
+
+  it("is non-empty", () => {
+    expect(KNOWN_PROTOCOL_VERSIONS.length).toBeGreaterThan(0);
+  });
+});
+
+describe("readHeaderValue", () => {
+  it("returns a plain string header", () => {
+    expect(readHeaderValue("2025-06-18")).toBe("2025-06-18");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(readHeaderValue("  2025-06-18  ")).toBe("2025-06-18");
+  });
+
+  it("takes the first value of a repeated header", () => {
+    expect(readHeaderValue(["2025-06-18", "2024-11-05"])).toBe("2025-06-18");
+  });
+
+  it("treats undefined, empty and whitespace-only values as absent", () => {
+    expect(readHeaderValue(undefined)).toBeUndefined();
+    expect(readHeaderValue("")).toBeUndefined();
+    expect(readHeaderValue("   ")).toBeUndefined();
+    expect(readHeaderValue([])).toBeUndefined();
+  });
+});
+
+describe("negotiateProtocolVersion", () => {
+  describe("the reported failure: a client newer than the bundled SDK", () => {
+    it("negotiates 2026-07-28 down to the newest version we support", () => {
+      const result: ProtocolNegotiationResult = negotiateProtocolVersion(
+        CLIENT_VERSION_FROM_ISSUE,
+      );
+
+      /*
+       * Before the fix this value produced a flat 400 from the SDK transport
+       * ("Unsupported protocol version: 2026-07-28"), which the user could only
+       * see in container logs.
+       */
+      expect(result.outcome).toBe(
+        ProtocolNegotiationOutcome.DowngradedToSupported,
+      );
+      expect(result.requestedVersion).toBe(CLIENT_VERSION_FROM_ISSUE);
+      expect(result.negotiatedVersion).toBe(LATEST_PROTOCOL_VERSION);
+    });
+
+    it("agrees with what the SDK answers during initialize", () => {
+      /*
+       * The SDK's initialize handler replies to an unknown version with
+       * LATEST_PROTOCOL_VERSION. The header negotiation has to land on the same
+       * value or the handshake and the follow-up requests would disagree.
+       */
+      const result: ProtocolNegotiationResult = negotiateProtocolVersion(
+        CLIENT_VERSION_FROM_ISSUE,
+      );
+      expect(result.negotiatedVersion).toBe(
+        getLatestSupportedProtocolVersion(),
+      );
+    });
+
+    it("downgrades any far-future version to the newest supported one", () => {
+      for (const version of ["2027-01-01", "2030-12-31", "9999-12-31"]) {
+        const result: ProtocolNegotiationResult =
+          negotiateProtocolVersion(version);
+        expect(result.outcome).toBe(
+          ProtocolNegotiationOutcome.DowngradedToSupported,
+        );
+        expect(result.negotiatedVersion).toBe(LATEST_PROTOCOL_VERSION);
+      }
+    });
+  });
+
+  describe("versions we support are passed through untouched", () => {
+    it.each(SUPPORTED_PROTOCOL_VERSIONS)(
+      "accepts %s as-is",
+      (version: string) => {
+        const result: ProtocolNegotiationResult =
+          negotiateProtocolVersion(version);
+
+        expect(result.outcome).toBe(ProtocolNegotiationOutcome.Supported);
+        expect(result.requestedVersion).toBe(version);
+        expect(result.negotiatedVersion).toBe(version);
+      },
+    );
+  });
+
+  describe("versions between two supported ones", () => {
+    it("picks the highest supported version at or below the request", () => {
+      /*
+       * 2025-08-01 sits between 2025-06-18 and 2025-11-25, so the newest
+       * version the client can be assumed to understand is 2025-06-18.
+       */
+      const result: ProtocolNegotiationResult =
+        negotiateProtocolVersion("2025-08-01");
+
+      expect(result.outcome).toBe(
+        ProtocolNegotiationOutcome.DowngradedToSupported,
+      );
+      expect(result.negotiatedVersion).toBe("2025-06-18");
+    });
+
+    it("never negotiates UP to a version newer than the client asked for", () => {
+      const result: ProtocolNegotiationResult =
+        negotiateProtocolVersion("2024-12-01");
+
+      expect(result.negotiatedVersion).toBe("2024-11-05");
+      expect((result.negotiatedVersion as string) < "2024-12-01").toBe(true);
+    });
+  });
+
+  describe("no shared version", () => {
+    it("reports a version older than everything we speak as unsupported", () => {
+      const oldest: string = KNOWN_PROTOCOL_VERSIONS[0] as string;
+      const result: ProtocolNegotiationResult =
+        negotiateProtocolVersion("2000-01-01");
+
+      expect(result.outcome).toBe(ProtocolNegotiationOutcome.Unsupported);
+      expect(result.requestedVersion).toBe("2000-01-01");
+      expect(result.negotiatedVersion).toBeUndefined();
+      expect("2000-01-01" < oldest).toBe(true);
+    });
+
+    it("treats the oldest supported version itself as supported, not unsupported", () => {
+      const oldest: string = KNOWN_PROTOCOL_VERSIONS[0] as string;
+      const result: ProtocolNegotiationResult =
+        negotiateProtocolVersion(oldest);
+
+      expect(result.outcome).toBe(ProtocolNegotiationOutcome.Supported);
+      expect(result.negotiatedVersion).toBe(oldest);
+    });
+
+    it.each([
+      "draft",
+      "v1",
+      "2025-6-18",
+      "20250618",
+      "not-a-version",
+      "2025-06-18-rc1",
+    ])(
+      "reports the unparseable value %p as unsupported instead of guessing",
+      (version: string) => {
+        const result: ProtocolNegotiationResult =
+          negotiateProtocolVersion(version);
+
+        expect(result.outcome).toBe(ProtocolNegotiationOutcome.Unsupported);
+        expect(result.requestedVersion).toBe(version);
+        expect(result.negotiatedVersion).toBeUndefined();
+      },
+    );
+  });
+
+  describe("no version requested", () => {
+    /*
+     * A blank header is classified the same as an absent one, but the two are
+     * NOT the same to the SDK: an empty string is not null, so it fails the
+     * SDK's membership check. RouteHandler therefore has to actually REMOVE a
+     * blank header rather than pass it through — see the HTTP-level test
+     * "an empty MCP-Protocol-Version header is dropped, not rejected".
+     */
+    it.each([undefined, "", "   "])(
+      "reports %p as not requested",
+      (header: string | undefined) => {
+        const result: ProtocolNegotiationResult =
+          negotiateProtocolVersion(header);
+
+        expect(result.outcome).toBe(ProtocolNegotiationOutcome.NotRequested);
+        expect(result.requestedVersion).toBeUndefined();
+        expect(result.negotiatedVersion).toBeUndefined();
+      },
+    );
+  });
+
+  it("handles a repeated header by using its first value", () => {
+    const result: ProtocolNegotiationResult = negotiateProtocolVersion([
+      CLIENT_VERSION_FROM_ISSUE,
+      "2025-06-18",
+    ]);
+
+    expect(result.requestedVersion).toBe(CLIENT_VERSION_FROM_ISSUE);
+    expect(result.outcome).toBe(
+      ProtocolNegotiationOutcome.DowngradedToSupported,
+    );
+  });
+
+  it("tolerates surrounding whitespace on a supported version", () => {
+    const result: ProtocolNegotiationResult = negotiateProtocolVersion(
+      ` ${LATEST_PROTOCOL_VERSION} `,
+    );
+
+    expect(result.outcome).toBe(ProtocolNegotiationOutcome.Supported);
+    expect(result.negotiatedVersion).toBe(LATEST_PROTOCOL_VERSION);
+  });
+
+  it("always returns a supported version when it returns one at all", () => {
+    const candidates: Array<string | undefined> = [
+      undefined,
+      "",
+      "2000-01-01",
+      "draft",
+      "2024-12-01",
+      "2025-08-01",
+      CLIENT_VERSION_FROM_ISSUE,
+      ...SUPPORTED_PROTOCOL_VERSIONS,
+    ];
+
+    for (const candidate of candidates) {
+      const result: ProtocolNegotiationResult =
+        negotiateProtocolVersion(candidate);
+      if (result.negotiatedVersion) {
+        expect(KNOWN_PROTOCOL_VERSIONS).toContain(result.negotiatedVersion);
+      }
+    }
+  });
+});
+
+describe("negotiateResponseFormat", () => {
+  it("streams SSE when the client explicitly accepts it (spec-compliant clients)", () => {
+    const result: AcceptNegotiationResult = negotiateResponseFormat(
+      "application/json, text/event-stream",
+    );
+
+    expect(result.format).toBe(ResponseFormat.ServerSentEvents);
+    expect(result.requestedAccept).toBe("application/json, text/event-stream");
+  });
+
+  it("streams SSE when the client accepts only text/event-stream", () => {
+    expect(negotiateResponseFormat("text/event-stream").format).toBe(
+      ResponseFormat.ServerSentEvents,
+    );
+  });
+
+  describe("the reported failure: clients that do not ask for text/event-stream", () => {
+    it("answers a JSON-only client with JSON instead of 406", () => {
+      const result: AcceptNegotiationResult =
+        negotiateResponseFormat("application/json");
+
+      expect(result.format).toBe(ResponseFormat.Json);
+    });
+
+    it("answers a wildcard Accept with JSON instead of 406", () => {
+      expect(negotiateResponseFormat("*/*").format).toBe(ResponseFormat.Json);
+    });
+
+    it("answers a missing Accept header with JSON (RFC 9110: anything goes)", () => {
+      expect(negotiateResponseFormat(undefined).format).toBe(
+        ResponseFormat.Json,
+      );
+      expect(negotiateResponseFormat("").format).toBe(ResponseFormat.Json);
+    });
+
+    it("accepts an application/* wildcard", () => {
+      expect(negotiateResponseFormat("application/*").format).toBe(
+        ResponseFormat.Json,
+      );
+    });
+  });
+
+  it("ignores q-values and other media type parameters", () => {
+    expect(
+      negotiateResponseFormat("application/json;q=0.9, text/event-stream;q=0.8")
+        .format,
+    ).toBe(ResponseFormat.ServerSentEvents);
+
+    expect(
+      negotiateResponseFormat("application/json; charset=utf-8").format,
+    ).toBe(ResponseFormat.Json);
+  });
+
+  it("is case-insensitive and whitespace-tolerant", () => {
+    expect(negotiateResponseFormat("  TEXT/EVENT-STREAM  ").format).toBe(
+      ResponseFormat.ServerSentEvents,
+    );
+    expect(negotiateResponseFormat("Application/JSON").format).toBe(
+      ResponseFormat.Json,
+    );
+  });
+
+  it("handles a repeated Accept header by using its first value", () => {
+    expect(
+      negotiateResponseFormat(["application/json", "text/html"]).format,
+    ).toBe(ResponseFormat.Json);
+  });
+
+  it("reports a client that accepts neither media type as unacceptable", () => {
+    const result: AcceptNegotiationResult = negotiateResponseFormat(
+      "text/html, application/xml",
+    );
+
+    expect(result.format).toBe(ResponseFormat.Unacceptable);
+    expect(result.requestedAccept).toBe("text/html, application/xml");
+  });
+
+  it("does not mistake text/html for text/event-stream", () => {
+    expect(negotiateResponseFormat("text/html").format).toBe(
+      ResponseFormat.Unacceptable,
+    );
+  });
+
+  it("exposes a normalized header that satisfies the SDK's own check", () => {
+    expect(NORMALIZED_ACCEPT_HEADER).toContain("application/json");
+    expect(NORMALIZED_ACCEPT_HEADER).toContain("text/event-stream");
+  });
+});
+
+describe("isInitializeRequestBody", () => {
+  it("recognizes a single initialize request", () => {
+    expect(
+      isInitializeRequestBody({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: CLIENT_VERSION_FROM_ISSUE },
+      }),
+    ).toBe(true);
+  });
+
+  it("recognizes an initialize request inside a JSON-RPC batch", () => {
+    expect(
+      isInitializeRequestBody([
+        { jsonrpc: "2.0", method: "notifications/initialized" },
+        { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      ]),
+    ).toBe(true);
+  });
+
+  it("rejects other JSON-RPC methods", () => {
+    expect(
+      isInitializeRequestBody({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    ).toBe(false);
+    expect(
+      isInitializeRequestBody({ jsonrpc: "2.0", id: 1, method: "tools/call" }),
+    ).toBe(false);
+  });
+
+  it("does not throw on missing or malformed bodies", () => {
+    expect(isInitializeRequestBody(undefined)).toBe(false);
+    expect(isInitializeRequestBody(null)).toBe(false);
+    expect(isInitializeRequestBody("initialize")).toBe(false);
+    expect(isInitializeRequestBody([])).toBe(false);
+    expect(isInitializeRequestBody([null, undefined])).toBe(false);
+    expect(isInitializeRequestBody({ method: 42 })).toBe(false);
+  });
+});
+
+/*
+ * The MCP SDK rebuilds the request it validates from Node's `rawHeaders` array,
+ * not from Express's parsed `headers` map. A negotiated value that only landed
+ * in `headers` would be invisible to it — which is exactly how the first
+ * attempt at this fix failed — so both views have to stay in sync.
+ */
+describe("request header rewriting", () => {
+  function makeRequest(rawHeaders: string[]): HeaderMutableRequest {
+    const headers: Record<string, string | string[] | undefined> = {};
+    for (let index: number = 0; index < rawHeaders.length; index += 2) {
+      headers[(rawHeaders[index] as string).toLowerCase()] = rawHeaders[
+        index + 1
+      ] as string;
+    }
+    return { headers, rawHeaders: [...rawHeaders] };
+  }
+
+  describe("setRequestHeader", () => {
+    it("updates both the parsed map and rawHeaders", () => {
+      const req: HeaderMutableRequest = makeRequest([
+        "Content-Type",
+        "application/json",
+        "MCP-Protocol-Version",
+        "2026-07-28",
+      ]);
+
+      setRequestHeader(req, "mcp-protocol-version", "2025-11-25");
+
+      expect(req.headers["mcp-protocol-version"]).toBe("2025-11-25");
+      expect(req.rawHeaders).toContain("2025-11-25");
+      expect(req.rawHeaders).not.toContain("2026-07-28");
+    });
+
+    it("matches the existing header case-insensitively", () => {
+      const req: HeaderMutableRequest = makeRequest([
+        "AcCePt",
+        "application/json",
+      ]);
+
+      setRequestHeader(req, "accept", NORMALIZED_ACCEPT_HEADER);
+
+      expect(req.rawHeaders).not.toContain("application/json");
+      expect(req.headers["accept"]).toBe(NORMALIZED_ACCEPT_HEADER);
+    });
+
+    it("adds the header when the request did not carry one", () => {
+      const req: HeaderMutableRequest = makeRequest([
+        "Content-Type",
+        "application/json",
+      ]);
+
+      setRequestHeader(req, "Accept", NORMALIZED_ACCEPT_HEADER);
+
+      expect(req.headers["accept"]).toBe(NORMALIZED_ACCEPT_HEADER);
+      expect(req.rawHeaders).toEqual([
+        "Content-Type",
+        "application/json",
+        "Accept",
+        NORMALIZED_ACCEPT_HEADER,
+      ]);
+    });
+
+    it("collapses a repeated header into a single value", () => {
+      const req: HeaderMutableRequest = makeRequest([
+        "Accept",
+        "text/html",
+        "Accept",
+        "application/xml",
+      ]);
+
+      setRequestHeader(req, "Accept", NORMALIZED_ACCEPT_HEADER);
+
+      expect(
+        (req.rawHeaders as string[]).filter((entry: string) => {
+          return entry.toLowerCase() === "accept";
+        }),
+      ).toHaveLength(1);
+      expect(req.rawHeaders).not.toContain("text/html");
+      expect(req.rawHeaders).not.toContain("application/xml");
+    });
+
+    it("leaves unrelated headers untouched", () => {
+      const req: HeaderMutableRequest = makeRequest([
+        "Content-Type",
+        "application/json",
+        "x-api-key",
+        "secret",
+        "Accept",
+        "*/" + "*",
+      ]);
+
+      setRequestHeader(req, "Accept", NORMALIZED_ACCEPT_HEADER);
+
+      expect(req.headers["content-type"]).toBe("application/json");
+      expect(req.headers["x-api-key"]).toBe("secret");
+      expect(req.rawHeaders).toContain("secret");
+    });
+
+    it("does not throw when the request has no rawHeaders", () => {
+      const req: HeaderMutableRequest = { headers: {} };
+
+      expect(() => {
+        return setRequestHeader(req, "Accept", NORMALIZED_ACCEPT_HEADER);
+      }).not.toThrow();
+      expect(req.headers["accept"]).toBe(NORMALIZED_ACCEPT_HEADER);
+    });
+  });
+
+  describe("removeRequestHeader", () => {
+    it("removes the header from both views", () => {
+      const req: HeaderMutableRequest = makeRequest([
+        "MCP-Protocol-Version",
+        "not-a-version",
+        "Content-Type",
+        "application/json",
+      ]);
+
+      removeRequestHeader(req, "mcp-protocol-version");
+
+      expect(req.headers["mcp-protocol-version"]).toBeUndefined();
+      expect(req.rawHeaders).toEqual(["Content-Type", "application/json"]);
+    });
+
+    it("removes every copy of a repeated header", () => {
+      const req: HeaderMutableRequest = makeRequest([
+        "MCP-Protocol-Version",
+        "a",
+        "MCP-Protocol-Version",
+        "b",
+        "Content-Type",
+        "application/json",
+      ]);
+
+      removeRequestHeader(req, "MCP-Protocol-Version");
+
+      expect(req.rawHeaders).toEqual(["Content-Type", "application/json"]);
+    });
+
+    it("is a no-op when the header is absent", () => {
+      const req: HeaderMutableRequest = makeRequest([
+        "Content-Type",
+        "application/json",
+      ]);
+
+      removeRequestHeader(req, "mcp-protocol-version");
+
+      expect(req.rawHeaders).toEqual(["Content-Type", "application/json"]);
+    });
+  });
+});
+
+/*
+ * Boundary and property coverage added after an adversarial audit of the fix
+ * (issue #3695). The audit confirmed two real defects that the original suite
+ * missed — a blank version header and the `text/*` media range — so these
+ * exercise the surrounding space rather than just the two known cases.
+ */
+describe("negotiateProtocolVersion — boundary and property coverage", () => {
+  /** Shift a YYYY-MM-DD version by whole days without using Date.now(). */
+  function shiftDays(version: string, days: number): string {
+    const parts: string[] = version.split("-");
+    const shifted: Date = new Date(
+      Date.UTC(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]) + days),
+    );
+    return shifted.toISOString().slice(0, 10);
+  }
+
+  describe("one day either side of every supported version", () => {
+    it.each(SUPPORTED_PROTOCOL_VERSIONS)(
+      "a version one day after %s never negotiates above it",
+      (version: string) => {
+        const result: ProtocolNegotiationResult = negotiateProtocolVersion(
+          shiftDays(version, 1),
+        );
+
+        expect(result.outcome).toBe(
+          ProtocolNegotiationOutcome.DowngradedToSupported,
+        );
+        // The day after X is still only guaranteed to understand X.
+        expect(result.negotiatedVersion).toBe(version);
+      },
+    );
+
+    it.each(SUPPORTED_PROTOCOL_VERSIONS)(
+      "a version one day before %s never negotiates up to it",
+      (version: string) => {
+        const result: ProtocolNegotiationResult = negotiateProtocolVersion(
+          shiftDays(version, -1),
+        );
+
+        if (result.negotiatedVersion) {
+          expect(result.negotiatedVersion < version).toBe(true);
+        } else {
+          // Only legitimate below the oldest version we speak.
+          expect(version).toBe(KNOWN_PROTOCOL_VERSIONS[0]);
+          expect(result.outcome).toBe(ProtocolNegotiationOutcome.Unsupported);
+        }
+      },
+    );
+  });
+
+  describe("syntactically valid but nonsensical dates", () => {
+    it.each(["0000-00-00", "2025-13-45", "2025-99-99", "9999-99-99"])(
+      "handles %s without throwing and never invents a version",
+      (version: string) => {
+        const result: ProtocolNegotiationResult =
+          negotiateProtocolVersion(version);
+
+        if (result.negotiatedVersion) {
+          expect(KNOWN_PROTOCOL_VERSIONS).toContain(result.negotiatedVersion);
+          expect(result.negotiatedVersion <= version).toBe(true);
+        } else {
+          expect(result.outcome).toBe(ProtocolNegotiationOutcome.Unsupported);
+        }
+      },
+    );
+  });
+
+  it("never returns a version newer than the client asked for, over a wide sweep", () => {
+    const probes: string[] = [];
+    for (const year of ["2023", "2024", "2025", "2026", "2027"]) {
+      for (const month of ["01", "06", "11", "12"]) {
+        for (const day of ["01", "15", "28"]) {
+          probes.push(`${year}-${month}-${day}`);
+        }
+      }
+    }
+
+    for (const probe of probes) {
+      const result: ProtocolNegotiationResult = negotiateProtocolVersion(probe);
+
+      if (result.negotiatedVersion) {
+        // The core safety property: we never claim a version the client did not.
+        expect(result.negotiatedVersion <= probe).toBe(true);
+        expect(KNOWN_PROTOCOL_VERSIONS).toContain(result.negotiatedVersion);
+      }
+    }
+  });
+
+  it("does not mutate the exported version list (it is served in HTTP responses)", () => {
+    const before: string[] = [...KNOWN_PROTOCOL_VERSIONS];
+
+    negotiateProtocolVersion("2026-07-28");
+    negotiateProtocolVersion("2000-01-01");
+    negotiateProtocolVersion("banana");
+    negotiateProtocolVersion(LATEST_PROTOCOL_VERSION);
+
+    expect(KNOWN_PROTOCOL_VERSIONS).toEqual(before);
+  });
+
+  it("round-trips every supported version unchanged", () => {
+    for (const version of SUPPORTED_PROTOCOL_VERSIONS) {
+      const result: ProtocolNegotiationResult =
+        negotiateProtocolVersion(version);
+      expect(result.negotiatedVersion).toBe(version);
+      expect(result.outcome).toBe(ProtocolNegotiationOutcome.Supported);
+    }
+  });
+});
+
+describe("negotiateResponseFormat — media ranges and malformed input", () => {
+  it("treats the text/* media range as accepting the event stream", () => {
+    /*
+     * Regression: text/* is a range that covers text/event-stream, but the
+     * first version of this fix matched only exact tokens, so a text/* client
+     * got a 406 while an application/* client was served.
+     */
+    expect(negotiateResponseFormat("text/*").format).toBe(
+      ResponseFormat.ServerSentEvents,
+    );
+  });
+
+  it("prefers the event stream when the client names both ranges", () => {
+    expect(negotiateResponseFormat("application/*, text/*").format).toBe(
+      ResponseFormat.ServerSentEvents,
+    );
+  });
+
+  it.each([
+    "application/json, text/event-stream",
+    "text/event-stream, application/json",
+    "text/event-stream;q=1.0, application/json;q=0.9",
+    "  text/event-stream  ,  application/json  ",
+    "APPLICATION/JSON, TEXT/EVENT-STREAM",
+  ])(
+    "orders and casings of a compliant Accept all stream SSE: %s",
+    (header: string) => {
+      expect(negotiateResponseFormat(header).format).toBe(
+        ResponseFormat.ServerSentEvents,
+      );
+    },
+  );
+
+  it.each([
+    ",",
+    ",,,",
+    ";",
+    ";;",
+    " , ; , ",
+    "application/json;",
+    ";q=0.9",
+    "/",
+    "text/",
+    "/event-stream",
+  ])("never throws on the malformed Accept header %p", (header: string) => {
+    expect(() => {
+      return negotiateResponseFormat(header);
+    }).not.toThrow();
+  });
+
+  it("does not mistake a type that merely contains the token as the token", () => {
+    // "application/vnd.text/event-stream+json" is not text/event-stream.
+    expect(
+      negotiateResponseFormat("application/vnd.text/event-stream+json").format,
+    ).not.toBe(ResponseFormat.ServerSentEvents);
+  });
+
+  it("handles an absurdly long Accept header without throwing", () => {
+    const header: string = new Array(500)
+      .fill("application/octet-stream")
+      .join(", ");
+
+    expect(() => {
+      return negotiateResponseFormat(header);
+    }).not.toThrow();
+    expect(negotiateResponseFormat(header).format).toBe(
+      ResponseFormat.Unacceptable,
+    );
+  });
+
+  it("always returns one of the three declared formats", () => {
+    const probes: Array<string | undefined> = [
+      undefined,
+      "",
+      "   ",
+      "*/*",
+      "text/*",
+      "application/*",
+      "application/json",
+      "text/event-stream",
+      "text/html",
+      ",",
+      "application/json;q=0",
+      "not a media type at all",
+    ];
+
+    for (const probe of probes) {
+      const format: ResponseFormat = negotiateResponseFormat(probe).format;
+      expect([
+        ResponseFormat.Json,
+        ResponseFormat.ServerSentEvents,
+        ResponseFormat.Unacceptable,
+      ]).toContain(format);
+    }
+  });
+});
+
+describe("request header rewriting — adversarial shapes", () => {
+  it("survives an odd-length rawHeaders array", () => {
+    const req: HeaderMutableRequest = {
+      headers: { accept: "application/json" },
+      // Malformed on purpose: a trailing name with no value.
+      rawHeaders: ["Accept", "application/json", "X-Dangling"],
+    };
+
+    expect(() => {
+      return setRequestHeader(req, "Accept", NORMALIZED_ACCEPT_HEADER);
+    }).not.toThrow();
+    expect(req.headers["accept"]).toBe(NORMALIZED_ACCEPT_HEADER);
+  });
+
+  it("collapses headers that differ only by case", () => {
+    const req: HeaderMutableRequest = {
+      headers: { accept: "text/html" },
+      rawHeaders: [
+        "Accept",
+        "text/html",
+        "ACCEPT",
+        "text/plain",
+        "aCcEpT",
+        "*/" + "*",
+      ],
+    };
+
+    setRequestHeader(req, "Accept", NORMALIZED_ACCEPT_HEADER);
+
+    const names: string[] = (req.rawHeaders as string[]).filter(
+      (_value: string, index: number) => {
+        // rawHeaders alternates name, value — even indexes are the names.
+        return index % 2 === 0;
+      },
+    );
+    expect(
+      names.filter((name: string) => {
+        return name.toLowerCase() === "accept";
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("stays consistent across several rewrites in sequence", () => {
+    const req: HeaderMutableRequest = {
+      headers: { "mcp-protocol-version": "2026-07-28" },
+      rawHeaders: ["MCP-Protocol-Version", "2026-07-28"],
+    };
+
+    setRequestHeader(req, "mcp-protocol-version", "2025-11-25");
+    setRequestHeader(req, "mcp-protocol-version", "2025-06-18");
+    setRequestHeader(req, "mcp-protocol-version", "2024-11-05");
+
+    expect(req.headers["mcp-protocol-version"]).toBe("2024-11-05");
+    expect(req.rawHeaders).toEqual(["mcp-protocol-version", "2024-11-05"]);
+  });
+
+  it("is idempotent — setting the same value twice changes nothing", () => {
+    const req: HeaderMutableRequest = {
+      headers: {},
+      rawHeaders: ["Content-Type", "application/json"],
+    };
+
+    setRequestHeader(req, "Accept", NORMALIZED_ACCEPT_HEADER);
+    const afterFirst: string[] = [...(req.rawHeaders as string[])];
+    setRequestHeader(req, "Accept", NORMALIZED_ACCEPT_HEADER);
+
+    expect(req.rawHeaders).toEqual(afterFirst);
+  });
+
+  it("removes a blank header rather than leaving an empty value behind", () => {
+    /*
+     * The bug this pins: an empty string is not null to the SDK, so a
+     * present-but-blank header still fails its membership check.
+     */
+    const req: HeaderMutableRequest = {
+      headers: { "mcp-protocol-version": "" },
+      rawHeaders: ["MCP-Protocol-Version", ""],
+    };
+
+    removeRequestHeader(req, "mcp-protocol-version");
+
+    expect(req.rawHeaders).toEqual([]);
+    expect("mcp-protocol-version" in req.headers).toBe(false);
+  });
+});
+
+describe("isInitializeRequestBody — malformed bodies", () => {
+  const NON_INITIALIZE_BODIES: Array<[string, unknown]> = [
+    ["a bare number", 42],
+    ["the bare string", "initialize"],
+    ["a boolean", true],
+    // An array of arrays: the inner array is not a JSON-RPC message.
+    ["a doubly nested batch", [[{ method: "initialize" }]]],
+    ["a capitalised key", { Method: "initialize" }],
+    ["a non-string method", { method: { toString: "initialize" } }],
+    ["initialize buried in params", { params: { method: "initialize" } }],
+  ];
+
+  it.each(NON_INITIALIZE_BODIES)(
+    "does not treat %s as an initialize request",
+    (_label: string, body: unknown) => {
+      expect(isInitializeRequestBody(body)).toBe(false);
+    },
+  );
+
+  it("finds initialize anywhere in a batch", () => {
+    expect(
+      isInitializeRequestBody([
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        { jsonrpc: "2.0", id: 2, method: "initialize", params: {} },
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("sanitizeForLog", () => {
+  /*
+   * Everything the diagnostics report comes off the network, so a caller must
+   * not be able to forge log lines or flood the log through them.
+   */
+  it("flattens newlines and carriage returns so log lines cannot be forged", () => {
+    const forged: string = sanitizeForLog(
+      "tools/list\nERROR: fake log line injected",
+    );
+
+    expect(forged).not.toContain("\n");
+    expect(forged).toContain("fake log line injected");
+  });
+
+  it("strips other control characters", () => {
+    expect(sanitizeForLog("a\u0000b\u001Fc\u007Fd")).toBe("a b c d");
+  });
+
+  it("caps an unbounded value", () => {
+    const result: string = sanitizeForLog("x".repeat(5000));
+
+    expect(result.length).toBeLessThan(200);
+    expect(result).toContain("truncated");
+  });
+
+  it("leaves an ordinary value untouched", () => {
+    expect(sanitizeForLog("application/json, text/event-stream")).toBe(
+      "application/json, text/event-stream",
+    );
+  });
+
+  it("maps empty and undefined to an empty string", () => {
+    expect(sanitizeForLog(undefined)).toBe("");
+    expect(sanitizeForLog("")).toBe("");
+  });
+});
+
+describe("readSingleValueHeader", () => {
+  /*
+   * Node collapses most repeated headers into ONE comma-joined string rather
+   * than an array. Treating that whole string as the value made a client which
+   * sent MCP-Protocol-Version twice fail the version format check and get a
+   * 400 — the exact rejection this fix exists to remove.
+   */
+  it("takes the first value of a comma-joined repeated header", () => {
+    expect(readSingleValueHeader("2026-07-28, 2025-06-18")).toBe("2026-07-28");
+  });
+
+  it("takes the first value of an array-shaped repeated header", () => {
+    expect(readSingleValueHeader(["2026-07-28", "2025-06-18"])).toBe(
+      "2026-07-28",
+    );
+  });
+
+  it("leaves a single value untouched", () => {
+    expect(readSingleValueHeader("2025-11-25")).toBe("2025-11-25");
+  });
+
+  it("trims whitespace around each form", () => {
+    expect(readSingleValueHeader("  2025-11-25 , 2024-11-05 ")).toBe(
+      "2025-11-25",
+    );
+  });
+
+  it("treats absent, empty and comma-only values as absent", () => {
+    expect(readSingleValueHeader(undefined)).toBeUndefined();
+    expect(readSingleValueHeader("")).toBeUndefined();
+    expect(readSingleValueHeader("   ")).toBeUndefined();
+    expect(readSingleValueHeader(",")).toBeUndefined();
+    expect(readSingleValueHeader(" , 2025-11-25")).toBeUndefined();
+  });
+});
+
+describe("negotiateProtocolVersion — repeated headers as Node delivers them", () => {
+  it("negotiates a comma-joined duplicate down instead of rejecting it", () => {
+    const result: ProtocolNegotiationResult = negotiateProtocolVersion(
+      "2026-07-28, 2025-06-18",
+    );
+
+    expect(result.outcome).toBe(
+      ProtocolNegotiationOutcome.DowngradedToSupported,
+    );
+    expect(result.negotiatedVersion).toBe(LATEST_PROTOCOL_VERSION);
+  });
+
+  it("accepts a comma-joined duplicate of a supported version", () => {
+    const result: ProtocolNegotiationResult = negotiateProtocolVersion(
+      `${LATEST_PROTOCOL_VERSION}, ${LATEST_PROTOCOL_VERSION}`,
+    );
+
+    expect(result.outcome).toBe(ProtocolNegotiationOutcome.Supported);
+    expect(result.negotiatedVersion).toBe(LATEST_PROTOCOL_VERSION);
+  });
+});

--- a/App/FeatureSet/MCP/Utils/TransportNegotiation.ts
+++ b/App/FeatureSet/MCP/Utils/TransportNegotiation.ts
@@ -1,0 +1,358 @@
+/**
+ * Transport Negotiation
+ *
+ * Real-world MCP clients are stricter and looser than the reference
+ * implementation in ways that used to break the OneUptime MCP endpoint at the
+ * transport layer, before a single tool ever ran — see GitHub issue #3695.
+ *
+ * Two incompatibilities showed up in the wild:
+ *
+ * 1. Protocol version. `StreamableHTTPServerTransport` rejects any
+ *    `MCP-Protocol-Version` request header whose value is not in the SDK's
+ *    `SUPPORTED_PROTOCOL_VERSIONS` list with a flat 400. A client that speaks a
+ *    NEWER revision of the spec than the bundled SDK knows about (Claude sent
+ *    `2026-07-28`) is therefore turned away even though the two sides share
+ *    several older versions. The MCP lifecycle says the opposite should happen:
+ *    the peers settle on the highest version they both support. These helpers
+ *    do that negotiation before the SDK sees the header.
+ *
+ * 2. Accept header. The SDK requires POSTs to list BOTH `application/json` and
+ *    `text/event-stream`, matching them with a naive substring test — so a
+ *    client that sends a wildcard Accept, sends nothing at all, or asks only for
+ *    JSON gets a 406 instead of a response. The spec lets the server answer a
+ *    POST with either media type, so we look at what the client actually
+ *    accepts and pick the response format to match.
+ *
+ * The negotiation itself is pure, so the behavior can be unit-tested without
+ * HTTP. Applying a negotiated value needs one more step, because the SDK
+ * rebuilds the request it validates from Node's `rawHeaders` array rather than
+ * from Express's parsed `headers` map — see `setRequestHeader` below.
+ */
+
+import {
+  LATEST_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+} from "@modelcontextprotocol/sdk/types.js";
+
+// Header names, lower-cased because Node normalizes incoming header keys.
+export const MCP_PROTOCOL_VERSION_HEADER: string = "mcp-protocol-version";
+export const ACCEPT_HEADER: string = "accept";
+
+/*
+ * Protocol versions are dated `YYYY-MM-DD`, so a plain lexicographic sort is
+ * also a chronological one. The SDK lists newest-first; keep a copy sorted
+ * oldest-first for the "highest version at or below X" search.
+ */
+export const KNOWN_PROTOCOL_VERSIONS: string[] = [
+  ...SUPPORTED_PROTOCOL_VERSIONS,
+].sort();
+
+const PROTOCOL_VERSION_FORMAT: RegExp = /^\d{4}-\d{2}-\d{2}$/;
+
+/** The Accept value we hand to the SDK once we have decided how to answer. */
+export const NORMALIZED_ACCEPT_HEADER: string =
+  "application/json, text/event-stream";
+
+export enum ProtocolNegotiationOutcome {
+  /** No `MCP-Protocol-Version` header — the SDK applies its own default. */
+  NotRequested = "not-requested",
+  /** The requested version is one we support; pass it through untouched. */
+  Supported = "supported",
+  /** The client is newer than us; we answer with the best version we share. */
+  DowngradedToSupported = "downgraded-to-supported",
+  /** Nothing in common (or an unparseable value) — the request must fail. */
+  Unsupported = "unsupported",
+}
+
+export interface ProtocolNegotiationResult {
+  outcome: ProtocolNegotiationOutcome;
+  /** Exactly what the client asked for, for logs and error payloads. */
+  requestedVersion: string | undefined;
+  /** The version to act on; undefined when nothing was requested or agreed. */
+  negotiatedVersion: string | undefined;
+}
+
+/**
+ * Read a header value that Node may hand back as a string, a repeated-header
+ * array, or nothing at all.
+ */
+export function readHeaderValue(
+  value: string | string[] | undefined,
+): string | undefined {
+  const raw: string | undefined = Array.isArray(value) ? value[0] : value;
+  const trimmed: string = (raw || "").trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Read a header that carries exactly one value, tolerating the two shapes a
+ * repeated header can arrive in.
+ *
+ * Node hands most repeated headers back as a single comma-joined string
+ * ("2026-07-28, 2025-06-18") rather than an array, so a client that sends the
+ * header twice would otherwise produce a value that matches no known version
+ * and gets rejected. Splitting is safe here precisely because a protocol
+ * version can never itself contain a comma — which is why this is NOT applied
+ * to Accept, where commas are the list separator.
+ */
+export function readSingleValueHeader(
+  value: string | string[] | undefined,
+): string | undefined {
+  const raw: string | undefined = readHeaderValue(value);
+
+  if (!raw) {
+    return undefined;
+  }
+
+  const first: string = (raw.split(",")[0] || "").trim();
+
+  return first.length > 0 ? first : undefined;
+}
+
+/**
+ * Settle on a protocol version for this request.
+ *
+ * A client that asks for a version newer than anything we know about is
+ * downgraded to the newest version we support, which is the same answer the
+ * SDK gives during `initialize` negotiation — so the header and the handshake
+ * agree instead of contradicting each other.
+ *
+ * A client that asks for a version OLDER than everything we support is a
+ * genuine mismatch: there is no shared version to fall back to, so it is
+ * reported as unsupported and the caller surfaces a precise error.
+ */
+export function negotiateProtocolVersion(
+  requestedHeader: string | string[] | undefined,
+): ProtocolNegotiationResult {
+  const requestedVersion: string | undefined =
+    readSingleValueHeader(requestedHeader);
+
+  if (!requestedVersion) {
+    return {
+      outcome: ProtocolNegotiationOutcome.NotRequested,
+      requestedVersion: undefined,
+      negotiatedVersion: undefined,
+    };
+  }
+
+  if (KNOWN_PROTOCOL_VERSIONS.includes(requestedVersion)) {
+    return {
+      outcome: ProtocolNegotiationOutcome.Supported,
+      requestedVersion,
+      negotiatedVersion: requestedVersion,
+    };
+  }
+
+  /*
+   * An unparseable value cannot be ordered against the known versions, so we
+   * cannot tell whether it is newer or older. Treat it as unsupported rather
+   * than guessing.
+   */
+  if (!PROTOCOL_VERSION_FORMAT.test(requestedVersion)) {
+    return {
+      outcome: ProtocolNegotiationOutcome.Unsupported,
+      requestedVersion,
+      negotiatedVersion: undefined,
+    };
+  }
+
+  // Highest version we support that is not newer than what the client asked for.
+  let bestMatch: string | undefined = undefined;
+  for (const candidate of KNOWN_PROTOCOL_VERSIONS) {
+    if (candidate < requestedVersion) {
+      bestMatch = candidate;
+    }
+  }
+
+  if (!bestMatch) {
+    // The client is older than every version we speak.
+    return {
+      outcome: ProtocolNegotiationOutcome.Unsupported,
+      requestedVersion,
+      negotiatedVersion: undefined,
+    };
+  }
+
+  return {
+    outcome: ProtocolNegotiationOutcome.DowngradedToSupported,
+    requestedVersion,
+    negotiatedVersion: bestMatch,
+  };
+}
+
+/** The newest protocol version this build of the server can speak. */
+export function getLatestSupportedProtocolVersion(): string {
+  return LATEST_PROTOCOL_VERSION;
+}
+
+export enum ResponseFormat {
+  /** Stream the JSON-RPC response back as `text/event-stream`. */
+  ServerSentEvents = "sse",
+  /** Answer with a single `application/json` body. */
+  Json = "json",
+  /** The client accepts neither; the request cannot be answered. */
+  Unacceptable = "unacceptable",
+}
+
+export interface AcceptNegotiationResult {
+  format: ResponseFormat;
+  /** Exactly what the client sent, for logs and error payloads. */
+  requestedAccept: string | undefined;
+}
+
+/**
+ * Decide how to answer a POST based on the client's Accept header.
+ *
+ * SSE is preferred when the client explicitly asks for it, because that is what
+ * spec-compliant MCP clients expect and it keeps today's behavior unchanged for
+ * them. Everything else that can take JSON — an explicit `application/json`, a
+ * `*` / `application/*` wildcard, or no Accept header at all (which HTTP says
+ * means "anything") — gets a plain JSON body, which every MCP client must be
+ * able to read.
+ */
+export function negotiateResponseFormat(
+  acceptHeader: string | string[] | undefined,
+): AcceptNegotiationResult {
+  const requestedAccept: string | undefined = readHeaderValue(acceptHeader);
+
+  // No Accept header means the client accepts any media type (RFC 9110).
+  if (!requestedAccept) {
+    return { format: ResponseFormat.Json, requestedAccept: undefined };
+  }
+
+  const mediaTypes: string[] = requestedAccept
+    .split(",")
+    .map((part: string) => {
+      // Drop parameters such as `;q=0.9` and normalize case.
+      return (part.split(";")[0] || "").trim().toLowerCase();
+    });
+
+  /*
+   * `text/*` is a media range that covers `text/event-stream`, so a client
+   * sending it has said it can take the stream — treat it the same as naming
+   * the type outright. (`*` alone is deliberately NOT in this list: see the
+   * wildcard note below.)
+   */
+  const acceptsEventStream: boolean =
+    mediaTypes.includes("text/event-stream") || mediaTypes.includes("text/*");
+
+  /*
+   * A wildcard means "anything", which covers JSON. Wildcards are answered with
+   * JSON rather than SSE: every MCP client can read a JSON body, whereas a
+   * client that sent a wildcard never said it can parse an event stream.
+   */
+  const acceptsJson: boolean =
+    mediaTypes.includes("application/json") ||
+    mediaTypes.includes("application/*") ||
+    mediaTypes.includes("*/*");
+
+  if (acceptsEventStream) {
+    return { format: ResponseFormat.ServerSentEvents, requestedAccept };
+  }
+
+  if (acceptsJson) {
+    return { format: ResponseFormat.Json, requestedAccept };
+  }
+
+  return { format: ResponseFormat.Unacceptable, requestedAccept };
+}
+
+/**
+ * The parts of a Node/Express request these helpers rewrite.
+ *
+ * `headers` is the parsed, lower-cased map Express exposes. `rawHeaders` is the
+ * flat `[name, value, name, value, ...]` array Node keeps alongside it — and it
+ * is the one that matters here, because the MCP SDK rebuilds the request it
+ * validates from `rawHeaders`, not from `headers`. Rewriting only `headers`
+ * would leave the SDK looking at the original value.
+ */
+export interface HeaderMutableRequest {
+  headers: Record<string, string | string[] | undefined>;
+  rawHeaders?: string[];
+}
+
+/**
+ * Drop every copy of a header from both views of the request.
+ */
+export function removeRequestHeader(
+  req: HeaderMutableRequest,
+  name: string,
+): void {
+  const lowerCasedName: string = name.toLowerCase();
+
+  delete req.headers[lowerCasedName];
+
+  const rawHeaders: string[] | undefined = req.rawHeaders;
+
+  if (!rawHeaders) {
+    return;
+  }
+
+  // Walk backwards so splicing does not shift entries we have yet to inspect.
+  for (let index: number = rawHeaders.length - 2; index >= 0; index -= 2) {
+    if ((rawHeaders[index] || "").toLowerCase() === lowerCasedName) {
+      rawHeaders.splice(index, 2);
+    }
+  }
+}
+
+/**
+ * Replace a header on both views of the request, collapsing any duplicates.
+ */
+export function setRequestHeader(
+  req: HeaderMutableRequest,
+  name: string,
+  value: string,
+): void {
+  removeRequestHeader(req, name);
+
+  req.headers[name.toLowerCase()] = value;
+  req.rawHeaders?.push(name, value);
+}
+
+/**
+ * Longest attacker-controlled value we will put in a single log field.
+ */
+const MAX_LOGGED_VALUE_LENGTH: number = 120;
+
+/**
+ * Make an attacker-controlled value safe to drop into a one-line log message.
+ *
+ * Everything the negotiation diagnostics report — header values, the JSON-RPC
+ * method name — arrives from the network. Newlines would let a caller forge
+ * extra log lines, and an unbounded value would let them flood the log, so
+ * control characters are stripped and the result is capped.
+ */
+export function sanitizeForLog(value: string | undefined): string {
+  if (!value) {
+    return "";
+  }
+
+  // eslint-disable-next-line no-control-regex
+  const flattened: string = value.replace(/[\u0000-\u001F\u007F]/g, " ");
+
+  return flattened.length > MAX_LOGGED_VALUE_LENGTH
+    ? `${flattened.slice(0, MAX_LOGGED_VALUE_LENGTH)}...(truncated)`
+    : flattened;
+}
+
+/**
+ * True when the POST body is (or contains) an `initialize` request.
+ *
+ * Version negotiation for `initialize` happens in the JSON-RPC body, where the
+ * SDK already answers an unknown version with the newest one it supports. So an
+ * unusable `MCP-Protocol-Version` header on an `initialize` request is dropped
+ * rather than rejected: the handshake is exactly where the two sides are
+ * supposed to agree on a version.
+ */
+export function isInitializeRequestBody(body: unknown): boolean {
+  const messages: unknown[] = Array.isArray(body) ? body : [body];
+
+  return messages.some((message: unknown) => {
+    return (
+      typeof message === "object" &&
+      message !== null &&
+      (message as { method?: unknown }).method === "initialize"
+    );
+  });
+}


### PR DESCRIPTION
Closes #3695.

## The bug

Connecting Claude to the built-in MCP server failed at the transport handshake, and the failure was invisible to the user — it appeared only in the app container logs, while every tool call came back looking like an API key permissions problem:

```
MCP transport error: Bad Request: Unsupported protocol version: 2026-07-28 (supported versions: 2025-11-25, ...)
MCP transport error: Not Acceptable: Client must accept both application/json and text/event-stream
```

Two checks in the bundled SDK's `StreamableHTTPServerTransport` are stricter than the spec they implement, and both fire before any tool runs.

**Protocol version.** The transport rejects any `MCP-Protocol-Version` outside its hardcoded list with a flat 400, so a client on a *newer* revision of the spec than the bundled SDK is turned away even though the two sides share four older versions. Claude declares `2026-07-28`; the SDK's newest is `2025-11-25`.

Upgrading the SDK does not help — I checked `1.30.0`, the latest release, and it still tops out at `2025-11-25` — and it would be the wrong shape of fix regardless, because the next client revision would break it again. The MCP lifecycle says peers settle on the highest version they both support, so that is what the server now does, before the SDK sees the header.

**Accept.** The transport requires a POST to list both `application/json` and `text/event-stream`, matched by naive substring, so `Accept: */*`, a JSON-only client, or no `Accept` header at all draws a 406 — even though the spec lets the server answer a POST with either media type.

| Request | Before | After |
|---|---|---|
| `MCP-Protocol-Version: 2026-07-28` | `400 Unsupported protocol version` | negotiated down to `2025-11-25`, succeeds |
| `Accept: application/json` | `406` | `200`, JSON body |
| `Accept: */*` or no `Accept` | `406` | `200`, JSON body |
| `Accept: text/*` | `406` | `200`, SSE stream |
| `MCP-Protocol-Version:` (blank) | `400` | header dropped, succeeds |
| same header sent twice | `400` | first value negotiated, succeeds |

## Errors are now visible

Negotiation that genuinely cannot succeed no longer fails silently. A client with no version in common gets a 400 naming the version it asked for and listing the ones this build speaks, with the same detail in a machine-readable `data` payload; a client that accepts neither media type gets a 406 naming what the endpoint can produce. `GET /mcp` and `/mcp/health` advertise the supported versions so a failed handshake is diagnosable from outside the container.

## Audit

I ran an adversarial audit of the first version of this fix — seven independent reviewers over separate dimensions, each claim then put through three refutation lenses. It found four more defects, all fixed here with regression tests:

- **Blank version header.** Classified as "not requested" but left on the request. An empty string is not `null` to the SDK, so it failed the same membership check and produced the same 400 — only *after* a successful `initialize`, which is exactly the confusing symptom from the issue.
- **Repeated version header.** Node collapses duplicates into one comma-joined string, which matches no version format, so the client was rejected. The original test missed this because it modelled a repeated header as an array, which Express never produces.
- **`Accept: text/*`** drew a 406 despite being a range covering `text/event-stream`, while `application/*` was honoured.
- **JSON-mode disconnect leak.** In JSON-response mode the SDK answers with a promise its own `close()` deletes without resolving, so a client disconnecting mid-request left the request, response, server and transport pinned for the life of the process. The `await` now races the response close.

Two smaller ones are fixed too: the transport-error diagnostic read the headers back *after* negotiation had rewritten them, so it echoed this server's own values instead of describing the caller; and the values it logs are attacker-controlled, so they are now stripped of control characters and length-capped rather than being able to forge log lines. One test assertion was also vacuous — `expect(json?.result?.isError).toBeFalsy()` passes on a JSON-RPC error, where `result` is undefined.

## Note for whoever touches this next

Rewriting `req.headers` alone does nothing. The SDK rebuilds the request it validates from Node's `rawHeaders` array via `@hono/node-server`, so a negotiated value has to land in both views. `setRequestHeader` does that, and there is a test class pinning it.

## Tests

395 tests across the 18 MCP suites pass (up from 314 before this change); `tsc --noEmit` over the whole App project exits 0; ESLint clean.

- `Tests/TransportNegotiation.test.ts` (new, 119 tests) — every supported version, boundary dates one day either side of each, far-future, between-versions, older-than-oldest, syntactically-valid nonsense (`2025-13-45`), malformed strings, a property sweep asserting the negotiated version is never newer than the request and is always one we support; Accept media ranges, q-values, casing, malformed headers, an assertion the parser never throws; the header-rewriting helpers against odd-length `rawHeaders` and case-colliding duplicates; and the log sanitizer against forged newlines and flooding.
- `Tests/RouteHandler.test.ts` (+45 tests) — end-to-end over the real Express handler: the full `initialize` → `initialized` → `tools/list` → `tools/call` handshake from a client declaring `2026-07-28`, the same across two replicas, JSON-RPC batch bodies in both response modes, concurrent requests with different `Accept` headers each getting their own content type, a failing tool surfacing in-band in JSON mode, CORS headers on the rejections, valid JSON-RPC envelopes on the 400/406, non-POST methods with a bad version header, and an assertion that no log line ever contains the API key.
