### PR TITLE
fix(on-call): say which shifts are covered by an override, and whose

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/ActiveOverridesCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/ActiveOverridesCard.tsx
@@ -1,0 +1,225 @@
+import { formatShiftInstant } from "./LayerSummary";
+import { getColorForUserId, getUserInitials } from "./LayerUserColors";
+import {
+  OverrideScopeKind,
+  OverrideSummaryRow,
+  OverrideUserDisplayInfo,
+} from "./OverridePresentation";
+import Dictionary from "Common/Types/Dictionary";
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import React, { FunctionComponent, ReactElement } from "react";
+
+/*
+ * The substitutions in force on this schedule, stated in full above the grid
+ * they explain.
+ *
+ * The calendar can only ever show the RESULT of an override — a block in the
+ * substitute's colour — and a block cannot say what it would have said without
+ * the override. That leaves the reader of a correct calendar unable to tell a
+ * substitution from an ordinary rotation, which is the complaint this card
+ * answers: it names the person who was overridden, the person their alerts now
+ * reach, the window, and whether the swap applies everywhere or to one policy.
+ *
+ * Rows come from OverridePresentation.buildOverrideSummaryRows, so this
+ * component holds no wording of its own and stays a pure render of props.
+ */
+
+export interface ComponentProps {
+  rows: Array<OverrideSummaryRow>;
+  // Display info for both sides of every row, keyed by user id.
+  userById: Dictionary<OverrideUserDisplayInfo>;
+  // The zone instants are rendered in; matches the grid below.
+  timezone?: string | undefined;
+  id?: string | undefined;
+}
+
+/*
+ * How many rows to list before collapsing the rest into a count. A schedule
+ * under heavy hand-off churn can carry dozens of future overrides, and a wall
+ * of them above the calendar would push the thing they explain off the screen.
+ * In-force overrides sort first (see buildOverrideSummaryRows), so the ones that
+ * survive the cut are always the ones that matter now.
+ */
+export const MAX_SHOWN_OVERRIDE_ROWS: number = 4;
+
+const ActiveOverridesCard: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement | null => {
+  if (props.rows.length === 0) {
+    return null;
+  }
+
+  const shownRows: Array<OverrideSummaryRow> = props.rows.slice(
+    0,
+    MAX_SHOWN_OVERRIDE_ROWS,
+  );
+  const hiddenCount: number = props.rows.length - shownRows.length;
+
+  const getAvatar: (userId: string) => ReactElement = (
+    userId: string,
+  ): ReactElement => {
+    const info: OverrideUserDisplayInfo | undefined = props.userById[userId];
+    return (
+      <span
+        className="inline-flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white"
+        style={{ backgroundColor: getColorForUserId(userId) }}
+      >
+        {getUserInitials(info?.name || "", info?.email || "")}
+      </span>
+    );
+  };
+
+  /*
+   * One side of the swap. The caption under the name is what makes the row
+   * self-explanatory: "Alice -> Bob" alone still needs the reader to know which
+   * direction an override runs, and getting that backwards means calling the
+   * wrong person at 3am.
+   */
+  const getParty: (data: {
+    userId: string;
+    name: string;
+    caption: string;
+    captionClassName: string;
+  }) => ReactElement = (data: {
+    userId: string;
+    name: string;
+    caption: string;
+    captionClassName: string;
+  }): ReactElement => {
+    return (
+      <div className="flex min-w-0 items-center gap-2">
+        {getAvatar(data.userId)}
+        <div className="min-w-0">
+          <div className="truncate text-sm font-semibold text-gray-900">
+            {data.name}
+          </div>
+          <div
+            className={`text-[11px] font-medium uppercase tracking-wide ${data.captionClassName}`}
+          >
+            {data.caption}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const getRow: (row: OverrideSummaryRow) => ReactElement = (
+    row: OverrideSummaryRow,
+  ): ReactElement => {
+    return (
+      <li
+        key={row.key}
+        data-testid="active-override-row"
+        className="rounded-lg border border-gray-200 bg-white px-3 py-2.5"
+      >
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          {getParty({
+            userId: row.originalUserId,
+            name: row.originalName,
+            caption: "Overridden",
+            captionClassName: "text-gray-400",
+          })}
+
+          <Icon
+            icon={IconProp.ArrowRight}
+            className="h-4 w-4 flex-shrink-0 text-indigo-500"
+            ariaLabel="alerts routed to"
+          />
+
+          {getParty({
+            userId: row.substituteUserId,
+            name: row.substituteName,
+            caption: "Alerts go here",
+            captionClassName: "text-indigo-600",
+          })}
+
+          {row.isActiveNow && (
+            <span className="ml-auto inline-flex flex-shrink-0 items-center gap-1.5 rounded-full bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-200">
+              <span className="relative flex h-1.5 w-1.5">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-indigo-400 opacity-75" />
+                <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-indigo-500" />
+              </span>
+              In force now
+            </span>
+          )}
+        </div>
+
+        <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-gray-500">
+          <span>
+            {formatShiftInstant(row.startsAt, props.timezone)}
+            <span className="mx-1 text-gray-300">&rarr;</span>
+            {formatShiftInstant(row.endsAt, props.timezone)}
+          </span>
+          <span className="text-gray-300">&middot;</span>
+          {/*
+           * The scope pill is the answer to "will this cover the page I care
+           * about". A global override is the wide, reassuring case and is drawn
+           * neutrally; a policy-scoped one is the narrow, surprising case and is
+           * drawn in amber, because a reader who assumes it is global will be
+           * paged by every OTHER policy that escalates here.
+           */}
+          <span
+            data-testid="override-scope-pill"
+            title={row.scope.detail}
+            className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium ring-1 ring-inset ${
+              row.scope.kind === OverrideScopeKind.Global
+                ? "bg-gray-50 text-gray-600 ring-gray-200"
+                : "bg-amber-50 text-amber-800 ring-amber-200"
+            }`}
+          >
+            <Icon
+              icon={
+                row.scope.kind === OverrideScopeKind.Global
+                  ? IconProp.Globe
+                  : IconProp.Alert
+              }
+              className="h-3 w-3"
+            />
+            {row.scope.label}
+          </span>
+        </div>
+      </li>
+    );
+  };
+
+  return (
+    <div
+      id={props.id}
+      data-testid="active-overrides-card"
+      className="rounded-xl border border-indigo-200 bg-indigo-50/40 p-4"
+    >
+      <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-indigo-700">
+        <Icon icon={IconProp.ArrowUturnRight} className="h-3.5 w-3.5" />
+        {props.rows.length === 1
+          ? "1 user override on this schedule"
+          : `${props.rows.length} user overrides on this schedule`}
+      </div>
+      {/*
+       * Deliberately not "during these windows the calendar shows the
+       * substitute": an override only takes effect where its window actually
+       * overlaps a shift of the person it overrides, and one booked over a day
+       * they were not rostered anyway changes nothing. It is still listed -
+       * somebody configured it and would go looking for it - so the wording has
+       * to describe what an override DOES without promising every row below
+       * changed the grid.
+       */}
+      <p className="mt-1 text-xs text-gray-600">
+        An override sends the alerts that would page one person to somebody
+        else. Wherever one covers a shift, the calendar below shows the
+        substitute rather than the person the rotation put on call.
+      </p>
+
+      <ul className="mt-3 space-y-2">{shownRows.map(getRow)}</ul>
+
+      {hiddenCount > 0 && (
+        <div className="mt-2 text-xs text-gray-500">
+          + {hiddenCount} more {hiddenCount === 1 ? "override" : "overrides"}{" "}
+          scheduled later in this window.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ActiveOverridesCard;

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/FinalScheduleSummary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/FinalScheduleSummary.tsx
@@ -6,6 +6,10 @@ import {
   formatShiftInstant,
   formatWindowSpan,
 } from "./LayerSummary";
+import {
+  OverrideScopeKind,
+  describeShiftOverride,
+} from "./OverridePresentation";
 import Dictionary from "Common/Types/Dictionary";
 import IconProp from "Common/Types/Icon/IconProp";
 import OneUptimeDate from "Common/Types/Date";
@@ -48,6 +52,12 @@ export interface ComponentProps {
    * override substitutes).
    */
   userById: Dictionary<UserInfo>;
+  /*
+   * policyId -> policy name, so a shift produced by a POLICY-SCOPED override
+   * can name the policy it is limited to. Omitted by callers that have no
+   * overrides to describe.
+   */
+  policyNameById?: Dictionary<string> | undefined;
   /*
    * Pre-computed coverage state from ScheduleShiftUtil.getCoverageState. Passed
    * in rather than derived here so this component and the calendar grid beside
@@ -110,6 +120,94 @@ const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
         style={{ backgroundColor: getColorForUserId(userId) }}
       >
         {getInitials(userId)}
+      </span>
+    );
+  };
+
+  /*
+   * The "this person is here because of an override" strip.
+   *
+   * A shift produced by an override names the right person to page, and that is
+   * exactly why it needs annotating: on its own it is indistinguishable from a
+   * shift the rotation produced, so a reader has no way to know that the roster
+   * says somebody else and that the substitution expires. Both halves are shown
+   * - who was overridden, and how far the override reaches.
+   */
+  const getOverrideStrip: (
+    shift: OnCallShift,
+    testId: string,
+  ) => ReactElement | null = (
+    shift: OnCallShift,
+    testId: string,
+  ): ReactElement | null => {
+    if (!shift.override) {
+      return null;
+    }
+
+    const described: {
+      originalName: string;
+      scope: { kind: OverrideScopeKind; label: string; detail: string };
+      coveringLabel: string;
+    } = describeShiftOverride({
+      override: shift.override,
+      userInfoById: props.userById,
+      policyNameById: props.policyNameById || {},
+    });
+
+    return (
+      <div
+        data-testid={testId}
+        className="mt-2.5 flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg bg-white/70 px-2 py-1.5 text-xs ring-1 ring-inset ring-indigo-200"
+      >
+        <span className="inline-flex items-center gap-1 font-semibold text-indigo-700">
+          <Icon icon={IconProp.ArrowUturnRight} className="h-3.5 w-3.5" />
+          Override
+        </span>
+        <span className="text-gray-700">{described.coveringLabel}</span>
+        <span
+          title={described.scope.detail}
+          className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-[11px] font-medium ring-1 ring-inset ${
+            described.scope.kind === OverrideScopeKind.Global
+              ? "bg-gray-50 text-gray-600 ring-gray-200"
+              : "bg-amber-50 text-amber-800 ring-amber-200"
+          }`}
+        >
+          {described.scope.label}
+        </span>
+        <span className="basis-full text-[11px] text-gray-500">
+          Override runs{" "}
+          {formatShiftInstant(shift.override.overrideStartsAt, props.timezone)}
+          <span className="mx-1 text-gray-300">&rarr;</span>
+          {formatShiftInstant(shift.override.overrideEndsAt, props.timezone)}
+        </span>
+      </div>
+    );
+  };
+
+  /*
+   * The compact form of the same fact, for the upcoming hand-off rows where
+   * there is room for one line and no more.
+   */
+  const getOverridePill: (shift: OnCallShift) => ReactElement | null = (
+    shift: OnCallShift,
+  ): ReactElement | null => {
+    if (!shift.override) {
+      return null;
+    }
+
+    const described: { coveringLabel: string } = describeShiftOverride({
+      override: shift.override,
+      userInfoById: props.userById,
+      policyNameById: props.policyNameById || {},
+    });
+
+    return (
+      <span
+        data-testid="upcoming-override-pill"
+        className="mt-0.5 inline-flex w-fit items-center gap-1 rounded-md bg-indigo-50 px-1.5 py-0.5 text-[11px] font-medium text-indigo-700 ring-1 ring-inset ring-indigo-200"
+      >
+        <Icon icon={IconProp.ArrowUturnRight} className="h-3 w-3" />
+        {described.coveringLabel}
       </span>
     );
   };
@@ -180,6 +278,7 @@ const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
             </div>
           </div>
         </div>
+        {getOverrideStrip(current, "on-call-now-override")}
       </div>
     );
   };
@@ -217,6 +316,7 @@ const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
             </div>
           </div>
         </div>
+        {getOverrideStrip(next, "up-next-override")}
       </div>
     );
   };
@@ -333,7 +433,7 @@ const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
                 className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-3 py-2.5"
               >
                 {getAvatar(shift.userId, "h-7 w-7 text-[10px]")}
-                <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 flex-1 flex-col">
                   <div className="truncate text-sm font-semibold text-gray-900">
                     {getName(shift.userId)}
                   </div>
@@ -342,6 +442,7 @@ const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
                     <span className="mx-1 text-gray-300">&rarr;</span>
                     {formatShiftInstant(shift.end, props.timezone)}
                   </div>
+                  {getOverridePill(shift)}
                 </div>
                 <div className="flex flex-shrink-0 flex-col items-end gap-0.5">
                   <span className="rounded-md bg-gray-50 px-2 py-0.5 text-[11px] font-medium text-gray-600 ring-1 ring-inset ring-gray-200">

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerCard.tsx
@@ -1,6 +1,10 @@
 import LayerConfigForm from "./LayerConfigForm";
 import LayerRotationSummary from "./LayerRotationSummary";
 import { getLayerPreviewEvents, LayerPreviewResult } from "./LayerShiftPreview";
+import {
+  OverrideUserDisplayInfo,
+  describeShiftOverride,
+} from "./OverridePresentation";
 import { OverrideUserInfo } from "./ScheduleOverrides";
 import LayerUser from "./LayerUser";
 import { getColorForUserId, getUserInitials } from "./LayerUserColors";
@@ -139,7 +143,16 @@ const LayerCard: FunctionComponent<ComponentProps> = (
    * merging) so the header line is honest for restricted layers.
    */
   const coverageShifts: Array<OnCallShift> =
-    ScheduleShiftUtil.groupEventsIntoShifts(preview.events);
+    ScheduleShiftUtil.groupEventsIntoShifts(preview.events, {
+      /*
+       * Override-aware so the "on call now" line can name the person being
+       * covered. The default key folds a substitute's own rotation turn into
+       * the window they are covering, and a merged shift keeps only the first
+       * segment's override - which is how this line used to be able to say
+       * "covering" with nothing to say who for.
+       */
+      groupKey: ScheduleShiftUtil.groupKeyByUserAndOverride,
+    });
   const currentAndNext: CurrentAndNextShift =
     ScheduleShiftUtil.getCurrentAndNextShift(coverageShifts, preview.now);
 
@@ -168,6 +181,31 @@ const LayerCard: FunctionComponent<ComponentProps> = (
   }
 
   /*
+   * Name + email for everyone who can appear on this card: the layer's own
+   * users and the substitutes an override brought in. describeShiftOverride
+   * needs both fields, so this cannot be derived from nameById above.
+   */
+  const overrideDisplayInfoById: Dictionary<OverrideUserDisplayInfo> = {};
+  for (const layerUser of props.users) {
+    const id: string = layerUser.user?.id?.toString() || "";
+    if (id && !overrideDisplayInfoById[id]) {
+      overrideDisplayInfoById[id] = {
+        name: layerUser.user?.name?.toString() || "",
+        email: layerUser.user?.email?.toString() || "",
+      };
+    }
+  }
+  for (const userId in props.overrideUserInfo) {
+    const info: OverrideUserInfo | undefined = props.overrideUserInfo[userId];
+    if (info && !overrideDisplayInfoById[userId]) {
+      overrideDisplayInfoById[userId] = {
+        name: info.name,
+        email: info.email,
+      };
+    }
+  }
+
+  /*
    * True when the person on call right now got there through an override rather
    * than through this layer's rotation. Drives the "covering" tag: seeing a name
    * that is not in the layer's user list, with no explanation, reads as a bug.
@@ -183,6 +221,26 @@ const LayerCard: FunctionComponent<ComponentProps> = (
   const isCurrentUserSubstitute: boolean = Boolean(
     currentAndNext.current && !layerUserIds.has(currentAndNext.current.userId),
   );
+
+  /*
+   * "Covering for Alice Nakamura" when the shift carries the override that put
+   * this person on it.
+   *
+   * Falls back to the old, unnamed wording only when the substitution is
+   * visible (the name on the line is not one of this layer's users) but the
+   * shift did not carry its provenance - a shape the grouping above should
+   * prevent, though saying "covering" with no name still beats saying nothing
+   * and letting a stranger's name read as a bug.
+   */
+  const coveringLabel: string | null = currentAndNext.current?.override
+    ? describeShiftOverride({
+        override: currentAndNext.current.override,
+        userInfoById: overrideDisplayInfoById,
+        policyNameById: {},
+      }).coveringLabel
+    : isCurrentUserSubstitute
+      ? "Covering via override"
+      : null;
 
   const userCount: number = props.users.length;
   const shownUsers: Array<OnCallDutyPolicyScheduleLayerUser> =
@@ -349,9 +407,12 @@ const LayerCard: FunctionComponent<ComponentProps> = (
                   {nameById[currentAndNext.current.userId] || "Unknown user"}
                 </span>{" "}
                 on call now
-                {isCurrentUserSubstitute && (
-                  <span className="ml-1 font-medium text-indigo-600">
-                    (covering via override)
+                {coveringLabel && (
+                  <span
+                    data-testid="layer-card-covering"
+                    className="ml-1 font-medium text-indigo-600"
+                  >
+                    ({coveringLabel.toLowerCase()})
                   </span>
                 )}
               </span>

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerRotationSummary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerRotationSummary.tsx
@@ -7,6 +7,10 @@ import {
   summarizeRestriction,
   summarizeRotation,
 } from "./LayerSummary";
+import {
+  OverrideUserDisplayInfo,
+  describeShiftOverride,
+} from "./OverridePresentation";
 import { OverrideUserInfo } from "./ScheduleOverrides";
 import CalendarEvent from "Common/Types/Calendar/CalendarEvent";
 import Dictionary from "Common/Types/Dictionary";
@@ -73,6 +77,13 @@ const LayerRotationSummary: FunctionComponent<ComponentProps> = (
    */
   const usersById: Record<string, UserDisplay> = {};
   const orderedUsers: Array<UserDisplay> = [];
+  /*
+   * Name + email for everyone who can appear in a turn row - the layer's own
+   * users plus the substitutes an override brought in. Separate from usersById
+   * because that one carries display chrome (colour, initials) rather than the
+   * raw fields describeShiftOverride needs.
+   */
+  const overrideDisplayInfoById: Dictionary<OverrideUserDisplayInfo> = {};
   for (const layerUser of props.users) {
     const user: User | undefined = layerUser.user;
     const userId: string = user?.id?.toString() || "";
@@ -91,7 +102,23 @@ const LayerRotationSummary: FunctionComponent<ComponentProps> = (
         ),
       };
     }
+    if (!overrideDisplayInfoById[userId]) {
+      overrideDisplayInfoById[userId] = {
+        name: user?.name?.toString() || "",
+        email: user?.email?.toString() || "",
+      };
+    }
     orderedUsers.push(usersById[userId]!);
+  }
+
+  for (const userId in props.overrideUserInfo) {
+    const info: OverrideUserInfo | undefined = props.overrideUserInfo[userId];
+    if (info && !overrideDisplayInfoById[userId]) {
+      overrideDisplayInfoById[userId] = {
+        name: info.name,
+        email: info.email,
+      };
+    }
   }
 
   const getUserDisplay: (userId: string) => UserDisplay = (
@@ -156,10 +183,18 @@ const LayerRotationSummary: FunctionComponent<ComponentProps> = (
     return <></>;
   }
 
-  // Group raw coverage into rotation turns (absorb within-turn off-hours gaps).
+  /*
+   * Group raw coverage into rotation turns (absorb within-turn off-hours gaps),
+   * but never across an override boundary: a turn that is partly covered is two
+   * different facts about who gets paged, and merging them would leave the row
+   * showing one of the two with no way to say so.
+   */
   const turns: Array<OnCallShift> = ScheduleShiftUtil.groupEventsIntoShifts(
     props.events,
-    { mergeAcrossGaps: true },
+    {
+      mergeAcrossGaps: true,
+      groupKey: ScheduleShiftUtil.groupKeyByUserAndOverride,
+    },
   );
 
   const { current }: { current: OnCallShift | null } =
@@ -250,9 +285,24 @@ const LayerRotationSummary: FunctionComponent<ComponentProps> = (
             <span className="truncate text-sm font-semibold text-gray-900">
               {user.name}
             </span>
-            {user.isSubstitute && (
-              <span className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-indigo-700 ring-1 ring-inset ring-indigo-200">
-                Covering
+            {/*
+             * Name the person being covered when the turn carries the override
+             * that produced it. "Covering" on its own tells the reader the one
+             * thing they can already see - that this name is not in the
+             * rotation - while withholding the one thing they cannot.
+             */}
+            {(turn.override || user.isSubstitute) && (
+              <span
+                data-testid="rotation-covering-pill"
+                className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-indigo-700 ring-1 ring-inset ring-indigo-200"
+              >
+                {turn.override
+                  ? describeShiftOverride({
+                      override: turn.override,
+                      userInfoById: overrideDisplayInfoById,
+                      policyNameById: {},
+                    }).coveringLabel
+                  : "Covering"}
               </span>
             )}
             {isCurrent &&

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayersPreview.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayersPreview.tsx
@@ -1,6 +1,20 @@
+import ActiveOverridesCard from "./ActiveOverridesCard";
 import { getCoverageWindowEnd } from "./CoverageWindow";
 import FinalScheduleSummary from "./FinalScheduleSummary";
 import { getColorForUserId } from "./LayerUserColors";
+import {
+  OVERRIDE_EVENT_CLASS_NAME,
+  OVERRIDE_TITLE_MARKER,
+  OverrideSummaryRow,
+  buildOverrideEventTooltip,
+  buildOverrideSummaryRows,
+  buildPlainEventTooltip,
+  describeOverrideScope,
+  describeSubstituteCoverage,
+  formatOverrideEventTitle,
+  formatUserLabel,
+  getUserDisplayName,
+} from "./OverridePresentation";
 import TimezoneSelectButton from "./TimezoneSelectButton";
 import CalendarEvent from "Common/Types/Calendar/CalendarEvent";
 import OneUptimeDate from "Common/Types/Date";
@@ -75,29 +89,14 @@ interface UserColorAssignment {
   name: string;
   email: string;
   color: string;
-  isSubstitute?: boolean;
+  /*
+   * Set for a user who is only on this calendar because an override routes
+   * somebody else's alerts to them, and says WHOSE - "Covering Alice Scheduled".
+   * A bare "Covering" tag names the wrong half of the swap: the reader can
+   * already see who is covering, what they cannot see is who is being covered.
+   */
+  coveringLabel?: string;
 }
-
-const getDisplayName: (info: UserInfo | undefined) => string = (
-  info: UserInfo | undefined,
-): string => {
-  if (!info) {
-    return "Unknown user";
-  }
-  return info.name || info.email || "Unknown user";
-};
-
-const formatUserLabel: (info: UserInfo | undefined) => string = (
-  info: UserInfo | undefined,
-): string => {
-  if (!info) {
-    return "Unknown user";
-  }
-  if (info.name && info.email) {
-    return `${info.name} (${info.email})`;
-  }
-  return info.name || info.email || "Unknown user";
-};
 
 const LayersPreview: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
@@ -239,6 +238,18 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
   const overrideUserInfo: Dictionary<UserInfo> =
     overrideResolution.userInfoById;
   const policyContextIdString: string = overrideResolution.policyContextId;
+  const policyNameById: Dictionary<string> = overrideResolution.policyNameById;
+
+  /*
+   * Everyone who can appear on this screen: the roster, plus the substitutes an
+   * override brought in. Built once here because the grid, the legend, the
+   * summary and the overrides card all have to name the same person the same
+   * way - a substitute known only to the override fetch would otherwise read as
+   * "Unknown user" on whichever surface forgot to merge the two maps.
+   */
+  const allUsersById: Dictionary<UserInfo> = useMemo(() => {
+    return { ...scheduleUsersById, ...overrideUserInfo };
+  }, [scheduleUsersById, overrideUserInfo]);
 
   const uniqueUsers: Array<UserColorAssignment> = useMemo(() => {
     const seen: Set<string> = new Set<string>();
@@ -252,7 +263,7 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
       seen.add(userId);
       result.push({
         userId,
-        name: getDisplayName(info),
+        name: getUserDisplayName(info),
         email: info.email,
         color: getColorForUserId(userId),
       });
@@ -267,15 +278,19 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
       const info: UserInfo | undefined = overrideUserInfo[routeId];
       result.push({
         userId: routeId,
-        name: getDisplayName(info),
+        name: getUserDisplayName(info),
         email: info?.email || "",
         color: getColorForUserId(routeId),
-        isSubstitute: true,
+        coveringLabel: describeSubstituteCoverage({
+          substituteUserId: routeId,
+          records: overrideRecords,
+          userInfoById: allUsersById,
+        }),
       });
     }
 
     return result;
-  }, [scheduleUsersById, overrideRecords, overrideUserInfo]);
+  }, [scheduleUsersById, overrideRecords, overrideUserInfo, allUsersById]);
 
   /*
    * Build the LayerProps array once from the current layers/users. Shared by
@@ -337,8 +352,17 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
       });
     }
 
-    const shifts: Array<OnCallShift> =
-      ScheduleShiftUtil.groupEventsIntoShifts(events);
+    /*
+     * Grouped so an override window is its own shift. The default grouping is
+     * by user id alone, which folds a substitute's OWN rostered segment into
+     * the segment they are covering - and a shift only inherits metadata from
+     * its first segment, so the merged block would silently lose the fact that
+     * half of it is cover. See ScheduleShiftUtil.groupKeyByUserAndOverride.
+     */
+    const shifts: Array<OnCallShift> = ScheduleShiftUtil.groupEventsIntoShifts(
+      events,
+      { groupKey: ScheduleShiftUtil.groupKeyByUserAndOverride },
+    );
 
     /*
      * assignedUserCount counts ASSIGNMENT ROWS, not distinct people, and is
@@ -399,7 +423,9 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
      */
     setCalendarGaps(
       ScheduleShiftUtil.getCoverageGaps(
-        ScheduleShiftUtil.groupEventsIntoShifts(events),
+        ScheduleShiftUtil.groupEventsIntoShifts(events, {
+          groupKey: ScheduleShiftUtil.groupKeyByUserAndOverride,
+        }),
         startTime,
         endTime,
         // Sub-minute slivers would render as invisible hairlines on the grid.
@@ -407,31 +433,60 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
       ),
     );
 
-    const userById: Dictionary<UserInfo> = {
-      ...scheduleUsersById,
-      ...overrideUserInfo,
-    };
-
     events.forEach((event: CalendarEvent) => {
       const meta: OverrideEventMeta | null =
         UserOverrideUtil.getOverrideMeta(event);
       const displayedUserId: string = event.title;
-      const displayedInfo: UserInfo | undefined = userById[displayedUserId];
+      const displayedInfo: UserInfo | undefined = allUsersById[displayedUserId];
 
       event.color = getColorForUserId(displayedUserId);
 
-      if (meta) {
-        const originalInfo: UserInfo | undefined =
-          userById[meta.originalUserId];
-        const originalLabel: string =
-          originalInfo?.name || originalInfo?.email || "original user";
-        const substituteLabel: string =
-          displayedInfo?.name || displayedInfo?.email || "substitute user";
-        event.title = `${substituteLabel} (covering ${originalLabel})`;
-        event.desc = `Override: ${substituteLabel} is covering for ${originalLabel}.`;
-      } else {
+      if (!meta) {
         event.title = formatUserLabel(displayedInfo);
+        event.desc = buildPlainEventTooltip({
+          userLabel: formatUserLabel(displayedInfo),
+          start: event.start,
+          end: event.end,
+          timezone: viewAsTimezone,
+        });
+        return;
       }
+
+      /*
+       * An overridden block carries FOUR cues, because no single one survives
+       * every way this grid gets read. The label says it in words; the leading
+       * marker survives a column too narrow for words; the accent stripe (drawn
+       * in the OVERRIDDEN person's colour, see Calendar.css) survives a column
+       * too narrow for any text at all, and is the only cue that also says
+       * WHOSE shift this was; and the tooltip carries the full statement,
+       * including the override's own window and whether it is global.
+       */
+      const substituteName: string = getUserDisplayName(displayedInfo);
+      const originalName: string = getUserDisplayName(
+        allUsersById[meta.originalUserId],
+      );
+
+      const policyId: string = meta.onCallDutyPolicyId || "";
+
+      event.title = formatOverrideEventTitle({
+        substituteName,
+        originalName,
+      });
+      event.desc = buildOverrideEventTooltip({
+        substituteName,
+        originalName,
+        overrideStartsAt: meta.overrideStartsAt,
+        overrideEndsAt: meta.overrideEndsAt,
+        scope: describeOverrideScope({
+          onCallDutyPolicyId: meta.onCallDutyPolicyId,
+          ...(policyId && policyNameById[policyId]
+            ? { policyName: policyNameById[policyId]! }
+            : {}),
+        }),
+        timezone: viewAsTimezone,
+      });
+      event.accentColor = getColorForUserId(meta.originalUserId);
+      event.className = OVERRIDE_EVENT_CLASS_NAME;
     });
 
     setCalendarEvents(events);
@@ -442,8 +497,9 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
     startTime,
     endTime,
     overrideRecords,
-    overrideUserInfo,
-    scheduleUsersById,
+    allUsersById,
+    policyNameById,
+    viewAsTimezone,
   ]);
 
   /*
@@ -513,6 +569,20 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
     : `Viewing in ${viewAsTimezone}. This schedule has no timezone set, so it is paged in the server's local time.`;
 
   const hasActiveOverrides: boolean = overrideRecords.length > 0;
+
+  /*
+   * Rows for the overrides card above the grid. Keyed off `now` so a
+   * substitution that starts while the page is open flips to "in force now"
+   * on the same 30-second tick that moves the rest of the screen.
+   */
+  const overrideSummaryRows: Array<OverrideSummaryRow> = useMemo(() => {
+    return buildOverrideSummaryRows({
+      records: overrideRecords,
+      userInfoById: allUsersById,
+      policyNameById,
+      now,
+    });
+  }, [overrideRecords, allUsersById, policyNameById, now]);
 
   /*
    * Say which overrides this preview applied. Silence would be worse than the
@@ -617,8 +687,25 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
           windowEnd={summaryData.windowEnd}
           coverage={summaryData.coverage}
           timezone={viewAsTimezone}
-          userById={{ ...scheduleUsersById, ...overrideUserInfo }}
+          userById={allUsersById}
+          policyNameById={policyNameById}
         />
+      )}
+
+      {/*
+       * The substitutions in force, spelled out above the grid. The grid can
+       * only ever show the RESULT of an override — it has no way to say what it
+       * would have shown without one — so this card is the only place the
+       * overridden person is named at all.
+       */}
+      {overrideSummaryRows.length > 0 && (
+        <div className="mb-4">
+          <ActiveOverridesCard
+            rows={overrideSummaryRows}
+            userById={allUsersById}
+            timezone={viewAsTimezone}
+          />
+        </div>
       )}
 
       {/*
@@ -643,14 +730,36 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
                   style={{ backgroundColor: u.color }}
                 />
                 <span className="font-medium text-gray-900">{u.name}</span>
-                {u.isSubstitute && (
-                  <span className="text-[10px] font-medium uppercase tracking-wide text-indigo-600">
-                    Covering
+                {u.coveringLabel && (
+                  <span
+                    data-testid="legend-covering-label"
+                    className="text-[10px] font-medium uppercase tracking-wide text-indigo-600"
+                  >
+                    {u.coveringLabel}
                   </span>
                 )}
               </div>
             );
           })}
+          {/*
+           * Names the striped edge drawn on substituted blocks. Without this
+           * the stripe is decoration: the reader can see that two blocks differ
+           * without being told that the difference means somebody else's alerts
+           * are being answered.
+           */}
+          {hasActiveOverrides && (
+            <div
+              data-testid="legend-override-key"
+              className="inline-flex items-center gap-1.5 rounded-md bg-white px-2 py-1 text-xs text-gray-700 ring-1 ring-inset ring-indigo-200"
+              title="A block with a striped edge is covered by a substitute. The stripe is the colour of the person who was overridden."
+            >
+              <span className="oneuptime-calendar-override-swatch inline-block h-2.5 w-2.5 rounded-sm" />
+              <span className="font-medium text-indigo-700">
+                Covered by an override
+              </span>
+            </div>
+          )}
+
           {/*
            * Names the hatched bands drawn on the grid below. Only shown when
            * the visible range actually contains one, so a fully-covered week
@@ -670,9 +779,13 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
 
       {hasActiveOverrides && (
         <div className="mt-2 text-xs text-gray-500">
-          Events labelled{" "}
-          <span className="font-medium text-indigo-600">covering</span> are
-          handled by a substitute user via an active override.
+          A block marked{" "}
+          <span className="font-medium text-indigo-600">
+            {OVERRIDE_TITLE_MARKER} covering
+          </span>{" "}
+          is an override: the name on it is the substitute the alerts go to, and
+          the name in brackets is the person whose shift it was. Hover a block
+          for the override&apos;s window and scope.
         </div>
       )}
 

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/OverridePresentation.ts
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/OverridePresentation.ts
@@ -1,0 +1,336 @@
+import { formatShiftInstant } from "./LayerSummary";
+import Dictionary from "Common/Types/Dictionary";
+import OneUptimeDate from "Common/Types/Date";
+import {
+  OverrideEventMeta,
+  UserOverrideRecord,
+} from "Common/Types/OnCallDutyPolicy/UserOverrideUtil";
+
+/*
+ * Every word the schedule screens use to describe a user override lives here.
+ *
+ * The screens answer one question — who gets paged — and an override is the
+ * case where the honest answer has two names in it: the person the rotation put
+ * on call, and the person their alerts are actually going to. The calendar used
+ * to render only the second, in the substitute's own colour, which reads
+ * exactly like an ordinary shift; a reader could not tell that a substitution
+ * had happened at all, let alone whose. https://github.com/OneUptime/oneuptime
+ *
+ * Keeping the wording in one pure module means the block label, its tooltip,
+ * the banner above the grid, the legend and the "on call right now" card cannot
+ * describe the same substitution three different ways — and it means all of
+ * them are testable without mounting a calendar.
+ */
+
+export interface OverrideUserDisplayInfo {
+  name: string;
+  email: string;
+}
+
+/*
+ * The marker prefixed to an overridden block's label. A week-view column is
+ * often too narrow for a name, let alone two, so the FIRST characters are the
+ * only ones guaranteed to survive - which is why the cue that this block is a
+ * substitution goes at the very front rather than in a trailing suffix.
+ */
+export const OVERRIDE_TITLE_MARKER: string = "⇄";
+
+/*
+ * The class the calendar puts on an overridden block. Defined here rather than
+ * inline at the call site so the stylesheet rule
+ * (.oneuptime-calendar-event--override in Common/UI/Components/Calendar/
+ * Calendar.css) and the code that asks for it are greppable from each other.
+ */
+export const OVERRIDE_EVENT_CLASS_NAME: string =
+  "oneuptime-calendar-event--override";
+
+// Shown on the label/legend when a user has no name or email loaded.
+export const UNKNOWN_USER_LABEL: string = "Unknown user";
+
+export function getUserDisplayName(
+  info: OverrideUserDisplayInfo | undefined,
+): string {
+  if (!info) {
+    return UNKNOWN_USER_LABEL;
+  }
+  return info.name || info.email || UNKNOWN_USER_LABEL;
+}
+
+// "Alice Scheduled (alice@example.com)" when both are known.
+export function formatUserLabel(
+  info: OverrideUserDisplayInfo | undefined,
+): string {
+  if (!info) {
+    return UNKNOWN_USER_LABEL;
+  }
+  if (info.name && info.email) {
+    return `${info.name} (${info.email})`;
+  }
+  return info.name || info.email || UNKNOWN_USER_LABEL;
+}
+
+/*
+ * Whether an override applies through every policy or through exactly one.
+ *
+ * This is the difference the user themselves chose when they created it: from
+ * the project's On-Call Duty > User Overrides page (global) or from a single
+ * policy's own User Overrides tab (scoped). A screen that shows the
+ * substitution without the scope leaves the reader unable to answer "will this
+ * cover the page I actually care about?", which for a policy-scoped override is
+ * frequently no.
+ */
+export enum OverrideScopeKind {
+  Global = "Global",
+  Policy = "Policy",
+}
+
+export interface OverrideScopeDescription {
+  kind: OverrideScopeKind;
+  // Short enough for a pill: "Global override", "Only for Database On-Call".
+  label: string;
+  // A full sentence for tooltips and help text.
+  detail: string;
+}
+
+export function describeOverrideScope(data: {
+  onCallDutyPolicyId?: string | null | undefined;
+  policyName?: string | undefined;
+}): OverrideScopeDescription {
+  if (!data.onCallDutyPolicyId) {
+    return {
+      kind: OverrideScopeKind.Global,
+      label: "Global override",
+      detail:
+        "This is a global override, so it applies to every on-call policy that escalates to this schedule.",
+    };
+  }
+
+  /*
+   * The name is fetched alongside the override, but a policy the viewer cannot
+   * read (or one deleted between the two reads) leaves it blank. Say
+   * "policy-scoped" rather than inventing a name or, worse, falling back to
+   * "global" - claiming wider coverage than exists is the one error here that
+   * could send somebody to bed expecting a page that never comes.
+   */
+  if (!data.policyName) {
+    return {
+      kind: OverrideScopeKind.Policy,
+      label: "Policy override",
+      detail:
+        "This override is scoped to one on-call policy, so it only re-routes alerts escalating through that policy.",
+    };
+  }
+
+  return {
+    kind: OverrideScopeKind.Policy,
+    label: `Only for ${data.policyName}`,
+    detail: `This override is scoped to the ${data.policyName} policy, so it only re-routes alerts escalating through ${data.policyName}.`,
+  };
+}
+
+/*
+ * The label painted on an overridden calendar block.
+ *
+ * The substitute comes first because the block's primary job is still "who is
+ * on call in this slot", and that is them. What follows says whose slot it is.
+ */
+export function formatOverrideEventTitle(data: {
+  substituteName: string;
+  originalName: string;
+}): string {
+  return `${OVERRIDE_TITLE_MARKER} ${data.substituteName} (covering ${data.originalName})`;
+}
+
+/*
+ * The hover text for an overridden block. Multi-line on purpose: this is where
+ * a reader goes when the block itself is too narrow to have told them anything,
+ * so it repeats the whole substitution rather than assuming the label was read.
+ */
+export function buildOverrideEventTooltip(data: {
+  substituteName: string;
+  originalName: string;
+  overrideStartsAt: Date;
+  overrideEndsAt: Date;
+  scope: OverrideScopeDescription;
+  timezone?: string | undefined;
+}): string {
+  return [
+    `Override: ${data.originalName} → ${data.substituteName}`,
+    `Alerts that would page ${data.originalName} go to ${data.substituteName}.`,
+    `Override window: ${formatShiftInstant(
+      data.overrideStartsAt,
+      data.timezone,
+    )} → ${formatShiftInstant(data.overrideEndsAt, data.timezone)}`,
+    data.scope.detail,
+  ].join("\n");
+}
+
+// The label for a block with nobody substituted in - an ordinary shift.
+export function buildPlainEventTooltip(data: {
+  userLabel: string;
+  start: Date;
+  end: Date;
+  timezone?: string | undefined;
+}): string {
+  return [
+    `On call: ${data.userLabel}`,
+    `${formatShiftInstant(data.start, data.timezone)} → ${formatShiftInstant(
+      data.end,
+      data.timezone,
+    )}`,
+  ].join("\n");
+}
+
+/*
+ * One row of the "Active overrides" panel: the whole substitution stated once,
+ * in the order the reader asks it - who was overridden, who is being paged
+ * instead, for how long, and under what scope.
+ */
+export interface OverrideSummaryRow {
+  key: string;
+  originalUserId: string;
+  originalName: string;
+  substituteUserId: string;
+  substituteName: string;
+  startsAt: Date;
+  endsAt: Date;
+  scope: OverrideScopeDescription;
+  // True when the override is in force at the instant the panel was built.
+  isActiveNow: boolean;
+}
+
+/*
+ * Turn the fetched override records into panel rows, newest-starting first
+ * among the ones already running.
+ *
+ * Records whose window has entirely passed are dropped: the panel sits above a
+ * calendar the reader can navigate into the past, but its claim is about what
+ * is in force, and listing a finished substitution there would read as one that
+ * still applies.
+ */
+export function buildOverrideSummaryRows(data: {
+  records: Array<UserOverrideRecord>;
+  userInfoById: Dictionary<OverrideUserDisplayInfo>;
+  policyNameById: Dictionary<string>;
+  now: Date;
+}): Array<OverrideSummaryRow> {
+  const rows: Array<OverrideSummaryRow> = [];
+
+  for (const record of data.records) {
+    if (OneUptimeDate.isOnOrBefore(record.endsAt, data.now)) {
+      continue;
+    }
+
+    const policyId: string = record.onCallDutyPolicyId || "";
+
+    rows.push({
+      key: `${record.overrideUserId}-${record.routeAlertsToUserId}-${record.startsAt.getTime()}-${record.endsAt.getTime()}-${policyId}`,
+      originalUserId: record.overrideUserId,
+      originalName: getUserDisplayName(
+        data.userInfoById[record.overrideUserId],
+      ),
+      substituteUserId: record.routeAlertsToUserId,
+      substituteName: getUserDisplayName(
+        data.userInfoById[record.routeAlertsToUserId],
+      ),
+      startsAt: record.startsAt,
+      endsAt: record.endsAt,
+      scope: describeOverrideScope({
+        onCallDutyPolicyId: record.onCallDutyPolicyId,
+        ...(policyId && data.policyNameById[policyId]
+          ? { policyName: data.policyNameById[policyId]! }
+          : {}),
+      }),
+      isActiveNow:
+        OneUptimeDate.isOnOrBefore(record.startsAt, data.now) &&
+        OneUptimeDate.isAfter(record.endsAt, data.now),
+    });
+  }
+
+  /*
+   * In force first, then by start. A reader scanning this panel during an
+   * incident wants the substitution that is live right now, not the one booked
+   * for next month, and sorting by start alone would bury it under any override
+   * that happens to have started earlier.
+   */
+  return rows.sort((a: OverrideSummaryRow, b: OverrideSummaryRow) => {
+    if (a.isActiveNow !== b.isActiveNow) {
+      return a.isActiveNow ? -1 : 1;
+    }
+    return a.startsAt.getTime() - b.startsAt.getTime();
+  });
+}
+
+/*
+ * "Covering Alice Scheduled" / "Covering Alice Scheduled and 2 others" for the
+ * calendar legend, where one substitute can stand in for several people and the
+ * chip has room for roughly one name.
+ */
+export function describeSubstituteCoverage(data: {
+  substituteUserId: string;
+  records: Array<UserOverrideRecord>;
+  userInfoById: Dictionary<OverrideUserDisplayInfo>;
+}): string {
+  const names: Array<string> = [];
+  const seen: Set<string> = new Set<string>();
+
+  for (const record of data.records) {
+    if (record.routeAlertsToUserId !== data.substituteUserId) {
+      continue;
+    }
+    if (seen.has(record.overrideUserId)) {
+      continue;
+    }
+    seen.add(record.overrideUserId);
+    names.push(getUserDisplayName(data.userInfoById[record.overrideUserId]));
+  }
+
+  if (names.length === 0) {
+    // A substitute with no record behind them should not exist; say the least.
+    return "Covering";
+  }
+
+  if (names.length === 1) {
+    return `Covering ${names[0]}`;
+  }
+
+  if (names.length === 2) {
+    return `Covering ${names[0]} and ${names[1]}`;
+  }
+
+  return `Covering ${names[0]} and ${names.length - 1} others`;
+}
+
+/*
+ * The one-line explanation shown beside the "on call right now" name and on
+ * each upcoming hand-off: who this person is standing in for.
+ */
+export function describeShiftOverride(data: {
+  override: OverrideEventMeta;
+  userInfoById: Dictionary<OverrideUserDisplayInfo>;
+  policyNameById: Dictionary<string>;
+}): {
+  originalName: string;
+  scope: OverrideScopeDescription;
+  // "Covering for Alice Scheduled"
+  coveringLabel: string;
+} {
+  const originalName: string = getUserDisplayName(
+    data.userInfoById[data.override.originalUserId],
+  );
+
+  const policyId: string = data.override.onCallDutyPolicyId || "";
+
+  const scope: OverrideScopeDescription = describeOverrideScope({
+    onCallDutyPolicyId: data.override.onCallDutyPolicyId,
+    ...(policyId && data.policyNameById[policyId]
+      ? { policyName: data.policyNameById[policyId]! }
+      : {}),
+  });
+
+  return {
+    originalName,
+    scope,
+    coveringLabel: `Covering for ${originalName}`,
+  };
+}

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/ScheduleOverrides.ts
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/ScheduleOverrides.ts
@@ -59,6 +59,16 @@ export interface ScheduleOverrideResolution {
   attachedPolicyCount: number;
   // userId -> display info, for substitutes and the users they are covering.
   userInfoById: Dictionary<OverrideUserInfo>;
+  /*
+   * policyId -> policy name, for every POLICY-SCOPED override in `records`.
+   *
+   * A scoped override only re-routes alerts escalating through its own policy,
+   * which is a materially different promise from a global one - so a surface
+   * that shows the substitution has to be able to name the policy it is limited
+   * to. Absent for a policy the viewer cannot read; callers fall back to the
+   * unnamed "policy override" wording rather than claiming global reach.
+   */
+  policyNameById: Dictionary<string>;
 }
 
 /*
@@ -147,6 +157,10 @@ async function fetchOverrides(params: {
         overrideUserId: true,
         routeAlertsToUserId: true,
         onCallDutyPolicyId: true,
+        // Named on screen so a scoped override can say WHICH policy it covers.
+        onCallDutyPolicy: {
+          name: true,
+        },
         overrideUser: {
           name: true,
           email: true,
@@ -179,6 +193,7 @@ const NOTHING_TO_RESOLVE: ScheduleOverrideResolution = {
   policyContextState: PolicyContextState.PolicyAgnostic,
   attachedPolicyCount: 0,
   userInfoById: {},
+  policyNameById: {},
 };
 
 /*
@@ -294,7 +309,16 @@ export function useScheduleUserOverrides(
       }
 
       const userInfoById: Dictionary<OverrideUserInfo> = {};
+      const policyNameById: Dictionary<string> = {};
       for (const override of overrides) {
+        const overridePolicyId: string =
+          override.onCallDutyPolicyId?.toString() || "";
+        const overridePolicyName: string =
+          override.onCallDutyPolicy?.name?.toString() || "";
+        if (overridePolicyId && overridePolicyName) {
+          policyNameById[overridePolicyId] = overridePolicyName;
+        }
+
         const overriddenId: string = override.overrideUserId?.toString() || "";
         const substituteId: string =
           override.routeAlertsToUserId?.toString() || "";
@@ -342,6 +366,7 @@ export function useScheduleUserOverrides(
           : PolicyContextState.PolicyAgnostic,
         attachedPolicyCount,
         userInfoById,
+        policyNameById,
       });
     };
 

--- a/Common/Tests/App/Dashboard/OnCallLayerCardOverrides.test.tsx
+++ b/Common/Tests/App/Dashboard/OnCallLayerCardOverrides.test.tsx
@@ -170,10 +170,16 @@ describe("Layer card names the substitute during an override (issue #3411)", () 
     const line: string = getOnCallNowLineText();
     expect(line).toContain(USER_A_NAME);
     expect(line).not.toContain(USER_B_NAME);
-    expect(line).not.toContain("covering via override");
+    expect(line).not.toContain("covering");
   });
 
-  test("during an override the SUBSTITUTE is named, and marked as covering", () => {
+  test("during an override the SUBSTITUTE is named, and says who they cover for", () => {
+    /*
+     * The line used to read "(covering via override)", which told the reader
+     * the one thing the unfamiliar name already told them - that this person is
+     * not in the rotation - and withheld the one thing it did not: whose shift
+     * they have. Naming the overridden user is the point.
+     */
     renderCard({
       overrides: [activeGlobalOverride()],
       overrideUserInfo: SUBSTITUTE_INFO,
@@ -181,7 +187,9 @@ describe("Layer card names the substitute during an override (issue #3411)", () 
 
     const line: string = getOnCallNowLineText();
     expect(line).toContain(USER_B_NAME);
-    expect(line).toContain("covering via override");
+    expect(line.toLowerCase()).toContain(
+      `covering for ${USER_A_NAME}`.toLowerCase(),
+    );
     expect(line).not.toContain(`${USER_A_NAME} on call now`);
   });
 
@@ -241,20 +249,29 @@ describe("Rotation summary marks a covered turn (issue #3411)", () => {
     );
   }
 
-  test("the covered turn is attributed to the substitute and tagged Covering", () => {
+  test("the covered turn is attributed to the substitute and names who they cover for", () => {
     renderSummary({
       overrides: [activeGlobalOverride()],
       overrideUserInfo: SUBSTITUTE_INFO,
     });
 
     expect(screen.getAllByText(USER_B_NAME).length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Covering").length).toBeGreaterThan(0);
+
+    const pills: Array<HTMLElement> = screen.getAllByTestId(
+      "rotation-covering-pill",
+    );
+    expect(pills.length).toBeGreaterThan(0);
+    /*
+     * The turn carries the override that produced it, so the pill can name the
+     * person being covered rather than saying the bare word "Covering".
+     */
+    expect(pills[0]!.textContent).toBe(`Covering for ${USER_A_NAME}`);
   });
 
-  test("without an override no turn is tagged Covering", () => {
+  test("without an override no turn is tagged as covering", () => {
     renderSummary({ overrides: [], overrideUserInfo: {} });
 
-    expect(screen.queryByText("Covering")).toBeNull();
+    expect(screen.queryByTestId("rotation-covering-pill")).toBeNull();
   });
 
   /*

--- a/Common/Tests/App/Dashboard/OnCallOverridePresentation.test.ts
+++ b/Common/Tests/App/Dashboard/OnCallOverridePresentation.test.ts
@@ -1,0 +1,496 @@
+import Dictionary from "../../../Types/Dictionary";
+import OneUptimeDate from "../../../Types/Date";
+import {
+  OverrideEventMeta,
+  UserOverrideRecord,
+} from "../../../Types/OnCallDutyPolicy/UserOverrideUtil";
+import {
+  OVERRIDE_TITLE_MARKER,
+  OverrideScopeKind,
+  OverrideSummaryRow,
+  OverrideUserDisplayInfo,
+  UNKNOWN_USER_LABEL,
+  buildOverrideEventTooltip,
+  buildOverrideSummaryRows,
+  describeOverrideScope,
+  describeShiftOverride,
+  describeSubstituteCoverage,
+  formatOverrideEventTitle,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/OverridePresentation";
+
+/*
+ * The wording the on-call schedule screens use for a substitution.
+ *
+ * These are pinned rather than left to the components because the whole
+ * complaint they answer is a wording one: the calendar named the substitute and
+ * stopped, so a reader could not tell an override from an ordinary shift, nor
+ * see whose shift had been taken, nor whether the swap reached the policy they
+ * were worried about. Each test below names the specific misreading it prevents.
+ */
+
+const POLICY_ID: string = "policy-1";
+const OTHER_POLICY_ID: string = "policy-2";
+
+const ALICE: string = "user-alice";
+const BOB: string = "user-bob";
+const CAROL: string = "user-carol";
+const DAN: string = "user-dan";
+
+const USERS: Dictionary<OverrideUserDisplayInfo> = {
+  [ALICE]: { name: "Alice Scheduled", email: "alice@example.com" },
+  [BOB]: { name: "Bob Covering", email: "bob@example.com" },
+  [CAROL]: { name: "Carol Elsewhere", email: "carol@example.com" },
+  [DAN]: { name: "", email: "dan@example.com" },
+};
+
+const POLICY_NAMES: Dictionary<string> = {
+  [POLICY_ID]: "Database On-Call",
+};
+
+function at(hours: number): Date {
+  return new Date(2026, 0, 1, hours, 0, 0, 0);
+}
+
+function record(data: {
+  from: string;
+  to: string;
+  startHour: number;
+  endHour: number;
+  policyId?: string | null | undefined;
+}): UserOverrideRecord {
+  return {
+    overrideUserId: data.from,
+    routeAlertsToUserId: data.to,
+    startsAt: at(data.startHour),
+    endsAt: at(data.endHour),
+    onCallDutyPolicyId: data.policyId ?? null,
+  };
+}
+
+function meta(data: {
+  from: string;
+  to: string;
+  policyId?: string | null | undefined;
+}): OverrideEventMeta {
+  return {
+    isOverride: true,
+    originalUserId: data.from,
+    overrideUserId: data.to,
+    overrideStartsAt: at(9),
+    overrideEndsAt: at(17),
+    onCallDutyPolicyId: data.policyId ?? null,
+  };
+}
+
+describe("describeOverrideScope", () => {
+  test("a global override says so, and says it reaches every policy", () => {
+    const scope: ReturnType<typeof describeOverrideScope> =
+      describeOverrideScope({ onCallDutyPolicyId: null });
+
+    expect(scope.kind).toBe(OverrideScopeKind.Global);
+    expect(scope.label).toBe("Global override");
+    expect(scope.detail).toContain("every on-call policy");
+  });
+
+  test("undefined is treated as global, exactly as null is", () => {
+    /*
+     * The record type allows string | null | undefined and the database returns
+     * whichever the write path happened to produce. Two spellings of "no
+     * policy" that describe themselves differently would put two different
+     * sentences on two screens looking at the same override.
+     */
+    expect(describeOverrideScope({}).kind).toBe(OverrideScopeKind.Global);
+    expect(describeOverrideScope({ onCallDutyPolicyId: undefined })).toEqual(
+      describeOverrideScope({ onCallDutyPolicyId: null }),
+    );
+  });
+
+  test("a scoped override names the policy it is limited to", () => {
+    const scope: ReturnType<typeof describeOverrideScope> =
+      describeOverrideScope({
+        onCallDutyPolicyId: POLICY_ID,
+        policyName: "Database On-Call",
+      });
+
+    expect(scope.kind).toBe(OverrideScopeKind.Policy);
+    expect(scope.label).toBe("Only for Database On-Call");
+    expect(scope.detail).toContain("Database On-Call");
+  });
+
+  test("a scoped override with an unreadable policy stays scoped, never global", () => {
+    /*
+     * The failure that matters. If a missing policy name fell back to the
+     * global wording, a reader would be told their cover applies everywhere
+     * when it applies to one policy - and would go to bed expecting a page that
+     * their other three policies will send to the person who is away.
+     */
+    const scope: ReturnType<typeof describeOverrideScope> =
+      describeOverrideScope({ onCallDutyPolicyId: POLICY_ID });
+
+    expect(scope.kind).toBe(OverrideScopeKind.Policy);
+    expect(scope.label).toBe("Policy override");
+    expect(scope.label).not.toContain("Global");
+    expect(scope.detail).toContain("one on-call policy");
+  });
+});
+
+describe("formatOverrideEventTitle", () => {
+  test("leads with the swap marker, then the substitute, then whose shift it was", () => {
+    const title: string = formatOverrideEventTitle({
+      substituteName: "Bob Covering",
+      originalName: "Alice Scheduled",
+    });
+
+    expect(title).toBe("⇄ Bob Covering (covering Alice Scheduled)");
+  });
+
+  test("the marker is the first character, so it survives truncation", () => {
+    /*
+     * A week-view column clips the label from the right. Any cue placed after
+     * the names is the first thing to disappear on exactly the narrow screens
+     * where the reader most needs it, which is why the marker is a prefix.
+     */
+    const title: string = formatOverrideEventTitle({
+      substituteName: "Bob Covering",
+      originalName: "Alice Scheduled",
+    });
+
+    expect(title.startsWith(OVERRIDE_TITLE_MARKER)).toBe(true);
+    expect(title.slice(0, 6)).toContain(OVERRIDE_TITLE_MARKER);
+  });
+
+  test("the substitute is named before the person they are covering", () => {
+    const title: string = formatOverrideEventTitle({
+      substituteName: "Bob Covering",
+      originalName: "Alice Scheduled",
+    });
+
+    /*
+     * Order carries meaning here: the block's job is still "who is on call in
+     * this slot". Reversing it would read as Alice being on call with Bob as a
+     * footnote - the precise misreading that gets the wrong person called.
+     */
+    expect(title.indexOf("Bob Covering")).toBeLessThan(
+      title.indexOf("Alice Scheduled"),
+    );
+  });
+});
+
+describe("buildOverrideEventTooltip", () => {
+  const tooltip: string = buildOverrideEventTooltip({
+    substituteName: "Bob Covering",
+    originalName: "Alice Scheduled",
+    overrideStartsAt: at(9),
+    overrideEndsAt: at(17),
+    scope: describeOverrideScope({
+      onCallDutyPolicyId: POLICY_ID,
+      policyName: "Database On-Call",
+    }),
+    timezone: "UTC",
+  });
+
+  test("states the direction of the swap in both arrow and prose form", () => {
+    expect(tooltip).toContain("Override: Alice Scheduled → Bob Covering");
+    expect(tooltip).toContain(
+      "Alerts that would page Alice Scheduled go to Bob Covering.",
+    );
+  });
+
+  test("carries the override's OWN window, not the block's", () => {
+    /*
+     * A block is the intersection of a shift and an override, so its edges are
+     * usually not the override's. Showing only the block's window would let a
+     * reader think the cover ends when this shift does.
+     */
+    expect(tooltip).toContain("Override window:");
+    expect(tooltip).toContain("9:00 AM");
+    expect(tooltip).toContain("5:00 PM");
+  });
+
+  test("carries the scope, so hovering answers 'does this cover my policy'", () => {
+    expect(tooltip).toContain("Database On-Call");
+  });
+
+  test("is multi-line, since the native tooltip is the fallback for a clipped label", () => {
+    expect(tooltip.split("\n").length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe("buildOverrideSummaryRows", () => {
+  test("states both parties, the window and the scope for each override", () => {
+    const rows: Array<OverrideSummaryRow> = buildOverrideSummaryRows({
+      records: [
+        record({
+          from: ALICE,
+          to: BOB,
+          startHour: 9,
+          endHour: 17,
+          policyId: POLICY_ID,
+        }),
+      ],
+      userInfoById: USERS,
+      policyNameById: POLICY_NAMES,
+      now: at(12),
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.originalName).toBe("Alice Scheduled");
+    expect(rows[0]!.substituteName).toBe("Bob Covering");
+    expect(rows[0]!.startsAt).toEqual(at(9));
+    expect(rows[0]!.endsAt).toEqual(at(17));
+    expect(rows[0]!.scope.label).toBe("Only for Database On-Call");
+    expect(rows[0]!.isActiveNow).toBe(true);
+  });
+
+  test("drops overrides whose window has already ended", () => {
+    /*
+     * The panel's claim is about what is in force. A finished substitution
+     * listed there reads as a live one, and the calendar underneath can be
+     * navigated into the past without changing what the panel means.
+     */
+    const rows: Array<OverrideSummaryRow> = buildOverrideSummaryRows({
+      records: [record({ from: ALICE, to: BOB, startHour: 1, endHour: 5 })],
+      userInfoById: USERS,
+      policyNameById: {},
+      now: at(12),
+    });
+
+    expect(rows).toHaveLength(0);
+  });
+
+  test("keeps a future override, marked as not yet in force", () => {
+    const rows: Array<OverrideSummaryRow> = buildOverrideSummaryRows({
+      records: [record({ from: ALICE, to: BOB, startHour: 20, endHour: 22 })],
+      userInfoById: USERS,
+      policyNameById: {},
+      now: at(12),
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.isActiveNow).toBe(false);
+  });
+
+  test("an override that is in force sorts above one that merely started earlier", () => {
+    /*
+     * The panel is read during an incident. Sorting by start alone buries the
+     * live substitution under a long-running future one, which is the single
+     * row the reader actually came for.
+     */
+    const rows: Array<OverrideSummaryRow> = buildOverrideSummaryRows({
+      records: [
+        // starts earlier, but has not begun relative to `now`... it has ended.
+        record({ from: ALICE, to: CAROL, startHour: 18, endHour: 20 }),
+        record({ from: ALICE, to: BOB, startHour: 11, endHour: 13 }),
+      ],
+      userInfoById: USERS,
+      policyNameById: {},
+      now: at(12),
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.substituteName).toBe("Bob Covering");
+    expect(rows[0]!.isActiveNow).toBe(true);
+    expect(rows[1]!.substituteName).toBe("Carol Elsewhere");
+  });
+
+  test("an override boundary is half-open: it stops being in force at its end instant", () => {
+    const rows: Array<OverrideSummaryRow> = buildOverrideSummaryRows({
+      records: [record({ from: ALICE, to: BOB, startHour: 9, endHour: 12 })],
+      userInfoById: USERS,
+      policyNameById: {},
+      now: at(12),
+    });
+
+    // Ends exactly at `now`, so it is over - and therefore not listed at all.
+    expect(rows).toHaveLength(0);
+  });
+
+  test("a user with no name falls back to their email, never to a blank", () => {
+    const rows: Array<OverrideSummaryRow> = buildOverrideSummaryRows({
+      records: [record({ from: ALICE, to: DAN, startHour: 9, endHour: 17 })],
+      userInfoById: USERS,
+      policyNameById: {},
+      now: at(12),
+    });
+
+    expect(rows[0]!.substituteName).toBe("dan@example.com");
+  });
+
+  test("a user missing from the map is named, not silently blank", () => {
+    const rows: Array<OverrideSummaryRow> = buildOverrideSummaryRows({
+      records: [
+        record({ from: ALICE, to: "user-nobody", startHour: 9, endHour: 17 }),
+      ],
+      userInfoById: USERS,
+      policyNameById: {},
+      now: at(12),
+    });
+
+    expect(rows[0]!.substituteName).toBe(UNKNOWN_USER_LABEL);
+  });
+
+  test("two overrides differing only in scope get distinct keys", () => {
+    /*
+     * Same pair, same window, one global and one scoped, is a legal
+     * configuration. Colliding keys would make React drop one row - hiding a
+     * substitution the reader has to know about.
+     */
+    const rows: Array<OverrideSummaryRow> = buildOverrideSummaryRows({
+      records: [
+        record({ from: ALICE, to: BOB, startHour: 9, endHour: 17 }),
+        record({
+          from: ALICE,
+          to: BOB,
+          startHour: 9,
+          endHour: 17,
+          policyId: POLICY_ID,
+        }),
+      ],
+      userInfoById: USERS,
+      policyNameById: POLICY_NAMES,
+      now: at(12),
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.key).not.toBe(rows[1]!.key);
+  });
+});
+
+describe("describeSubstituteCoverage", () => {
+  test("names the person being covered, not just the fact of covering", () => {
+    expect(
+      describeSubstituteCoverage({
+        substituteUserId: BOB,
+        records: [record({ from: ALICE, to: BOB, startHour: 9, endHour: 17 })],
+        userInfoById: USERS,
+      }),
+    ).toBe("Covering Alice Scheduled");
+  });
+
+  test("two people covered are both named", () => {
+    expect(
+      describeSubstituteCoverage({
+        substituteUserId: BOB,
+        records: [
+          record({ from: ALICE, to: BOB, startHour: 9, endHour: 13 }),
+          record({ from: CAROL, to: BOB, startHour: 13, endHour: 17 }),
+        ],
+        userInfoById: USERS,
+      }),
+    ).toBe("Covering Alice Scheduled and Carol Elsewhere");
+  });
+
+  test("three or more collapse to a count rather than overflowing the chip", () => {
+    expect(
+      describeSubstituteCoverage({
+        substituteUserId: BOB,
+        records: [
+          record({ from: ALICE, to: BOB, startHour: 9, endHour: 11 }),
+          record({ from: CAROL, to: BOB, startHour: 11, endHour: 13 }),
+          record({ from: DAN, to: BOB, startHour: 13, endHour: 17 }),
+        ],
+        userInfoById: USERS,
+      }),
+    ).toBe("Covering Alice Scheduled and 2 others");
+  });
+
+  test("the same person covered twice is counted once", () => {
+    expect(
+      describeSubstituteCoverage({
+        substituteUserId: BOB,
+        records: [
+          record({ from: ALICE, to: BOB, startHour: 9, endHour: 11 }),
+          record({ from: ALICE, to: BOB, startHour: 14, endHour: 17 }),
+        ],
+        userInfoById: USERS,
+      }),
+    ).toBe("Covering Alice Scheduled");
+  });
+
+  test("ignores overrides routed to somebody else", () => {
+    expect(
+      describeSubstituteCoverage({
+        substituteUserId: BOB,
+        records: [
+          record({ from: ALICE, to: CAROL, startHour: 9, endHour: 17 }),
+        ],
+        userInfoById: USERS,
+      }),
+    ).toBe("Covering");
+  });
+});
+
+describe("describeShiftOverride", () => {
+  test("produces the covering sentence and the scope for a shift", () => {
+    const described: ReturnType<typeof describeShiftOverride> =
+      describeShiftOverride({
+        override: meta({ from: ALICE, to: BOB, policyId: POLICY_ID }),
+        userInfoById: USERS,
+        policyNameById: POLICY_NAMES,
+      });
+
+    expect(described.originalName).toBe("Alice Scheduled");
+    expect(described.coveringLabel).toBe("Covering for Alice Scheduled");
+    expect(described.scope.label).toBe("Only for Database On-Call");
+  });
+
+  test("a global override reads as global", () => {
+    const described: ReturnType<typeof describeShiftOverride> =
+      describeShiftOverride({
+        override: meta({ from: ALICE, to: BOB }),
+        userInfoById: USERS,
+        policyNameById: POLICY_NAMES,
+      });
+
+    expect(described.scope.kind).toBe(OverrideScopeKind.Global);
+  });
+
+  test("a policy id with no name in the map does not borrow another policy's name", () => {
+    const described: ReturnType<typeof describeShiftOverride> =
+      describeShiftOverride({
+        override: meta({ from: ALICE, to: BOB, policyId: OTHER_POLICY_ID }),
+        userInfoById: USERS,
+        policyNameById: POLICY_NAMES,
+      });
+
+    expect(described.scope.label).toBe("Policy override");
+    expect(described.scope.label).not.toContain("Database On-Call");
+  });
+});
+
+describe("timezone handling", () => {
+  test("the tooltip renders the override window in the zone it is given", () => {
+    /*
+     * The window is an absolute instant; which wall clock it is shown against
+     * is the reader's "view as" choice. Two viewers looking at the same
+     * override must each see their own zone, or one of them mis-plans their
+     * evening around the other's clock.
+     */
+    const instant: Date = OneUptimeDate.getInstantFromLocalWallClockInTimezone(
+      new Date(2026, 0, 1, 9, 0, 0),
+      "UTC",
+    );
+
+    const utc: string = buildOverrideEventTooltip({
+      substituteName: "Bob Covering",
+      originalName: "Alice Scheduled",
+      overrideStartsAt: instant,
+      overrideEndsAt: instant,
+      scope: describeOverrideScope({}),
+      timezone: "UTC",
+    });
+
+    const tokyo: string = buildOverrideEventTooltip({
+      substituteName: "Bob Covering",
+      originalName: "Alice Scheduled",
+      overrideStartsAt: instant,
+      overrideEndsAt: instant,
+      scope: describeOverrideScope({}),
+      timezone: "Asia/Tokyo",
+    });
+
+    expect(utc).toContain("9:00 AM");
+    expect(tokyo).toContain("6:00 PM");
+    expect(utc).not.toEqual(tokyo);
+  });
+});

--- a/Common/Tests/App/Dashboard/OnCallScheduleOverrideClarity.test.tsx
+++ b/Common/Tests/App/Dashboard/OnCallScheduleOverrideClarity.test.tsx
@@ -1,0 +1,677 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * The schedule calendar has to say that a shift is COVERED, not merely who is
+ * covering it.
+ *
+ * Before this, an overridden window was relabelled to the substitute and drawn
+ * in the substitute's own colour - a block indistinguishable from an ordinary
+ * rotation shift. The screen was correct and unreadable at the same time: it
+ * named the right person to page, while giving the reader no way to learn that
+ * the roster says somebody else, whose shift it was, when the substitution
+ * expires, or whether it reaches every policy or only one. Someone checking
+ * "am I covered on Thursday?" could look straight at the answer and not see it.
+ *
+ * These tests drive the real LayersPreview against a mocked ModelAPI and assert
+ * on the four surfaces that now carry the substitution: the calendar block
+ * itself (label, stripe colour, class and tooltip), the overrides card above
+ * the grid, the legend, and the "on call right now" card. Each is checked
+ * separately, because a reader who happens to look at only one of them still
+ * has to get the whole story.
+ */
+
+const getListMock: MockFunction = getJestMockFunction();
+
+/*
+ * The arrow wrappers matter: jest.mock is hoisted above the compiled requires,
+ * so the consts above are still in their temporal dead zone when the factory
+ * body runs. Dereferencing lazily, at call time, is what works.
+ */
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: () => {
+        return {
+          toString: (): string => {
+            return PROJECT_ID;
+          },
+        };
+      },
+    },
+  };
+});
+
+/*
+ * react-big-calendar is replaced by a list that exposes the FULL event objects
+ * rather than only their titles. The visual cues under test - the accent stripe
+ * colour and the override class name - never reach the DOM as text, so a mock
+ * that rendered titles alone could not tell a block that carries them from one
+ * that does not, which is exactly the regression this file exists to catch.
+ */
+jest.mock("../../../UI/Components/Calendar/Calendar", () => {
+  return {
+    __esModule: true,
+    default: (props: any) => {
+      return (
+        <ul data-testid="calendar-events">
+          {(props.events || []).map((event: any, index: number) => {
+            return (
+              <li
+                key={index}
+                data-testid="calendar-event"
+                data-event-class={event.className || ""}
+                data-event-color={event.color || ""}
+                data-event-accent={event.accentColor || ""}
+                data-event-desc={event.desc || ""}
+              >
+                {event.title}
+              </li>
+            );
+          })}
+        </ul>
+      );
+    },
+    DefaultCalendarView: {
+      Month: "month",
+      Week: "week",
+      Day: "day",
+      Agenda: "agenda",
+    },
+  };
+});
+
+import LayersPreview from "../../../../App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayersPreview";
+import { getColorForUserId } from "../../../../App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerUserColors";
+import { OVERRIDE_EVENT_CLASS_NAME } from "../../../../App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/OverridePresentation";
+import OnCallDutyPolicy from "../../../Models/DatabaseModels/OnCallDutyPolicy";
+import OnCallDutyPolicyEscalationRuleSchedule from "../../../Models/DatabaseModels/OnCallDutyPolicyEscalationRuleSchedule";
+import OnCallDutyPolicyScheduleLayer from "../../../Models/DatabaseModels/OnCallDutyPolicyScheduleLayer";
+import OnCallDutyPolicyScheduleLayerUser from "../../../Models/DatabaseModels/OnCallDutyPolicyScheduleLayerUser";
+import OnCallDutyPolicyUserOverride from "../../../Models/DatabaseModels/OnCallDutyPolicyUserOverride";
+import User from "../../../Models/DatabaseModels/User";
+import EqualToOrNull from "../../../Types/BaseDatabase/EqualToOrNull";
+import IsNull from "../../../Types/BaseDatabase/IsNull";
+import OneUptimeDate from "../../../Types/Date";
+import Dictionary from "../../../Types/Dictionary";
+import EventInterval from "../../../Types/Events/EventInterval";
+import Recurring from "../../../Types/Events/Recurring";
+import ObjectID from "../../../Types/ObjectID";
+import RestrictionTimes, {
+  RestrictionType,
+} from "../../../Types/OnCallDutyPolicy/RestrictionTimes";
+
+const PROJECT_ID: string = "11111111-1111-4111-8111-111111111111";
+const SCHEDULE_ID: string = "22222222-2222-4222-8222-222222222222";
+const LAYER_ID: string = "33333333-3333-4333-8333-333333333333";
+const POLICY_ID: string = "44444444-4444-4444-8444-444444444444";
+
+const POLICY_NAME: string = "Database On-Call";
+
+const USER_A_ID: string = "aaaaaaaa-1111-4111-8111-111111111111";
+const USER_B_ID: string = "bbbbbbbb-2222-4222-8222-222222222222";
+
+const USER_A_NAME: string = "Alice Scheduled";
+const USER_B_NAME: string = "Bob Covering";
+
+const TIMEOUT_MS: number = 10000;
+
+function objectId(id: string): ObjectID {
+  return new ObjectID(id);
+}
+
+function makeUser(id: string, name: string): User {
+  const user: User = new User();
+  user.id = objectId(id);
+  user.name = name as any;
+  user.email = `${id}@example.com` as any;
+  return user;
+}
+
+/*
+ * One 24/7 layer, rotating daily, started well in the past, with exactly one
+ * user assigned - so "who is on call right now" has a single correct answer no
+ * matter when the suite runs, and any second name on the screen can only have
+ * come from an override.
+ */
+function makeLayer(): OnCallDutyPolicyScheduleLayer {
+  const layer: OnCallDutyPolicyScheduleLayer =
+    new OnCallDutyPolicyScheduleLayer();
+  layer.id = objectId(LAYER_ID);
+  layer.projectId = objectId(PROJECT_ID);
+  layer.onCallDutyPolicyScheduleId = objectId(SCHEDULE_ID);
+  layer.order = 1;
+  layer.name = "Primary" as any;
+
+  const now: Date = OneUptimeDate.getCurrentDate();
+  layer.startsAt = OneUptimeDate.addRemoveDays(now, -30);
+  layer.handOffTime = OneUptimeDate.addRemoveDays(now, -30);
+
+  layer.rotation = Recurring.fromJSON({
+    _type: "Recurring",
+    value: {
+      intervalType: EventInterval.Day,
+      intervalCount: { _type: "PositiveNumber", value: 1 },
+    },
+  } as any) as any;
+
+  const restrictionTimes: RestrictionTimes = new RestrictionTimes();
+  restrictionTimes.restictionType = RestrictionType.None;
+  restrictionTimes.dayRestrictionTimes = null;
+  layer.restrictionTimes = restrictionTimes as any;
+
+  return layer;
+}
+
+function makeLayerUsers(): Dictionary<
+  Array<OnCallDutyPolicyScheduleLayerUser>
+> {
+  const layerUser: OnCallDutyPolicyScheduleLayerUser =
+    new OnCallDutyPolicyScheduleLayerUser();
+  layerUser.id = objectId("66666666-6666-4666-8666-666666666666");
+  layerUser.onCallDutyPolicyScheduleLayerId = objectId(LAYER_ID);
+  layerUser.onCallDutyPolicyScheduleId = objectId(SCHEDULE_ID);
+  layerUser.projectId = objectId(PROJECT_ID);
+  layerUser.order = 1;
+  layerUser.userId = objectId(USER_A_ID);
+  layerUser.user = makeUser(USER_A_ID, USER_A_NAME);
+
+  return { [LAYER_ID]: [layerUser] };
+}
+
+interface OverrideFixture {
+  onCallDutyPolicyId: string | null;
+  policyName?: string | undefined;
+  startsAt: Date;
+  endsAt: Date;
+}
+
+function activeOverride(data: {
+  onCallDutyPolicyId: string | null;
+  policyName?: string | undefined;
+}): OverrideFixture {
+  const now: Date = OneUptimeDate.getCurrentDate();
+  return {
+    onCallDutyPolicyId: data.onCallDutyPolicyId,
+    ...(data.policyName ? { policyName: data.policyName } : {}),
+    startsAt: OneUptimeDate.addRemoveHours(now, -1),
+    endsAt: OneUptimeDate.addRemoveHours(now, 1),
+  };
+}
+
+function toModel(fixture: OverrideFixture): OnCallDutyPolicyUserOverride {
+  const model: OnCallDutyPolicyUserOverride =
+    new OnCallDutyPolicyUserOverride();
+  model.id = objectId("77777777-7777-4777-8777-777777777777");
+  model.projectId = objectId(PROJECT_ID);
+  model.overrideUserId = objectId(USER_A_ID);
+  model.routeAlertsToUserId = objectId(USER_B_ID);
+  model.startsAt = fixture.startsAt;
+  model.endsAt = fixture.endsAt;
+  model.onCallDutyPolicyId = fixture.onCallDutyPolicyId
+    ? objectId(fixture.onCallDutyPolicyId)
+    : (null as any);
+  model.overrideUser = makeUser(USER_A_ID, USER_A_NAME);
+  model.routeAlertsToUser = makeUser(USER_B_ID, USER_B_NAME);
+
+  if (fixture.policyName) {
+    const policy: OnCallDutyPolicy = new OnCallDutyPolicy();
+    policy.id = objectId(fixture.onCallDutyPolicyId!);
+    policy.name = fixture.policyName as any;
+    model.onCallDutyPolicy = policy;
+  }
+
+  return model;
+}
+
+// Stands in for the server's WHERE clause on onCallDutyPolicyId.
+function matchesPolicyQuery(
+  fixture: OverrideFixture,
+  queryValue: unknown,
+): boolean {
+  if (queryValue instanceof IsNull) {
+    return fixture.onCallDutyPolicyId === null;
+  }
+  if (queryValue instanceof EqualToOrNull) {
+    return (
+      fixture.onCallDutyPolicyId === null ||
+      fixture.onCallDutyPolicyId === queryValue.toString()
+    );
+  }
+  return true;
+}
+
+function setupApi(options: {
+  overrides: Array<OverrideFixture>;
+  attachedPolicyIds: Array<string>;
+}): void {
+  getListMock.mockImplementation((args: any) => {
+    const modelName: string = args?.modelType?.name || "";
+
+    if (modelName === "OnCallDutyPolicyUserOverride") {
+      const matched: Array<OverrideFixture> = options.overrides.filter(
+        (fixture: OverrideFixture) => {
+          return matchesPolicyQuery(fixture, args?.query?.onCallDutyPolicyId);
+        },
+      );
+      return Promise.resolve({
+        data: matched.map(toModel),
+        count: matched.length,
+        skip: 0,
+        limit: matched.length,
+      });
+    }
+
+    if (modelName === "OnCallDutyPolicyEscalationRuleSchedule") {
+      const joins: Array<OnCallDutyPolicyEscalationRuleSchedule> =
+        options.attachedPolicyIds.map((policyId: string, index: number) => {
+          const join: OnCallDutyPolicyEscalationRuleSchedule =
+            new OnCallDutyPolicyEscalationRuleSchedule();
+          join.id = objectId(
+            `8888888${index}-8888-4888-8888-888888888888`.slice(0, 36),
+          );
+          join.projectId = objectId(PROJECT_ID);
+          join.onCallDutyPolicyScheduleId = objectId(SCHEDULE_ID);
+          join.onCallDutyPolicyId = objectId(policyId);
+          return join;
+        });
+      return Promise.resolve({
+        data: joins,
+        count: joins.length,
+        skip: 0,
+        limit: joins.length,
+      });
+    }
+
+    return Promise.resolve({ data: [], count: 0, skip: 0, limit: 0 });
+  });
+}
+
+function renderPreview(): void {
+  render(
+    <LayersPreview
+      layers={[makeLayer()]}
+      allLayerUsers={makeLayerUsers()}
+      timezone="UTC"
+      onCallDutyPolicyScheduleId={objectId(SCHEDULE_ID)}
+    />,
+  );
+}
+
+// The calendar block produced by the override, once the async fetches land.
+async function findOverrideEvent(): Promise<HTMLElement> {
+  let found: HTMLElement | null = null;
+
+  await waitFor(
+    () => {
+      const match: HTMLElement | undefined = screen
+        .getAllByTestId("calendar-event")
+        .find((node: HTMLElement) => {
+          return (
+            node.getAttribute("data-event-class") === OVERRIDE_EVENT_CLASS_NAME
+          );
+        });
+      if (!match) {
+        throw new Error("no override-marked calendar event yet");
+      }
+      found = match;
+    },
+    { timeout: TIMEOUT_MS },
+  );
+
+  return found!;
+}
+
+async function findOverridesCard(): Promise<HTMLElement> {
+  return screen.findByTestId("active-overrides-card", undefined, {
+    timeout: TIMEOUT_MS,
+  });
+}
+
+describe("The calendar block says a shift is covered, not just who is on it", () => {
+  beforeEach(() => {
+    getListMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("names the substitute AND the person whose shift it was", async () => {
+    setupApi({
+      overrides: [activeOverride({ onCallDutyPolicyId: null })],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    const event: HTMLElement = await findOverrideEvent();
+
+    expect(event.textContent).toContain(USER_B_NAME);
+    expect(event.textContent).toContain(`covering ${USER_A_NAME}`);
+  });
+
+  test("leads the label with the swap marker so it survives a narrow column", async () => {
+    setupApi({
+      overrides: [activeOverride({ onCallDutyPolicyId: null })],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    const event: HTMLElement = await findOverrideEvent();
+
+    expect((event.textContent || "").trimStart().startsWith("⇄")).toBe(true);
+  });
+
+  test("carries the overridden person's colour as the block's accent stripe", async () => {
+    /*
+     * The stripe is the only cue that works when the column is too narrow for
+     * any text at all, and the only one that says WHOSE shift this was without
+     * words. It must be the OVERRIDDEN user's colour, not the substitute's -
+     * the block is already painted in the substitute's.
+     */
+    setupApi({
+      overrides: [activeOverride({ onCallDutyPolicyId: null })],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    const event: HTMLElement = await findOverrideEvent();
+
+    expect(event.getAttribute("data-event-accent")).toBe(
+      getColorForUserId(USER_A_ID),
+    );
+    expect(event.getAttribute("data-event-color")).toBe(
+      getColorForUserId(USER_B_ID),
+    );
+    expect(event.getAttribute("data-event-accent")).not.toBe(
+      event.getAttribute("data-event-color"),
+    );
+  });
+
+  test("the tooltip states the swap, its window and its scope", async () => {
+    setupApi({
+      overrides: [
+        activeOverride({
+          onCallDutyPolicyId: POLICY_ID,
+          policyName: POLICY_NAME,
+        }),
+      ],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    const event: HTMLElement = await findOverrideEvent();
+    const tooltip: string = event.getAttribute("data-event-desc") || "";
+
+    expect(tooltip).toContain(`Override: ${USER_A_NAME} → ${USER_B_NAME}`);
+    expect(tooltip).toContain(
+      `Alerts that would page ${USER_A_NAME} go to ${USER_B_NAME}.`,
+    );
+    expect(tooltip).toContain("Override window:");
+    expect(tooltip).toContain(POLICY_NAME);
+  });
+
+  test("an ordinary shift gets no override class, stripe or covering wording", async () => {
+    /*
+     * The other half of the contract. A marker on every block would be no
+     * marker at all, so the plain segments either side of the override window
+     * must stay plain.
+     */
+    setupApi({
+      overrides: [activeOverride({ onCallDutyPolicyId: null })],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    await findOverrideEvent();
+
+    const plain: Array<HTMLElement> = screen
+      .getAllByTestId("calendar-event")
+      .filter((node: HTMLElement) => {
+        return node.getAttribute("data-event-class") === "";
+      });
+
+    expect(plain.length).toBeGreaterThan(0);
+    for (const node of plain) {
+      expect(node.getAttribute("data-event-accent")).toBe("");
+      expect(node.textContent).not.toContain("covering");
+      expect(node.textContent).not.toContain("⇄");
+    }
+  });
+
+  test("a schedule with no overrides marks nothing and shows no overrides card", async () => {
+    setupApi({ overrides: [], attachedPolicyIds: [POLICY_ID] });
+    renderPreview();
+
+    await waitFor(
+      () => {
+        expect(screen.getAllByTestId("calendar-event").length).toBeGreaterThan(
+          0,
+        );
+      },
+      { timeout: TIMEOUT_MS },
+    );
+
+    for (const node of screen.getAllByTestId("calendar-event")) {
+      expect(node.getAttribute("data-event-class")).toBe("");
+    }
+    expect(screen.queryByTestId("active-overrides-card")).toBeNull();
+    expect(screen.queryByTestId("legend-override-key")).toBeNull();
+  });
+});
+
+describe("The overrides card states the substitution in full", () => {
+  beforeEach(() => {
+    getListMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("names both parties and labels which is which", async () => {
+    /*
+     * "Alice -> Bob" on its own still requires the reader to know which way an
+     * override runs. Getting that backwards means calling the person who is
+     * away, so both sides are labelled in words.
+     */
+    setupApi({
+      overrides: [activeOverride({ onCallDutyPolicyId: null })],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    const card: HTMLElement = await findOverridesCard();
+    const row: HTMLElement = within(card).getByTestId("active-override-row");
+
+    expect(row.textContent).toContain(USER_A_NAME);
+    expect(row.textContent).toContain("Overridden");
+    expect(row.textContent).toContain(USER_B_NAME);
+    expect(row.textContent).toContain("Alerts go here");
+  });
+
+  test("marks an override that is running right now", async () => {
+    setupApi({
+      overrides: [activeOverride({ onCallDutyPolicyId: null })],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    const card: HTMLElement = await findOverridesCard();
+    expect(card.textContent).toContain("In force now");
+  });
+
+  test("a GLOBAL override is labelled as reaching every policy", async () => {
+    setupApi({
+      overrides: [activeOverride({ onCallDutyPolicyId: null })],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    const card: HTMLElement = await findOverridesCard();
+    const pill: HTMLElement = within(card).getByTestId("override-scope-pill");
+
+    expect(pill.textContent).toContain("Global override");
+    expect(pill.getAttribute("title")).toContain("every on-call policy");
+  });
+
+  test("a POLICY-SCOPED override names the policy it is limited to", async () => {
+    /*
+     * The distinction the reader cannot afford to miss: this substitution
+     * covers alerts escalating through ONE policy. Every other policy attached
+     * to this schedule still pages the person who is away.
+     */
+    setupApi({
+      overrides: [
+        activeOverride({
+          onCallDutyPolicyId: POLICY_ID,
+          policyName: POLICY_NAME,
+        }),
+      ],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    const card: HTMLElement = await findOverridesCard();
+    const pill: HTMLElement = within(card).getByTestId("override-scope-pill");
+
+    expect(pill.textContent).toContain(`Only for ${POLICY_NAME}`);
+    expect(pill.textContent).not.toContain("Global");
+  });
+
+  test("shows the override's own window, not the shift's", async () => {
+    setupApi({
+      overrides: [activeOverride({ onCallDutyPolicyId: null })],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    const card: HTMLElement = await findOverridesCard();
+    const now: Date = OneUptimeDate.getCurrentDate();
+
+    /*
+     * The fixture window is now-1h to now+1h, while the layer's shift is a full
+     * day. Asserting on the year alone would pass for either; the hour is what
+     * distinguishes them.
+     */
+    const startHour: string = OneUptimeDate.getDateAsFormattedStringInTimezone({
+      date: OneUptimeDate.addRemoveHours(now, -1),
+      timezone: "UTC",
+      showWeekday: true,
+    });
+
+    expect(card.textContent).toContain(startHour);
+  });
+});
+
+describe("The legend and the on-call card carry the same story", () => {
+  beforeEach(() => {
+    getListMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("the legend names who the substitute is covering, not just that they are", async () => {
+    setupApi({
+      overrides: [activeOverride({ onCallDutyPolicyId: null })],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    const label: HTMLElement = await screen.findByTestId(
+      "legend-covering-label",
+      undefined,
+      { timeout: TIMEOUT_MS },
+    );
+
+    expect(label.textContent).toBe(`Covering ${USER_A_NAME}`);
+  });
+
+  test("the legend explains the striped edge drawn on covered blocks", async () => {
+    setupApi({
+      overrides: [activeOverride({ onCallDutyPolicyId: null })],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    const key: HTMLElement = await screen.findByTestId(
+      "legend-override-key",
+      undefined,
+      { timeout: TIMEOUT_MS },
+    );
+
+    expect(key.textContent).toContain("Covered by an override");
+    expect(key.getAttribute("title")).toContain("overridden");
+  });
+
+  test("'on call right now' says the person is there via an override, and whose shift it was", async () => {
+    setupApi({
+      overrides: [
+        activeOverride({
+          onCallDutyPolicyId: POLICY_ID,
+          policyName: POLICY_NAME,
+        }),
+      ],
+      attachedPolicyIds: [POLICY_ID],
+    });
+    renderPreview();
+
+    const strip: HTMLElement = await screen.findByTestId(
+      "on-call-now-override",
+      undefined,
+      { timeout: TIMEOUT_MS },
+    );
+
+    expect(strip.textContent).toContain("Override");
+    expect(strip.textContent).toContain(`Covering for ${USER_A_NAME}`);
+    expect(strip.textContent).toContain(`Only for ${POLICY_NAME}`);
+    expect(strip.textContent).toContain("Override runs");
+  });
+
+  test("an un-overridden schedule shows no override strip on the on-call card", async () => {
+    setupApi({ overrides: [], attachedPolicyIds: [POLICY_ID] });
+    renderPreview();
+
+    await waitFor(
+      () => {
+        expect(screen.getAllByTestId("calendar-event").length).toBeGreaterThan(
+          0,
+        );
+      },
+      { timeout: TIMEOUT_MS },
+    );
+
+    expect(screen.queryByTestId("on-call-now-override")).toBeNull();
+    expect(screen.queryByTestId("legend-covering-label")).toBeNull();
+  });
+});

--- a/Common/Tests/App/Dashboard/OnCallSchedulePreviewOverrides.test.tsx
+++ b/Common/Tests/App/Dashboard/OnCallSchedulePreviewOverrides.test.tsx
@@ -336,13 +336,34 @@ function renderPreview(): void {
  * question the user asked - "who is covering right now" - and not about whether
  * a name appears anywhere on a screen that also lists a whole week of shifts.
  */
-async function getOnCallNowText(): Promise<string> {
+async function getOnCallNowCard(): Promise<HTMLElement> {
   const heading: HTMLElement = await screen.findByText(/On call right now/i);
   const card: HTMLElement | null = heading.closest("div.rounded-xl");
   if (!card) {
     throw new Error("Could not find the 'On call right now' card");
   }
-  return card.textContent || "";
+  return card as HTMLElement;
+}
+
+async function getOnCallNowText(): Promise<string> {
+  return (await getOnCallNowCard()).textContent || "";
+}
+
+/*
+ * The card names the person on call AND, when they are a substitute, the person
+ * they are covering - so "which name is in this card" no longer distinguishes
+ * the two. This reads the headline name only: the one the card asserts is on
+ * call right now, as opposed to the one named inside the override strip.
+ */
+async function getOnCallNowHeadlineName(): Promise<string> {
+  const card: HTMLElement = await getOnCallNowCard();
+  const headline: HTMLElement | null = card.querySelector(
+    "div.text-base.font-semibold",
+  );
+  if (!headline) {
+    throw new Error("Could not find the on-call name in the card");
+  }
+  return headline.textContent || "";
 }
 
 describe("Schedule preview reflects the overrides that alert routing applies (issue #3411)", () => {
@@ -369,7 +390,14 @@ describe("Schedule preview reflects the overrides that alert routing applies (is
       { timeout: 10000 },
     );
 
-    expect(await getOnCallNowText()).not.toContain(USER_A_NAME);
+    /*
+     * The overridden user must not be presented as the person on call - that
+     * was the original bug. They ARE named in the card, but only inside the
+     * override strip that explains whose shift this was; naming them there is
+     * the point of that strip.
+     */
+    expect(await getOnCallNowHeadlineName()).toBe(USER_B_NAME);
+    expect(await getOnCallNowText()).toContain(`Covering for ${USER_A_NAME}`);
   });
 
   test("the calendar grid relabels the overridden window to the substitute", async () => {

--- a/Common/Tests/Types/OnCallDutyPolicy/OverrideProvenance.test.ts
+++ b/Common/Tests/Types/OnCallDutyPolicy/OverrideProvenance.test.ts
@@ -1,0 +1,295 @@
+import CalendarEvent from "../../../Types/Calendar/CalendarEvent";
+import ScheduleShiftUtil, {
+  OnCallShift,
+} from "../../../Types/OnCallDutyPolicy/ScheduleShiftUtil";
+import UserOverrideUtil, {
+  OverrideEventMeta,
+  UserOverrideRecord,
+} from "../../../Types/OnCallDutyPolicy/UserOverrideUtil";
+
+/*
+ * PROVENANCE: the two facts a screen needs before it can honestly describe a
+ * substitution, and which the engine used to drop on the floor.
+ *
+ * 1. WHICH override produced a segment - global, or scoped to one policy.
+ *    Without it a renderer can say "Bob is covering Alice" but not whether that
+ *    holds for the policy the reader actually cares about. A scoped override
+ *    re-routes exactly one policy's alerts; every OTHER policy escalating to
+ *    the same schedule still pages Alice. Presenting the two identically is the
+ *    difference between "you are covered" and "you are covered for one of your
+ *    four policies".
+ *
+ * 2. That an override window stays its OWN shift. The default grouping folds
+ *    consecutive segments of the same user together, and a shift inherits
+ *    metadata only from its first segment - so a substitute who is also on the
+ *    roster ends up with one merged block that either carries the wrong
+ *    override or none. https://github.com/OneUptime/oneuptime
+ */
+
+const POLICY_ID: string = "policy-database-oncall";
+
+function at(hours: number, minutes: number = 0): Date {
+  return new Date(2026, 0, 1, hours, minutes, 0, 0);
+}
+
+function event(
+  title: string,
+  startHour: number,
+  endHour: number,
+): CalendarEvent {
+  return {
+    id: 1,
+    title: title,
+    allDay: false,
+    start: at(startHour),
+    end: at(endHour),
+  };
+}
+
+function record(data: {
+  from: string;
+  to: string;
+  startHour: number;
+  endHour: number;
+  policyId?: string | null | undefined;
+}): UserOverrideRecord {
+  return {
+    overrideUserId: data.from,
+    routeAlertsToUserId: data.to,
+    startsAt: at(data.startHour),
+    endsAt: at(data.endHour),
+    onCallDutyPolicyId:
+      data.policyId === undefined ? null : (data.policyId as string | null),
+  };
+}
+
+function overriddenSegment(events: Array<CalendarEvent>): CalendarEvent {
+  const found: CalendarEvent | undefined = events.find(
+    (candidate: CalendarEvent) => {
+      return UserOverrideUtil.getOverrideMeta(candidate) !== null;
+    },
+  );
+
+  if (!found) {
+    throw new Error("expected at least one override segment");
+  }
+
+  return found;
+}
+
+describe("OverrideEventMeta carries the override's policy scope", () => {
+  test("a GLOBAL override stamps a null policy, not an absent key", () => {
+    const events: Array<CalendarEvent> =
+      UserOverrideUtil.applyOverridesToEvents({
+        events: [event("A", 8, 14)],
+        overrides: [record({ from: "A", to: "B", startHour: 9, endHour: 13 })],
+      });
+
+    const meta: OverrideEventMeta | null = UserOverrideUtil.getOverrideMeta(
+      overriddenSegment(events),
+    );
+
+    expect(meta).not.toBeNull();
+    /*
+     * Explicitly null rather than undefined so a consumer tests ONE value for
+     * "global". A key that is sometimes absent invites `meta.onCallDutyPolicyId
+     * === null` checks that silently fail for the undefined case and render the
+     * scoped wording for a global override.
+     */
+    expect(meta!.onCallDutyPolicyId).toBeNull();
+  });
+
+  test("a POLICY-SCOPED override stamps that policy's id", () => {
+    const events: Array<CalendarEvent> =
+      UserOverrideUtil.applyOverridesToEvents({
+        events: [event("A", 8, 14)],
+        overrides: [
+          record({
+            from: "A",
+            to: "B",
+            startHour: 9,
+            endHour: 13,
+            policyId: POLICY_ID,
+          }),
+        ],
+        currentOnCallDutyPolicyId: POLICY_ID,
+      });
+
+    const meta: OverrideEventMeta | null = UserOverrideUtil.getOverrideMeta(
+      overriddenSegment(events),
+    );
+
+    expect(meta!.onCallDutyPolicyId).toBe(POLICY_ID);
+  });
+
+  test("when a scoped and a global override compete, the meta names the one that actually won", () => {
+    /*
+     * applyOverridesToEvents sorts policy-scoped first so the scoped
+     * substitution claims the window. The stamped scope has to agree with that
+     * outcome: a segment routed by the scoped override that reported itself as
+     * global would tell the reader the swap covers every policy when it covers
+     * exactly one.
+     */
+    const events: Array<CalendarEvent> =
+      UserOverrideUtil.applyOverridesToEvents({
+        events: [event("A", 8, 14)],
+        overrides: [
+          record({ from: "A", to: "GLOBAL", startHour: 9, endHour: 13 }),
+          record({
+            from: "A",
+            to: "SCOPED",
+            startHour: 9,
+            endHour: 13,
+            policyId: POLICY_ID,
+          }),
+        ],
+        currentOnCallDutyPolicyId: POLICY_ID,
+      });
+
+    const segment: CalendarEvent = overriddenSegment(events);
+    expect(segment.title).toBe("SCOPED");
+    expect(UserOverrideUtil.getOverrideMeta(segment)!.onCallDutyPolicyId).toBe(
+      POLICY_ID,
+    );
+  });
+
+  test("the segments OUTSIDE the override window carry no meta at all", () => {
+    const events: Array<CalendarEvent> =
+      UserOverrideUtil.applyOverridesToEvents({
+        events: [event("A", 8, 14)],
+        overrides: [record({ from: "A", to: "B", startHour: 9, endHour: 13 })],
+      });
+
+    const untouched: Array<CalendarEvent> = events.filter(
+      (candidate: CalendarEvent) => {
+        return UserOverrideUtil.getOverrideMeta(candidate) === null;
+      },
+    );
+
+    // 08:00-09:00 and 13:00-14:00 are still plain A.
+    expect(untouched).toHaveLength(2);
+    for (const segment of untouched) {
+      expect(segment.title).toBe("A");
+    }
+  });
+});
+
+describe("ScheduleShiftUtil.groupKeyByUserAndOverride", () => {
+  test("keeps a substitute's own shift separate from the one they are covering", () => {
+    /*
+     * The regression this exists for. B is rostered 14:00-18:00 in their own
+     * right and is ALSO covering A from 12:00-14:00. The two segments touch and
+     * belong to the same user, so the default grouping merges them into one
+     * 12:00-18:00 block - and since a shift inherits metadata from its first
+     * segment only, the merged block claims to be four hours of cover when half
+     * of it is B's ordinary turn.
+     */
+    const events: Array<CalendarEvent> =
+      UserOverrideUtil.applyOverridesToEvents({
+        events: [event("A", 8, 14), { ...event("B", 14, 18), id: 2 }],
+        overrides: [record({ from: "A", to: "B", startHour: 12, endHour: 14 })],
+      });
+
+    const merged: Array<OnCallShift> =
+      ScheduleShiftUtil.groupEventsIntoShifts(events);
+    const split: Array<OnCallShift> = ScheduleShiftUtil.groupEventsIntoShifts(
+      events,
+      { groupKey: ScheduleShiftUtil.groupKeyByUserAndOverride },
+    );
+
+    // The default grouping folds B's cover into B's own turn: one block.
+    const mergedB: Array<OnCallShift> = merged.filter((s: OnCallShift) => {
+      return s.userId === "B";
+    });
+    expect(mergedB).toHaveLength(1);
+    expect(mergedB[0]!.end).toEqual(at(18));
+
+    // The override-aware grouping keeps them apart.
+    const splitB: Array<OnCallShift> = split.filter((s: OnCallShift) => {
+      return s.userId === "B";
+    });
+    expect(splitB).toHaveLength(2);
+
+    const cover: OnCallShift = splitB[0]!;
+    const ownTurn: OnCallShift = splitB[1]!;
+
+    expect(cover.start).toEqual(at(12));
+    expect(cover.end).toEqual(at(14));
+    expect(cover.override).toBeDefined();
+    expect(cover.override!.originalUserId).toBe("A");
+
+    expect(ownTurn.start).toEqual(at(14));
+    expect(ownTurn.end).toEqual(at(18));
+    expect(ownTurn.override).toBeUndefined();
+  });
+
+  test("two consecutive windows covering DIFFERENT people stay two shifts", () => {
+    const events: Array<CalendarEvent> =
+      UserOverrideUtil.applyOverridesToEvents({
+        events: [event("A", 8, 12), { ...event("C", 12, 16), id: 2 }],
+        overrides: [
+          record({ from: "A", to: "B", startHour: 8, endHour: 12 }),
+          record({ from: "C", to: "B", startHour: 12, endHour: 16 }),
+        ],
+      });
+
+    const shifts: Array<OnCallShift> = ScheduleShiftUtil.groupEventsIntoShifts(
+      events,
+      { groupKey: ScheduleShiftUtil.groupKeyByUserAndOverride },
+    );
+
+    expect(shifts).toHaveLength(2);
+    expect(shifts[0]!.override!.originalUserId).toBe("A");
+    expect(shifts[1]!.override!.originalUserId).toBe("C");
+  });
+
+  test("an ordinary rotation is grouped exactly as the default key groups it", () => {
+    /*
+     * The new key must not fragment schedules that have no overrides at all -
+     * every "upcoming hand-offs" list in the dashboard is built from it, and a
+     * key that split on something invisible would show hand-offs that are not
+     * hand-offs.
+     */
+    const events: Array<CalendarEvent> = [
+      event("A", 8, 12),
+      { ...event("A", 12, 16), id: 2 },
+      { ...event("B", 16, 20), id: 3 },
+    ];
+
+    const withDefault: Array<OnCallShift> =
+      ScheduleShiftUtil.groupEventsIntoShifts(events);
+    const withOverrideKey: Array<OnCallShift> =
+      ScheduleShiftUtil.groupEventsIntoShifts(events, {
+        groupKey: ScheduleShiftUtil.groupKeyByUserAndOverride,
+      });
+
+    expect(withOverrideKey).toEqual(withDefault);
+    expect(withOverrideKey).toHaveLength(2);
+  });
+
+  test("one override spanning a rotation boundary stays a single shift", () => {
+    /*
+     * Unlike groupKeyByUserOverrideAndLayer, this key deliberately ignores the
+     * rotation period: a person covering across a hand-over is doing one
+     * continuous stretch of cover, and splitting it would invent a hand-off the
+     * reader cannot act on.
+     */
+    const events: Array<CalendarEvent> =
+      UserOverrideUtil.applyOverridesToEvents({
+        events: [event("A", 8, 12), { ...event("C", 12, 16), id: 2 }],
+        overrides: [record({ from: "A", to: "B", startHour: 8, endHour: 12 })],
+      });
+
+    const shifts: Array<OnCallShift> = ScheduleShiftUtil.groupEventsIntoShifts(
+      events,
+      { groupKey: ScheduleShiftUtil.groupKeyByUserAndOverride },
+    );
+
+    const bShifts: Array<OnCallShift> = shifts.filter((s: OnCallShift) => {
+      return s.userId === "B";
+    });
+    expect(bShifts).toHaveLength(1);
+    expect(bShifts[0]!.start).toEqual(at(8));
+    expect(bShifts[0]!.end).toEqual(at(12));
+  });
+});

--- a/Common/Types/Calendar/CalendarEvent.ts
+++ b/Common/Types/Calendar/CalendarEvent.ts
@@ -9,4 +9,20 @@ export default interface CalendarEvent extends JSONObject {
   desc?: string | undefined;
   color?: string | undefined;
   textColor?: string | undefined;
+  /*
+   * A SECOND colour for the block, painted as a stripe down its leading edge.
+   * Used when a block is about two people rather than one — an on-call shift
+   * covered by a substitute is drawn in the substitute's colour with the
+   * overridden person's colour on the edge, so the swap is legible at a glance
+   * and, crucially, survives the label being truncated to nothing in a narrow
+   * week-view column.
+   */
+  accentColor?: string | undefined;
+  /*
+   * Extra class names for the rendered block. The calendar itself defines no
+   * semantics for these; it forwards them so a caller can attach its own
+   * treatment (see .oneuptime-calendar-event--override in Calendar.css) without
+   * the generic component learning what an override is.
+   */
+  className?: string | undefined;
 }

--- a/Common/Types/OnCallDutyPolicy/ScheduleShiftUtil.ts
+++ b/Common/Types/OnCallDutyPolicy/ScheduleShiftUtil.ts
@@ -256,6 +256,35 @@ export default class ScheduleShiftUtil {
   }
 
   /*
+   * Grouping that keeps a shift inside ONE override window: the on-call user
+   * id, plus the override identity when the segment came from an override.
+   *
+   * This is what every surface that LABELS a shift as covered-by-override must
+   * group with. The default key is the user id alone, so a substitute who is
+   * ALSO on the roster has their own rostered segment and the segment they are
+   * covering folded into a single shift — and since a shift only inherits
+   * metadata from its FIRST segment, the merged shift would carry either a
+   * stale override or none at all. Either way the screen names the right person
+   * for the wrong reason: "Bob until 9pm", with nothing saying that half of that
+   * stretch is Bob covering for Alice.
+   *
+   * Unlike groupKeyByUserOverrideAndLayer this deliberately ignores the layer
+   * and the rotation period, so an ordinary hand-over inside one person's turn
+   * still reads as one shift. The only boundary it adds is the one the reader
+   * can see a reason for.
+   */
+  public static groupKeyByUserAndOverride(event: CalendarEvent): string {
+    const override: OverrideEventMeta | null =
+      UserOverrideUtil.getOverrideMeta(event);
+
+    if (!override) {
+      return event.title;
+    }
+
+    return `${event.title}|${override.originalUserId}@${override.overrideStartsAt.getTime()}-${override.overrideEndsAt.getTime()}`;
+  }
+
+  /*
    * Grouping that keeps a shift inside ONE layer, ONE override window and ONE
    * rotation period: the user id, plus the override identity (original user +
    * window) when the segment was produced by an override, plus the layer id

--- a/Common/Types/OnCallDutyPolicy/UserOverrideUtil.ts
+++ b/Common/Types/OnCallDutyPolicy/UserOverrideUtil.ts
@@ -16,6 +16,17 @@ export interface OverrideEventMeta {
   overrideUserId: string;
   overrideStartsAt: Date;
   overrideEndsAt: Date;
+  /*
+   * Which override produced this segment: null/undefined for a GLOBAL override
+   * (one that applies through every on-call policy), the policy's id for a
+   * policy-scoped one. Carried on the segment so a renderer can say WHY the
+   * substitution is in force without having to reverse-map the segment back to
+   * the override record that made it - a lookup by (users + window) that cannot
+   * distinguish two overrides sharing both. It is the same distinction the user
+   * makes when creating one from the project's overrides page (global) versus a
+   * policy's own overrides tab (scoped).
+   */
+  onCallDutyPolicyId?: string | null | undefined;
 }
 
 /*
@@ -150,6 +161,11 @@ export default class UserOverrideUtil {
       overrideUserId: override.routeAlertsToUserId,
       overrideStartsAt: override.startsAt,
       overrideEndsAt: override.endsAt,
+      /*
+       * Normalise the record's absent/null policy to null so a consumer can
+       * test one value for "global" instead of three.
+       */
+      onCallDutyPolicyId: override.onCallDutyPolicyId || null,
     };
 
     segments.push({

--- a/Common/UI/Components/Calendar/Calendar.css
+++ b/Common/UI/Components/Calendar/Calendar.css
@@ -302,3 +302,81 @@
   );
   border: 1px solid rgba(217, 119, 6, 0.4);
 }
+
+/* ---------- Override (substituted) events ----------
+   A block that says "somebody else is taking this person's alerts". The colour
+   alone cannot carry that: it is the SUBSTITUTE's colour, and a reader who does
+   not already know the roster cannot tell it from an ordinary shift. Three
+   independent cues, so none of them has to survive on its own:
+
+   1. a stripe down the leading edge in the OVERRIDDEN person's colour, which
+      is what makes the swap readable when the week-view column is too narrow
+      to show any text at all;
+   2. a dotted inner rule beside it, so the distinction still lands in
+      greyscale and for a reader who cannot separate the two hues;
+   3. the label itself, which the caller prefixes.
+
+   --oneuptime-event-accent is set per event by Calendar.tsx's eventPropGetter
+   from CalendarEvent.accentColor; the fallback keeps the stripe visible if a
+   caller sets the class without a colour. */
+.oneuptime-calendar .rbc-event.oneuptime-calendar-event--override {
+  position: relative;
+  padding-left: 0.75rem;
+  overflow: hidden;
+}
+
+.oneuptime-calendar .rbc-event.oneuptime-calendar-event--override::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 0.3125rem;
+  background-color: var(--oneuptime-event-accent, #6b7280);
+  /* Sits above the label so a long name cannot paint over the cue. */
+  z-index: 1;
+}
+
+.oneuptime-calendar .rbc-event.oneuptime-calendar-event--override::after {
+  content: "";
+  position: absolute;
+  top: 0.15rem;
+  bottom: 0.15rem;
+  left: 0.4375rem;
+  border-left: 1px dotted currentColor;
+  opacity: 0.65;
+  z-index: 1;
+}
+
+/* The agenda view renders events as table rows, where an absolutely positioned
+   stripe has nothing to anchor to. Give that view a plain left border instead
+   so the same event is still marked there. */
+.oneuptime-calendar
+  .rbc-agenda-view
+  table.rbc-agenda-table
+  tbody
+  > tr.oneuptime-calendar-event--override
+  > td:first-child {
+  border-left: 0.25rem solid var(--oneuptime-event-accent, #6b7280);
+}
+
+/* Legend swatch for the override key. The block it names is drawn in two
+   people's colours, so the swatch is too - generic hues here, since the key
+   speaks for every override on the grid rather than for one of them. */
+.oneuptime-calendar-override-swatch {
+  position: relative;
+  overflow: hidden;
+  background-color: #6366f1; /* indigo-500 - stands for the substitute */
+  border: 1px solid rgba(79, 70, 229, 0.35); /* indigo-600 */
+}
+
+.oneuptime-calendar-override-swatch::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 45%;
+  /* Stands for the person who was overridden. */
+  background-color: #9ca3af; /* gray-400 */
+}

--- a/Common/UI/Components/Calendar/Calendar.tsx
+++ b/Common/UI/Components/Calendar/Calendar.tsx
@@ -75,9 +75,33 @@ const CalendarElement: FunctionComponent<ComponentProps> = (
       display: "block",
     };
 
-    return {
-      style,
-    };
+    /*
+     * The accent colour reaches CSS as a custom property rather than as a
+     * border here, so the stylesheet decides how to draw it (an inset stripe
+     * today) and the two can be changed together in one place.
+     */
+    if (event.accentColor) {
+      (style as Record<string, string>)["--oneuptime-event-accent"] =
+        event.accentColor.toString();
+    }
+
+    const className: string | undefined = event.className
+      ? event.className.toString()
+      : undefined;
+
+    return className ? { style, className } : { style };
+  };
+
+  /*
+   * react-big-calendar's default tooltip is the title, which is already
+   * truncated in the block itself — so hovering a clipped label tells the
+   * reader exactly as little as looking at it did. Prefer `desc`, which callers
+   * use for the full, multi-line explanation of what the block means.
+   */
+  const eventTooltipGetter: (event: CalendarEvent) => string = (
+    event: CalendarEvent,
+  ): string => {
+    return event.desc?.toString() || event.title;
   };
 
   return (
@@ -94,6 +118,7 @@ const CalendarElement: FunctionComponent<ComponentProps> = (
         views={CALENDAR_VIEWS}
         defaultView={props.defaultCalendarView || "week"}
         eventPropGetter={eventStyleGetter}
+        tooltipAccessor={eventTooltipGetter}
         popup
         onRangeChange={(range: Date[] | { start: Date; end: Date }) => {
           if (Array.isArray(range)) {


### PR DESCRIPTION
## The problem

When you add a user override — global, from **On-Call Duty → User Overrides**, or local, from a policy's own **User Overrides** tab — the schedule calendar relabels the covered window to the substitute and draws it in the substitute's own colour.

That block is indistinguishable from an ordinary rotation block. The screen is correct and unreadable at the same time: it names the right person to page, while giving the reader no way to learn that the roster says somebody else, **whose** shift it was, when the substitution expires, or whether it applies to every policy or to just one.

Here is the old calendar. Two of these five blocks are overrides. Nothing on them says so:

![before](https://raw.githubusercontent.com/OneUptime/oneuptime/claude/on-call-override-calendar-edd935-screenshots/0-before-block.png)

## After

The same week. The two covered blocks now carry a `⇄` marker and a stripe down the leading edge in the **overridden** person's colour, so the swap is legible even where the column is too narrow for text:

![after](https://raw.githubusercontent.com/OneUptime/oneuptime/claude/on-call-override-calendar-edd935-screenshots/3-override-block.png)

Above the grid, every substitution is now stated in full — who was overridden, where the alerts actually go, the window, and the scope:

![summary](https://raw.githubusercontent.com/OneUptime/oneuptime/claude/on-call-override-calendar-edd935-screenshots/1-overrides-summary.png)

<details>
<summary>The full week view, and the previous version of the panel above</summary>

![week](https://raw.githubusercontent.com/OneUptime/oneuptime/claude/on-call-override-calendar-edd935-screenshots/2-calendar-week.png)

Before — the same schedule, same two overrides in force. "Carla Devi" is on call with nothing saying why, and no mention of the overrides anywhere:

![before summary](https://raw.githubusercontent.com/OneUptime/oneuptime/claude/on-call-override-calendar-edd935-screenshots/0-before-summary.png)

</details>

## What changed

Four surfaces now carry the substitution, because a reader who looks at only one of them still has to get the whole story:

- **The calendar block.** The label leads with a swap marker (`⇄ Bob (covering Alice)`); the block gains a stripe in the overridden person's colour plus a dotted inner rule, so the cue survives a narrow column *and* greyscale. Hovering gives the swap, the override's own window and its scope — `CalendarEvent.desc` was already being written for overrides and was never read, because the calendar passed no `tooltipAccessor`.
- **A new "user overrides on this schedule" card** above the grid: each substitution with both parties captioned **Overridden** / **Alerts go here**, the window, whether it is in force right now, and the scope.
- **"On call right now" / "Up next"** gain an override strip naming who is being covered; upcoming hand-offs gain a covering pill.
- **The legend** names who each substitute is covering and explains the striped edge.

### Global vs. local overrides are told apart everywhere

A policy-scoped override only re-routes alerts escalating through *its* policy; every other policy attached to the schedule still pages the person who is away. That distinction was invisible.

`OverrideEventMeta` now carries the override's policy id, so a renderer no longer has to reverse-map a segment back to the record that produced it (a lookup by users + window that cannot separate two overrides sharing both). `ScheduleOverrides` fetches the policy name so a scoped override can say which policy it is limited to.

A missing policy name degrades to "Policy override", **never** to "Global override" — claiming wider coverage than exists is the one error here that sends somebody to bed expecting a page that never comes.

### A grouping bug this surfaced

`ScheduleShiftUtil.groupKeyByUserAndOverride` is new, and is used wherever a shift is labelled as covered. The default grouping is by user id alone, so a substitute who is *also* on the roster had their own rotation turn folded into the window they were covering — and a shift inherits metadata from its first segment only, so the merged block silently lost the fact that half of it was cover.

### Also

The layer card and rotation summary said "covering" / "covering via override" without naming anyone. They now name the overridden user too.

## Tests

New:
- `Common/Tests/Types/OnCallDutyPolicy/OverrideProvenance.test.ts` — the policy scope stamped on a segment (including which override wins when a scoped and a global one compete), and the new group key.
- `Common/Tests/App/Dashboard/OnCallOverridePresentation.test.ts` — every string the screens use for a substitution, including that an unnamed policy never reads as global.
- `Common/Tests/App/Dashboard/OnCallScheduleOverrideClarity.test.tsx` — drives the real `LayersPreview` against a mocked `ModelAPI` and asserts on all four surfaces, plus the negative cases (an ordinary shift stays unmarked; a schedule with no overrides shows no card, key or strip).

Updated: `OnCallSchedulePreviewOverrides.test.tsx` and `OnCallLayerCardOverrides.test.tsx` pinned the old, weaker wording — one asserted the overridden user's name appears *nowhere* in the "on call right now" card, which is now false by design. They assert the stronger contract instead.

All green locally: 15 suites / ~319 tests across the on-call type utils, the calendar-feed and materialised-shift suites nearest the changed types, and the dashboard render suites. ESLint clean on every changed file.
