### PR TITLE
fix(probe): say why a monitor target could not be resolved, instead of "Unknown"

### DIFF
--- a/Common/Server/Utils/DataSource/EgressGuard.ts
+++ b/Common/Server/Utils/DataSource/EgressGuard.ts
@@ -3,6 +3,10 @@ import http from "http";
 import https from "https";
 import net from "net";
 import BadDataException from "../../../Types/Exception/BadDataException";
+import EgressGuardException, {
+  EgressFailureReason,
+} from "../../../Types/Exception/EgressGuardException";
+import logger from "../Logger";
 
 /*
  * SSRF egress guard for outbound connections whose target is chosen by a
@@ -80,6 +84,21 @@ export interface EgressGuardOptions {
    * requests set it to false and receive one indistinguishable failure.
    */
   includeResolvedAddressInError?: boolean | undefined;
+  /*
+   * TOTAL wall-clock budget for name resolution, across every attempt. It is a
+   * safety net against a wedged resolver, not a latency policy: callers with
+   * their own deadline (probe monitors have an execution-context timeout) pass
+   * a value above the resolver's own configured budget so the resolver's
+   * nameserver failover is allowed to finish, and let their deadline do the
+   * real bounding. Defaults to DEFAULT_DNS_RESOLVE_BUDGET_IN_MS.
+   */
+  resolveTimeoutInMs?: number | undefined;
+  /*
+   * How many getaddrinfo attempts to make inside the budget above. Retrying
+   * absorbs the transient resolver failures (EAI_AGAIN, a nameserver
+   * restarting) that otherwise surface as a hard "target is down".
+   */
+  resolveAttempts?: number | undefined;
 }
 
 export interface PinnedAgents {
@@ -112,7 +131,23 @@ export interface AddressVerdict {
   isPrivateNetwork?: boolean | undefined;
 }
 
-const DNS_LOOKUP_TIMEOUT_IN_MS: number = 5000;
+/*
+ * Total resolution budget. Chosen so existing callers see no change in
+ * worst-case latency versus the single 5s lookup this replaced — the retries
+ * below fit INSIDE the same budget rather than extending it.
+ */
+export const DEFAULT_DNS_RESOLVE_BUDGET_IN_MS: number = 5000;
+
+/*
+ * getaddrinfo fails transiently far more often than a host actually
+ * disappears — EAI_AGAIN under resolver load is the classic case, and it is
+ * why the Helm chart ships fallback nameservers. One shot at it turned every
+ * such blip into a monitor-down incident.
+ */
+export const DEFAULT_DNS_RESOLVE_ATTEMPTS: number = 3;
+
+// Short enough that three attempts still fit comfortably in a 5s budget.
+const DNS_RESOLVE_RETRY_DELAY_IN_MS: number = 150;
 
 interface Ipv4Range {
   base: number;
@@ -485,8 +520,9 @@ export default class DataSourceEgressGuard {
     return { blocked: true, reason: "not a valid IP address" };
   }
 
-  private static async defaultResolve(
+  private static async lookupOnce(
     hostname: string,
+    timeoutInMs: number,
   ): Promise<Array<ResolvedAddress>> {
     /*
      * dns.lookup (getaddrinfo) rather than dns.resolve so /etc/hosts and
@@ -506,7 +542,7 @@ export default class DataSourceEgressGuard {
       (_resolve: (value: never) => void, reject: (error: Error) => void) => {
         timeoutHandle = setTimeout(() => {
           reject(new BadDataException(`DNS lookup timed out for ${hostname}`));
-        }, DNS_LOOKUP_TIMEOUT_IN_MS);
+        }, timeoutInMs);
       },
     );
 
@@ -517,6 +553,77 @@ export default class DataSourceEgressGuard {
         clearTimeout(timeoutHandle);
       }
     }
+  }
+
+  /*
+   * Resolve with a bounded number of retries inside ONE total budget.
+   *
+   * A resolver that answers "no" instantly (NXDOMAIN, SERVFAIL, EAI_AGAIN) is
+   * retried within milliseconds, which is exactly the case that used to turn a
+   * momentary blip into an incident. A resolver that HANGS consumes the budget
+   * on its first attempt and is not retried, so the worst case is unchanged
+   * from the single lookup this replaced.
+   */
+  private static async defaultResolve(
+    hostname: string,
+    options?: EgressGuardOptions,
+  ): Promise<Array<ResolvedAddress>> {
+    const budgetInMs: number = Math.max(
+      1,
+      options?.resolveTimeoutInMs ?? DEFAULT_DNS_RESOLVE_BUDGET_IN_MS,
+    );
+    const maxAttempts: number = Math.max(
+      1,
+      options?.resolveAttempts ?? DEFAULT_DNS_RESOLVE_ATTEMPTS,
+    );
+
+    const startedAt: number = Date.now();
+
+    /*
+     * Keep the FIRST failure, not the last. Attempt one gets the whole budget,
+     * so its error is either the real resolver errno or a genuine full-budget
+     * timeout; a later attempt runs on whatever is left and can time out
+     * generically, burying the diagnosis. That errno is the entire value here
+     * — for detail-permitted callers it IS the user-facing message, and for a
+     * probe it is all the operator log has to go on.
+     */
+    let firstError: unknown = undefined;
+
+    for (let attempt: number = 1; attempt <= maxAttempts; attempt++) {
+      const remainingInMs: number = budgetInMs - (Date.now() - startedAt);
+
+      if (remainingInMs <= 0) {
+        break;
+      }
+
+      try {
+        return await this.lookupOnce(hostname, remainingInMs);
+      } catch (error) {
+        if (firstError === undefined) {
+          firstError = error;
+        }
+      }
+
+      /*
+       * Only sleep when another attempt can still start AND finish inside the
+       * budget; otherwise the delay is pure added latency on a failure.
+       */
+      const budgetLeftInMs: number = budgetInMs - (Date.now() - startedAt);
+      if (
+        attempt >= maxAttempts ||
+        budgetLeftInMs <= DNS_RESOLVE_RETRY_DELAY_IN_MS
+      ) {
+        break;
+      }
+
+      await new Promise<void>((resolve: () => void) => {
+        setTimeout(resolve, DNS_RESOLVE_RETRY_DELAY_IN_MS);
+      });
+    }
+
+    throw (
+      firstError ?? new BadDataException(`DNS lookup timed out for ${hostname}`)
+    );
   }
 
   /*
@@ -533,7 +640,10 @@ export default class DataSourceEgressGuard {
     const label: string = options?.targetLabel || DEFAULT_TARGET_LABEL;
 
     if (!hostname) {
-      throw new BadDataException(`${label} host is required.`);
+      throw new EgressGuardException(
+        `${label} host is required.`,
+        EgressFailureReason.InvalidTarget,
+      );
     }
 
     // Literal [::1] style hosts arrive with brackets from URL parsing.
@@ -542,10 +652,15 @@ export default class DataSourceEgressGuard {
     if (net.isIP(bareHostname) !== 0) {
       const verdict: AddressVerdict = this.checkAddress(bareHostname, options);
       if (verdict.blocked) {
-        throw new BadDataException(
+        /*
+         * A literal IP is echoed back with full detail on purpose: it tells
+         * the caller only what the caller itself typed.
+         */
+        throw new EgressGuardException(
           `${label} host ${bareHostname} is not allowed: ${verdict.reason}.${
             verdict.isPrivateNetwork ? options?.privateNetworkHint || "" : ""
           }`,
+          EgressFailureReason.AddressBlocked,
         );
       }
       return [{ address: bareHostname, family: net.isIP(bareHostname) }];
@@ -554,7 +669,7 @@ export default class DataSourceEgressGuard {
     const resolveFunction: EgressResolveFunction =
       options?.resolveFunction ||
       ((host: string) => {
-        return this.defaultResolve(host);
+        return this.defaultResolve(host, options);
       });
 
     let addresses: Array<ResolvedAddress> = [];
@@ -562,25 +677,40 @@ export default class DataSourceEgressGuard {
       addresses = await resolveFunction(bareHostname);
     } catch (error) {
       if (options?.includeResolvedAddressInError === false) {
-        throw new BadDataException(
+        /*
+         * The cause is destroyed for the caller by design, so log it here:
+         * this is the only place an operator can still learn whether a
+         * monitor failed on DNS or on address policy.
+         */
+        logger.debug(
+          `EgressGuard: could not resolve ${bareHostname} - ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        throw new EgressGuardException(
           `${label} host ${bareHostname} could not be reached.`,
+          EgressFailureReason.Unreachable,
         );
       }
-      throw new BadDataException(
+      throw new EgressGuardException(
         `Could not resolve ${label.toLowerCase()} host ${bareHostname}: ${
           error instanceof Error ? error.message : String(error)
         }`,
+        EgressFailureReason.ResolutionFailed,
       );
     }
 
     if (addresses.length === 0) {
       if (options?.includeResolvedAddressInError === false) {
-        throw new BadDataException(
+        logger.debug(`EgressGuard: ${bareHostname} resolved to no addresses.`);
+        throw new EgressGuardException(
           `${label} host ${bareHostname} could not be reached.`,
+          EgressFailureReason.Unreachable,
         );
       }
-      throw new BadDataException(
+      throw new EgressGuardException(
         `Could not resolve ${label.toLowerCase()} host ${bareHostname}.`,
+        EgressFailureReason.ResolutionFailed,
       );
     }
 
@@ -591,14 +721,24 @@ export default class DataSourceEgressGuard {
       );
       if (verdict.blocked) {
         if (options?.includeResolvedAddressInError === false) {
-          throw new BadDataException(
+          logger.debug(
+            `EgressGuard: ${bareHostname} resolved to a blocked address - ${verdict.reason}.`,
+          );
+          /*
+           * Reported as Unreachable, NOT AddressBlocked. Sharing one reason
+           * with the DNS branches above is what stops a tenant on a shared
+           * probe from using the difference to enumerate internal names.
+           */
+          throw new EgressGuardException(
             `${label} host ${bareHostname} could not be reached.`,
+            EgressFailureReason.Unreachable,
           );
         }
-        throw new BadDataException(
+        throw new EgressGuardException(
           `${label} host ${bareHostname} resolves to ${resolved.address}, which is not allowed: ${verdict.reason}.${
             verdict.isPrivateNetwork ? options?.privateNetworkHint || "" : ""
           }`,
+          EgressFailureReason.AddressBlocked,
         );
       }
     }
@@ -618,24 +758,29 @@ export default class DataSourceEgressGuard {
     const label: string = options?.targetLabel || DEFAULT_TARGET_LABEL;
 
     if (!urlString) {
-      throw new BadDataException(`${label} URL is required.`);
+      throw new EgressGuardException(
+        `${label} URL is required.`,
+        EgressFailureReason.InvalidTarget,
+      );
     }
 
     let url: URL;
     try {
       url = new URL(urlString);
     } catch {
-      throw new BadDataException(
+      throw new EgressGuardException(
         `Invalid ${label.toLowerCase()} URL: ${urlString}`,
+        EgressFailureReason.InvalidTarget,
       );
     }
 
     if (url.protocol !== "http:" && url.protocol !== "https:") {
-      throw new BadDataException(
+      throw new EgressGuardException(
         `${label} URL must use http or https (got ${url.protocol.replace(
           ":",
           "",
         )}).`,
+        EgressFailureReason.InvalidTarget,
       );
     }
 

--- a/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
@@ -1371,6 +1371,15 @@ ${contextBlock}
       );
     }
 
+    /*
+     * How many times the probe actually tried matters when reading a failure:
+     * "tried once" and "tried three times" describe very different levels of
+     * confidence, and the count was already collected but never shown.
+     */
+    if (probeResponse?.totalAttempts !== undefined) {
+      responseDetails.push(`- Attempts: ${probeResponse.totalAttempts}`);
+    }
+
     // Add Request Failed Details if available
     if (probeResponse?.requestFailedDetails) {
       const requestFailedDetails: RequestFailedDetails =

--- a/Common/Tests/Server/Utils/DataSource/EgressGuard.test.ts
+++ b/Common/Tests/Server/Utils/DataSource/EgressGuard.test.ts
@@ -1,13 +1,20 @@
+import dns from "dns";
 import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
 import { IsBillingEnabled } from "../../../../Server/EnvironmentConfig";
 import DataSourceEgressGuard, {
   AddressVerdict,
+  DEFAULT_DNS_RESOLVE_ATTEMPTS,
+  DEFAULT_DNS_RESOLVE_BUDGET_IN_MS,
   EgressGuardOptions,
   EgressLookupFunction,
   EgressResolveFunction,
   ResolvedAddress,
 } from "../../../../Server/Utils/DataSource/EgressGuard";
+import logger from "../../../../Server/Utils/Logger";
 import BadDataException from "../../../../Types/Exception/BadDataException";
+import EgressGuardException, {
+  EgressFailureReason,
+} from "../../../../Types/Exception/EgressGuardException";
 
 const ENV_VAR_NAME: string = "DATA_SOURCE_BLOCK_PRIVATE_ADDRESSES";
 
@@ -999,5 +1006,894 @@ describe("DataSourceEgressGuard.shouldBlockPrivateAddresses - BILLING_ENABLED is
     expect(DataSourceEgressGuard.checkAddress("169.254.169.254").blocked).toBe(
       true,
     );
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Typed failure reasons.
+ *
+ * Callers downstream of the guard used to have nothing but its message string
+ * to reason about. A shared probe suppresses that string down to one sanitized
+ * sentence (see the security block further down), so
+ * API.getRequestFailedDetails matched none of its patterns and reported the
+ * customer's monitor failure as phase "Unknown" with no actionable detail.
+ *
+ * Every throw site now carries an EgressFailureReason. These tests pin the
+ * reason AND the exact message at each site: the reason has to be usable, and
+ * the message must not have drifted while the reason was added.
+ * ---------------------------------------------------------------------------
+ */
+
+type ExpectEgressFailureFunction = (
+  error: Error,
+  expectedReason: EgressFailureReason,
+) => EgressGuardException;
+
+const expectEgressFailure: ExpectEgressFailureFunction = (
+  error: Error,
+  expectedReason: EgressFailureReason,
+): EgressGuardException => {
+  /*
+   * instanceof BadDataException is asserted as well: EgressGuardException
+   * extends it precisely so every pre-existing `instanceof BadDataException`
+   * check — including the fail-fast paths in the probe monitors — keeps
+   * behaving exactly as it did before the type existed.
+   */
+  expect(error).toBeInstanceOf(EgressGuardException);
+  expect(error).toBeInstanceOf(BadDataException);
+
+  const egressError: EgressGuardException = error as EgressGuardException;
+  expect(egressError.reason).toBe(expectedReason);
+
+  return egressError;
+};
+
+const rejectingResolveFunction: EgressResolveFunction = (
+  _hostname: string,
+): Promise<Array<ResolvedAddress>> => {
+  return Promise.reject(new Error("getaddrinfo EAI_AGAIN"));
+};
+
+describe("DataSourceEgressGuard - typed failure reasons", () => {
+  test("isTargetUnreachable is false only for InvalidTarget", () => {
+    /*
+     * This mapping is what decides whether a probe double-checks its own
+     * internet connectivity before believing a monitor is down. A malformed
+     * target is the tenant's configuration and must surface immediately; every
+     * other refusal is a reachability claim that deserves a second opinion.
+     */
+    expect(
+      new EgressGuardException(
+        "x",
+        EgressFailureReason.InvalidTarget,
+      ).isTargetUnreachable(),
+    ).toBe(false);
+
+    const unreachableReasons: Array<EgressFailureReason> = [
+      EgressFailureReason.Unreachable,
+      EgressFailureReason.ResolutionFailed,
+      EgressFailureReason.AddressBlocked,
+    ];
+    for (const reason of unreachableReasons) {
+      expect(new EgressGuardException("x", reason).isTargetUnreachable()).toBe(
+        true,
+      );
+    }
+  });
+
+  test("an empty hostname is InvalidTarget", async () => {
+    const error: Error = await captureRejection(
+      DataSourceEgressGuard.assertHostnameAllowed("", {
+        blockPrivateAddresses: true,
+      }),
+    );
+    const egressError: EgressGuardException = expectEgressFailure(
+      error,
+      EgressFailureReason.InvalidTarget,
+    );
+    expect(egressError.message).toBe("Data source host is required.");
+    expect(egressError.isTargetUnreachable()).toBe(false);
+  });
+
+  test.each([
+    [
+      "127.0.0.1",
+      "Data source host 127.0.0.1 is not allowed: loopback address.",
+    ],
+    [
+      "169.254.169.254",
+      "Data source host 169.254.169.254 is not allowed: link-local address (cloud metadata range).",
+    ],
+  ])(
+    "a blocked literal IP (%s) is AddressBlocked and keeps its full message",
+    async (address: string, expectedMessage: string) => {
+      const error: Error = await captureRejection(
+        DataSourceEgressGuard.assertHostnameAllowed(address, {
+          blockPrivateAddresses: false,
+        }),
+      );
+      const egressError: EgressGuardException = expectEgressFailure(
+        error,
+        EgressFailureReason.AddressBlocked,
+      );
+      expect(egressError.message).toBe(expectedMessage);
+      expect(egressError.isTargetUnreachable()).toBe(true);
+    },
+  );
+
+  test("a blocked literal IP keeps full detail even when detail is suppressed", async () => {
+    /*
+     * The literal path deliberately ignores includeResolvedAddressInError:
+     * echoing back an address the caller typed itself reveals nothing about
+     * the probe's network, and turning it into "could not be reached" would
+     * hide a plain configuration mistake for no security gain.
+     */
+    const error: Error = await captureRejection(
+      DataSourceEgressGuard.assertHostnameAllowed("169.254.169.254", {
+        blockPrivateAddresses: false,
+        targetLabel: "Monitor target",
+        includeResolvedAddressInError: false,
+      }),
+    );
+    const egressError: EgressGuardException = expectEgressFailure(
+      error,
+      EgressFailureReason.AddressBlocked,
+    );
+    expect(egressError.message).toBe(
+      "Monitor target host 169.254.169.254 is not allowed: link-local address (cloud metadata range).",
+    );
+  });
+
+  test.each([
+    ["", "Data source URL is required."],
+    ["not a valid url", "Invalid data source URL: not a valid url"],
+    [
+      "ftp://example.com/file",
+      "Data source URL must use http or https (got ftp).",
+    ],
+    [
+      "file:///etc/passwd",
+      "Data source URL must use http or https (got file).",
+    ],
+  ])(
+    "an unusable URL (%s) is InvalidTarget",
+    async (urlString: string, expectedMessage: string) => {
+      const error: Error = await captureRejection(
+        DataSourceEgressGuard.assertUrlAllowed(urlString, {
+          blockPrivateAddresses: true,
+        }),
+      );
+      const egressError: EgressGuardException = expectEgressFailure(
+        error,
+        EgressFailureReason.InvalidTarget,
+      );
+      expect(egressError.message).toBe(expectedMessage);
+      expect(egressError.isTargetUnreachable()).toBe(false);
+    },
+  );
+
+  test.each([undefined, true])(
+    "a resolver rejection is ResolutionFailed when includeResolvedAddressInError is %s",
+    async (includeResolvedAddressInError: boolean | undefined) => {
+      const error: Error = await captureRejection(
+        DataSourceEgressGuard.assertHostnameAllowed("missing.example.com", {
+          blockPrivateAddresses: true,
+          resolveFunction: rejectingResolveFunction,
+          includeResolvedAddressInError: includeResolvedAddressInError,
+        }),
+      );
+      const egressError: EgressGuardException = expectEgressFailure(
+        error,
+        EgressFailureReason.ResolutionFailed,
+      );
+      expect(egressError.message).toBe(
+        "Could not resolve data source host missing.example.com: getaddrinfo EAI_AGAIN",
+      );
+      expect(egressError.isTargetUnreachable()).toBe(true);
+    },
+  );
+
+  test.each([undefined, true])(
+    "an empty DNS answer is ResolutionFailed when includeResolvedAddressInError is %s",
+    async (includeResolvedAddressInError: boolean | undefined) => {
+      const resolver: Resolver = makeResolver([]);
+      const error: Error = await captureRejection(
+        DataSourceEgressGuard.assertHostnameAllowed("empty.example.com", {
+          blockPrivateAddresses: true,
+          resolveFunction: resolver.resolveFunction,
+          includeResolvedAddressInError: includeResolvedAddressInError,
+        }),
+      );
+      const egressError: EgressGuardException = expectEgressFailure(
+        error,
+        EgressFailureReason.ResolutionFailed,
+      );
+      expect(egressError.message).toBe(
+        "Could not resolve data source host empty.example.com.",
+      );
+      expect(egressError.isTargetUnreachable()).toBe(true);
+    },
+  );
+
+  test.each([undefined, true])(
+    "a blocked resolved address is AddressBlocked when includeResolvedAddressInError is %s",
+    async (includeResolvedAddressInError: boolean | undefined) => {
+      const resolver: Resolver = makeResolver([
+        { address: "10.23.45.67", family: 4 },
+      ]);
+      const error: Error = await captureRejection(
+        DataSourceEgressGuard.assertHostnameAllowed("internal.example.com", {
+          blockPrivateAddresses: true,
+          resolveFunction: resolver.resolveFunction,
+          includeResolvedAddressInError: includeResolvedAddressInError,
+        }),
+      );
+      const egressError: EgressGuardException = expectEgressFailure(
+        error,
+        EgressFailureReason.AddressBlocked,
+      );
+      expect(egressError.message).toBe(
+        "Data source host internal.example.com resolves to 10.23.45.67, which is not allowed: private network address.",
+      );
+      expect(egressError.isTargetUnreachable()).toBe(true);
+    },
+  );
+
+  test("all three resolve-path failures collapse to Unreachable when detail is suppressed", async () => {
+    const blockedResolver: Resolver = makeResolver([
+      { address: "10.23.45.67", family: 4 },
+    ]);
+    const emptyResolver: Resolver = makeResolver([]);
+    const suppressedOptions: EgressGuardOptions = {
+      blockPrivateAddresses: true,
+      targetLabel: "Monitor target",
+      includeResolvedAddressInError: false,
+    };
+
+    const resolveFunctions: Array<EgressResolveFunction> = [
+      rejectingResolveFunction,
+      emptyResolver.resolveFunction,
+      blockedResolver.resolveFunction,
+    ];
+
+    for (const resolveFunction of resolveFunctions) {
+      const error: Error = await captureRejection(
+        DataSourceEgressGuard.assertHostnameAllowed("host.example.com", {
+          ...suppressedOptions,
+          resolveFunction: resolveFunction,
+        }),
+      );
+      const egressError: EgressGuardException = expectEgressFailure(
+        error,
+        EgressFailureReason.Unreachable,
+      );
+      expect(egressError.message).toBe(
+        "Monitor target host host.example.com could not be reached.",
+      );
+      expect(egressError.isTargetUnreachable()).toBe(true);
+    }
+  });
+
+  test("assertUrlAllowed forwards the hostname's reason unchanged", async () => {
+    /*
+     * assertUrlAllowed is the entry point the HTTP monitors use, so the reason
+     * has to survive the extra call frame — otherwise the URL form of the same
+     * failure would still report phase "Unknown".
+     */
+    const blockedResolver: Resolver = makeResolver([
+      { address: "10.23.45.67", family: 4 },
+    ]);
+
+    const detailedError: Error = await captureRejection(
+      DataSourceEgressGuard.assertUrlAllowed("https://internal.example.com", {
+        blockPrivateAddresses: true,
+        resolveFunction: blockedResolver.resolveFunction,
+      }),
+    );
+    expectEgressFailure(detailedError, EgressFailureReason.AddressBlocked);
+
+    const suppressedError: Error = await captureRejection(
+      DataSourceEgressGuard.assertUrlAllowed(
+        "https://order.abbeysbakehouse.com/",
+        {
+          blockPrivateAddresses: true,
+          targetLabel: "Monitor target",
+          includeResolvedAddressInError: false,
+          resolveFunction: rejectingResolveFunction,
+        },
+      ),
+    );
+    const egressError: EgressGuardException = expectEgressFailure(
+      suppressedError,
+      EgressFailureReason.Unreachable,
+    );
+    expect(egressError.message).toBe(
+      "Monitor target host order.abbeysbakehouse.com could not be reached.",
+    );
+  });
+
+  test("createGuardedLookup hands the typed exception to its callback", async () => {
+    /*
+     * The guarded lookup is installed into third-party clients, which surface
+     * whatever the callback was handed. The reason must survive that hop too.
+     */
+    const lookup: EgressLookupFunction =
+      DataSourceEgressGuard.createGuardedLookup({
+        blockPrivateAddresses: true,
+        resolveFunction: makeResolver([{ address: "10.23.45.67", family: 4 }])
+          .resolveFunction,
+      });
+
+    const result: LookupResult = await callLookup(lookup, {});
+
+    expectEgressFailure(
+      result.error as unknown as Error,
+      EgressFailureReason.AddressBlocked,
+    );
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * THE SECURITY INVARIANT.
+ *
+ * On OneUptime Cloud a shared probe resolves every tenant's hostnames against
+ * the probe network's own resolver. A tenant who could tell "did not resolve"
+ * apart from "resolved, but the address is blocked" would own a DNS oracle for
+ * the probe network: point a monitor at internal-name.corp and read the
+ * difference to learn whether the name exists.
+ *
+ * So with includeResolvedAddressInError:false the three resolve-path branches
+ * must be BYTE-IDENTICAL in everything a caller can observe. The reason enum
+ * added for the diagnostics fix is the newest thing that could reopen this,
+ * which is why it is compared here alongside the message.
+ * ---------------------------------------------------------------------------
+ */
+describe("DataSourceEgressGuard - the sanitized failure is one indistinguishable failure", () => {
+  const ORACLE_HOSTNAME: string = "internal-name.example.com";
+  const SECRET_ADDRESS: string = "10.23.45.67";
+
+  interface EgressFailureFingerprint {
+    constructorName: string;
+    message: string;
+    reason: string;
+    code: number;
+    isTargetUnreachable: boolean;
+    ownProperties: string;
+  }
+
+  type FingerprintFunction = (error: Error) => EgressFailureFingerprint;
+
+  /*
+   * Everything a caller can see, minus the stack (whose frames legitimately
+   * differ). Own enumerable properties are folded in wholesale so that a
+   * future change which attaches, say, a `resolvedAddress` to only one branch
+   * fails this test instead of quietly reopening the oracle.
+   */
+  const fingerprint: FingerprintFunction = (
+    error: Error,
+  ): EgressFailureFingerprint => {
+    const egressError: EgressGuardException = error as EgressGuardException;
+    const ownProperties: Record<string, unknown> = {};
+
+    for (const key of Object.keys(error).sort()) {
+      if (key === "stack") {
+        continue;
+      }
+      ownProperties[key] = (error as unknown as Record<string, unknown>)[key];
+    }
+
+    return {
+      constructorName: error.constructor.name,
+      message: error.message,
+      reason: egressError.reason,
+      code: egressError.code as unknown as number,
+      isTargetUnreachable: egressError.isTargetUnreachable(),
+      ownProperties: JSON.stringify(ownProperties),
+    };
+  };
+
+  const suppressedOptions: EgressGuardOptions = {
+    blockPrivateAddresses: true,
+    targetLabel: "Monitor target",
+    includeResolvedAddressInError: false,
+  };
+
+  type FailWithFunction = (
+    resolveFunction: EgressResolveFunction,
+    options?: EgressGuardOptions,
+  ) => Promise<Error>;
+
+  const failWith: FailWithFunction = (
+    resolveFunction: EgressResolveFunction,
+    options: EgressGuardOptions = suppressedOptions,
+  ): Promise<Error> => {
+    return captureRejection(
+      DataSourceEgressGuard.assertHostnameAllowed(ORACLE_HOSTNAME, {
+        ...options,
+        resolveFunction: resolveFunction,
+      }),
+    );
+  };
+
+  /*
+   * The resolver rejection deliberately carries the secret address in its own
+   * message, so a branch that passed the underlying error through would be
+   * caught by the leak assertions below as well as by the equality one.
+   */
+  const resolverRejects: EgressResolveFunction = (
+    _hostname: string,
+  ): Promise<Array<ResolvedAddress>> => {
+    return Promise.reject(
+      new Error(`getaddrinfo ENOTFOUND ${ORACLE_HOSTNAME} ${SECRET_ADDRESS}`),
+    );
+  };
+
+  const resolverReturnsNothing: EgressResolveFunction = (
+    _hostname: string,
+  ): Promise<Array<ResolvedAddress>> => {
+    return Promise.resolve([]);
+  };
+
+  const resolverReturnsPrivateAddress: EgressResolveFunction = (
+    _hostname: string,
+  ): Promise<Array<ResolvedAddress>> => {
+    return Promise.resolve([{ address: SECRET_ADDRESS, family: 4 }]);
+  };
+
+  test("the DNS-failure, empty-answer and blocked-address branches are indistinguishable", async () => {
+    const resolverRejectedError: Error = await failWith(resolverRejects);
+    const emptyAnswerError: Error = await failWith(resolverReturnsNothing);
+    const blockedAddressError: Error = await failWith(
+      resolverReturnsPrivateAddress,
+    );
+
+    const expectedFingerprint: EgressFailureFingerprint = {
+      constructorName: "EgressGuardException",
+      message: `Monitor target host ${ORACLE_HOSTNAME} could not be reached.`,
+      reason: EgressFailureReason.Unreachable,
+      code: fingerprint(resolverRejectedError).code,
+      isTargetUnreachable: true,
+      ownProperties: fingerprint(resolverRejectedError).ownProperties,
+    };
+
+    for (const error of [
+      resolverRejectedError,
+      emptyAnswerError,
+      blockedAddressError,
+    ]) {
+      expect(fingerprint(error)).toEqual(expectedFingerprint);
+
+      /*
+       * Pinned absolutely, not just relative to each other: mutual equality
+       * alone would still pass if some future change attached the same new
+       * leaky field (a cause, a resolved address) to every branch.
+       */
+      expect(Object.keys(error).sort()).toEqual(["_code", "reason"]);
+    }
+  });
+
+  test("no sanitized message leaks the resolved address, the policy reason or the resolver error", async () => {
+    const errors: Array<Error> = [
+      await failWith(resolverRejects),
+      await failWith(resolverReturnsNothing),
+      await failWith(resolverReturnsPrivateAddress),
+    ];
+
+    for (const error of errors) {
+      expect(error.message).not.toContain(SECRET_ADDRESS);
+      expect(error.message).not.toContain("private network");
+      expect(error.message).not.toContain("ENOTFOUND");
+      expect(error.message).not.toContain("resolve");
+      expect(JSON.stringify(error)).not.toContain(SECRET_ADDRESS);
+    }
+  });
+
+  test("the same three branches ARE distinguishable when detail is allowed", async () => {
+    /*
+     * Guards the guard: without this, a bug that made the sanitized path the
+     * ONLY path would leave the invariant test above passing while every
+     * operator-facing message quietly lost its diagnosis.
+     */
+    const detailedOptions: EgressGuardOptions = {
+      blockPrivateAddresses: true,
+      targetLabel: "Monitor target",
+    };
+
+    const messages: Array<string> = [
+      (await failWith(resolverRejects, detailedOptions)).message,
+      (await failWith(resolverReturnsNothing, detailedOptions)).message,
+      (await failWith(resolverReturnsPrivateAddress, detailedOptions)).message,
+    ];
+
+    expect(new Set(messages).size).toBe(3);
+    expect(messages[2]).toContain(SECRET_ADDRESS);
+  });
+
+  test("operators still learn the real cause through the debug log", async () => {
+    /*
+     * Destroying the cause for the caller is the point, so the debug log is
+     * the ONLY channel left for whoever has to fix the monitor. If this ever
+     * stops firing, a sanitized failure becomes undiagnosable everywhere.
+     */
+    const debugSpy: jest.SpyInstance = jest
+      .spyOn(logger, "debug")
+      .mockImplementation((): void => {
+        // Swallow the output; only the call itself is under test.
+      });
+
+    await failWith(resolverRejects);
+    await failWith(resolverReturnsNothing);
+    await failWith(resolverReturnsPrivateAddress);
+
+    const loggedLines: Array<string> = debugSpy.mock.calls.map(
+      (call: Array<unknown>) => {
+        return String(call[0]);
+      },
+    );
+
+    expect(loggedLines).toHaveLength(3);
+    expect(loggedLines[0]).toContain("ENOTFOUND");
+    expect(loggedLines[1]).toContain("no addresses");
+    expect(loggedLines[2]).toContain("private network address");
+
+    for (const line of loggedLines) {
+      expect(line).toContain(ORACLE_HOSTNAME);
+    }
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * DNS resolution retries.
+ *
+ * The customer incident that started all of this was a single transient
+ * getaddrinfo failure on ONE monitor out of ~75 on the same probe: one lookup,
+ * no retry, straight to a monitor-down incident. getaddrinfo fails transiently
+ * (EAI_AGAIN under resolver load, a nameserver restarting) far more often than
+ * a host actually disappears, which is why the probe's Helm chart already
+ * ships fallback nameservers.
+ *
+ * defaultResolve is private, so every test here drives the real path:
+ * assertHostnameAllowed with NO resolveFunction and dns.promises.lookup
+ * replaced.
+ * ---------------------------------------------------------------------------
+ */
+describe("DataSourceEgressGuard - DNS resolution retries", () => {
+  const PUBLIC_ANSWER: Array<ResolvedAddress> = [
+    { address: "93.184.216.34", family: 4 },
+  ];
+  const HOSTNAME: string = "order.abbeysbakehouse.com";
+
+  type FakeLookupImplementation = (
+    hostname: string,
+    lookupOptions: { all?: boolean | undefined },
+  ) => Promise<Array<ResolvedAddress>>;
+
+  type InstallLookupSpyFunction = (
+    implementation: FakeLookupImplementation,
+  ) => jest.Mock;
+
+  /*
+   * `as never` sidesteps dns.promises.lookup's overload set, the same trick
+   * the guard itself uses when handing a lookup to http.Agent.
+   */
+  const installLookupSpy: InstallLookupSpyFunction = (
+    implementation: FakeLookupImplementation,
+  ): jest.Mock => {
+    const lookupMock: jest.Mock = jest.fn(implementation);
+    jest.spyOn(dns.promises, "lookup").mockImplementation(lookupMock as never);
+    return lookupMock;
+  };
+
+  type TransientLookupFunction = (
+    failuresBeforeSuccess: number,
+  ) => FakeLookupImplementation;
+
+  const transientlyFailingLookup: TransientLookupFunction = (
+    failuresBeforeSuccess: number,
+  ): FakeLookupImplementation => {
+    let attempts: number = 0;
+    return (): Promise<Array<ResolvedAddress>> => {
+      attempts++;
+      if (attempts <= failuresBeforeSuccess) {
+        const error: NodeJS.ErrnoException = new Error(
+          `getaddrinfo EAI_AGAIN ${HOSTNAME}`,
+        );
+        error.code = "EAI_AGAIN";
+        return Promise.reject(error);
+      }
+      return Promise.resolve(PUBLIC_ANSWER);
+    };
+  };
+
+  const alwaysFailingLookup: FakeLookupImplementation = (): Promise<
+    Array<ResolvedAddress>
+  > => {
+    const error: NodeJS.ErrnoException = new Error(
+      `getaddrinfo EAI_AGAIN ${HOSTNAME}`,
+    );
+    error.code = "EAI_AGAIN";
+    return Promise.reject(error);
+  };
+
+  const neverSettlingLookup: FakeLookupImplementation = (): Promise<
+    Array<ResolvedAddress>
+  > => {
+    return new Promise<Array<ResolvedAddress>>((): void => {
+      // Models a wedged resolver: it neither answers nor fails.
+    });
+  };
+
+  test("the tuning constants have not drifted", () => {
+    /*
+     * Both are load-bearing. The budget is what keeps worst-case latency equal
+     * to the single 5s lookup this replaced, and callers (the probe) pass a
+     * larger one deliberately; the attempt count is what absorbs a blip.
+     */
+    expect(DEFAULT_DNS_RESOLVE_BUDGET_IN_MS).toBe(5000);
+    expect(DEFAULT_DNS_RESOLVE_ATTEMPTS).toBe(3);
+  });
+
+  test("a lookup that fails twice and then succeeds no longer fails the caller", async () => {
+    /*
+     * THE regression test for the customer incident. Against the old
+     * single-shot defaultResolve this rejects with
+     * "could not be reached" and the lookup is called exactly once.
+     */
+    const lookupMock: jest.Mock = installLookupSpy(transientlyFailingLookup(2));
+
+    const addresses: Array<ResolvedAddress> =
+      await DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+        blockPrivateAddresses: true,
+        targetLabel: "Monitor target",
+        includeResolvedAddressInError: false,
+      });
+
+    expect(addresses).toEqual(PUBLIC_ANSWER);
+    expect(lookupMock).toHaveBeenCalledTimes(3);
+  });
+
+  test("the same transient failure DOES take the monitor down when retrying is off", async () => {
+    /*
+     * The other half of the pair above, and the closest this suite can get to
+     * running the old code: resolveAttempts:1 IS the single-shot defaultResolve
+     * that produced the customer's incident, driven by the identical lookup.
+     * One knob is the whole difference between a resolved monitor and
+     * "Monitor target host order.abbeysbakehouse.com could not be reached."
+     */
+    const lookupMock: jest.Mock = installLookupSpy(transientlyFailingLookup(2));
+
+    const error: Error = await captureRejection(
+      DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+        blockPrivateAddresses: true,
+        targetLabel: "Monitor target",
+        includeResolvedAddressInError: false,
+        resolveAttempts: 1,
+      }),
+    );
+
+    expect(lookupMock).toHaveBeenCalledTimes(1);
+    expect(error.message).toBe(
+      `Monitor target host ${HOSTNAME} could not be reached.`,
+    );
+  });
+
+  test("asks getaddrinfo for every record, not just the first", () => {
+    /*
+     * all:true is a security property, not a detail: a multi-record answer
+     * that mixed one public decoy with a private target would otherwise slip
+     * past the per-address checks.
+     */
+    const lookupMock: jest.Mock = installLookupSpy(transientlyFailingLookup(0));
+
+    return DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+      blockPrivateAddresses: true,
+    }).then(() => {
+      expect(lookupMock).toHaveBeenCalledWith(HOSTNAME, { all: true });
+    });
+  });
+
+  test("the happy path costs exactly one lookup", async () => {
+    const lookupMock: jest.Mock = installLookupSpy(transientlyFailingLookup(0));
+
+    await DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+      blockPrivateAddresses: true,
+    });
+
+    expect(lookupMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a persistently failing lookup is tried DEFAULT_DNS_RESOLVE_ATTEMPTS times and then reported", async () => {
+    const lookupMock: jest.Mock = installLookupSpy(alwaysFailingLookup);
+
+    const error: Error = await captureRejection(
+      DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+        blockPrivateAddresses: true,
+      }),
+    );
+
+    expect(lookupMock).toHaveBeenCalledTimes(DEFAULT_DNS_RESOLVE_ATTEMPTS);
+    const egressError: EgressGuardException = expectEgressFailure(
+      error,
+      EgressFailureReason.ResolutionFailed,
+    );
+    // The LAST attempt's error is what surfaces, not a synthesized one.
+    expect(egressError.message).toBe(
+      `Could not resolve data source host ${HOSTNAME}: getaddrinfo EAI_AGAIN ${HOSTNAME}`,
+    );
+  });
+
+  test("resolveAttempts: 1 disables retrying entirely", async () => {
+    const lookupMock: jest.Mock = installLookupSpy(alwaysFailingLookup);
+
+    await captureRejection(
+      DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+        blockPrivateAddresses: true,
+        resolveAttempts: 1,
+      }),
+    );
+
+    expect(lookupMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a caller-supplied resolveAttempts is honoured", async () => {
+    const lookupMock: jest.Mock = installLookupSpy(alwaysFailingLookup);
+
+    await captureRejection(
+      DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+        blockPrivateAddresses: true,
+        resolveAttempts: 5,
+      }),
+    );
+
+    expect(lookupMock).toHaveBeenCalledTimes(5);
+  });
+
+  test("retries stop as soon as the answer is good, even with a large attempt budget", async () => {
+    const lookupMock: jest.Mock = installLookupSpy(transientlyFailingLookup(1));
+
+    await DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+      blockPrivateAddresses: true,
+      resolveAttempts: 5,
+    });
+
+    expect(lookupMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a retried answer is still subject to the address policy", async () => {
+    /*
+     * Retrying must not become a way around the guard: the addresses the last
+     * attempt returned go through exactly the same checks.
+     */
+    let attempts: number = 0;
+    installLookupSpy((): Promise<Array<ResolvedAddress>> => {
+      attempts++;
+      if (attempts === 1) {
+        return Promise.reject(new Error("getaddrinfo EAI_AGAIN"));
+      }
+      return Promise.resolve([{ address: "169.254.169.254", family: 4 }]);
+    });
+
+    const error: Error = await captureRejection(
+      DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+        blockPrivateAddresses: false,
+      }),
+    );
+
+    const egressError: EgressGuardException = expectEgressFailure(
+      error,
+      EgressFailureReason.AddressBlocked,
+    );
+    expect(egressError.message).toContain("169.254.169.254");
+  });
+
+  test("the total budget caps the retries below the attempt count", async () => {
+    /*
+     * resolveAttempts is a ceiling inside the budget, never an extension of
+     * it: a 200ms budget cannot fit three attempts once the inter-attempt
+     * delay is paid, so fewer are made.
+     */
+    const budgetInMs: number = 200;
+    const lookupMock: jest.Mock = installLookupSpy(alwaysFailingLookup);
+
+    const startedAt: number = Date.now();
+    const error: Error = await captureRejection(
+      DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+        blockPrivateAddresses: true,
+        resolveTimeoutInMs: budgetInMs,
+      }),
+    );
+    const elapsedInMs: number = Date.now() - startedAt;
+
+    expect(lookupMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(lookupMock.mock.calls.length).toBeLessThan(
+      DEFAULT_DNS_RESOLVE_ATTEMPTS,
+    );
+    expect(elapsedInMs).toBeLessThan(budgetInMs + 500);
+    expectEgressFailure(error, EgressFailureReason.ResolutionFailed);
+  });
+
+  test("a wedged resolver gives up at the budget instead of hanging", async () => {
+    const budgetInMs: number = 25;
+    const lookupMock: jest.Mock = installLookupSpy(neverSettlingLookup);
+
+    const error: Error = await captureRejection(
+      DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+        blockPrivateAddresses: true,
+        resolveTimeoutInMs: budgetInMs,
+      }),
+    );
+
+    expect(lookupMock).toHaveBeenCalledTimes(1);
+    const egressError: EgressGuardException = expectEgressFailure(
+      error,
+      EgressFailureReason.ResolutionFailed,
+    );
+    expect(egressError.message).toContain("DNS lookup timed out");
+  });
+
+  test("retrying does not make the worst case any slower than the single lookup it replaced", async () => {
+    /*
+     * The retries live INSIDE one budget. A resolver that hangs burns the
+     * whole budget on its first attempt, so it must not be retried — otherwise
+     * every genuinely dead host would cost attempts x budget and the probe's
+     * own execution timeout would start firing instead.
+     */
+    const budgetInMs: number = 400;
+    const lookupMock: jest.Mock = installLookupSpy(neverSettlingLookup);
+
+    const startedAt: number = Date.now();
+    await captureRejection(
+      DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+        blockPrivateAddresses: true,
+        resolveTimeoutInMs: budgetInMs,
+        resolveAttempts: DEFAULT_DNS_RESOLVE_ATTEMPTS,
+      }),
+    );
+    const elapsedInMs: number = Date.now() - startedAt;
+
+    expect(lookupMock).toHaveBeenCalledTimes(1);
+    expect(elapsedInMs).toBeLessThan(budgetInMs * 2);
+  });
+
+  test("an injected resolveFunction replaces the retry path entirely and is called once", async () => {
+    /*
+     * Pinning the real behaviour rather than an aspiration: resolveFunction is
+     * a full substitution for defaultResolve, so callers that inject one own
+     * their own retry policy and see exactly one call. Existing callers and
+     * every other test in this file depend on that.
+     */
+    const lookupMock: jest.Mock = installLookupSpy(transientlyFailingLookup(0));
+
+    let resolveFunctionCalls: number = 0;
+    const resolveFunction: EgressResolveFunction = (
+      _hostname: string,
+    ): Promise<Array<ResolvedAddress>> => {
+      resolveFunctionCalls++;
+      return Promise.reject(new Error("getaddrinfo EAI_AGAIN"));
+    };
+
+    await captureRejection(
+      DataSourceEgressGuard.assertHostnameAllowed(HOSTNAME, {
+        blockPrivateAddresses: true,
+        resolveFunction: resolveFunction,
+        resolveAttempts: 5,
+      }),
+    );
+
+    expect(resolveFunctionCalls).toBe(1);
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  test("a literal IP never touches the resolver at all", async () => {
+    const lookupMock: jest.Mock = installLookupSpy(transientlyFailingLookup(0));
+
+    await DataSourceEgressGuard.assertHostnameAllowed("93.184.216.34", {
+      blockPrivateAddresses: true,
+    });
+
+    expect(lookupMock).not.toHaveBeenCalled();
   });
 });

--- a/Common/Tests/Server/Utils/Monitor/MonitorRootCauseTargetResolution.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorRootCauseTargetResolution.test.ts
@@ -1,0 +1,423 @@
+/*
+ * The evaluator's import chain pulls the native isolated-vm addon
+ * (MonitorCriteriaEvaluator → VMAPI → VMRunner). Nothing under test here
+ * touches the sandbox, and the prebuilt binary cannot always dlopen in the
+ * test environment — so stub the module out before anything imports it.
+ */
+jest.mock("isolated-vm", () => {
+  return {};
+});
+
+import MonitorCriteriaEvaluator from "../../../../Server/Utils/Monitor/MonitorCriteriaEvaluator";
+import API from "../../../../Utils/API";
+import EgressGuardException, {
+  EgressFailureReason,
+} from "../../../../Types/Exception/EgressGuardException";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import MonitorStep from "../../../../Types/Monitor/MonitorStep";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import RequestFailedDetails, {
+  RequestFailedPhase,
+} from "../../../../Types/Probe/RequestFailedDetails";
+import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
+import DataToProcess from "../../../../Server/Utils/Monitor/DataToProcess";
+import URL from "../../../../Types/API/URL";
+import ObjectID from "../../../../Types/ObjectID";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * THE ROOT CAUSE A CUSTOMER ACTUALLY READS WHEN A TARGET CANNOT BE RESOLVED.
+ *
+ * A website monitor for https://order.abbeysbakehouse.com/ raised an incident
+ * whose entire root cause was:
+ *
+ *   Response Snapshot -> Response Time: 0.00 ms ; Timed Out: No
+ *   Request Failed Details ->
+ *     Failed Phase: Unknown
+ *     Error Description: Request failed: Monitor target host
+ *       order.abbeysbakehouse.com could not be reached.
+ *     Raw Error Message: <the same sentence>
+ *
+ * One monitor out of ~75 on the same cluster. Nothing in that text told the
+ * customer what to check, there was no Error Code line at all, and "Unknown"
+ * actively suggested a product bug rather than a resolver hiccup.
+ *
+ * The cause was a classification gap, not a rendering one: the egress guard
+ * deliberately sanitizes its message down to one sentence (a shared cloud probe
+ * must not let a tenant tell "did not resolve" from "resolved but blocked", or
+ * they can enumerate internal DNS names), and that sanitized sentence matched
+ * none of API.getRequestFailedDetails' string patterns, so it fell through to
+ * the Unknown default with errorCode undefined.
+ *
+ * This suite pins the surface the customer read: it drives the REAL classifier
+ * with a REAL EgressGuardException and asserts what MonitorCriteriaEvaluator
+ * renders from it, so the fix cannot be undone at either end. It also pins the
+ * new "- Attempts:" line, which is the other half of reading such a failure —
+ * "tried once" and "tried three times" mean very different things — and a
+ * plain HTTP 500 control case so the new branch is not shadowing the old ones.
+ */
+
+type EvaluatorPrivate = {
+  buildRootCauseContext: (input: {
+    dataToProcess: DataToProcess;
+    monitorStep: MonitorStep;
+    monitor: Monitor;
+  }) => Promise<string | null>;
+};
+
+const Evaluator: EvaluatorPrivate =
+  MonitorCriteriaEvaluator as unknown as EvaluatorPrivate;
+
+const CUSTOMER_URL: string = "https://order.abbeysbakehouse.com/";
+
+/*
+ * Byte-for-byte the sentence the guard throws for this customer's host when
+ * detail is suppressed — DNS failure and address-policy rejection produce the
+ * SAME sentence on purpose. Tests build the exception from it rather than
+ * hand-writing requestFailedDetails, so the classifier is exercised too.
+ */
+const SANITIZED_GUARD_MESSAGE: string =
+  "Monitor target host order.abbeysbakehouse.com could not be reached.";
+
+/*
+ * The description is a constant in API.getRequestFailedDetails rather than an
+ * exported symbol, so read it back through the classifier instead of copying
+ * a paragraph that would silently drift out of date.
+ */
+const UNREACHABLE_DETAILS: RequestFailedDetails = API.getRequestFailedDetails(
+  new EgressGuardException(
+    SANITIZED_GUARD_MESSAGE,
+    EgressFailureReason.Unreachable,
+  ),
+);
+
+function makeMonitor(): Monitor {
+  const monitor: Monitor = new Monitor();
+  monitor.monitorType = MonitorType.Website;
+  return monitor;
+}
+
+function makeMonitorStep(): MonitorStep {
+  const monitorStep: MonitorStep = new MonitorStep();
+  monitorStep.setMonitorDestination(URL.fromString(CUSTOMER_URL));
+  return monitorStep;
+}
+
+function makeProbeResponse(
+  overrides: Partial<ProbeMonitorResponse> = {},
+): ProbeMonitorResponse {
+  return {
+    projectId: ObjectID.generate(),
+    monitorId: ObjectID.generate(),
+    monitorStepId: ObjectID.generate(),
+    probeId: ObjectID.generate(),
+    failureCause: "",
+    monitoredAt: new Date("2026-09-10T09:15:00.000Z"),
+    isOnline: false,
+    responseTimeInMs: 0,
+    isTimeout: false,
+    ...overrides,
+  };
+}
+
+async function renderRootCause(
+  probeResponse: ProbeMonitorResponse,
+): Promise<string> {
+  const context: string | null = await Evaluator.buildRootCauseContext({
+    dataToProcess: probeResponse,
+    monitorStep: makeMonitorStep(),
+    monitor: makeMonitor(),
+  });
+
+  expect(context).not.toBeNull();
+  return context as string;
+}
+
+/*
+ * The rendered block is a flat list of "**Section**" headings, so pull one
+ * section's body out by slicing between its heading and the next one. Used to
+ * prove WHERE a line lands, not just that it exists somewhere.
+ */
+function section(context: string, heading: string): string {
+  const marker: string = `**${heading}**`;
+  const start: number = context.indexOf(marker);
+
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const afterHeading: string = context.substring(start + marker.length);
+  const nextHeading: number = afterHeading.indexOf("**");
+
+  return nextHeading === -1
+    ? afterHeading
+    : afterHeading.substring(0, nextHeading);
+}
+
+/** The failing probe response exactly as the customer's incident recorded it. */
+function customerFailureResponse(): ProbeMonitorResponse {
+  return makeProbeResponse({
+    totalAttempts: 1,
+    requestFailedDetails: {
+      failedPhase: RequestFailedPhase.TargetResolution,
+      errorCode: "TARGET_UNREACHABLE",
+      errorDescription: UNREACHABLE_DETAILS.errorDescription,
+      rawErrorMessage: SANITIZED_GUARD_MESSAGE,
+    },
+  });
+}
+
+describe("Root cause for a target the probe could not resolve", () => {
+  test("classifier turns the sanitized guard sentence into a Target Resolution failure", () => {
+    /*
+     * Guards the input to every assertion below. Against the old code this
+     * failed on the very first expect: the sentence matched no pattern, so the
+     * phase was Unknown and errorCode was undefined.
+     */
+    expect(UNREACHABLE_DETAILS.failedPhase).toBe(
+      RequestFailedPhase.TargetResolution,
+    );
+    expect(UNREACHABLE_DETAILS.errorCode).toBe("TARGET_UNREACHABLE");
+    expect(UNREACHABLE_DETAILS.errorDescription).not.toBe(
+      SANITIZED_GUARD_MESSAGE,
+    );
+    expect(UNREACHABLE_DETAILS.rawErrorMessage).toBe(SANITIZED_GUARD_MESSAGE);
+  });
+
+  test("renders the failed phase as Target Resolution, never Unknown", async () => {
+    const context: string = await renderRootCause(customerFailureResponse());
+
+    expect(context).toContain("- Failed Phase: Target Resolution");
+    expect(context).not.toContain("- Failed Phase: Unknown");
+  });
+
+  test("renders an Error Code line, which the customer's incident lacked entirely", async () => {
+    const context: string = await renderRootCause(customerFailureResponse());
+
+    /*
+     * The renderer only emits this line when errorCode is truthy. The old
+     * classifier left it undefined, so the incident had no Error Code line at
+     * all — the assertion below is precisely the regression.
+     */
+    expect(context).toContain("- Error Code: TARGET_UNREACHABLE");
+  });
+
+  test("renders an actionable error description instead of echoing the raw sentence", async () => {
+    const context: string = await renderRootCause(customerFailureResponse());
+
+    expect(context).toContain(
+      `- Error Description: ${UNREACHABLE_DETAILS.errorDescription}`,
+    );
+
+    // The old text was literally "Request failed: " + the raw sentence.
+    expect(context).not.toContain(
+      `- Error Description: Request failed: ${SANITIZED_GUARD_MESSAGE}`,
+    );
+
+    /*
+     * Pin the actionable content, not just its identity with the constant:
+     * the description has to name what to check and how an internal host is
+     * meant to be monitored, or the incident is no more useful than before.
+     */
+    const description: string = UNREACHABLE_DETAILS.errorDescription;
+    expect(description).toContain("DNS");
+    expect(description).toContain("nameservers");
+    expect(description).toContain("PROBE_ALLOW_PRIVATE_NETWORK_MONITORS=true");
+  });
+
+  test("still shows the raw guard message for debugging", async () => {
+    const context: string = await renderRootCause(customerFailureResponse());
+
+    expect(context).toContain(
+      "- Raw Error Message: Monitor target host order.abbeysbakehouse.com could not be reached.",
+    );
+  });
+
+  test("keeps the rest of the customer's snapshot intact", async () => {
+    const context: string = await renderRootCause(customerFailureResponse());
+
+    expect(context).toContain(`- Destination: ${CUSTOMER_URL}`);
+    expect(context).toContain("- Response Time: 0.00 ms");
+    expect(context).toContain("- Timed Out: No");
+  });
+
+  test("does not disclose which failure the guard actually hit", async () => {
+    /*
+     * The sanitization is a security property, not an accident: a tenant on a
+     * shared cloud probe who can tell "did not resolve" from "resolved to an
+     * address I am not allowed to dial" can enumerate internal DNS names. The
+     * richer classification must not leak that distinction back out.
+     */
+    const context: string = await renderRootCause(customerFailureResponse());
+
+    expect(context).not.toContain("ResolutionFailed");
+    expect(context).not.toContain("AddressBlocked");
+  });
+
+  test("every unreachable reason renders the same code and description", async () => {
+    /*
+     * A self-hosted probe is allowed detail, so the guard hands the classifier
+     * the specific ResolutionFailed / AddressBlocked reasons there. The
+     * TENANT-facing text must still collapse them: differing codes or wording
+     * would reopen the oracle one layer below the guard's sanitized message.
+     */
+    const rendered: Array<string> = [];
+
+    for (const reason of [
+      EgressFailureReason.Unreachable,
+      EgressFailureReason.ResolutionFailed,
+      EgressFailureReason.AddressBlocked,
+    ]) {
+      const details: RequestFailedDetails = API.getRequestFailedDetails(
+        new EgressGuardException(SANITIZED_GUARD_MESSAGE, reason),
+      );
+
+      expect(details.errorCode).toBe("TARGET_UNREACHABLE");
+      expect(details.errorDescription).toBe(
+        UNREACHABLE_DETAILS.errorDescription,
+      );
+
+      rendered.push(
+        await renderRootCause(
+          makeProbeResponse({
+            totalAttempts: 1,
+            requestFailedDetails: details,
+          }),
+        ),
+      );
+    }
+
+    expect(rendered[1]).toBe(rendered[0]);
+    expect(rendered[2]).toBe(rendered[0]);
+  });
+
+  test("an invalid target is NOT collapsed into the unreachable text", async () => {
+    /*
+     * InvalidTarget is the tenant's own configuration echoed back — it reveals
+     * nothing about the probe's network — so it has to surface as its own
+     * code, or a typo'd monitor URL reads as a DNS outage.
+     */
+    const details: RequestFailedDetails = API.getRequestFailedDetails(
+      new EgressGuardException(
+        "Monitor destination must be a valid HTTP or HTTPS URL.",
+        EgressFailureReason.InvalidTarget,
+      ),
+    );
+
+    expect(details.failedPhase).toBe(RequestFailedPhase.TargetResolution);
+    expect(details.errorCode).toBe("INVALID_TARGET");
+    expect(details.errorDescription).not.toBe(
+      UNREACHABLE_DETAILS.errorDescription,
+    );
+
+    const context: string = await renderRootCause(
+      makeProbeResponse({ requestFailedDetails: details }),
+    );
+
+    expect(context).toContain("- Error Code: INVALID_TARGET");
+    expect(context).not.toContain("TARGET_UNREACHABLE");
+  });
+});
+
+describe("Root cause Attempts line", () => {
+  test("renders '- Attempts: 1' for a single attempt", async () => {
+    const context: string = await renderRootCause(
+      makeProbeResponse({ totalAttempts: 1 }),
+    );
+
+    expect(context).toContain("- Attempts: 1");
+  });
+
+  test("renders '- Attempts: 3' when the probe retried", async () => {
+    const context: string = await renderRootCause(
+      makeProbeResponse({ totalAttempts: 3 }),
+    );
+
+    expect(context).toContain("- Attempts: 3");
+    expect(context).not.toContain("- Attempts: 1");
+  });
+
+  test("renders no Attempts line at all when the count is unknown", async () => {
+    const context: string = await renderRootCause(
+      makeProbeResponse({ totalAttempts: undefined }),
+    );
+
+    /*
+     * Absent, not "- Attempts: undefined" and not "- Attempts: 0" — an
+     * unreported count must not be rendered as a real one.
+     */
+    expect(context).not.toContain("- Attempts:");
+    expect(/^- Attempts:/m.test(context)).toBe(false);
+  });
+});
+
+describe("Root cause section placement", () => {
+  test("Attempts belongs to the Response Snapshot, after Timed Out", async () => {
+    const context: string = await renderRootCause(customerFailureResponse());
+
+    const snapshot: string = section(context, "Response Snapshot");
+    const failure: string = section(context, "Request Failed Details");
+
+    expect(snapshot).toContain("- Attempts: 1");
+    expect(failure).not.toContain("- Attempts:");
+
+    /*
+     * How long the check took and whether it timed out describe one attempt;
+     * the count of attempts summarizes them, so it reads last in the section.
+     */
+    expect(snapshot.indexOf("- Attempts:")).toBeGreaterThan(
+      snapshot.indexOf("- Timed Out:"),
+    );
+  });
+
+  test("failure classification stays out of the Response Snapshot", async () => {
+    const context: string = await renderRootCause(customerFailureResponse());
+
+    const snapshot: string = section(context, "Response Snapshot");
+    const failure: string = section(context, "Request Failed Details");
+
+    expect(snapshot).not.toContain("- Failed Phase:");
+    expect(snapshot).not.toContain("- Error Code:");
+    expect(failure).toContain("- Failed Phase: Target Resolution");
+    expect(failure).toContain("- Error Code: TARGET_UNREACHABLE");
+  });
+});
+
+describe("Root cause for an ordinary HTTP failure (control)", () => {
+  /*
+   * The Target Resolution branch runs BEFORE all the string matching in the
+   * classifier and adds a section-level line to the renderer, so prove the
+   * everyday case a customer sees far more often is untouched.
+   */
+  test("an HTTP 500 still renders its own phase, code, description and snapshot", async () => {
+    const context: string = await renderRootCause(
+      makeProbeResponse({
+        responseCode: 500,
+        responseTimeInMs: 1234,
+        totalAttempts: 2,
+        requestFailedDetails: {
+          failedPhase: RequestFailedPhase.ServerResponse,
+          errorCode: "HTTP_500",
+          errorDescription:
+            "The server responded with HTTP 500 Internal Server Error. This indicates a server-side error.",
+          rawErrorMessage: "Request failed with status code 500",
+        },
+      }),
+    );
+
+    expect(context).toContain("- Response Status Code: 500");
+    expect(context).toContain("- Response Time: 1234 ms");
+    expect(context).toContain("- Timed Out: No");
+    expect(context).toContain("- Attempts: 2");
+    expect(context).toContain("- Failed Phase: Server Response");
+    expect(context).toContain("- Error Code: HTTP_500");
+    expect(context).toContain(
+      "- Error Description: The server responded with HTTP 500 Internal Server Error. This indicates a server-side error.",
+    );
+    expect(context).toContain(
+      "- Raw Error Message: Request failed with status code 500",
+    );
+
+    // The new branch must not have swallowed the old classification.
+    expect(context).not.toContain("- Failed Phase: Target Resolution");
+    expect(context).not.toContain("TARGET_UNREACHABLE");
+  });
+});

--- a/Common/Tests/Utils/RequestFailedDetails.test.ts
+++ b/Common/Tests/Utils/RequestFailedDetails.test.ts
@@ -1,0 +1,325 @@
+import BadDataException from "../../Types/Exception/BadDataException";
+import EgressGuardException, {
+  EgressFailureReason,
+} from "../../Types/Exception/EgressGuardException";
+import RequestFailedDetails, {
+  RequestFailedPhase,
+} from "../../Types/Probe/RequestFailedDetails";
+import API from "../../Utils/API";
+import { describe, expect, test } from "@jest/globals";
+import {
+  AxiosError,
+  AxiosHeaders,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from "axios";
+
+/*
+ * Tests for API.getRequestFailedDetails - the function that turns a thrown
+ * request error into the "Request Failed Details" block a user reads on an
+ * incident. Common/Tests/Utils/API.test.ts covers the rest of API; this file
+ * covers classification only.
+ */
+
+/*
+ * The exact sentence the egress guard produced for the reported incident.
+ * EgressGuard builds `${label} host ${bareHostname} could not be reached.`
+ * for every failure branch once detail is suppressed, which is what the probe
+ * asks for. Kept verbatim here so this file fails if that wording ever drifts
+ * away from what the customer actually saw.
+ */
+const CUSTOMER_SANITIZED_MESSAGE: string =
+  "Monitor target host order.abbeysbakehouse.com could not be reached.";
+
+// A dotted quad anywhere in user-facing text would leak a resolved address.
+const IPV4_PATTERN: RegExp = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/;
+
+/*
+ * Builds an axios error that carries a real response, which is the only way to
+ * reach the ServerResponse branch (it keys on axiosError.response).
+ */
+function createAxiosResponseError(status: number): AxiosError {
+  const config: InternalAxiosRequestConfig = {
+    headers: new AxiosHeaders(),
+  } as InternalAxiosRequestConfig;
+
+  const response: AxiosResponse = {
+    data: {},
+    status: status,
+    statusText: "",
+    headers: {},
+    config: config,
+  };
+
+  return new AxiosError(
+    `Request failed with status code ${status}`,
+    "ERR_BAD_RESPONSE",
+    config,
+    {},
+    response,
+  );
+}
+
+describe("API.getRequestFailedDetails - egress guard refusals", () => {
+  /*
+   * REGRESSION: the reported incident on https://order.abbeysbakehouse.com/.
+   * The guard refused the target before any socket was opened and threw its
+   * sanitized sentence. That sentence matched none of the string patterns
+   * below it, so the incident root cause read
+   *   Failed Phase: Unknown
+   *   Error Description: Request failed: Monitor target host ... could not be reached.
+   * which told the customer nothing. It must now be classified from the
+   * exception TYPE instead.
+   */
+  test("classifies the customer's sanitized guard failure as Target Resolution, not Unknown", () => {
+    const details: RequestFailedDetails = API.getRequestFailedDetails(
+      new EgressGuardException(
+        CUSTOMER_SANITIZED_MESSAGE,
+        EgressFailureReason.Unreachable,
+      ),
+    );
+
+    expect(details.failedPhase).toBe(RequestFailedPhase.TargetResolution);
+    expect(details.failedPhase).not.toBe(RequestFailedPhase.Unknown);
+    expect(details.errorCode).toBe("TARGET_UNREACHABLE");
+
+    // The description has to actually say something.
+    expect(details.errorDescription.length).toBeGreaterThan(0);
+
+    /*
+     * The old behaviour, asserted as gone: the default branch prefixed the
+     * guard's own sentence with "Request failed: " and called that an
+     * explanation.
+     */
+    expect(details.errorDescription.startsWith("Request failed:")).toBe(false);
+    expect(details.errorDescription).not.toBe(
+      `Request failed: ${CUSTOMER_SANITIZED_MESSAGE}`,
+    );
+    expect(details.errorDescription).not.toContain(CUSTOMER_SANITIZED_MESSAGE);
+
+    // The raw sentence is still carried through untouched for debugging.
+    expect(details.rawErrorMessage).toBe(CUSTOMER_SANITIZED_MESSAGE);
+  });
+
+  /*
+   * THE ORACLE INVARIANT. On a shared cloud probe every tenant's hostnames are
+   * resolved by the same resolver, so a tenant who could tell "did not resolve"
+   * apart from "resolved to an address we refuse to dial" could enumerate
+   * internal DNS names. The guard closes that by throwing one identical
+   * message with reason Unreachable from both branches; this function must not
+   * reopen it by deriving anything from the message or from anything else.
+   */
+  test("output for Unreachable is a function of the reason alone, not of the branch that threw", () => {
+    // Same sentence the DNS branch throws...
+    const fromDnsFailure: EgressGuardException = new EgressGuardException(
+      CUSTOMER_SANITIZED_MESSAGE,
+      EgressFailureReason.Unreachable,
+    );
+
+    // ...and the byte-identical sentence the address-policy branch throws.
+    const fromAddressPolicy: EgressGuardException = new EgressGuardException(
+      CUSTOMER_SANITIZED_MESSAGE,
+      EgressFailureReason.Unreachable,
+    );
+
+    const dnsDetails: RequestFailedDetails =
+      API.getRequestFailedDetails(fromDnsFailure);
+    const policyDetails: RequestFailedDetails =
+      API.getRequestFailedDetails(fromAddressPolicy);
+
+    expect(dnsDetails).toEqual(policyDetails);
+
+    /*
+     * And the classification must not vary with the host either, so an
+     * attacker cannot probe one hostname against another and diff the output.
+     */
+    const otherHostDetails: RequestFailedDetails = API.getRequestFailedDetails(
+      new EgressGuardException(
+        "Monitor target host internal-billing.corp could not be reached.",
+        EgressFailureReason.Unreachable,
+      ),
+    );
+
+    expect(otherHostDetails.failedPhase).toBe(dnsDetails.failedPhase);
+    expect(otherHostDetails.errorCode).toBe(dnsDetails.errorCode);
+    expect(otherHostDetails.errorDescription).toBe(dnsDetails.errorDescription);
+
+    /*
+     * The description is a fixed sentence, so it can neither name a resolved
+     * address nor state that the host resolved into a private range. The
+     * self-hosting hint deliberately spells the env var
+     * PROBE_ALLOW_PRIVATE_NETWORK_MONITORS in caps, which is guidance and not
+     * a statement about THIS host.
+     */
+    expect(IPV4_PATTERN.test(dnsDetails.errorDescription)).toBe(false);
+    expect(dnsDetails.errorDescription).not.toContain("private network");
+  });
+
+  test("InvalidTarget is a configuration error and echoes the original message", () => {
+    const message: string =
+      "Monitor target URL scheme ftp:// is not supported. Only http and https are allowed.";
+
+    const details: RequestFailedDetails = API.getRequestFailedDetails(
+      new EgressGuardException(message, EgressFailureReason.InvalidTarget),
+    );
+
+    expect(details.failedPhase).toBe(RequestFailedPhase.TargetResolution);
+    expect(details.errorCode).toBe("INVALID_TARGET");
+    /*
+     * Safe to echo: an unusable URL is the tenant's own configuration handed
+     * back, it says nothing about the probe's network.
+     */
+    expect(details.errorDescription).toContain(message);
+    expect(details.rawErrorMessage).toBe(message);
+  });
+
+  /*
+   * The detail-allowed reasons, which only a self-hosted probe produces
+   * (includeResolvedAddressInError = true). They are more specific internally
+   * but still report the same user-facing phase and code - the specificity
+   * lives in the raw message, which is preserved verbatim.
+   */
+  test.each([
+    [
+      EgressFailureReason.ResolutionFailed,
+      "Monitor target host order.abbeysbakehouse.com could not be resolved: getaddrinfo EAI_AGAIN.",
+    ],
+    [
+      EgressFailureReason.AddressBlocked,
+      "Monitor target host intranet.local resolves to 10.0.0.4 which is a private network address.",
+    ],
+  ])(
+    "reason %s maps to Target Resolution / TARGET_UNREACHABLE and preserves the raw message",
+    (reason: EgressFailureReason, message: string) => {
+      const details: RequestFailedDetails = API.getRequestFailedDetails(
+        new EgressGuardException(message, reason),
+      );
+
+      expect(details.failedPhase).toBe(RequestFailedPhase.TargetResolution);
+      expect(details.errorCode).toBe("TARGET_UNREACHABLE");
+      expect(details.rawErrorMessage).toBe(message);
+    },
+  );
+
+  test("keys on the exception type, not on the message text", () => {
+    /*
+     * A plain BadDataException carrying the very same sentence must still go
+     * through the old string rules. If this ever returns TargetResolution the
+     * new branch is matching text somewhere, which would misclassify unrelated
+     * errors.
+     */
+    const details: RequestFailedDetails = API.getRequestFailedDetails(
+      new BadDataException(CUSTOMER_SANITIZED_MESSAGE),
+    );
+
+    expect(details.failedPhase).toBe(RequestFailedPhase.Unknown);
+    expect(details.errorDescription).toBe(
+      `Request failed: ${CUSTOMER_SANITIZED_MESSAGE}`,
+    );
+
+    // And a BadDataException that DOES match a string rule is still matched.
+    const dnsDetails: RequestFailedDetails = API.getRequestFailedDetails(
+      new BadDataException("getaddrinfo ENOTFOUND example.com"),
+    );
+
+    expect(dnsDetails.failedPhase).toBe(RequestFailedPhase.DNSResolution);
+    expect(dnsDetails.errorCode).toBe("ENOTFOUND");
+  });
+});
+
+/*
+ * The pre-existing classification behaviour, pinned so the new egress-guard
+ * branch (which runs before all of it) cannot shadow anything.
+ */
+describe("API.getRequestFailedDetails - existing classification", () => {
+  test.each([
+    [
+      "plain ENOTFOUND",
+      new Error("getaddrinfo ENOTFOUND order.abbeysbakehouse.com"),
+      RequestFailedPhase.DNSResolution,
+      "ENOTFOUND",
+    ],
+    [
+      "axios ENOTFOUND",
+      new AxiosError("getaddrinfo ENOTFOUND example.com", "ENOTFOUND"),
+      RequestFailedPhase.DNSResolution,
+      "ENOTFOUND",
+    ],
+    [
+      "ECONNREFUSED",
+      new Error("connect ECONNREFUSED 127.0.0.1:443"),
+      RequestFailedPhase.TCPConnection,
+      "ECONNREFUSED",
+    ],
+    [
+      "ECONNRESET",
+      new Error("read ECONNRESET"),
+      RequestFailedPhase.TCPConnection,
+      "ECONNRESET",
+    ],
+    [
+      "axios ETIMEDOUT",
+      new AxiosError("connect ETIMEDOUT 93.184.216.34:443", "ETIMEDOUT"),
+      RequestFailedPhase.RequestTimeout,
+      "ETIMEDOUT",
+    ],
+    [
+      "axios timeout message with no code",
+      new Error("timeout of 5000ms exceeded"),
+      RequestFailedPhase.RequestTimeout,
+      "TIMEOUT",
+    ],
+    [
+      "expired certificate",
+      new Error("certificate has expired"),
+      RequestFailedPhase.CertificateError,
+      "CERT_HAS_EXPIRED",
+    ],
+    [
+      "self-signed certificate",
+      new Error("self-signed certificate in certificate chain"),
+      RequestFailedPhase.CertificateError,
+      "SELF_SIGNED_CERT",
+    ],
+  ])(
+    "%s is classified as before",
+    (
+      _name: string,
+      error: Error,
+      expectedPhase: RequestFailedPhase,
+      expectedErrorCode: string,
+    ) => {
+      const details: RequestFailedDetails = API.getRequestFailedDetails(error);
+
+      expect(details.failedPhase).toBe(expectedPhase);
+      expect(details.errorCode).toBe(expectedErrorCode);
+      expect(details.rawErrorMessage).toBe(error.message);
+    },
+  );
+
+  test.each([[500], [404], [403], [401], [400]])(
+    "an HTTP %s response is classified as Server Response",
+    (status: number) => {
+      const details: RequestFailedDetails = API.getRequestFailedDetails(
+        createAxiosResponseError(status),
+      );
+
+      expect(details.failedPhase).toBe(RequestFailedPhase.ServerResponse);
+      expect(details.errorCode).toBe(`HTTP_${status}`);
+      expect(details.errorDescription).toContain(
+        `Server responded with HTTP status ${status}.`,
+      );
+    },
+  );
+
+  test("an unrecognised error still falls through to Unknown", () => {
+    const details: RequestFailedDetails = API.getRequestFailedDetails(
+      new Error("something odd"),
+    );
+
+    expect(details.failedPhase).toBe(RequestFailedPhase.Unknown);
+    expect(details.errorCode).toBeUndefined();
+    expect(details.errorDescription).toBe("Request failed: something odd");
+    expect(details.rawErrorMessage).toBe("something odd");
+  });
+});

--- a/Common/Types/Exception/EgressGuardException.ts
+++ b/Common/Types/Exception/EgressGuardException.ts
@@ -1,0 +1,65 @@
+import BadDataException from "./BadDataException";
+
+/*
+ * Why the egress guard refused a target.
+ *
+ * The guard deliberately SANITIZES its message for tenant-facing callers (see
+ * EgressGuardOptions.includeResolvedAddressInError): a DNS failure and an
+ * address-policy rejection produce one byte-identical sentence, because a
+ * tenant who can tell them apart on a shared probe can enumerate internal DNS
+ * names. That is correct, and this type does not weaken it.
+ *
+ * What it fixes is the collateral damage. Callers downstream had nothing but
+ * that sanitized string to reason about, so API.getRequestFailedDetails matched
+ * none of its patterns and reported monitor failures as "Unknown" with no
+ * actionable detail. Carrying the STAGE on the exception restores the one bit
+ * every caller legitimately needs without reopening the oracle: when detail is
+ * suppressed, both the DNS branch and the address-policy branch report
+ * `Unreachable`, so nothing observable distinguishes them.
+ */
+export enum EgressFailureReason {
+  /*
+   * The target is structurally unusable: no host, an unparseable URL, or a
+   * scheme other than http/https. This is the tenant's own configuration
+   * echoed back and never reveals anything about the probe's network.
+   */
+  InvalidTarget = "InvalidTarget",
+
+  /*
+   * Detail-suppressed merge of "the resolver failed or returned nothing" and
+   * "the target resolves to an address policy forbids". Deliberately ONE
+   * value: these two must stay indistinguishable to tenant-facing callers.
+   */
+  Unreachable = "Unreachable",
+
+  // Detail permitted: the resolver threw, or returned no addresses at all.
+  ResolutionFailed = "ResolutionFailed",
+
+  // Detail permitted: an address the target resolves to is not allowed.
+  AddressBlocked = "AddressBlocked",
+}
+
+/*
+ * Extends BadDataException rather than replacing it so every existing
+ * `instanceof BadDataException` check — including the security-relevant
+ * fail-fast paths in the probe monitors — keeps behaving exactly as before.
+ */
+export default class EgressGuardException extends BadDataException {
+  public readonly reason: EgressFailureReason;
+
+  public constructor(message: string, reason: EgressFailureReason) {
+    super(message);
+    this.reason = reason;
+  }
+
+  /*
+   * True when the refusal is about REACHING the target rather than the target
+   * being malformed. Monitors treat these like any other network failure — a
+   * probe whose own resolver has died must not be believed when it says every
+   * monitor is down — whereas InvalidTarget is a configuration error that has
+   * to surface immediately and unconditionally.
+   */
+  public isTargetUnreachable(): boolean {
+    return this.reason !== EgressFailureReason.InvalidTarget;
+  }
+}

--- a/Common/Types/Probe/RequestFailedDetails.ts
+++ b/Common/Types/Probe/RequestFailedDetails.ts
@@ -20,6 +20,13 @@ export enum RequestFailedPhase {
   NetworkError = "Network Error",
   // Certificate error
   CertificateError = "Certificate Error",
+  /*
+   * The probe never opened a socket: it could not turn the target hostname
+   * into an address it is allowed to dial. Covers DNS failures and egress
+   * policy rejections, which are deliberately reported as one phase so a
+   * tenant cannot tell them apart (see EgressGuardException).
+   */
+  TargetResolution = "Target Resolution",
   // Unknown error
   Unknown = "Unknown",
 }

--- a/Common/Utils/API.ts
+++ b/Common/Utils/API.ts
@@ -11,6 +11,9 @@ import URL from "../Types/API/URL";
 import Dictionary from "../Types/Dictionary";
 import APIException from "../Types/Exception/ApiException";
 import BadDataException from "../Types/Exception/BadDataException";
+import EgressGuardException, {
+  EgressFailureReason,
+} from "../Types/Exception/EgressGuardException";
 import { JSONArray, JSONObject } from "../Types/JSON";
 import RequestFailedDetails, {
   RequestFailedPhase,
@@ -1157,6 +1160,37 @@ export default class API {
     const errorCode: string | undefined = axiosError?.code;
     const rawErrorMessage: string =
       (error as Error)?.message || String(error) || "Unknown error";
+
+    /*
+     * The egress guard refuses a target BEFORE any socket is opened, and for
+     * tenant-facing callers it sanitizes its message down to one sentence that
+     * matches none of the patterns below. Left to the fall-through, every such
+     * failure was reported as phase "Unknown" with the sanitized sentence
+     * echoed back as its own explanation — which is exactly what a monitor
+     * incident showed for a host whose DNS had hiccuped. Classify it here
+     * instead, from the exception TYPE rather than from its text.
+     */
+    if (error instanceof EgressGuardException) {
+      return {
+        failedPhase: RequestFailedPhase.TargetResolution,
+        errorCode:
+          error.reason === EgressFailureReason.InvalidTarget
+            ? "INVALID_TARGET"
+            : "TARGET_UNREACHABLE",
+        /*
+         * One constant description for every unreachable reason. It names all
+         * the possibilities without saying which occurred, so it stays useful
+         * without telling a tenant on a shared probe whether a hostname
+         * resolved — that difference is the enumeration oracle the guard's
+         * sanitized message exists to close.
+         */
+        errorDescription:
+          error.reason === EgressFailureReason.InvalidTarget
+            ? `The monitor's target is not a valid HTTP or HTTPS destination, so no request was attempted. ${rawErrorMessage}`
+            : "The probe could not obtain a usable network address for this host, so no connection was attempted and the target was never contacted. Either DNS did not answer, answered with no records, or returned an address this probe is not allowed to dial. Check that the hostname resolves publicly and that its authoritative nameservers are healthy. If this monitor targets an internal host, run it from a self-hosted probe with PROBE_ALLOW_PRIVATE_NETWORK_MONITORS=true.",
+        rawErrorMessage,
+      };
+    }
 
     // Helper to determine the phase and description based on error code/message
     const lowerMessage: string = rawErrorMessage.toLowerCase();

--- a/Probe/Tests/Utils/Monitors/HttpMonitorRequest.test.ts
+++ b/Probe/Tests/Utils/Monitors/HttpMonitorRequest.test.ts
@@ -17,6 +17,7 @@ import HttpMonitorRequest, {
   HTTP_MONITOR_MAX_REQUEST_BYTES,
   HTTP_MONITOR_MAX_RESPONSE_BYTES,
   HttpMonitorExecutionContext,
+  MONITOR_DNS_RESOLVE_BUDGET_IN_MS,
   PinnedHttpProxyAgent,
   PinnedHttpsProxyAgent,
   PreparedHttpMonitorRequest,
@@ -257,6 +258,7 @@ describe("HttpMonitorRequest.prepare", () => {
         targetLabel: "Monitor target",
         privateNetworkHint: PROBE_PRIVATE_NETWORK_HINT,
         includeResolvedAddressInError: false,
+        resolveTimeoutInMs: MONITOR_DNS_RESOLVE_BUDGET_IN_MS,
       },
     );
     expect(prepared.url.toString()).toBe(

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/ApiMonitorTargetResolution.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/ApiMonitorTargetResolution.test.ts
@@ -1,0 +1,257 @@
+// Set required env vars before importing anything that pulls Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+delete process.env["PROBE_ALLOW_PRIVATE_NETWORK_MONITORS"];
+
+import { afterEach, describe, expect, it } from "@jest/globals";
+import ApiMonitor, {
+  APIResponse,
+} from "../../../../Utils/Monitors/MonitorTypes/ApiMonitor";
+import HttpMonitorRequest from "../../../../Utils/Monitors/HttpMonitorRequest";
+import OnlineCheck from "../../../../Utils/OnlineCheck";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import URL from "Common/Types/API/URL";
+import { JSONObject } from "Common/Types/JSON";
+import RequestFailedDetails, {
+  RequestFailedPhase,
+} from "Common/Types/Probe/RequestFailedDetails";
+import API from "Common/Utils/API";
+import dns from "dns";
+
+/*
+ * The host from the customer incident this suite exists for: a single monitor
+ * out of ~75 on the same probe reported "could not be reached." with phase
+ * "Unknown", because the egress guard's deliberately sanitized sentence
+ * matched none of API.getRequestFailedDetails' string patterns.
+ */
+const TARGET_HOST: string = "order.abbeysbakehouse.test";
+const TARGET_URL: string = `https://${TARGET_HOST}/checkout`;
+
+/*
+ * The sanitized sentence is a SECURITY property: a DNS failure and an
+ * address-policy rejection must produce this exact same text so a tenant on a
+ * shared probe cannot use the difference to enumerate internal DNS names.
+ * Asserting on the literal keeps a future "more helpful message" from
+ * quietly reopening that oracle.
+ */
+const SANITIZED_FAILURE_CAUSE: string = `Monitor target host ${TARGET_HOST} could not be reached.`;
+
+// An address the probe is not allowed to dial (private ranges are blocked here).
+const BLOCKED_PRIVATE_ADDRESS: string = "10.23.45.67";
+
+// A public address that passes the guard, so the check proceeds to the request.
+const PUBLIC_ADDRESS: string = "93.184.216.34";
+
+/*
+ * EAI_AGAIN is the classic transient resolver answer: it fails in
+ * milliseconds and usually succeeds on the very next try, which is exactly
+ * the blip that used to become a hard monitor-down incident.
+ */
+function transientResolverError(): Error {
+  const error: NodeJS.ErrnoException = new Error(
+    `getaddrinfo EAI_AGAIN ${TARGET_HOST}`,
+  );
+  error.code = "EAI_AGAIN";
+  return error;
+}
+
+describe("ApiMonitor target resolution failures", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("reports a guard DNS failure as Target Resolution without opening a socket", async () => {
+    const lookupSpy: jest.SpyInstance = jest
+      .spyOn(dns.promises, "lookup")
+      .mockRejectedValue(transientResolverError() as never);
+    const prepareSpy: jest.SpyInstance = jest.spyOn(
+      HttpMonitorRequest,
+      "prepare",
+    );
+    const fetchSpy: jest.SpyInstance = jest.spyOn(API, "fetch");
+
+    const response: APIResponse | null = await ApiMonitor.ping(
+      URL.fromString(TARGET_URL),
+      { retry: 9, isOnlineCheckRequest: true },
+    );
+
+    expect(response).not.toBeNull();
+    expect(response!.isOnline).toBe(false);
+    expect(response!.statusCode).toBeUndefined();
+    expect(response!.responseBody).toBe("");
+    // The tenant-facing sentence itself is unchanged by the fix.
+    expect(response!.failureCause).toBe(SANITIZED_FAILURE_CAUSE);
+
+    const details: RequestFailedDetails = response!.requestFailedDetails!;
+    expect(details.failedPhase).toBe(RequestFailedPhase.TargetResolution);
+    expect(details.errorCode).toBe("TARGET_UNREACHABLE");
+    expect(details.rawErrorMessage).toBe(SANITIZED_FAILURE_CAUSE);
+
+    /*
+     * The old behaviour: no pattern matched, so the phase was Unknown and the
+     * "explanation" was the unhelpful sentence echoed back with a prefix.
+     */
+    expect(details.failedPhase).not.toBe(RequestFailedPhase.Unknown);
+    expect(details.errorDescription).not.toBe(
+      `Request failed: ${SANITIZED_FAILURE_CAUSE}`,
+    );
+    expect(details.errorDescription).toContain("no connection was attempted");
+
+    // Refused before any HTTP request was built or dispatched.
+    expect(lookupSpy).toHaveBeenCalled();
+    expect(prepareSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps one attempt and keeps a DNS failure indistinguishable from a blocked address", async () => {
+    const lookupSpy: jest.SpyInstance = jest
+      .spyOn(dns.promises, "lookup")
+      .mockRejectedValue(transientResolverError() as never);
+    const fetchSpy: jest.SpyInstance = jest.spyOn(API, "fetch");
+
+    const dnsFailureResponse: APIResponse | null = await ApiMonitor.ping(
+      URL.fromString(TARGET_URL),
+      { retry: 9, isOnlineCheckRequest: true },
+    );
+
+    // Same host, same options - only the resolver's answer differs.
+    lookupSpy.mockResolvedValue([
+      { address: BLOCKED_PRIVATE_ADDRESS, family: 4 },
+    ] as never);
+
+    const blockedAddressResponse: APIResponse | null = await ApiMonitor.ping(
+      URL.fromString(TARGET_URL),
+      { retry: 9, isOnlineCheckRequest: true },
+    );
+
+    expect(dnsFailureResponse).not.toBeNull();
+    expect(blockedAddressResponse).not.toBeNull();
+
+    /*
+     * A guard refusal is never retried by the monitor: retrying only some of
+     * them would make totalAttempts differ between "DNS failed" and "policy
+     * blocked", which is the very distinction the sanitized message hides.
+     * Transient retries happen inside the guard instead.
+     */
+    expect(dnsFailureResponse!.totalAttempts).toBe(1);
+    expect(blockedAddressResponse!.totalAttempts).toBe(1);
+    expect(dnsFailureResponse!.probeAttempts).toHaveLength(1);
+    expect(blockedAddressResponse!.probeAttempts).toHaveLength(1);
+
+    // Byte-identical, including the newly added structured details.
+    expect(dnsFailureResponse!.failureCause).toBe(SANITIZED_FAILURE_CAUSE);
+    expect(blockedAddressResponse!.failureCause).toBe(SANITIZED_FAILURE_CAUSE);
+    expect(JSON.stringify(blockedAddressResponse!.requestFailedDetails)).toBe(
+      JSON.stringify(dnsFailureResponse!.requestFailedDetails),
+    );
+
+    const blockedJson: string = JSON.stringify(blockedAddressResponse);
+    expect(blockedJson).not.toContain(BLOCKED_PRIVATE_ADDRESS);
+    expect(blockedJson).not.toContain("private network");
+    expect(blockedJson).not.toContain("AddressBlocked");
+    expect(blockedJson).not.toContain("ResolutionFailed");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("checks the probe's own connectivity before believing an unreachable target", async () => {
+    jest
+      .spyOn(dns.promises, "lookup")
+      .mockRejectedValue(transientResolverError() as never);
+    /*
+     * ApiMonitor asks the website reference check, because that is the
+     * protocol it speaks.
+     */
+    const onlineCheckSpy: jest.SpyInstance = jest
+      .spyOn(OnlineCheck, "canProbeMonitorWebsiteMonitors")
+      .mockResolvedValue(false as never);
+
+    /*
+     * A probe whose own resolver has died must not be believed when it says a
+     * monitor is down: null means "no verdict", so no incident is opened.
+     */
+    const noVerdictResponse: APIResponse | null = await ApiMonitor.ping(
+      URL.fromString(TARGET_URL),
+      { retry: 0 },
+    );
+
+    expect(noVerdictResponse).toBeNull();
+    expect(onlineCheckSpy).toHaveBeenCalledTimes(1);
+
+    onlineCheckSpy.mockResolvedValue(true as never);
+
+    const offlineResponse: APIResponse | null = await ApiMonitor.ping(
+      URL.fromString(TARGET_URL),
+      { retry: 0 },
+    );
+
+    expect(offlineResponse).not.toBeNull();
+    expect(offlineResponse!.isOnline).toBe(false);
+    expect(offlineResponse!.failureCause).toBe(SANITIZED_FAILURE_CAUSE);
+    expect(offlineResponse!.requestFailedDetails!.failedPhase).toBe(
+      RequestFailedPhase.TargetResolution,
+    );
+    expect(offlineResponse!.requestFailedDetails!.errorCode).toBe(
+      "TARGET_UNREACHABLE",
+    );
+    expect(onlineCheckSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips the connectivity check for a structurally invalid target", async () => {
+    const onlineCheckSpy: jest.SpyInstance = jest
+      .spyOn(OnlineCheck, "canProbeMonitorWebsiteMonitors")
+      .mockResolvedValue(false as never);
+    const lookupSpy: jest.SpyInstance = jest.spyOn(dns.promises, "lookup");
+
+    /*
+     * A non-http(s) scheme is the tenant's own configuration, not a network
+     * failure, so it has to surface immediately even on a probe that cannot
+     * reach the internet - otherwise a misconfigured monitor stays silent.
+     */
+    const response: APIResponse | null = await ApiMonitor.ping(
+      URL.fromString("ws://1.1.1.1/socket"),
+      { retry: 0 },
+    );
+
+    expect(response).not.toBeNull();
+    expect(response!.isOnline).toBe(false);
+    expect(response!.requestFailedDetails!.failedPhase).toBe(
+      RequestFailedPhase.TargetResolution,
+    );
+    expect(response!.requestFailedDetails!.errorCode).toBe("INVALID_TARGET");
+    expect(onlineCheckSpy).not.toHaveBeenCalled();
+    expect(lookupSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports the monitor online when a transient resolver failure recovers on retry", async () => {
+    const lookupSpy: jest.SpyInstance = jest
+      .spyOn(dns.promises, "lookup")
+      .mockRejectedValueOnce(transientResolverError() as never)
+      .mockResolvedValue([{ address: PUBLIC_ADDRESS, family: 4 }] as never);
+    const fetchSpy: jest.SpyInstance = jest
+      .spyOn(API, "fetch")
+      .mockResolvedValue(
+        new HTTPResponse<JSONObject>(200, { ok: true }, {}) as never,
+      );
+    const onlineCheckSpy: jest.SpyInstance = jest
+      .spyOn(OnlineCheck, "canProbeMonitorWebsiteMonitors")
+      .mockResolvedValue(false as never);
+
+    const response: APIResponse | null = await ApiMonitor.ping(
+      URL.fromString(TARGET_URL),
+      { retry: 0 },
+    );
+
+    /*
+     * The single un-retried lookup this replaced turned this exact blip into a
+     * monitor-down incident, so this assertion fails against the old guard.
+     */
+    expect(response).not.toBeNull();
+    expect(response!.isOnline).toBe(true);
+    expect(response!.statusCode).toBe(200);
+    expect(response!.failureCause).toBe("");
+    expect(response!.totalAttempts).toBe(1);
+    expect(lookupSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(onlineCheckSpy).not.toHaveBeenCalled();
+  });
+});

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/WebsiteMonitorTargetResolution.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/WebsiteMonitorTargetResolution.test.ts
@@ -1,0 +1,268 @@
+// Set required env vars before importing anything that pulls Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+delete process.env["PROBE_ALLOW_PRIVATE_NETWORK_MONITORS"];
+
+import { afterEach, describe, expect, it } from "@jest/globals";
+import WebsiteMonitor, {
+  ProbeWebsiteResponse,
+} from "../../../../Utils/Monitors/MonitorTypes/WebsiteMonitor";
+import OnlineCheck from "../../../../Utils/OnlineCheck";
+import URL from "Common/Types/API/URL";
+import HTML from "Common/Types/Html";
+import RequestFailedDetails, {
+  RequestFailedPhase,
+} from "Common/Types/Probe/RequestFailedDetails";
+import WebsiteRequest, { WebsiteResponse } from "Common/Types/WebsiteRequest";
+import dns from "dns";
+
+/*
+ * The exact sentence the egress guard produces for a monitor target it cannot
+ * turn into a dialable address. It is deliberately identical for "DNS failed"
+ * and "resolved to an address policy forbids" — a tenant on a shared probe who
+ * could tell those apart could enumerate internal DNS names. Pinned here as a
+ * literal so a change to the wording has to be a conscious one.
+ */
+function unreachableMessage(host: string): string {
+  return `Monitor target host ${host} could not be reached.`;
+}
+
+const PUBLIC_ADDRESS: string = "93.184.216.34";
+
+function websiteResponse(data: {
+  url: string;
+  statusCode: number;
+  body: string;
+}): WebsiteResponse {
+  return {
+    url: URL.fromString(data.url),
+    requestHeaders: {},
+    responseHeaders: {},
+    responseStatusCode: data.statusCode,
+    responseBody: new HTML(data.body),
+    isOnline: true,
+  };
+}
+
+describe("WebsiteMonitor target resolution failures", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /*
+   * The customer regression. A resolver hiccup on one hostname produced an
+   * incident whose entire root cause was "Failed Phase: Unknown / Request
+   * failed: <the sanitized sentence>", because getRequestFailedDetails had
+   * only that string to pattern-match and matched nothing.
+   */
+  it("classifies a resolver failure as Target Resolution instead of Unknown", async () => {
+    const host: string = "order.abbeysbakehouse.test";
+    const lookupSpy: jest.SpyInstance = jest
+      .spyOn(dns.promises, "lookup")
+      .mockRejectedValue(new Error(`getaddrinfo EAI_AGAIN ${host}`) as never);
+    const fetchSpy: jest.SpyInstance = jest.spyOn(WebsiteRequest, "fetch");
+
+    const response: ProbeWebsiteResponse | null = await WebsiteMonitor.ping(
+      URL.fromString(`https://${host}/`),
+      { retry: 0, isOnlineCheckRequest: true },
+    );
+
+    expect(response).not.toBeNull();
+    expect(response!.isOnline).toBe(false);
+
+    const details: RequestFailedDetails = response!.requestFailedDetails!;
+    expect(details.failedPhase).toBe(RequestFailedPhase.TargetResolution);
+    expect(details.failedPhase).not.toBe(RequestFailedPhase.Unknown);
+    expect(details.errorCode).toBe("TARGET_UNREACHABLE");
+    expect(details.errorDescription).toContain(
+      "could not obtain a usable network address",
+    );
+    /*
+     * The old behaviour echoed the sanitized sentence back as its own
+     * explanation. Anything that still does that is not an explanation.
+     */
+    expect(details.errorDescription).not.toBe(
+      `Request failed: ${unreachableMessage(host)}`,
+    );
+    expect(details.rawErrorMessage).toBe(unreachableMessage(host));
+
+    // The tenant-facing sentence itself must be byte-for-byte unchanged.
+    expect(response!.failureCause).toBe(unreachableMessage(host));
+
+    // No socket was ever opened: the guard refused before the request.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(lookupSpy).toHaveBeenCalled();
+  });
+
+  /*
+   * The oracle invariant at the monitor layer. Whatever the guard learned, the
+   * serialized monitor response for a DNS failure and for a blocked private
+   * address must be indistinguishable - including the attempt count, which is
+   * why the monitor-level retry decision was deliberately left alone.
+   */
+  it("makes a DNS failure and a blocked private address indistinguishable", async () => {
+    const host: string = "shared-oracle-host.example.test";
+    const privateAddress: string = "10.23.45.67";
+
+    jest
+      .spyOn(dns.promises, "lookup")
+      .mockRejectedValue(new Error(`getaddrinfo EAI_AGAIN ${host}`) as never);
+    const dnsFailureResponse: ProbeWebsiteResponse | null =
+      await WebsiteMonitor.ping(URL.fromString(`https://${host}/status`), {
+        retry: 0,
+        isOnlineCheckRequest: true,
+      });
+    jest.restoreAllMocks();
+
+    jest
+      .spyOn(dns.promises, "lookup")
+      .mockResolvedValue([{ address: privateAddress, family: 4 }] as never);
+    const blockedAddressResponse: ProbeWebsiteResponse | null =
+      await WebsiteMonitor.ping(URL.fromString(`https://${host}/status`), {
+        retry: 0,
+        isOnlineCheckRequest: true,
+      });
+
+    expect(dnsFailureResponse).not.toBeNull();
+    expect(blockedAddressResponse).not.toBeNull();
+
+    expect(dnsFailureResponse!.failureCause).toBe(unreachableMessage(host));
+    expect(blockedAddressResponse!.failureCause).toBe(
+      dnsFailureResponse!.failureCause,
+    );
+    expect(blockedAddressResponse!.requestFailedDetails).toEqual(
+      dnsFailureResponse!.requestFailedDetails,
+    );
+
+    // A guard refusal is never retried, whichever branch produced it.
+    expect(dnsFailureResponse!.totalAttempts).toBe(1);
+    expect(blockedAddressResponse!.totalAttempts).toBe(1);
+
+    const serializedDnsFailure: string = JSON.stringify(dnsFailureResponse);
+    const serializedBlockedAddress: string = JSON.stringify(
+      blockedAddressResponse,
+    );
+    expect(serializedDnsFailure).not.toContain(privateAddress);
+    expect(serializedBlockedAddress).not.toContain(privateAddress);
+    expect(serializedDnsFailure).not.toContain("private network");
+    expect(serializedBlockedAddress).not.toContain("private network");
+  });
+
+  /*
+   * The behaviour change. A guard refusal is a BadDataException, and the
+   * probe-self-health branch used to exclude BadDataException outright - so a
+   * probe whose own resolver had died reported every monitor as down without
+   * ever checking whether it could reach the internet itself.
+   */
+  it("suppresses an unreachable-target failure when the probe itself is offline", async () => {
+    const host: string = "probe-resolver-died.example.test";
+    jest
+      .spyOn(dns.promises, "lookup")
+      .mockRejectedValue(new Error(`getaddrinfo EAI_AGAIN ${host}`) as never);
+    const onlineCheckSpy: jest.SpyInstance = jest
+      .spyOn(OnlineCheck, "canProbeMonitorWebsiteMonitors")
+      .mockResolvedValue(false);
+
+    const response: ProbeWebsiteResponse | null = await WebsiteMonitor.ping(
+      URL.fromString(`https://${host}/`),
+      { retry: 0 },
+    );
+
+    expect(onlineCheckSpy).toHaveBeenCalledTimes(1);
+    expect(response).toBeNull();
+  });
+
+  it("reports an unreachable-target failure when the probe itself is online", async () => {
+    const host: string = "target-really-gone.example.test";
+    jest
+      .spyOn(dns.promises, "lookup")
+      .mockRejectedValue(new Error(`getaddrinfo EAI_AGAIN ${host}`) as never);
+    const onlineCheckSpy: jest.SpyInstance = jest
+      .spyOn(OnlineCheck, "canProbeMonitorWebsiteMonitors")
+      .mockResolvedValue(true);
+
+    const response: ProbeWebsiteResponse | null = await WebsiteMonitor.ping(
+      URL.fromString(`https://${host}/`),
+      { retry: 0 },
+    );
+
+    expect(onlineCheckSpy).toHaveBeenCalledTimes(1);
+    expect(response).not.toBeNull();
+    expect(response!.isOnline).toBe(false);
+    expect(response!.failureCause).toBe(unreachableMessage(host));
+    expect(response!.requestFailedDetails?.failedPhase).toBe(
+      RequestFailedPhase.TargetResolution,
+    );
+    expect(response!.requestFailedDetails?.errorCode).toBe(
+      "TARGET_UNREACHABLE",
+    );
+  });
+
+  /*
+   * A structurally invalid target is the tenant's own configuration echoed
+   * back. It reveals nothing about the probe's network and cannot be fixed by
+   * waiting, so it must surface immediately rather than being swallowed by a
+   * probe-health check that would report it as "probe offline".
+   */
+  it("surfaces an invalid target without consulting the probe health check", async () => {
+    const lookupSpy: jest.SpyInstance = jest.spyOn(dns.promises, "lookup");
+    const onlineCheckSpy: jest.SpyInstance = jest
+      .spyOn(OnlineCheck, "canProbeMonitorWebsiteMonitors")
+      .mockResolvedValue(false);
+
+    const response: ProbeWebsiteResponse | null = await WebsiteMonitor.ping(
+      URL.fromString("ws://not-an-http-target.example.test/socket"),
+      { retry: 0 },
+    );
+
+    expect(onlineCheckSpy).not.toHaveBeenCalled();
+    expect(response).not.toBeNull();
+    expect(response!.isOnline).toBe(false);
+    expect(response!.requestFailedDetails?.failedPhase).toBe(
+      RequestFailedPhase.TargetResolution,
+    );
+    expect(response!.requestFailedDetails?.errorCode).toBe("INVALID_TARGET");
+    expect(response!.failureCause).toBe(
+      "Monitor target URL must use http or https (got ws).",
+    );
+    // The scheme is rejected before any name resolution is attempted.
+    expect(lookupSpy).not.toHaveBeenCalled();
+  });
+
+  /*
+   * End-to-end proof that the in-guard retry is what stops the customer's
+   * false incident: the very first getaddrinfo fails the way a loaded resolver
+   * fails, the second succeeds, and the monitor is simply online. Before the
+   * retry existed this single blip was a hard monitor-down.
+   */
+  it("stays online when the first resolver attempt fails and the retry succeeds", async () => {
+    const host: string = "transient-resolver.example.test";
+    const lookupSpy: jest.SpyInstance = jest
+      .spyOn(dns.promises, "lookup")
+      .mockRejectedValueOnce(
+        new Error(`getaddrinfo EAI_AGAIN ${host}`) as never,
+      )
+      .mockResolvedValue([{ address: PUBLIC_ADDRESS, family: 4 }] as never);
+    const fetchSpy: jest.SpyInstance = jest
+      .spyOn(WebsiteRequest, "fetch")
+      .mockResolvedValue(
+        websiteResponse({
+          url: `https://${host}/`,
+          statusCode: 200,
+          body: "recovered",
+        }) as never,
+      );
+
+    const response: ProbeWebsiteResponse | null = await WebsiteMonitor.ping(
+      URL.fromString(`https://${host}/`),
+      { retry: 0, isOnlineCheckRequest: true },
+    );
+
+    expect(response).not.toBeNull();
+    expect(response!.isOnline).toBe(true);
+    expect(response!.statusCode).toBe(200);
+    expect(response!.requestFailedDetails).toBeUndefined();
+    expect(lookupSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Probe/Utils/Monitors/HttpMonitorRequest.ts
+++ b/Probe/Utils/Monitors/HttpMonitorRequest.ts
@@ -264,6 +264,20 @@ export class PinnedHttpsProxyAgent extends HttpsProxyAgent<string> {
   }
 }
 
+/*
+ * Total budget for the pre-flight name resolution of a monitor target.
+ *
+ * It has to sit ABOVE the resolver budget the probe itself is configured with,
+ * or the guard cuts the lookup off before the resolver has finished its own
+ * failover and a reachable host is reported down. The Helm chart ships
+ * timeout:2 + attempts:2 over a cluster resolver plus two fallback
+ * nameservers, so a single getaddrinfo can legitimately take ~12s before it
+ * succeeds on a fallback — the very resilience those fallbacks exist to
+ * provide. This is only a hang guard; the real per-check bound is the
+ * monitor's own execution-context deadline, which reports an honest timeout.
+ */
+export const MONITOR_DNS_RESOLVE_BUDGET_IN_MS: number = 15000;
+
 export default class HttpMonitorRequest {
   /*
    * Prepare exactly ONE network hop. Callers invoke this again for retries,
@@ -303,6 +317,7 @@ export default class HttpMonitorRequest {
         targetLabel: "Monitor target",
         privateNetworkHint: PROBE_PRIVATE_NETWORK_HINT,
         includeResolvedAddressInError: false,
+        resolveTimeoutInMs: MONITOR_DNS_RESOLVE_BUDGET_IN_MS,
       });
     } finally {
       if (shouldTimeDnsLookup) {

--- a/Probe/Utils/Monitors/MonitorTypes/ApiMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/ApiMonitor.ts
@@ -14,6 +14,7 @@ import API from "Common/Utils/API";
 import HttpPhaseTimings from "Common/Types/Monitor/HttpPhaseTimings";
 import logger, { EXTERNAL_FAULT } from "Common/Server/Utils/Logger";
 import BadDataException from "Common/Types/Exception/BadDataException";
+import EgressGuardException from "Common/Types/Exception/EgressGuardException";
 import TimeoutException from "Common/Types/Exception/TimeoutException";
 import { HttpTimingCollector } from "../../HttpTimingAgents";
 import HttpMonitorRequest, {
@@ -329,11 +330,30 @@ export default class ApiMonitor {
       }
 
       const responseReceivedAt: Date = new Date();
+      /*
+       * A sanitized guard refusal must not report how long it took. The two
+       * branches it merges do measurably different amounts of work — a DNS
+       * failure is retried inside the guard, an address-policy rejection
+       * follows one successful lookup — and this number is shipped to the
+       * tenant on probeAttempts. Reporting it would hand back, as a plain
+       * integer, exactly the "did this hostname resolve?" bit the merged
+       * message exists to withhold. Zero matches the top-level
+       * responseTimeInMS these same paths already report for the same reason.
+       *
+       * This closes the REPORTED channel only. A determined tenant can still
+       * time checks externally, as they could before any of this; equalizing
+       * that would mean padding every refusal out to the full DNS budget.
+       */
+      const isSanitizedGuardRefusal: boolean =
+        err instanceof EgressGuardException && err.isTargetUnreachable();
+
       options.attempts.push({
         attemptNumber: options.currentRetryCount || 1,
         attemptedAt,
         responseReceivedAt,
-        responseTimeInMs: responseReceivedAt.getTime() - attemptedAt.getTime(),
+        responseTimeInMs: isSanitizedGuardRefusal
+          ? 0
+          : responseReceivedAt.getTime() - attemptedAt.getTime(),
         responseCode: undefined,
         isOnline: false,
         failureCause: API.getFriendlyErrorMessage(err as Error),
@@ -350,11 +370,27 @@ export default class ApiMonitor {
         return await this.ping(url, options);
       }
 
-      if (
-        !(err instanceof BadDataException) &&
-        !(err instanceof TimeoutException) &&
-        !options.isOnlineCheckRequest
-      ) {
+      /*
+       * A guard refusal that is about REACHING the target (DNS, or an address
+       * policy) is a network failure like any other, so it gets the same
+       * probe-health sanity check every other network failure gets: a probe
+       * whose own resolver has died must not be believed when it reports that
+       * a monitor is down. Only a structurally invalid target skips the check,
+       * because that is the tenant's configuration and has to surface as-is.
+       *
+       * The retry decision above is deliberately NOT changed the same way:
+       * retrying only some guard refusals would make the attempt count differ
+       * between a hostname that failed DNS and one blocked by policy, which is
+       * the distinction the sanitized message exists to hide. Transient
+       * resolver failures are retried inside the guard instead.
+       */
+      const shouldVerifyProbeIsOnline: boolean =
+        err instanceof EgressGuardException
+          ? err.isTargetUnreachable()
+          : !(err instanceof BadDataException) &&
+            !(err instanceof TimeoutException);
+
+      if (shouldVerifyProbeIsOnline && !options.isOnlineCheckRequest) {
         if (!(await OnlineCheck.canProbeMonitorWebsiteMonitors())) {
           logger.error(
             `API Monitor - Probe is not online. Cannot ping  ${options.monitorId?.toString()} ${requestType} ${url.toString()} - ERROR: ${err}`,

--- a/Probe/Utils/Monitors/MonitorTypes/ExternalStatusPageMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/ExternalStatusPageMonitor.ts
@@ -8,6 +8,7 @@ import ExternalStatusPageMonitorResponse, {
 } from "Common/Types/Monitor/ExternalStatusPageMonitor/ExternalStatusPageMonitorResponse";
 import ExternalStatusPageProviderType from "Common/Types/Monitor/ExternalStatusPageProviderType";
 import BadDataException from "Common/Types/Exception/BadDataException";
+import EgressGuardException from "Common/Types/Exception/EgressGuardException";
 import TimeoutException from "Common/Types/Exception/TimeoutException";
 import Headers from "Common/Types/API/Headers";
 import HTTPMethod from "Common/Types/API/HTTPMethod";
@@ -516,11 +517,24 @@ export default class ExternalStatusPageMonitorUtil {
         return await ExternalStatusPageMonitorUtil.fetch(config, options);
       }
 
-      // Check if the probe is online
-      if (
-        !ExternalStatusPageMonitorUtil.isFailClosedError(err) &&
-        !options.isOnlineCheckRequest
-      ) {
+      /*
+       * Check if the probe is online.
+       *
+       * An egress-guard refusal that is about REACHING the target (DNS, or an
+       * address policy) is a network failure like any other and must not be
+       * believed on its own — a probe whose own resolver has died would
+       * otherwise report every status page as unreachable. It reaches this
+       * catch as an EgressGuardException, which extends BadDataException and
+       * so would fail closed here; the same carve-out is made in
+       * WebsiteMonitor and ApiMonitor. A structurally invalid target still
+       * fails closed, because that is the tenant's configuration.
+       */
+      const shouldVerifyProbeIsOnline: boolean =
+        err instanceof EgressGuardException
+          ? err.isTargetUnreachable()
+          : !ExternalStatusPageMonitorUtil.isFailClosedError(err);
+
+      if (shouldVerifyProbeIsOnline && !options.isOnlineCheckRequest) {
         if (!(await OnlineCheck.canProbeMonitorWebsiteMonitors())) {
           logger.error(
             `ExternalStatusPageMonitor - Probe is not online. Cannot fetch ${options?.monitorId?.toString()} ${config.statusPageUrl} - ERROR: ${err}`,

--- a/Probe/Utils/Monitors/MonitorTypes/WebsiteMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/WebsiteMonitor.ts
@@ -14,6 +14,7 @@ import API from "Common/Utils/API";
 import logger, { EXTERNAL_FAULT } from "Common/Server/Utils/Logger";
 import { AxiosError } from "axios";
 import BadDataException from "Common/Types/Exception/BadDataException";
+import EgressGuardException from "Common/Types/Exception/EgressGuardException";
 import TimeoutException from "Common/Types/Exception/TimeoutException";
 import { HttpTimingCollector } from "../../HttpTimingAgents";
 import HttpMonitorRequest, {
@@ -296,11 +297,30 @@ export default class WebsiteMonitor {
       const statusCodeForAttempt: number | undefined =
         err instanceof AxiosError ? err.response?.status : undefined;
 
+      /*
+       * A sanitized guard refusal must not report how long it took. The two
+       * branches it merges do measurably different amounts of work — a DNS
+       * failure is retried inside the guard, an address-policy rejection
+       * follows one successful lookup — and this number is shipped to the
+       * tenant on probeAttempts. Reporting it would hand back, as a plain
+       * integer, exactly the "did this hostname resolve?" bit the merged
+       * message exists to withhold. Zero matches the top-level
+       * responseTimeInMS these same paths already report for the same reason.
+       *
+       * This closes the REPORTED channel only. A determined tenant can still
+       * time checks externally, as they could before any of this; equalizing
+       * that would mean padding every refusal out to the full DNS budget.
+       */
+      const isSanitizedGuardRefusal: boolean =
+        err instanceof EgressGuardException && err.isTargetUnreachable();
+
       options.attempts.push({
         attemptNumber: options.currentRetryCount || 1,
         attemptedAt,
         responseReceivedAt,
-        responseTimeInMs: responseReceivedAt.getTime() - attemptedAt.getTime(),
+        responseTimeInMs: isSanitizedGuardRefusal
+          ? 0
+          : responseReceivedAt.getTime() - attemptedAt.getTime(),
         responseCode: statusCodeForAttempt,
         isOnline: false,
         failureCause: failureCauseForAttempt,
@@ -367,11 +387,27 @@ export default class WebsiteMonitor {
         };
       }
 
-      if (
-        !(err instanceof BadDataException) &&
-        !(err instanceof TimeoutException) &&
-        !options.isOnlineCheckRequest
-      ) {
+      /*
+       * A guard refusal that is about REACHING the target (DNS, or an address
+       * policy) is a network failure like any other, so it gets the same
+       * probe-health sanity check every other network failure gets: a probe
+       * whose own resolver has died must not be believed when it reports that
+       * a monitor is down. Only a structurally invalid target skips the check,
+       * because that is the tenant's configuration and has to surface as-is.
+       *
+       * The retry decision above is deliberately NOT changed the same way:
+       * retrying only some guard refusals would make the attempt count differ
+       * between a hostname that failed DNS and one blocked by policy, which is
+       * the distinction the sanitized message exists to hide. Transient
+       * resolver failures are retried inside the guard instead.
+       */
+      const shouldVerifyProbeIsOnline: boolean =
+        err instanceof EgressGuardException
+          ? err.isTargetUnreachable()
+          : !(err instanceof BadDataException) &&
+            !(err instanceof TimeoutException);
+
+      if (shouldVerifyProbeIsOnline && !options.isOnlineCheckRequest) {
         if (!(await OnlineCheck.canProbeMonitorWebsiteMonitors())) {
           logger.error(
             `Website Monitor - Probe is not online. Cannot ping ${options.monitorId?.toString()} ${requestType} ${url.toString()} - ERROR: ${err}`,


### PR DESCRIPTION
## The report

A customer's website monitor raised an incident whose entire root cause read:

```
Response Snapshot
- Response Time: 0.00 ms
- Timed Out: No

Request Failed Details
- Failed Phase: Unknown
- Error Description: Request failed: Monitor target host order.abbeysbakehouse.com could not be reached.
- Raw Error Message: Monitor target host order.abbeysbakehouse.com could not be reached.
```

One of ~75 monitors on the same cluster. No error code, no phase, and the same sentence printed twice. Nothing to act on.

## What was actually happening

The probe validates a monitor target before connecting — resolve the hostname, then check the resulting address is one it may dial. When that pre-flight fails, `EgressGuard` deliberately returns **one sanitized sentence** so a tenant on a shared probe cannot tell "did not resolve" from "resolved but blocked" and use the difference to enumerate internal DNS names.

**That property is correct and is preserved here.** What was broken is everything around it:

1. **The phase was garbage.** `API.getRequestFailedDetails` matched that sentence against none of its string patterns and fell through to the default branch — `Unknown`, no error code, and the sentence reprinted as its own explanation. `0.00 ms` / `Timed Out: No` are hardcoded placeholders on that path, not measurements, which is why the incident looked like a measured result and wasn't one.

2. **No retries.** Guard refusals are `BadDataException`, which both `WebsiteMonitor` and `ApiMonitor` exclude from the retry loop. A single transient resolver failure went straight to an incident, while an ordinary socket error would have been retried.

3. **No probe-health check.** The same exclusion skipped `OnlineCheck`, so a probe whose own resolver had died would be believed unconditionally when it reported every monitor down.

4. **The DNS ceiling was below the probe's own resolver budget.** Hardcoded 5s, while the `dnsConfig` our Helm chart ships (`timeout:2`, `attempts:2`, cluster resolver + two fallback nameservers) can legitimately take ~12s to fail over. The guard cut short the very fallbacks that exist to absorb DNS blips — and the chart comment says they're there to prevent "intermittent `getaddrinfo EAI_AGAIN` failures (false monitor-down alerts)".

This is a regression from `78b19735bd fix(security): block SSRF in HTTP monitors`, which introduced the pre-flight *and* added the `BadDataException` carve-outs in (2) and (3) in the same commit. Before it, a DNS failure surfaced as an axios `ENOTFOUND` and got the normal retries and phase.

For the reported host specifically I ruled out the address-policy branch: `order.abbeysbakehouse.com` is a CNAME chain through Azure Traffic Manager (60s TTL) to `20.62.13.29`, which the guard allows. So it was name resolution, and the probe never opened a socket.

## The change

- **`EgressGuardException`** (new, extends `BadDataException` so every existing `instanceof` check is unaffected) carries which stage failed. Detail-suppressed failures **all** report reason `Unreachable`, so the DNS and address-policy branches stay byte-identical.
- **`RequestFailedPhase.TargetResolution`**, classified from the exception *type* rather than its text, with an error code and one constant, actionable description that names all the possibilities without saying which occurred.
- **Bounded DNS retry inside one total budget.** A fast-failing resolver is retried in milliseconds; a *hanging* one consumes the budget on attempt 1 and is not retried, so worst-case latency is unchanged for existing callers. Retrying inside the guard (rather than at the monitor) keeps `totalAttempts` identical across branches.
- **`MONITOR_DNS_RESOLVE_BUDGET_IN_MS = 15000`** for probes, above the shipped resolver budget. The real per-check bound stays the monitor's execution-context deadline, which reports an honest timeout.
- **Probe-health check** now applies to unreachable targets in `WebsiteMonitor`, `ApiMonitor` and `ExternalStatusPageMonitor`. Structurally invalid targets still fail fast — that's the tenant's configuration.
- **Attempt count** rendered in the incident root cause.
- The real resolver errno is logged on the probe (`logger.debug`) — the only operator channel left once the message is sanitized.

## Security notes for the reviewer

The sanitized message is unchanged, byte for byte. Two things surfaced in review and were fixed before this PR:

- The retry initially ran on only one of the two merged branches, giving the DNS path a ~300ms floor and 3 lookups vs 1 — and that elapsed time is shipped to the tenant on `probeAttempts.responseTimeInMs`. Sanitized refusals now report **zero** attempt time, matching what that path already does for the top-level `responseTimeInMS`. This closes the *reported* channel; a tenant can still time checks externally, as they could before — equalizing that would mean padding every refusal out to the full DNS budget, which didn't seem worth it. Flagging it explicitly rather than leaving it implied.
- A budget-truncated retry could bury the real resolver errno behind a generic "DNS lookup timed out". The first error is now kept.

## Tests

**83 new tests**, all green locally (307 passing across the 5 Common suites, including the 178 pre-existing `EgressGuard` tests unchanged):

- `EgressGuard.test.ts` (+37) — typed reason at every throw site; **the indistinguishability invariant**, comparing all three suppressed branches on a full fingerprint (message, reason, constructor, exception code, own enumerable keys) so a future divergence in any field fails; the inverse test so it can't pass vacuously; retry behaviour, budget arithmetic, and the constants pinned.
- `RequestFailedDetails.test.ts` (new, 20) — the customer's exact error asserted to no longer be `Unknown`; output proven to be a function of the reason alone; plus regression coverage for the pre-existing classification rules this branch sits in front of.
- `WebsiteMonitorTargetResolution.test.ts` / `ApiMonitorTargetResolution.test.ts` (new, 11) — end-to-end: a transient resolver failure that recovers now comes back **online**; `totalAttempts` still 1; DNS and blocked-address failures still indistinguishable in the serialized response; the probe-health check suppresses the report when the probe itself is offline.
- `MonitorRootCauseTargetResolution.test.ts` (new, 15) — the rendered incident text, at the exact surface the customer read.

`tsc --noEmit` clean for Common and Probe; `prettier --check` clean.

## Follow-up, not in this PR

`Probes in Agreement` compares each probe's last *stored* result rather than requiring fresh independent checks, so it's weaker corroboration than it reads.