### PR TITLE
Show live signup password progress and special-character guidance

### DIFF
--- a/App/FeatureSet/Accounts/src/Components/PasswordRequirements/PasswordRequirements.tsx
+++ b/App/FeatureSet/Accounts/src/Components/PasswordRequirements/PasswordRequirements.tsx
@@ -1,11 +1,15 @@
 import {
+  MAXIMUM_PASSWORD_LENGTH,
   MINIMUM_SIGNUP_PASSWORD_LENGTH,
   getSignupPasswordValidationError,
+  isPredictableSignupPassword,
 } from "Common/Types/Password";
 import IconProp from "Common/Types/Icon/IconProp";
 import Icon from "Common/UI/Components/Icon/Icon";
 import React, { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
+
+const SPECIAL_CHARACTER_PATTERN: RegExp = /[\p{P}\p{S}]/u;
 
 export interface ComponentProps {
   id: string;
@@ -17,13 +21,27 @@ const PasswordRequirements: (props: ComponentProps) => ReactElement = (
   props: ComponentProps,
 ): ReactElement => {
   const { t } = useTranslation();
+  const length: number = Array.from(props.password).length;
+  const lengthProgress: number = Math.min(
+    length,
+    MINIMUM_SIGNUP_PASSWORD_LENGTH,
+  );
+  const hasValidLength: boolean =
+    length >= MINIMUM_SIGNUP_PASSWORD_LENGTH &&
+    length <= MAXIMUM_PASSWORD_LENGTH;
+  const hasUnpredictableContent: boolean =
+    props.password.trim().length > 0 &&
+    !isPredictableSignupPassword(props.password);
+  const hasSpecialCharacter: boolean = SPECIAL_CHARACTER_PATTERN.test(
+    props.password,
+  );
   const validationError: string | null =
     props.error || getSignupPasswordValidationError(props.password);
   const meetsRequirements: boolean = validationError === null;
   const showGuidance: boolean =
     !props.error &&
     (!props.password ||
-      (Array.from(props.password).length < MINIMUM_SIGNUP_PASSWORD_LENGTH &&
+      (length < MINIMUM_SIGNUP_PASSWORD_LENGTH &&
         props.password.trim().length > 0));
 
   const message: string =
@@ -40,13 +58,27 @@ const PasswordRequirements: (props: ComponentProps) => ReactElement = (
             nsSeparator: false,
           }));
 
+  const requirements: Array<{ label: string; complete: boolean }> = [
+    {
+      label: t("Between {{minimum}} and {{maximum}} characters", {
+        minimum: MINIMUM_SIGNUP_PASSWORD_LENGTH,
+        maximum: MAXIMUM_PASSWORD_LENGTH,
+      }),
+      complete: hasValidLength,
+    },
+    {
+      label: t("Avoid common or repeated patterns"),
+      complete: hasUnpredictableContent,
+    },
+  ];
+
   return (
     <div
       id={props.id}
       role="status"
       aria-live="polite"
       aria-atomic="true"
-      className={`mt-3 flex min-h-[96px] items-center gap-3 rounded-lg border p-3 text-sm leading-5 transition-colors duration-150 motion-reduce:transition-none sm:min-h-[80px] sm:px-4 ${
+      className={`mt-3 rounded-lg border p-3 text-sm leading-5 transition-colors duration-150 motion-reduce:transition-none sm:px-4 ${
         meetsRequirements
           ? "border-emerald-200 bg-emerald-50 text-emerald-800"
           : showGuidance
@@ -54,15 +86,7 @@ const PasswordRequirements: (props: ComponentProps) => ReactElement = (
             : "border-amber-200 bg-amber-50 text-amber-900"
       }`}
     >
-      <div
-        className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white shadow-sm ring-1 ${
-          meetsRequirements
-            ? "text-emerald-600 ring-emerald-200"
-            : showGuidance
-              ? "text-indigo-600 ring-indigo-100"
-              : "text-amber-600 ring-amber-200"
-        }`}
-      >
+      <div className="flex items-start gap-2">
         <Icon
           icon={
             meetsRequirements
@@ -71,22 +95,99 @@ const PasswordRequirements: (props: ComponentProps) => ReactElement = (
                 ? IconProp.Lock
                 : IconProp.InformationCircle
           }
-          className="h-5 w-5"
+          className="h-5 w-5 shrink-0"
         />
-      </div>
-      <div className="min-w-0">
         <p
-          className="font-medium"
+          className="min-w-0 font-medium"
           data-testid={props.error ? "error-message" : undefined}
         >
           {message}
         </p>
-        {showGuidance && (
-          <p className="mt-1 text-gray-600">
-            {t("Try a few unrelated words.")}
-          </p>
-        )}
       </div>
+      <div className="mt-3 flex flex-wrap justify-between gap-x-3 gap-y-1 text-xs text-gray-600">
+        <span>{t("Password length")}</span>
+        <span className="tabular-nums">
+          {t("{{length}} / {{minimum}} characters minimum", {
+            length,
+            minimum: MINIMUM_SIGNUP_PASSWORD_LENGTH,
+          })}
+        </span>
+      </div>
+      <div
+        role="progressbar"
+        aria-label={t("Password length")}
+        aria-valuemin={0}
+        aria-valuemax={MINIMUM_SIGNUP_PASSWORD_LENGTH}
+        aria-valuenow={lengthProgress}
+        aria-valuetext={t("{{length}} / {{minimum}} characters minimum", {
+          length,
+          minimum: MINIMUM_SIGNUP_PASSWORD_LENGTH,
+        })}
+        className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-gray-200"
+      >
+        <div
+          style={{
+            width: `${(lengthProgress / MINIMUM_SIGNUP_PASSWORD_LENGTH) * 100}%`,
+          }}
+          className={`h-full rounded-full transition-all duration-150 motion-reduce:transition-none ${
+            meetsRequirements
+              ? "bg-emerald-500"
+              : showGuidance
+                ? "bg-indigo-500"
+                : "bg-amber-500"
+          }`}
+        />
+      </div>
+      <ul className="mt-3 space-y-1.5">
+        {requirements.map(
+          (requirement: { label: string; complete: boolean }) => {
+            return (
+              <li
+                key={requirement.label}
+                className={`flex items-start gap-2 ${requirement.complete ? "text-emerald-800" : "text-gray-600"}`}
+              >
+                <Icon
+                  icon={
+                    requirement.complete
+                      ? IconProp.CheckCircle
+                      : IconProp.EmptyCircle
+                  }
+                  className="h-4 w-4 shrink-0 mt-0.5"
+                />
+                <span className="sr-only">
+                  {t(requirement.complete ? "Complete:" : "Incomplete:", {
+                    keySeparator: false,
+                    nsSeparator: false,
+                  })}{" "}
+                </span>
+                <span>{requirement.label}</span>
+              </li>
+            );
+          },
+        )}
+        <li
+          className={`flex items-start gap-2 ${hasSpecialCharacter ? "text-emerald-800" : "text-gray-600"}`}
+        >
+          <Icon
+            icon={
+              hasSpecialCharacter
+                ? IconProp.CheckCircle
+                : IconProp.InformationCircle
+            }
+            className="h-4 w-4 shrink-0 mt-0.5"
+          />
+          <span>
+            {hasSpecialCharacter
+              ? t("Special character included (optional)")
+              : t("Special characters are optional. Try !, @, # or $.")}
+          </span>
+        </li>
+      </ul>
+      {showGuidance && (
+        <p className="mt-2 text-xs text-gray-600">
+          {t("Try a few unrelated words.")}
+        </p>
+      )}
     </div>
   );
 };

--- a/App/FeatureSet/Accounts/src/Locales/da.json
+++ b/App/FeatureSet/Accounts/src/Locales/da.json
@@ -187,5 +187,13 @@
   "Password is required.": "Adgangskode er påkrævet.",
   "Password must be a string.": "Adgangskoden skal være en tekststreng.",
   "Account details": "Kontooplysninger",
-  "Secure your account": "Beskyt din konto"
+  "Secure your account": "Beskyt din konto",
+  "Between {{minimum}} and {{maximum}} characters": "Mellem {{minimum}} og {{maximum}} tegn",
+  "Avoid common or repeated patterns": "Undgå almindelige eller gentagne mønstre",
+  "Password length": "Adgangskodens længde",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / mindst {{minimum}} tegn",
+  "Complete:": "Opfyldt:",
+  "Incomplete:": "Ikke opfyldt:",
+  "Special character included (optional)": "Specialtegn inkluderet (valgfrit)",
+  "Special characters are optional. Try !, @, # or $.": "Specialtegn er valgfrie. Prøv !, @, # eller $."
 }

--- a/App/FeatureSet/Accounts/src/Locales/de.json
+++ b/App/FeatureSet/Accounts/src/Locales/de.json
@@ -187,5 +187,13 @@
   "Password is required.": "Ein Passwort ist erforderlich.",
   "Password must be a string.": "Das Passwort muss eine Zeichenfolge sein.",
   "Account details": "Kontodetails",
-  "Secure your account": "Sichern Sie Ihr Konto"
+  "Secure your account": "Sichern Sie Ihr Konto",
+  "Between {{minimum}} and {{maximum}} characters": "Zwischen {{minimum}} und {{maximum}} Zeichen",
+  "Avoid common or repeated patterns": "Häufige oder sich wiederholende Muster vermeiden",
+  "Password length": "Passwortlänge",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / mindestens {{minimum}} Zeichen",
+  "Complete:": "Erfüllt:",
+  "Incomplete:": "Nicht erfüllt:",
+  "Special character included (optional)": "Sonderzeichen enthalten (optional)",
+  "Special characters are optional. Try !, @, # or $.": "Sonderzeichen sind optional. Probiere !, @, # oder $."
 }

--- a/App/FeatureSet/Accounts/src/Locales/en.json
+++ b/App/FeatureSet/Accounts/src/Locales/en.json
@@ -187,5 +187,13 @@
   "Password is required.": "Password is required.",
   "Password must be a string.": "Password must be a string.",
   "Account details": "Account details",
-  "Secure your account": "Secure your account"
+  "Secure your account": "Secure your account",
+  "Between {{minimum}} and {{maximum}} characters": "Between {{minimum}} and {{maximum}} characters",
+  "Avoid common or repeated patterns": "Avoid common or repeated patterns",
+  "Password length": "Password length",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / {{minimum}} characters minimum",
+  "Complete:": "Complete:",
+  "Incomplete:": "Incomplete:",
+  "Special character included (optional)": "Special character included (optional)",
+  "Special characters are optional. Try !, @, # or $.": "Special characters are optional. Try !, @, # or $."
 }

--- a/App/FeatureSet/Accounts/src/Locales/es.json
+++ b/App/FeatureSet/Accounts/src/Locales/es.json
@@ -187,5 +187,13 @@
   "Password is required.": "La contraseña es obligatoria.",
   "Password must be a string.": "La contraseña debe ser una cadena de texto.",
   "Account details": "Datos de la cuenta",
-  "Secure your account": "Protege tu cuenta"
+  "Secure your account": "Protege tu cuenta",
+  "Between {{minimum}} and {{maximum}} characters": "Entre {{minimum}} y {{maximum}} caracteres",
+  "Avoid common or repeated patterns": "Evita patrones comunes o repetidos",
+  "Password length": "Longitud de la contraseña",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / {{minimum}} caracteres como mínimo",
+  "Complete:": "Cumplido:",
+  "Incomplete:": "No cumplido:",
+  "Special character included (optional)": "Carácter especial incluido (opcional)",
+  "Special characters are optional. Try !, @, # or $.": "Los caracteres especiales son opcionales. Prueba !, @, # o $."
 }

--- a/App/FeatureSet/Accounts/src/Locales/fa.json
+++ b/App/FeatureSet/Accounts/src/Locales/fa.json
@@ -187,5 +187,13 @@
   "Password is required.": "وارد کردن گذرواژه الزامی است.",
   "Password must be a string.": "گذرواژه باید یک رشتهٔ متنی باشد.",
   "Account details": "جزئیات حساب",
-  "Secure your account": "حساب خود را ایمن کنید"
+  "Secure your account": "حساب خود را ایمن کنید",
+  "Between {{minimum}} and {{maximum}} characters": "بین {{minimum}} و {{maximum}} نویسه",
+  "Avoid common or repeated patterns": "از الگوهای رایج یا تکراری خودداری کنید",
+  "Password length": "طول رمز عبور",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / حداقل {{minimum}} نویسه",
+  "Complete:": "رعایت شده:",
+  "Incomplete:": "رعایت نشده:",
+  "Special character included (optional)": "نویسهٔ ویژه دارد (اختیاری)",
+  "Special characters are optional. Try !, @, # or $.": "نویسه‌های ویژه اختیاری هستند. از !، @، # یا $ استفاده کنید."
 }

--- a/App/FeatureSet/Accounts/src/Locales/fr.json
+++ b/App/FeatureSet/Accounts/src/Locales/fr.json
@@ -187,5 +187,13 @@
   "Password is required.": "Le mot de passe est obligatoire.",
   "Password must be a string.": "Le mot de passe doit être une chaîne de caractères.",
   "Account details": "Informations du compte",
-  "Secure your account": "Sécurisez votre compte"
+  "Secure your account": "Sécurisez votre compte",
+  "Between {{minimum}} and {{maximum}} characters": "Entre {{minimum}} et {{maximum}} caractères",
+  "Avoid common or repeated patterns": "Évitez les motifs courants ou répétés",
+  "Password length": "Longueur du mot de passe",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / {{minimum}} caractères minimum",
+  "Complete:": "Respecté :",
+  "Incomplete:": "Non respecté :",
+  "Special character included (optional)": "Caractère spécial inclus (facultatif)",
+  "Special characters are optional. Try !, @, # or $.": "Les caractères spéciaux sont facultatifs. Essayez !, @, # ou $."
 }

--- a/App/FeatureSet/Accounts/src/Locales/hi.json
+++ b/App/FeatureSet/Accounts/src/Locales/hi.json
@@ -187,5 +187,13 @@
   "Password is required.": "पासवर्ड आवश्यक है।",
   "Password must be a string.": "पासवर्ड एक टेक्स्ट स्ट्रिंग होना चाहिए।",
   "Account details": "खाते की जानकारी",
-  "Secure your account": "अपना खाता सुरक्षित करें"
+  "Secure your account": "अपना खाता सुरक्षित करें",
+  "Between {{minimum}} and {{maximum}} characters": "{{minimum}} से {{maximum}} अक्षर",
+  "Avoid common or repeated patterns": "आम या दोहराए जाने वाले पैटर्न से बचें",
+  "Password length": "पासवर्ड की लंबाई",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / कम से कम {{minimum}} अक्षर",
+  "Complete:": "पूरी हुई:",
+  "Incomplete:": "पूरी नहीं हुई:",
+  "Special character included (optional)": "विशेष चिह्न शामिल है (वैकल्पिक)",
+  "Special characters are optional. Try !, @, # or $.": "विशेष चिह्न वैकल्पिक हैं। !, @, # या $ आज़माएँ।"
 }

--- a/App/FeatureSet/Accounts/src/Locales/it.json
+++ b/App/FeatureSet/Accounts/src/Locales/it.json
@@ -187,5 +187,13 @@
   "Password is required.": "La password è obbligatoria.",
   "Password must be a string.": "La password deve essere una stringa di testo.",
   "Account details": "Dettagli dell’account",
-  "Secure your account": "Proteggi il tuo account"
+  "Secure your account": "Proteggi il tuo account",
+  "Between {{minimum}} and {{maximum}} characters": "Tra {{minimum}} e {{maximum}} caratteri",
+  "Avoid common or repeated patterns": "Evita sequenze comuni o ripetute",
+  "Password length": "Lunghezza della password",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / minimo {{minimum}} caratteri",
+  "Complete:": "Soddisfatto:",
+  "Incomplete:": "Non soddisfatto:",
+  "Special character included (optional)": "Carattere speciale incluso (facoltativo)",
+  "Special characters are optional. Try !, @, # or $.": "I caratteri speciali sono facoltativi. Prova !, @, # o $."
 }

--- a/App/FeatureSet/Accounts/src/Locales/ja.json
+++ b/App/FeatureSet/Accounts/src/Locales/ja.json
@@ -187,5 +187,13 @@
   "Password is required.": "パスワードは必須です。",
   "Password must be a string.": "パスワードは文字列で入力してください。",
   "Account details": "アカウント情報",
-  "Secure your account": "アカウントのセキュリティ"
+  "Secure your account": "アカウントのセキュリティ",
+  "Between {{minimum}} and {{maximum}} characters": "{{minimum}}文字以上{{maximum}}文字以下",
+  "Avoid common or repeated patterns": "よく使われるパターンや繰り返しを避ける",
+  "Password length": "パスワードの長さ",
+  "{{length}} / {{minimum}} characters minimum": "{{length}}文字 / 最低{{minimum}}文字",
+  "Complete:": "達成済み：",
+  "Incomplete:": "未達成：",
+  "Special character included (optional)": "記号が含まれています（任意）",
+  "Special characters are optional. Try !, @, # or $.": "記号の使用は任意です。!、@、#、$ などを使ってみてください。"
 }

--- a/App/FeatureSet/Accounts/src/Locales/ko.json
+++ b/App/FeatureSet/Accounts/src/Locales/ko.json
@@ -187,5 +187,13 @@
   "Password is required.": "비밀번호는 필수입니다.",
   "Password must be a string.": "비밀번호는 문자열이어야 합니다.",
   "Account details": "계정 정보",
-  "Secure your account": "계정 보안"
+  "Secure your account": "계정 보안",
+  "Between {{minimum}} and {{maximum}} characters": "{{minimum}}자 이상 {{maximum}}자 이하",
+  "Avoid common or repeated patterns": "흔하거나 반복되는 패턴 피하기",
+  "Password length": "비밀번호 길이",
+  "{{length}} / {{minimum}} characters minimum": "{{length}}자 / 최소 {{minimum}}자",
+  "Complete:": "충족:",
+  "Incomplete:": "미충족:",
+  "Special character included (optional)": "특수 문자 포함됨 (선택 사항)",
+  "Special characters are optional. Try !, @, # or $.": "특수 문자는 선택 사항입니다. !, @, # 또는 $를 사용해 보세요."
 }

--- a/App/FeatureSet/Accounts/src/Locales/nl.json
+++ b/App/FeatureSet/Accounts/src/Locales/nl.json
@@ -187,5 +187,13 @@
   "Password is required.": "Een wachtwoord is verplicht.",
   "Password must be a string.": "Het wachtwoord moet een tekenreeks zijn.",
   "Account details": "Accountgegevens",
-  "Secure your account": "Beveilig je account"
+  "Secure your account": "Beveilig je account",
+  "Between {{minimum}} and {{maximum}} characters": "Tussen {{minimum}} en {{maximum}} tekens",
+  "Avoid common or repeated patterns": "Vermijd veelvoorkomende of herhaalde patronen",
+  "Password length": "Wachtwoordlengte",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / minimaal {{minimum}} tekens",
+  "Complete:": "Voldaan:",
+  "Incomplete:": "Niet voldaan:",
+  "Special character included (optional)": "Speciaal teken toegevoegd (optioneel)",
+  "Special characters are optional. Try !, @, # or $.": "Speciale tekens zijn optioneel. Probeer !, @, # of $."
 }

--- a/App/FeatureSet/Accounts/src/Locales/no.json
+++ b/App/FeatureSet/Accounts/src/Locales/no.json
@@ -187,5 +187,13 @@
   "Password is required.": "Passord er påkrevd.",
   "Password must be a string.": "Passordet må være en tekststreng.",
   "Account details": "Kontodetaljer",
-  "Secure your account": "Sikre kontoen din"
+  "Secure your account": "Sikre kontoen din",
+  "Between {{minimum}} and {{maximum}} characters": "Mellom {{minimum}} og {{maximum}} tegn",
+  "Avoid common or repeated patterns": "Unngå vanlige eller gjentatte mønstre",
+  "Password length": "Passordlengde",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / minst {{minimum}} tegn",
+  "Complete:": "Oppfylt:",
+  "Incomplete:": "Ikke oppfylt:",
+  "Special character included (optional)": "Spesialtegn inkludert (valgfritt)",
+  "Special characters are optional. Try !, @, # or $.": "Spesialtegn er valgfrie. Prøv !, @, # eller $."
 }

--- a/App/FeatureSet/Accounts/src/Locales/pt.json
+++ b/App/FeatureSet/Accounts/src/Locales/pt.json
@@ -187,5 +187,13 @@
   "Password is required.": "A senha é obrigatória.",
   "Password must be a string.": "A senha deve ser uma sequência de texto.",
   "Account details": "Detalhes da conta",
-  "Secure your account": "Proteja sua conta"
+  "Secure your account": "Proteja sua conta",
+  "Between {{minimum}} and {{maximum}} characters": "Entre {{minimum}} e {{maximum}} caracteres",
+  "Avoid common or repeated patterns": "Evite padrões comuns ou repetidos",
+  "Password length": "Comprimento da senha",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / mínimo de {{minimum}} caracteres",
+  "Complete:": "Atendido:",
+  "Incomplete:": "Não atendido:",
+  "Special character included (optional)": "Caractere especial incluído (opcional)",
+  "Special characters are optional. Try !, @, # or $.": "Caracteres especiais são opcionais. Experimente !, @, # ou $."
 }

--- a/App/FeatureSet/Accounts/src/Locales/ru.json
+++ b/App/FeatureSet/Accounts/src/Locales/ru.json
@@ -187,5 +187,13 @@
   "Password is required.": "Необходимо указать пароль.",
   "Password must be a string.": "Пароль должен быть строкой.",
   "Account details": "Данные учетной записи",
-  "Secure your account": "Защитите свою учетную запись"
+  "Secure your account": "Защитите свою учетную запись",
+  "Between {{minimum}} and {{maximum}} characters": "От {{minimum}} до {{maximum}} символов",
+  "Avoid common or repeated patterns": "Избегайте распространённых или повторяющихся последовательностей",
+  "Password length": "Длина пароля",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / минимум {{minimum}} символов",
+  "Complete:": "Выполнено:",
+  "Incomplete:": "Не выполнено:",
+  "Special character included (optional)": "Специальный символ добавлен (необязательно)",
+  "Special characters are optional. Try !, @, # or $.": "Специальные символы необязательны. Попробуйте !, @, # или $."
 }

--- a/App/FeatureSet/Accounts/src/Locales/sv.json
+++ b/App/FeatureSet/Accounts/src/Locales/sv.json
@@ -187,5 +187,13 @@
   "Password is required.": "Lösenord krävs.",
   "Password must be a string.": "Lösenordet måste vara en textsträng.",
   "Account details": "Kontouppgifter",
-  "Secure your account": "Skydda ditt konto"
+  "Secure your account": "Skydda ditt konto",
+  "Between {{minimum}} and {{maximum}} characters": "Mellan {{minimum}} och {{maximum}} tecken",
+  "Avoid common or repeated patterns": "Undvik vanliga eller upprepade mönster",
+  "Password length": "Lösenordets längd",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} / minst {{minimum}} tecken",
+  "Complete:": "Uppfyllt:",
+  "Incomplete:": "Inte uppfyllt:",
+  "Special character included (optional)": "Specialtecken inkluderat (valfritt)",
+  "Special characters are optional. Try !, @, # or $.": "Specialtecken är valfria. Prova !, @, # eller $."
 }

--- a/App/FeatureSet/Accounts/src/Locales/zh-CN.json
+++ b/App/FeatureSet/Accounts/src/Locales/zh-CN.json
@@ -187,5 +187,13 @@
   "Password is required.": "请输入密码。",
   "Password must be a string.": "密码必须是字符串。",
   "Account details": "账户信息",
-  "Secure your account": "保护你的账户"
+  "Secure your account": "保护你的账户",
+  "Between {{minimum}} and {{maximum}} characters": "{{minimum}} 至 {{maximum}} 个字符",
+  "Avoid common or repeated patterns": "避免常见或重复的模式",
+  "Password length": "密码长度",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} 个字符 / 至少 {{minimum}} 个字符",
+  "Complete:": "已满足：",
+  "Incomplete:": "未满足：",
+  "Special character included (optional)": "已包含特殊字符（可选）",
+  "Special characters are optional. Try !, @, # or $.": "特殊字符为可选项。可以尝试 !、@、# 或 $。"
 }

--- a/App/FeatureSet/Accounts/src/Locales/zh-TW.json
+++ b/App/FeatureSet/Accounts/src/Locales/zh-TW.json
@@ -187,5 +187,13 @@
   "Password is required.": "請輸入密碼。",
   "Password must be a string.": "密碼必須是字串。",
   "Account details": "帳戶資訊",
-  "Secure your account": "保護你的帳戶"
+  "Secure your account": "保護你的帳戶",
+  "Between {{minimum}} and {{maximum}} characters": "{{minimum}} 至 {{maximum}} 個字元",
+  "Avoid common or repeated patterns": "避免常見或重複的模式",
+  "Password length": "密碼長度",
+  "{{length}} / {{minimum}} characters minimum": "{{length}} 個字元 / 至少 {{minimum}} 個字元",
+  "Complete:": "已符合：",
+  "Incomplete:": "未符合：",
+  "Special character included (optional)": "已包含特殊字元（選填）",
+  "Special characters are optional. Try !, @, # or $.": "特殊字元為選填項目。可以試試 !、@、# 或 $。"
 }

--- a/Common/Tests/App/Accounts/PasswordRequirements.test.tsx
+++ b/Common/Tests/App/Accounts/PasswordRequirements.test.tsx
@@ -1,0 +1,254 @@
+import "@testing-library/jest-dom";
+import { afterEach, describe, expect, test } from "@jest/globals";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import React from "react";
+import i18n from "../../../../App/FeatureSet/Accounts/src/Utils/i18n";
+import french from "../../../../App/FeatureSet/Accounts/src/Locales/fr.json";
+import PasswordRequirements from "../../../../App/FeatureSet/Accounts/src/Components/PasswordRequirements/PasswordRequirements";
+
+const VALID_PASSWORD: string = "violet river lantern";
+
+function renderRequirements(password: string, error?: string): void {
+  render(
+    <PasswordRequirements
+      id="requirements"
+      password={password}
+      error={error}
+    />,
+  );
+}
+
+describe("Password requirements progress", () => {
+  afterEach(async () => {
+    cleanup();
+    await i18n.changeLanguage("en");
+  });
+
+  test.each([
+    ["", 0],
+    ["r", 1],
+    ["river", 5],
+    ["🌲river lantern", 14],
+    ["🌲 river lantern", 15],
+    [VALID_PASSWORD, 20],
+    ["violet river lantern".repeat(5), 100],
+    ["violet river lantern".repeat(5) + "!", 101],
+  ])(
+    "shows Unicode character progress for %p",
+    (password: string, length: number) => {
+      renderRequirements(password);
+      const progress: HTMLElement = screen.getByRole("progressbar", {
+        name: "Password length",
+      });
+      expect(progress).toHaveAttribute("aria-valuemin", "0");
+      expect(progress).toHaveAttribute("aria-valuemax", "15");
+      expect(progress).toHaveAttribute(
+        "aria-valuenow",
+        String(Math.min(length, 15)),
+      );
+      expect(progress).toHaveAttribute(
+        "aria-valuetext",
+        `${length} / 15 characters minimum`,
+      );
+      expect(
+        screen.getByText(`${length} / 15 characters minimum`),
+      ).toBeVisible();
+      expect(progress.firstElementChild).toHaveStyle({
+        width: `${(Math.min(length, 15) / 15) * 100}%`,
+      });
+    },
+  );
+
+  test("shows requirements before typing with a polite accessible status", () => {
+    renderRequirements("");
+    const status: HTMLElement = screen.getByRole("status");
+    expect(status).toHaveAttribute("id", "requirements");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveAttribute("aria-atomic", "true");
+    const checklist: HTMLElement = screen.getByRole("list");
+    const items: Array<HTMLElement> =
+      within(checklist).getAllByRole("listitem");
+    expect(items[0]).toHaveTextContent(
+      "Incomplete: Between 15 and 100 characters",
+    );
+    expect(items[1]).toHaveTextContent(
+      "Incomplete: Avoid common or repeated patterns",
+    );
+    expect(items[2]).toHaveTextContent(
+      "Special characters are optional. Try !, @, # or $.",
+    );
+    expect(screen.queryByTestId("error-message")).not.toBeInTheDocument();
+  });
+
+  test("translates progress and preserves spoken completion states containing colons", async () => {
+    await i18n.changeLanguage("fr");
+    renderRequirements("river!");
+    const progress: HTMLElement = screen.getByRole("progressbar", {
+      name: french["Password length"],
+    });
+    expect(progress).toHaveAttribute("aria-valuenow", "6");
+    expect(progress).toHaveAttribute(
+      "aria-valuetext",
+      french["{{length}} / {{minimum}} characters minimum"]
+        .replace("{{length}}", "6")
+        .replace("{{minimum}}", "15"),
+    );
+    const items: Array<HTMLElement> = screen.getAllByRole("listitem");
+    expect(items[0]).toHaveTextContent(french["Incomplete:"]);
+    expect(items[1]).toHaveTextContent(french["Complete:"]);
+    expect(items[2]).toHaveTextContent(
+      french["Special character included (optional)"],
+    );
+  });
+
+  test("updates each check independently and reverses progress when edited", () => {
+    const { rerender } = render(
+      <PasswordRequirements id="requirements" password="river" />,
+    );
+    expect(screen.getAllByRole("listitem")[0]).toHaveTextContent("Incomplete:");
+    expect(screen.getAllByRole("listitem")[1]).toHaveTextContent("Complete:");
+
+    rerender(
+      <PasswordRequirements id="requirements" password="PasswordPassword" />,
+    );
+    expect(screen.getAllByRole("listitem")[0]).toHaveTextContent("Complete:");
+    expect(screen.getAllByRole("listitem")[1]).toHaveTextContent("Incomplete:");
+    expect(screen.getByRole("status")).not.toHaveTextContent(
+      "Password meets requirements",
+    );
+    expect(screen.getByRole("progressbar").firstElementChild).toHaveClass(
+      "bg-amber-500",
+    );
+
+    rerender(
+      <PasswordRequirements id="requirements" password={VALID_PASSWORD} />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Password meets requirements",
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    expect(screen.getAllByRole("listitem")[0]).toHaveTextContent("Complete:");
+    expect(screen.getAllByRole("listitem")[1]).toHaveTextContent("Complete:");
+
+    rerender(<PasswordRequirements id="requirements" password="r" />);
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "1",
+    );
+    expect(screen.getByRole("status")).not.toHaveTextContent(
+      "Password meets requirements",
+    );
+    rerender(<PasswordRequirements id="requirements" password="" />);
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "0",
+    );
+    expect(screen.getAllByRole("listitem")[1]).toHaveTextContent("Incomplete:");
+  });
+
+  test.each(["!", "@", "#", "$", "_", "-", "£", "＋", "。", "🔒"])(
+    "recognizes the optional special character %s without displaying the password",
+    (symbol: string) => {
+      const password: string = VALID_PASSWORD + symbol;
+      renderRequirements(password);
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Special character included (optional)",
+      );
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Password meets requirements",
+      );
+      expect(screen.getByRole("status")).not.toHaveTextContent(password);
+    },
+  );
+
+  test.each([
+    VALID_PASSWORD,
+    "café rivière forêt",
+    "雨の中で踊る小さな青い鳥たちの歌",
+  ])(
+    "keeps a valid passphrase without special characters complete (%p)",
+    (password: string) => {
+      renderRequirements(password);
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Password meets requirements",
+      );
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Special characters are optional.",
+      );
+      expect(screen.getByRole("status")).not.toHaveTextContent(
+        "Special character included",
+      );
+    },
+  );
+
+  test("removes the special-character check when the character is deleted", () => {
+    const { rerender } = render(
+      <PasswordRequirements
+        id="requirements"
+        password={VALID_PASSWORD + "!"}
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Special character included",
+    );
+    rerender(
+      <PasswordRequirements id="requirements" password={VALID_PASSWORD} />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Special characters are optional.",
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Password meets requirements",
+    );
+  });
+
+  test.each([
+    " ".repeat(15),
+    "!".repeat(15),
+    "Password123456789!",
+    "abcabcabcabcabc",
+    "123456789012345",
+  ])(
+    "does not imply completion for predictable or blank full-length input (%p)",
+    (password: string) => {
+      renderRequirements(password);
+      expect(screen.getByRole("progressbar")).toHaveAttribute(
+        "aria-valuenow",
+        "15",
+      );
+      expect(screen.getAllByRole("listitem")[1]).toHaveTextContent(
+        "Incomplete:",
+      );
+      expect(screen.getByRole("status")).not.toHaveTextContent(
+        "Password meets requirements",
+      );
+    },
+  );
+
+  test("clears length completion and explains exceeding the maximum", () => {
+    renderRequirements(VALID_PASSWORD.repeat(5) + "!");
+    expect(screen.getAllByRole("listitem")[0]).toHaveTextContent("Incomplete:");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Password cannot be more than 100 characters.",
+    );
+    expect(screen.getByRole("status")).not.toHaveTextContent(
+      "Password meets requirements",
+    );
+  });
+
+  test("retains progress alongside a single external validation error", () => {
+    renderRequirements(VALID_PASSWORD, "Password cannot be used.");
+    expect(screen.getAllByText("Password cannot be used.")).toHaveLength(1);
+    expect(screen.getByTestId("error-message")).toHaveTextContent(
+      "Password cannot be used.",
+    );
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "15",
+    );
+    expect(screen.getByRole("status")).not.toHaveTextContent(
+      "Password meets requirements",
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+});

--- a/Common/Tests/App/Accounts/RegisterPassword.test.tsx
+++ b/Common/Tests/App/Accounts/RegisterPassword.test.tsx
@@ -14,6 +14,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
@@ -153,7 +154,7 @@ describe("Signup password requirements", () => {
     expect(requirements).toHaveAttribute("aria-atomic", "true");
     expect(password).toHaveAttribute("aria-describedby", requirements.id);
     expect(password).toHaveAccessibleDescription(
-      "Use at least 15 characters. Try a few unrelated words.",
+      /Use at least 15 characters\..*0 \/ 15 characters minimum.*Special characters are optional\./,
     );
     expect(password).toHaveAttribute("type", "password");
     expect(password).not.toHaveAttribute("aria-invalid");
@@ -226,6 +227,68 @@ describe("Signup password requirements", () => {
     expect(screen.getByRole("status")).not.toHaveClass("text-emerald-800");
   });
 
+  test("advances progress with each keystroke and retains the checklist after completion", async () => {
+    await renderPage();
+    const user: ReturnType<typeof userEvent.setup> = userEvent.setup({
+      delay: null,
+    });
+    const password: HTMLElement = screen.getByTestId("password");
+    const progress: HTMLElement = screen.getByRole("progressbar", {
+      name: "Password length",
+    });
+
+    await user.type(password, "river");
+    expect(progress).toHaveAttribute("aria-valuenow", "5");
+    await user.type(password, " lantern");
+    expect(progress).toHaveAttribute("aria-valuenow", "13");
+    await user.type(password, "!");
+    expect(progress).toHaveAttribute("aria-valuenow", "14");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Special character included (optional)",
+    );
+    expect(screen.getByRole("status")).not.toHaveTextContent(
+      "Password meets requirements",
+    );
+    await user.type(password, "7");
+    expect(progress).toHaveAttribute("aria-valuenow", "15");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Password meets requirements",
+    );
+    expect(within(screen.getByRole("status")).getByRole("list")).toBeVisible();
+
+    await user.keyboard("{Backspace}{Backspace}");
+    expect(progress).toHaveAttribute("aria-valuenow", "13");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Special characters are optional.",
+    );
+    await user.clear(password);
+    expect(progress).toHaveAttribute("aria-valuenow", "0");
+    expect(ModelAPI.createOrUpdate).not.toHaveBeenCalled();
+  });
+
+  test("keeps pasted Unicode progress and optional symbols consistent with signup validation", async () => {
+    await renderPage();
+    await fillForm("🌲 river lantern!");
+    const progress: HTMLElement = screen.getByRole("progressbar", {
+      name: "Password length",
+    });
+    expect(progress).toHaveAttribute(
+      "aria-valuetext",
+      "16 / 15 characters minimum",
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Special character included (optional)",
+    );
+    await submit();
+    expect(ModelAPI.createOrUpdate).toHaveBeenCalledTimes(1);
+    const request: Parameters<typeof ModelAPI.createOrUpdate>[0] = jest.mocked(
+      ModelAPI.createOrUpdate,
+    ).mock.calls[0]![0];
+    expect((request.model as User).password?.toString()).toBe(
+      "🌲 river lantern!",
+    );
+  });
+
   test.each([
     [
       "six characters previously accepted",
@@ -295,7 +358,7 @@ describe("Signup password requirements", () => {
       "Password meets requirements",
     );
     expect(screen.getByTestId("password")).toHaveAccessibleDescription(
-      "Choose a less predictable password. Try a few unrelated words.",
+      /Choose a less predictable password\..*Complete: Between 15 and 100 characters.*Incomplete: Avoid common or repeated patterns/,
     );
   });
 
@@ -328,7 +391,7 @@ describe("Signup password requirements", () => {
     expect(requirements).toContainElement(screen.getByTestId("error-message"));
     expect(password).toHaveAttribute("aria-invalid", "true");
     expect(password).toHaveAttribute("aria-describedby", requirements.id);
-    expect(password).toHaveAccessibleDescription(message);
+    expect(password).toHaveAccessibleDescription(new RegExp(message));
 
     await setField("password", VALID_PASSWORD);
 
@@ -337,7 +400,7 @@ describe("Signup password requirements", () => {
       expect(requirements).toHaveTextContent("Password meets requirements");
       expect(password).not.toHaveAttribute("aria-invalid");
       expect(password).toHaveAccessibleDescription(
-        "Password meets requirements",
+        /Password meets requirements.*Complete: Between 15 and 100 characters.*Complete: Avoid common or repeated patterns/,
       );
     });
     expect(ModelAPI.createOrUpdate).not.toHaveBeenCalled();

--- a/Common/Tests/Types/SignupPassword.test.ts
+++ b/Common/Tests/Types/SignupPassword.test.ts
@@ -1,10 +1,74 @@
 import {
   getPasswordValidationError,
   getSignupPasswordValidationError,
+  isPredictableSignupPassword,
   MAXIMUM_PASSWORD_LENGTH,
   MINIMUM_SIGNUP_PASSWORD_LENGTH,
 } from "../../Types/Password";
 import { describe, expect, test } from "@jest/globals";
+
+describe("signup password pattern feedback", () => {
+  test.each(["", " ", "\t\n", "\u00a0\u2003"])(
+    "does not mark the pattern requirement complete for blank input (%p)",
+    (value: string) => {
+      expect(isPredictableSignupPassword(value)).toBe(true);
+    },
+  );
+
+  test.each([
+    ["a common word", "password"],
+    ["a common word with mixed case and digits", "PaSsWoRd123"],
+    ["a common word padded with punctuation", " !welcome! "],
+    ["a common word with currency symbols", "£admin123$"],
+    ["a common word with math symbols", "+letmein="],
+    ["a common word with modifier symbols", "^changeme^"],
+    ["a repeated character", "aa"],
+    ["repeated punctuation", "!!"],
+    ["repeated Unicode symbols", "🔒🔒"],
+    ["repeated words with separators", "river-river"],
+    ["a numeric sequence", "12345"],
+    ["a reversed numeric sequence", "54321"],
+    ["an alphabetical sequence", "abcde"],
+    ["a reversed alphabetical sequence", "edcba"],
+    ["a keyboard sequence", "qwerty"],
+    ["a reversed keyboard sequence", "ytrewq"],
+  ])(
+    "identifies %s before reaching the minimum length",
+    (_label: string, value: string) => {
+      expect(Array.from(value).length).toBeLessThan(
+        MINIMUM_SIGNUP_PASSWORD_LENGTH,
+      );
+      expect(isPredictableSignupPassword(value)).toBe(true);
+      expect(getSignupPasswordValidationError(value)).toBe(
+        "Password must be at least 15 characters.",
+      );
+    },
+  );
+
+  test.each([
+    ["unrelated lowercase words", "river fox"],
+    ["mixed character types", "N7#pR2!v"],
+    ["non-Latin words", "花鳥風月海"],
+    ["accented words", "café rivière"],
+    ["varied emoji", "🌍🍋🎈🐢🌊"],
+  ])(
+    "can complete the pattern requirement for %s while length is unfinished",
+    (_label: string, value: string) => {
+      expect(isPredictableSignupPassword(value)).toBe(false);
+      expect(getSignupPasswordValidationError(value)).toBe(
+        "Password must be at least 15 characters.",
+      );
+    },
+  );
+
+  test("keeps maximum-length errors ahead of pattern errors", () => {
+    const value: string = "a".repeat(MAXIMUM_PASSWORD_LENGTH + 1);
+    expect(isPredictableSignupPassword(value)).toBe(true);
+    expect(getSignupPasswordValidationError(value)).toBe(
+      "Password cannot be more than 100 characters.",
+    );
+  });
+});
 
 describe("signup password policy", () => {
   test.each([undefined, null, ""])(
@@ -91,6 +155,7 @@ describe("signup password policy", () => {
     "    password    ",
     "🔒".repeat(15),
   ])("rejects obvious predictable patterns (%p)", (value: string) => {
+    expect(isPredictableSignupPassword(value)).toBe(true);
     expect(getSignupPasswordValidationError(value)).toBe(
       "Choose a less predictable password. Try a few unrelated words.",
     );
@@ -107,6 +172,7 @@ describe("signup password policy", () => {
     "🌍🍋🎈🐢🌊🍂🪁🦉🚲🎸🍄🧭🐬🌻a",
     "a password manager picked this phrase",
   ])("accepts long passwords and passphrases (%p)", (value: string) => {
+    expect(isPredictableSignupPassword(value)).toBe(false);
     expect(getSignupPasswordValidationError(value)).toBeNull();
   });
 

--- a/Common/Types/Password.ts
+++ b/Common/Types/Password.ts
@@ -39,6 +39,40 @@ const COMMON_SIGNUP_PASSWORDS: Set<string> = new Set([
 
 const REPEATED_SIGNUP_PASSWORD_PATTERN: RegExp = /^(.{1,14})\1+$/u;
 
+/**
+ * Check obvious patterns independently of length so signup can show each
+ * requirement as the user types. Blank input returns true so an empty form
+ * cannot complete this requirement.
+ * Passing this check alone does not mean the password is valid or strong.
+ */
+export function isPredictableSignupPassword(password: string): boolean {
+  if (password.trim().length === 0) {
+    return true;
+  }
+
+  // Comparison only: padding, punctuation and casing do not rescue an obvious pattern.
+  const comparable: string =
+    password.toLowerCase().replace(/[\s\p{P}\p{Sc}\p{Sm}\p{Sk}]/gu, "") ||
+    password.toLowerCase().replace(/\s/gu, "");
+  const sequences: Array<string> = [
+    "0123456789",
+    "abcdefghijklmnopqrstuvwxyz",
+    "qwertyuiopasdfghjklzxcvbnm",
+  ];
+  const isSequence: boolean = sequences.some((sequence: string): boolean => {
+    return (
+      sequence.repeat(10).includes(comparable) ||
+      Array.from(sequence).reverse().join("").repeat(10).includes(comparable)
+    );
+  });
+
+  return (
+    REPEATED_SIGNUP_PASSWORD_PATTERN.test(comparable) ||
+    COMMON_SIGNUP_PASSWORDS.has(comparable.replace(/\d+$/u, "")) ||
+    isSequence
+  );
+}
+
 /** New accounts use a stronger policy; existing credentials remain valid. */
 export function getSignupPasswordValidationError(
   password: unknown,
@@ -66,27 +100,7 @@ export function getSignupPasswordValidationError(
     return `Password cannot be more than ${MAXIMUM_PASSWORD_LENGTH} characters.`;
   }
 
-  // Comparison only: padding, punctuation and casing do not rescue an obvious pattern.
-  const comparable: string =
-    password.toLowerCase().replace(/[\s\p{P}\p{Sc}\p{Sm}\p{Sk}]/gu, "") ||
-    password.toLowerCase().replace(/\s/gu, "");
-  const sequences: Array<string> = [
-    "0123456789",
-    "abcdefghijklmnopqrstuvwxyz",
-    "qwertyuiopasdfghjklzxcvbnm",
-  ];
-  const isSequence: boolean = sequences.some((sequence: string): boolean => {
-    return (
-      sequence.repeat(10).includes(comparable) ||
-      Array.from(sequence).reverse().join("").repeat(10).includes(comparable)
-    );
-  });
-
-  if (
-    REPEATED_SIGNUP_PASSWORD_PATTERN.test(comparable) ||
-    COMMON_SIGNUP_PASSWORDS.has(comparable.replace(/\d+$/u, "")) ||
-    isSequence
-  ) {
+  if (isPredictableSignupPassword(password)) {
     return "Choose a less predictable password. Try a few unrelated words.";
   }
 

--- a/E2E/Tests/Accounts/SignupPassword.spec.ts
+++ b/E2E/Tests/Accounts/SignupPassword.spec.ts
@@ -45,18 +45,89 @@ test.describe("Signup password feedback", () => {
       "new-password",
     );
     await expect(password).toHaveAccessibleDescription(
-      "Use at least 15 characters. Try a few unrelated words.",
+      /Use at least 15 characters\..*0 \/ 15 characters minimum.*Special characters are optional\./,
     );
     await expect(page.getByRole("status")).not.toContainText(
       "Password meets requirements",
     );
     await password.fill(passphrase);
-    await expect(page.getByRole("status")).toHaveText(
+    await expect(page.getByRole("status")).toContainText(
       "Password meets requirements",
     );
     await password.clear();
     await expect(page.getByRole("status")).toContainText(
       "Use at least 15 characters.",
+    );
+  });
+
+  test("shows progress on every keystroke and updates optional special characters", async ({
+    page,
+  }: {
+    page: Page;
+  }) => {
+    await page.goto(registrationUrl);
+    const password: Locator = page.getByTestId("password");
+    const progress: Locator = page.getByRole("progressbar", {
+      name: "Password length",
+    });
+    await expect(progress).toHaveAttribute("aria-valuenow", "0");
+    await password.pressSequentially("river");
+    await expect(progress).toHaveAttribute("aria-valuenow", "5");
+    await password.pressSequentially(" lantern!");
+    await expect(progress).toHaveAttribute("aria-valuenow", "14");
+    await expect(page.getByRole("status")).toContainText(
+      "Special character included (optional)",
+    );
+    await expect(page.getByRole("status")).not.toContainText(
+      "Password meets requirements",
+    );
+    await password.pressSequentially("7");
+    await expect(progress).toHaveAttribute("aria-valuenow", "15");
+    await expect(page.getByRole("status")).toContainText(
+      "Password meets requirements",
+    );
+    await expect(page.getByRole("status").getByRole("list")).toBeVisible();
+    await password.press("Backspace");
+    await password.press("Backspace");
+    await expect(progress).toHaveAttribute("aria-valuenow", "13");
+    await expect(page.getByRole("status")).toContainText(
+      "Special characters are optional.",
+    );
+    await password.clear();
+    await expect(progress).toHaveAttribute("aria-valuenow", "0");
+  });
+
+  test("counts Unicode consistently and keeps a predictable full-length password incomplete", async ({
+    page,
+  }: {
+    page: Page;
+  }) => {
+    await page.goto(registrationUrl);
+    const password: Locator = page.getByTestId("password");
+    const progress: Locator = page.getByRole("progressbar", {
+      name: "Password length",
+    });
+    await password.fill("🌲river lantern");
+    await expect(progress).toHaveAttribute("aria-valuenow", "14");
+    await expect(progress).toHaveAttribute(
+      "aria-valuetext",
+      "14 / 15 characters minimum",
+    );
+    await password.fill("🌲 river lantern");
+    await expect(progress).toHaveAttribute("aria-valuenow", "15");
+    await expect(page.getByRole("status")).toContainText(
+      "Password meets requirements",
+    );
+    await password.fill("Password123456789!");
+    await expect(progress).toHaveAttribute("aria-valuenow", "15");
+    await expect(page.getByRole("status")).toContainText(
+      "Incomplete: Avoid common or repeated patterns",
+    );
+    await expect(page.getByRole("status")).toContainText(
+      "Special character included (optional)",
+    );
+    await expect(page.getByRole("status")).not.toContainText(
+      "Password meets requirements",
     );
   });
 
@@ -168,6 +239,11 @@ test.describe("Signup password feedback", () => {
             ? "Password meets requirements"
             : "Choose a less predictable password.",
         );
+        await expect(page.getByRole("progressbar")).toBeVisible();
+        await expect(page.getByRole("status").getByRole("list")).toBeVisible();
+        await expect(
+          page.getByText("Special characters are optional. Try !, @, # or $."),
+        ).toBeVisible();
         expect(
           await page.evaluate(() => {
             return document.documentElement.scrollWidth <= window.innerWidth;


### PR DESCRIPTION
### Title of this pull request?

Show live signup password progress and special-character guidance

### Small Description?

Signup previously replaced password guidance with a single success message, leaving users unable to see their progress. Add a live Unicode character counter and length bar, a persistent checklist for length and predictable patterns, and optional special-character examples that update while typing or deleting. Long passphrases remain valid under the existing signup policy.

Reuse the server's pattern check for the checklist, preserve accessible password descriptions and spoken completion states, and translate the new feedback across all 17 Accounts locales.

### Validation

- Password policy and legacy password regression suites: 107 tests passed.
- Signup identity-handler integration suite: 40 tests passed.
- Password feedback component and full registration form suites: 63 tests passed.
- Signup browser suite: 20 tests passed across Chromium and Firefox, including 320px/390px phone layouts.
- `npm run compile` passed in Accounts, Common, and E2E.
- `npm run i18n:validate` passed.
- Root `npm run fix` passed for all six changed TypeScript files with every repository lint rule enabled. A temporary TypeScript project scoped type discovery to the changed files; no lint rules were disabled.

Browser validation uses the full worktree Accounts bundle on an isolated local preview because the configured Docker development backend returned 502 and became unavailable. The live HTTP API E2E group was not run; the real signup handler is covered by the integration suite with persistence and external effects mocked.

### Pull Request Checklist:

- [ ] CI jobs pass before requesting review.
- [x] Code linted locally.
- [x] Unit, regression, integration, and browser tests added where appropriate.

### Related Issue?

None.

### Screenshots (if appropriate):

Visually checked the partial and completed password panels at desktop and 320px phone widths; browser tests also cover 390px.
