### PR TITLE
fix(ci): get the red jobs on master back to green

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/AIAgentTask/CodeFixRunStatus.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIAgentTask/CodeFixRunStatus.tsx
@@ -40,6 +40,17 @@ const TASK_TYPE_LABEL: { [key in CodeFixTaskType]: string } = {
   [CodeFixTaskType.ImproveTracing]: "Improve Tracing",
   [CodeFixTaskType.FixPerformance]: "Fix Performance",
   [CodeFixTaskType.FixFromIncident]: "Fix from Incident",
+  /*
+   * The GitHub-triggered recipes name their GitHub subject rather than a
+   * OneUptime one: nothing in this product started them, so "the issue" or
+   * "the pull request" is the only handle the reader has on the row. They are
+   * spelled with the same verbs the app uses inside the thread it was
+   * mentioned in (implement/fix an issue, revise a pull request, review a
+   * pull request), and say GitHub because a repository can also be GitLab.
+   */
+  [CodeFixTaskType.GitHubIssueFix]: "Fix GitHub Issue",
+  [CodeFixTaskType.GitHubPullRequestRevision]: "Revise GitHub Pull Request",
+  [CodeFixTaskType.GitHubPullRequestReview]: "Review GitHub Pull Request",
 };
 
 export function getCodeFixTaskTypeLabel(taskType: string | undefined): string {

--- a/Common/Tests/UI/ReactRouterSingletonBuild.test.ts
+++ b/Common/Tests/UI/ReactRouterSingletonBuild.test.ts
@@ -58,12 +58,22 @@ function renderSharedLink(nodeEnv: string): RenderResult {
 
   fs.copyFileSync(APP_LINK, path.join(root, "shared", "AppLink.tsx"));
   const entry: string = path.join(root, "public", "Entry.tsx");
+  /*
+   * The entry renders through react-dom/server.browser rather than the bare
+   * react-dom/server specifier. esbuild-config aliases "react-dom" to an
+   * absolute directory, and an esbuild alias rewrites subpaths too, so
+   * "react-dom/server" would become a plain file path and skip react-dom's
+   * exports map - landing on server.node.js, which imports "stream" and "util"
+   * and cannot resolve on the browser platform this config builds for.
+   * server.browser is the renderer that exports map picks for a browser build
+   * anyway, so this asks for it directly instead of relying on the alias.
+   */
   fs.writeFileSync(
     entry,
     `
       import React from "react";
       import { MemoryRouter } from "react-router-dom";
-      import { renderToStaticMarkup } from "react-dom/server";
+      import { renderToStaticMarkup } from "react-dom/server.browser";
       import AppLink from "../shared/AppLink";
 
       globalThis.routerFixtureMarkup = renderToStaticMarkup(

--- a/Probe/Utils/Monitors/SyntheticRuntime/WorkerController.ts
+++ b/Probe/Utils/Monitors/SyntheticRuntime/WorkerController.ts
@@ -470,7 +470,8 @@ export default class WorkerController {
      */
     return Math.min(
       CONTROLLER_BOOTSTRAP_TOTAL_BUDGET_IN_MS,
-      this.getBootstrapTimeoutInMs(options) * this.getBootstrapAttempts(options),
+      this.getBootstrapTimeoutInMs(options) *
+        this.getBootstrapAttempts(options),
     );
   }
 


### PR DESCRIPTION
### Title of this pull request?

fix(ci): get the red jobs on master back to green

### Small Description?

> **In progress — do not merge yet.** Three of the five red jobs are fixed here. The `Common Test` billing failures and the Playwright `test-e2e-*` failures are still being worked and will be pushed to this branch. The checklist below is deliberately unticked until they land.

`master` currently has five red jobs. This is what each one is and what has been fixed so far.

**Fixed in this PR**

| Job | Failure | Fix |
| --- | --- | --- |
| `Compile` / `compile-dashboard` | `TS2739` at `CodeFixRunStatus.tsx:34` | `54f81c00e6` added `GitHubIssueFix`, `GitHubPullRequestRevision` and `GitHubPullRequestReview` to `CodeFixTaskType` but left `TASK_TYPE_LABEL` behind. The map is keyed exhaustively over the enum, so `tsc` has rejected it on every master commit since. Added the three labels. |
| `Common Jobs` / `js-lint` | `prettier/prettier` at `WorkerController.ts:473` | `9d799c3410` landed a line prettier wants wrapped. Rewrapped it. |
| `Common Test` (shard 1/8) | `ReactRouterSingletonBuild.test.ts` — esbuild `Could not resolve "stream" / "util"` | The fixture builds for the browser platform, and `esbuild-config` aliases `react-dom` to an absolute directory. An esbuild alias rewrites subpaths too, so `react-dom/server` resolved to a plain file path, skipped react-dom's exports map and landed on `server.node.js`, which imports node builtins. Switched the fixture entry to `react-dom/server.browser` — the renderer the exports map picks for a browser build anyway. The test still bundles the real `AppLink` against two physical router installations, which is the thing it exists to prove. |

**Still outstanding**

| Job | Failure | Status |
| --- | --- | --- |
| `Common Test` (shards 1/8 and 5/8) | `MonitorPayAsYouGoBilling` / `TelemetryPayAsYouGoBilling` — `canUsePayAsYouGo` asserted with one argument, called with two | `e00cdbc1c5` gave `canUsePayAsYouGo` an `options` parameter and the callers forward it, so the mock records `(projectId, undefined)`. Being worked — the fix must keep proving the right project id reaches the service, not just widen the assertion. |
| `Push Test Images` / `test-e2e-*` | 13 Playwright failures, 467 tests never ran | Two clusters: the new `SignupPassword` API tests from `ebbbd4f142` expect a `message` field the 400 response does not carry, and UI signup never reaches `/dashboard/welcome`, which fails `beforeAll` in six dashboard suites. The 467 skipped tests are collateral — the failures burn retries until Playwright's 90-minute `globalTimeout` fires. The last green e2e run finished in ~33 minutes, so no timeout change is needed; fixing the failures restores the budget. |

### Pull Request Checklist:

- [ ] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

None — this is CI repair. Each fix names the commit that introduced the failure.

### Screenshots (if appropriate):

n/a
