### PR TITLE
Shorten the save payment method button label

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Settings/Billing.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/Billing.tsx
@@ -780,7 +780,7 @@ const Settings: FunctionComponent<ComponentProps> = (
               onClose={() => {
                 setShowPaymentMethodModal(false);
               }}
-              submitButtonText={`Save payment method and enable paid usage`}
+              submitButtonText={`Save payment method`}
               error={modalError || ""}
               isBodyLoading={isModalLoading}
               submitButtonType={ButtonType.Submit}

--- a/Common/Tests/App/Dashboard/BillingPaidUsageFlow.test.tsx
+++ b/Common/Tests/App/Dashboard/BillingPaidUsageFlow.test.tsx
@@ -398,7 +398,7 @@ describe("Billing page paid usage flow", () => {
       await screen.findByRole("button", { name: "Add Payment Method" }),
     );
     const save: HTMLElement = await screen.findByRole("button", {
-      name: "Save payment method and enable paid usage",
+      name: "Save payment method",
     });
     await waitFor(() => {
       expect(save).not.toBeDisabled();
@@ -447,7 +447,7 @@ describe("Billing page paid usage flow", () => {
       await screen.findByRole("button", { name: "Add Payment Method" }),
     );
     const save: HTMLElement = await screen.findByRole("button", {
-      name: "Save payment method and enable paid usage",
+      name: "Save payment method",
     });
     await waitFor(() => {
       expect(save).not.toBeDisabled();


### PR DESCRIPTION
Change the Add Payment Method modal’s submit button to “Save payment method.” The existing successful-save and retry tests now require that exact label.

Validation:
- BillingPaidUsageFlow: all 12 tests passed with ts-jest isolated modules; type checking was run separately.
- Both changed files passed Prettier, and `git diff --check` passed.
- Root `npm run fix` (scoped to the changed files) and Dashboard `npm run compile -- --noEmit` were terminated with SIGKILL before completion.
- Common `npm run compile -- --noEmit` was also attempted, then stopped without a result after the PR was merged. Full lint and compilation validation remains incomplete locally.
- Live Docker verification was unavailable because the local Docker daemon was not running.
