### PR TITLE
Fix user invitations returning server errors after billing failures

### DIFF
--- a/App/FeatureSet/Workers/Jobs/PaymentProvider/UpdateTeamMembersIfNull.ts
+++ b/App/FeatureSet/Workers/Jobs/PaymentProvider/UpdateTeamMembersIfNull.ts
@@ -1,18 +1,36 @@
 import RunCron from "../../Utils/Cron";
-import { EVERY_DAY, EVERY_MINUTE } from "Common/Utils/CronTime";
-import { IsDevelopment } from "Common/Server/EnvironmentConfig";
+import { EVERY_FIFTEEN_MINUTE, EVERY_MINUTE } from "Common/Utils/CronTime";
+import {
+  IsBillingEnabled,
+  IsDevelopment,
+} from "Common/Server/EnvironmentConfig";
 import ProjectService from "Common/Server/Services/ProjectService";
 import TeamMemberService from "Common/Server/Services/TeamMemberService";
 import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import logger from "Common/Server/Utils/Logger";
 import Project from "Common/Models/DatabaseModels/Project";
 
+/*
+ * Keep the existing name so previously registered repeatable jobs still have a
+ * handler. Reconcile every subscribed project: a missed membership-triggered
+ * update can leave an older, non-null count, while a failed provider call leaves
+ * an unknown count. Matching counts do not call the payment provider again.
+ */
 RunCron(
   "PaymentProvider:UpdateTeamMembersIfNull",
-  { schedule: IsDevelopment ? EVERY_MINUTE : EVERY_DAY, runOnStartup: false },
+  {
+    schedule: IsDevelopment ? EVERY_MINUTE : EVERY_FIFTEEN_MINUTE,
+    runOnStartup: false,
+  },
   async () => {
+    if (!IsBillingEnabled) {
+      return;
+    }
+
     const projects: Array<Project> = await ProjectService.findAllBy({
       query: {
-        paymentProviderSubscriptionSeats: QueryHelper.isNull(),
+        paymentProviderSubscriptionId: QueryHelper.notNull(),
+        paymentProviderPlanId: QueryHelper.notNull(),
       },
       select: {
         _id: true,
@@ -23,9 +41,17 @@ RunCron(
     });
 
     for (const project of projects) {
-      await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
-        project.id!,
-      );
+      try {
+        await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+          project.id!,
+        );
+      } catch (err) {
+        logger.error(
+          "Could not reconcile subscription seats. The next scheduled sweep will retry this project.",
+          { projectId: project.id?.toString() },
+        );
+        logger.error(err, { projectId: project.id?.toString() });
+      }
     }
   },
 );

--- a/App/Tests/Workers/Jobs/PaymentProvider/UpdateTeamMembersIfNull.test.ts
+++ b/App/Tests/Workers/Jobs/PaymentProvider/UpdateTeamMembersIfNull.test.ts
@@ -1,0 +1,263 @@
+import Project from "Common/Models/DatabaseModels/Project";
+import * as EnvironmentConfig from "Common/Server/EnvironmentConfig";
+import Queue from "Common/Server/Infrastructure/Queue";
+import ProjectService from "Common/Server/Services/ProjectService";
+import TeamMemberService from "Common/Server/Services/TeamMemberService";
+import logger from "Common/Server/Utils/Logger";
+import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
+import ObjectID from "Common/Types/ObjectID";
+import { EVERY_FIFTEEN_MINUTE } from "Common/Utils/CronTime";
+import { FindOperator } from "typeorm";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import JobDictionary from "../../../../FeatureSet/Workers/Utils/JobDictionary";
+import "../../../../FeatureSet/Workers/Jobs/PaymentProvider/UpdateTeamMembersIfNull";
+
+/*
+ * Run the real cron registration and its registered handler. Only the queue,
+ * database service and seat synchronizer are replaced, so this covers the
+ * repair path used after an invitation survives a payment-provider outage.
+ */
+jest.mock("Common/Server/EnvironmentConfig", () => {
+  return { __esModule: true, IsBillingEnabled: true, IsDevelopment: false };
+});
+
+jest.mock("Common/Server/Infrastructure/Queue", () => {
+  return {
+    __esModule: true,
+    QueueName: { Worker: "Worker" },
+    default: { addJob: jest.fn().mockResolvedValue(undefined) },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: { findAllBy: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Services/TeamMemberService", () => {
+  return {
+    __esModule: true,
+    default: {
+      updateSubscriptionSeatsByUniqueTeamMembersInProject: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: { debug: jest.fn(), error: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Utils/Telemetry", () => {
+  return {
+    __esModule: true,
+    SpanStatusCode: { ERROR: 2 },
+    default: {
+      startActiveSpan: (data: { fn: (span: unknown) => void }): void => {
+        data.fn({
+          recordException: jest.fn(),
+          setStatus: jest.fn(),
+          end: jest.fn(),
+        });
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Telemetry/CaptureSpan", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return (
+        _target: unknown,
+        _key: string,
+        descriptor: PropertyDescriptor,
+      ): PropertyDescriptor => {
+        return descriptor;
+      };
+    },
+  };
+});
+
+jest.mock("Common/Utils/UUID", () => {
+  return {
+    __esModule: true,
+    default: {
+      generate: jest.fn(() => {
+        return "33333333-3333-4333-8333-333333333333";
+      }),
+    },
+  };
+});
+
+const JOB_NAME: string = "PaymentProvider:UpdateTeamMembersIfNull";
+const FIRST_PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const SECOND_PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+const findProjects: jest.Mock = ProjectService.findAllBy as jest.Mock;
+const syncSeats: jest.Mock =
+  TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject as jest.Mock;
+const billingEnvironment: { IsBillingEnabled: boolean } = EnvironmentConfig;
+const runJob: PromiseVoidFunction = JobDictionary.getJobFunction(JOB_NAME);
+const registrationCalls: Array<Array<unknown>> = (
+  Queue.addJob as jest.Mock
+).mock.calls.map((call: Array<unknown>): Array<unknown> => {
+  return [...call];
+});
+
+function project(id: ObjectID, seats?: number): Project {
+  return {
+    id: id,
+    paymentProviderSubscriptionId: `sub_${id.toString()}`,
+    paymentProviderPlanId: "price_growth",
+    paymentProviderSubscriptionSeats: seats,
+  } as Project;
+}
+
+beforeEach(() => {
+  billingEnvironment.IsBillingEnabled = true;
+  findProjects.mockReset().mockResolvedValue([]);
+  syncSeats.mockReset().mockResolvedValue(undefined);
+  (logger.error as jest.Mock).mockClear();
+});
+
+describe("subscription seat reconciliation registration", () => {
+  test("keeps the existing job name and schedules a sweep every fifteen minutes", () => {
+    expect(typeof runJob).toBe("function");
+    expect(registrationCalls).toEqual([
+      ["Worker", JOB_NAME, JOB_NAME, {}, { scheduleAt: EVERY_FIFTEEN_MINUTE }],
+    ]);
+  });
+});
+
+describe("subscription seat reconciliation sweep", () => {
+  test("includes stale non-null seat counts and initially missing counts", async () => {
+    findProjects.mockResolvedValue([
+      project(FIRST_PROJECT_ID, 1),
+      project(SECOND_PROJECT_ID),
+    ]);
+
+    await runJob();
+
+    const lookup: {
+      query: Record<string, FindOperator<string>>;
+      select: Record<string, boolean>;
+      props: { isRoot: boolean };
+    } = findProjects.mock.calls[0]![0] as {
+      query: Record<string, FindOperator<string>>;
+      select: Record<string, boolean>;
+      props: { isRoot: boolean };
+    };
+
+    // The old IS NULL seat filter permanently missed failed updates to an
+    // existing subscription. Only subscription and plan eligibility belong here.
+    expect(Object.keys(lookup.query).sort()).toEqual([
+      "paymentProviderPlanId",
+      "paymentProviderSubscriptionId",
+    ]);
+    for (const column of Object.keys(lookup.query)) {
+      expect(lookup.query[column]!.getSql?.(column)).toContain("IS NOT NULL");
+    }
+    expect(lookup.select).toEqual({ _id: true });
+    expect(lookup.props).toEqual({ isRoot: true });
+    expect(syncSeats.mock.calls).toEqual([
+      [FIRST_PROJECT_ID],
+      [SECOND_PROJECT_ID],
+    ]);
+  });
+
+  test("does no work when billing is disabled", async () => {
+    billingEnvironment.IsBillingEnabled = false;
+
+    await runJob();
+
+    expect(findProjects).not.toHaveBeenCalled();
+    expect(syncSeats).not.toHaveBeenCalled();
+  });
+
+  test("does not contact the synchronizer when no projects qualify", async () => {
+    await runJob();
+
+    expect(findProjects).toHaveBeenCalledTimes(1);
+    expect(syncSeats).not.toHaveBeenCalled();
+  });
+
+  test("a failed project does not prevent another project from synchronizing", async () => {
+    const failure: Error = new Error("Payment provider rate limit");
+    findProjects.mockResolvedValue([
+      project(FIRST_PROJECT_ID, 1),
+      project(SECOND_PROJECT_ID, 3),
+    ]);
+    syncSeats.mockRejectedValueOnce(failure);
+
+    await expect(runJob()).resolves.toBeUndefined();
+
+    expect(syncSeats.mock.calls).toEqual([
+      [FIRST_PROJECT_ID],
+      [SECOND_PROJECT_ID],
+    ]);
+    expect(logger.error).toHaveBeenCalledWith(failure, {
+      projectId: FIRST_PROJECT_ID.toString(),
+    });
+  });
+
+  test("a subsequent sweep retries a project whose earlier synchronization failed", async () => {
+    findProjects.mockResolvedValue([project(FIRST_PROJECT_ID, 1)]);
+    syncSeats.mockRejectedValueOnce(new Error("Provider unavailable"));
+
+    await runJob();
+    await runJob();
+
+    expect(findProjects).toHaveBeenCalledTimes(2);
+    expect(syncSeats.mock.calls).toEqual([
+      [FIRST_PROJECT_ID],
+      [FIRST_PROJECT_ID],
+    ]);
+  });
+
+  test("processes projects sequentially rather than issuing a provider burst", async () => {
+    let finishFirst: (() => void) | undefined;
+    let startFirst: (() => void) | undefined;
+    const firstSync: Promise<void> = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const firstStarted: Promise<void> = new Promise<void>((resolve) => {
+      startFirst = resolve;
+    });
+    findProjects.mockResolvedValue([
+      project(FIRST_PROJECT_ID, 1),
+      project(SECOND_PROJECT_ID, 3),
+    ]);
+    syncSeats.mockImplementationOnce((): Promise<void> => {
+      startFirst!();
+      return firstSync;
+    });
+
+    const sweep: Promise<void> = runJob();
+    await firstStarted;
+
+    expect(syncSeats.mock.calls).toEqual([[FIRST_PROJECT_ID]]);
+    finishFirst!();
+    await sweep;
+    expect(syncSeats.mock.calls).toEqual([
+      [FIRST_PROJECT_ID],
+      [SECOND_PROJECT_ID],
+    ]);
+  });
+
+  test("reports a failed project lookup as a failed job", async () => {
+    const failure: Error = new Error("Database unavailable");
+    findProjects.mockRejectedValue(failure);
+
+    await expect(runJob()).rejects.toThrow(failure);
+    expect(syncSeats).not.toHaveBeenCalled();
+  });
+});

--- a/App/Tests/Workers/Jobs/PaymentProvider/UpdateTeamMembersIfNull.test.ts
+++ b/App/Tests/Workers/Jobs/PaymentProvider/UpdateTeamMembersIfNull.test.ts
@@ -157,8 +157,10 @@ describe("subscription seat reconciliation sweep", () => {
       props: { isRoot: boolean };
     };
 
-    // The old IS NULL seat filter permanently missed failed updates to an
-    // existing subscription. Only subscription and plan eligibility belong here.
+    /*
+     * The old IS NULL seat filter permanently missed failed updates to an
+     * existing subscription. Only subscription and plan eligibility belong here.
+     */
     expect(Object.keys(lookup.query).sort()).toEqual([
       "paymentProviderPlanId",
       "paymentProviderSubscriptionId",
@@ -226,12 +228,16 @@ describe("subscription seat reconciliation sweep", () => {
   test("processes projects sequentially rather than issuing a provider burst", async () => {
     let finishFirst: (() => void) | undefined;
     let startFirst: (() => void) | undefined;
-    const firstSync: Promise<void> = new Promise<void>((resolve) => {
-      finishFirst = resolve;
-    });
-    const firstStarted: Promise<void> = new Promise<void>((resolve) => {
-      startFirst = resolve;
-    });
+    const firstSync: Promise<void> = new Promise<void>(
+      (resolve: () => void) => {
+        finishFirst = resolve;
+      },
+    );
+    const firstStarted: Promise<void> = new Promise<void>(
+      (resolve: () => void) => {
+        startFirst = resolve;
+      },
+    );
     findProjects.mockResolvedValue([
       project(FIRST_PROJECT_ID, 1),
       project(SECOND_PROJECT_ID, 3),

--- a/Common/Server/Services/ProjectService.ts
+++ b/Common/Server/Services/ProjectService.ts
@@ -113,6 +113,7 @@ import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCom
 import PositiveNumber from "../../Types/PositiveNumber";
 import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 import InMemoryTTLCache from "../Infrastructure/InMemoryTTLCache";
+import { IsNull, UpdateResult } from "typeorm";
 
 export interface CurrentPlan {
   plan: PlanType | null;
@@ -2704,6 +2705,41 @@ These are no longer recorded against the project and have to be cancelled by han
     }
   }
 
+  /**
+   * Record seat synchronization state only for the subscription that was read.
+   * The normal update path locates rows first and then writes by id, which can
+   * overwrite a replacement subscription's state during a concurrent plan change.
+   */
+  @CaptureSpan()
+  public async updateSubscriptionSeats(data: {
+    projectId: ObjectID;
+    subscriptionId: string;
+    planId: string;
+    seats: number | null;
+  }): Promise<number> {
+    const result: UpdateResult = await this.getRepository().update(
+      {
+        _id: data.projectId.toString(),
+        paymentProviderSubscriptionId: data.subscriptionId,
+        paymentProviderPlanId: data.planId,
+        deletedAt: IsNull(),
+      },
+      {
+        paymentProviderSubscriptionSeats:
+          data.seats === null
+            ? () => {
+                return "NULL";
+              }
+            : data.seats,
+        version: () => {
+          return '"version" + 1';
+        },
+      },
+    );
+
+    return result.affected || 0;
+  }
+
   @CaptureSpan()
   public async reactiveSubscription(projectId: ObjectID): Promise<void> {
     logger.debug("Reactivating subscription for project " + projectId, {
@@ -2744,7 +2780,13 @@ These are no longer recorded against the project and have to be cancelled by han
       );
     }
 
-    if (!project.paymentProviderSubscriptionSeats) {
+    // A pending seat synchronization leaves the acknowledged count empty.
+    // Reactivation can still use the memberships already stored in the project.
+    const seats: number =
+      project.paymentProviderSubscriptionSeats ??
+      (await TeamMemberService.getUniqueTeamMemberCountInProject(projectId));
+
+    if (!seats) {
       throw new BadDataException(
         "Payment Provider subscription seats not found",
       );
@@ -2792,7 +2834,7 @@ These are no longer recorded against the project and have to be cancelled by han
       meteredSubscriptionId: project.paymentProviderMeteredSubscriptionId,
       serverMeteredPlans: AllMeteredPlans,
       newPlan: subscriptionPlan,
-      quantity: project.paymentProviderSubscriptionSeats,
+      quantity: seats,
       isYearly: SubscriptionPlan.isYearlyPlan(project.paymentProviderPlanId),
       endTrialAt: endTrialAt,
     });

--- a/Common/Server/Services/ProjectService.ts
+++ b/Common/Server/Services/ProjectService.ts
@@ -2780,8 +2780,10 @@ These are no longer recorded against the project and have to be cancelled by han
       );
     }
 
-    // A pending seat synchronization leaves the acknowledged count empty.
-    // Reactivation can still use the memberships already stored in the project.
+    /*
+     * A pending seat synchronization leaves the acknowledged count empty.
+     * Reactivation can still use the memberships already stored in the project.
+     */
     const seats: number =
       project.paymentProviderSubscriptionSeats ??
       (await TeamMemberService.getUniqueTeamMemberCountInProject(projectId));

--- a/Common/Server/Services/TeamMemberService.ts
+++ b/Common/Server/Services/TeamMemberService.ts
@@ -1,5 +1,6 @@
 import DatabaseConfig from "../DatabaseConfig";
 import { IsBillingEnabled } from "../EnvironmentConfig";
+import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 import CreateBy from "../Types/Database/CreateBy";
 import DeleteBy from "../Types/Database/DeleteBy";
 import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
@@ -174,18 +175,24 @@ export class TeamMemberService extends DatabaseService<TeamMember> {
         id: createBy.data.projectId!,
         select: {
           seatLimit: true,
-          paymentProviderSubscriptionSeats: true,
         },
         props: {
           isRoot: true,
         },
       });
 
+      // Billing can lag after a provider outage. Admission limits must use
+      // persisted memberships, including pending invitations.
+      const numberOfMembers: number =
+        project &&
+        (project.seatLimit || createBy.props.currentPlan === PlanType.Free)
+          ? await this.getUniqueTeamMemberCountInProject(projectId)
+          : 0;
+
       if (
         project &&
         project.seatLimit &&
-        project.paymentProviderSubscriptionSeats &&
-        project.paymentProviderSubscriptionSeats >= project.seatLimit
+        numberOfMembers >= project.seatLimit
       ) {
         throw new BadDataException(Errors.TeamMemberService.LIMIT_REACHED);
       }
@@ -193,8 +200,7 @@ export class TeamMemberService extends DatabaseService<TeamMember> {
       if (
         createBy.props.currentPlan === PlanType.Free &&
         project &&
-        project.paymentProviderSubscriptionSeats &&
-        project.paymentProviderSubscriptionSeats >= 1
+        numberOfMembers >= 1
       ) {
         throw new BadDataException(
           Errors.TeamMemberService.LIMIT_REACHED_FOR_FREE_PLAN,
@@ -535,7 +541,7 @@ export class TeamMemberService extends DatabaseService<TeamMember> {
       onCreate.createBy.data.projectId!,
     );
 
-    await this.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+    await this.syncSubscriptionSeatsAfterMembershipChange(
       onCreate.createBy.data.projectId!,
     );
 
@@ -726,9 +732,7 @@ export class TeamMemberService extends DatabaseService<TeamMember> {
 
     for (const item of onDelete.carryForward as Array<TeamMember>) {
       await this.refreshTokens(item.userId!, item.projectId!);
-      await this.updateSubscriptionSeatsByUniqueTeamMembersInProject(
-        item.projectId!,
-      );
+      await this.syncSubscriptionSeatsAfterMembershipChange(item.projectId!);
 
       /*
        * Before the notification settings go: the "removed from on-call
@@ -1269,6 +1273,27 @@ export class TeamMemberService extends DatabaseService<TeamMember> {
     });
   }
 
+  /**
+   * The membership write has already committed. A payment-provider outage
+   * must not report a failed invite or prevent removal cleanup. The scheduled
+   * seat reconciliation retries projects whose acknowledged count is stale.
+   */
+  @CaptureSpan()
+  private async syncSubscriptionSeatsAfterMembershipChange(
+    projectId: ObjectID,
+  ): Promise<void> {
+    try {
+      await this.updateSubscriptionSeatsByUniqueTeamMembersInProject(projectId);
+    } catch (err) {
+      logger.error(
+        err as Error,
+        {
+          projectId: projectId.toString(),
+        } as LogAttributes,
+      );
+    }
+  }
+
   @CaptureSpan()
   public async updateSubscriptionSeatsByUniqueTeamMembersInProject(
     projectId: ObjectID,
@@ -1277,30 +1302,60 @@ export class TeamMemberService extends DatabaseService<TeamMember> {
       return;
     }
 
-    const numberOfMembers: number =
-      await this.getUniqueTeamMemberCountInProject(projectId);
-    const project: Project | null = await ProjectService.findOneById({
-      id: projectId,
-      select: {
-        paymentProviderSubscriptionId: true,
-        paymentProviderPlanId: true,
-      },
-      props: {
-        isRoot: true,
-      },
+    // Serialize the request and worker paths, then read the latest count so
+    // an older synchronization cannot overwrite a newer seat quantity.
+    const mutex: SemaphoreMutex = await Semaphore.lock({
+      key: projectId.toString(),
+      namespace: "team-member-subscription-seats",
+      lockTimeout: 60000,
+      acquireTimeout: 5000,
     });
 
-    if (
-      project &&
-      project.paymentProviderSubscriptionId &&
-      project?.paymentProviderPlanId
-    ) {
+    try {
+      const project: Project | null = await ProjectService.findOneById({
+        id: projectId,
+        select: {
+          paymentProviderSubscriptionId: true,
+          paymentProviderPlanId: true,
+          paymentProviderSubscriptionSeats: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      if (
+        !project?.paymentProviderSubscriptionId ||
+        !project.paymentProviderPlanId
+      ) {
+        return;
+      }
+
       const plan: SubscriptionPlan | undefined =
-        SubscriptionPlan.getSubscriptionPlanById(
-          project?.paymentProviderPlanId,
-        );
+        SubscriptionPlan.getSubscriptionPlanById(project.paymentProviderPlanId);
 
       if (!plan) {
+        return;
+      }
+
+      const numberOfMembers: number =
+        await this.getUniqueTeamMemberCountInProject(projectId);
+
+      if (project.paymentProviderSubscriptionSeats === numberOfMembers) {
+        return;
+      }
+
+      // The provider may apply the quantity and then time out. Persist that
+      // uncertainty before calling it, so even a later return to the previous
+      // member count cannot make reconciliation mistake the seats for synced.
+      const invalidated: number = await ProjectService.updateSubscriptionSeats({
+        projectId: projectId,
+        subscriptionId: project.paymentProviderSubscriptionId,
+        planId: project.paymentProviderPlanId,
+        seats: null,
+      });
+
+      if (invalidated === 0) {
         return;
       }
 
@@ -1309,15 +1364,14 @@ export class TeamMemberService extends DatabaseService<TeamMember> {
         numberOfMembers,
       );
 
-      await ProjectService.updateOneById({
-        id: projectId,
-        data: {
-          paymentProviderSubscriptionSeats: numberOfMembers,
-        },
-        props: {
-          isRoot: true,
-        },
+      await ProjectService.updateSubscriptionSeats({
+        projectId: projectId,
+        subscriptionId: project.paymentProviderSubscriptionId,
+        planId: project.paymentProviderPlanId,
+        seats: numberOfMembers,
       });
+    } finally {
+      await Semaphore.release(mutex);
     }
   }
 

--- a/Common/Server/Services/TeamMemberService.ts
+++ b/Common/Server/Services/TeamMemberService.ts
@@ -181,8 +181,10 @@ export class TeamMemberService extends DatabaseService<TeamMember> {
         },
       });
 
-      // Billing can lag after a provider outage. Admission limits must use
-      // persisted memberships, including pending invitations.
+      /*
+       * Billing can lag after a provider outage. Admission limits must use
+       * persisted memberships, including pending invitations.
+       */
       const numberOfMembers: number =
         project &&
         (project.seatLimit || createBy.props.currentPlan === PlanType.Free)
@@ -1302,8 +1304,10 @@ export class TeamMemberService extends DatabaseService<TeamMember> {
       return;
     }
 
-    // Serialize the request and worker paths, then read the latest count so
-    // an older synchronization cannot overwrite a newer seat quantity.
+    /*
+     * Serialize the request and worker paths, then read the latest count so
+     * an older synchronization cannot overwrite a newer seat quantity.
+     */
     const mutex: SemaphoreMutex = await Semaphore.lock({
       key: projectId.toString(),
       namespace: "team-member-subscription-seats",
@@ -1345,9 +1349,11 @@ export class TeamMemberService extends DatabaseService<TeamMember> {
         return;
       }
 
-      // The provider may apply the quantity and then time out. Persist that
-      // uncertainty before calling it, so even a later return to the previous
-      // member count cannot make reconciliation mistake the seats for synced.
+      /*
+       * The provider may apply the quantity and then time out. Persist that
+       * uncertainty before calling it, so even a later return to the previous
+       * member count cannot make reconciliation mistake the seats for synced.
+       */
       const invalidated: number = await ProjectService.updateSubscriptionSeats({
         projectId: projectId,
         subscriptionId: project.paymentProviderSubscriptionId,

--- a/Common/Tests/Server/Services/ProjectServiceExtendTrial.test.ts
+++ b/Common/Tests/Server/Services/ProjectServiceExtendTrial.test.ts
@@ -1,5 +1,6 @@
 import ProjectService from "../../../Server/Services/ProjectService";
 import BillingService from "../../../Server/Services/BillingService";
+import TeamMemberService from "../../../Server/Services/TeamMemberService";
 import Project from "../../../Models/DatabaseModels/Project";
 import SubscriptionPlan from "../../../Types/Billing/SubscriptionPlan";
 import SubscriptionStatus from "../../../Types/Billing/SubscriptionStatus";
@@ -366,6 +367,7 @@ describe("ProjectService.reactiveSubscription", () => {
 
   interface ReactivationSpies {
     findOneById: jest.SpyInstance;
+    getUniqueTeamMemberCountInProject: jest.SpyInstance;
     changePlan: jest.SpyInstance;
     getSubscriptionStatus: jest.SpyInstance;
     updateOneById: jest.SpyInstance;
@@ -383,6 +385,10 @@ describe("ProjectService.reactiveSubscription", () => {
     const findOneById: jest.SpyInstance = jest
       .spyOn(ProjectService, "findOneById")
       .mockResolvedValue(data?.project || fakeReactivationProject());
+
+    const getUniqueTeamMemberCountInProject: jest.SpyInstance = jest
+      .spyOn(TeamMemberService, "getUniqueTeamMemberCountInProject")
+      .mockResolvedValue(6);
 
     jest
       .spyOn(SubscriptionPlan, "getSubscriptionPlanById")
@@ -415,7 +421,13 @@ describe("ProjectService.reactiveSubscription", () => {
       .spyOn(ProjectService, "updateOneById")
       .mockResolvedValue(undefined as never);
 
-    return { findOneById, changePlan, getSubscriptionStatus, updateOneById };
+    return {
+      findOneById,
+      getUniqueTeamMemberCountInProject,
+      changePlan,
+      getSubscriptionStatus,
+      updateOneById,
+    };
   }
 
   function getUpdatedData(spies: ReactivationSpies): Record<string, unknown> {
@@ -444,6 +456,92 @@ describe("ProjectService.reactiveSubscription", () => {
           }),
         }),
       );
+    });
+  });
+
+  describe("recovering a pending seat synchronization", () => {
+    it.each([null, undefined])(
+      "uses persisted memberships when acknowledged seats are %s",
+      async (seats: null | undefined) => {
+        const spies: ReactivationSpies = setupReactivation({
+          project: fakeReactivationProject({
+            paymentProviderSubscriptionSeats: seats,
+          }),
+        });
+
+        await ProjectService.reactiveSubscription(PROJECT_ID);
+
+        expect(spies.getUniqueTeamMemberCountInProject).toHaveBeenCalledWith(
+          PROJECT_ID,
+        );
+        expect(spies.changePlan).toHaveBeenCalledWith(
+          expect.objectContaining({ quantity: 6 }),
+        );
+      },
+    );
+
+    it("retains an existing positive seat count", async () => {
+      const spies: ReactivationSpies = setupReactivation();
+
+      await ProjectService.reactiveSubscription(PROJECT_ID);
+
+      expect(spies.getUniqueTeamMemberCountInProject).not.toHaveBeenCalled();
+      expect(spies.changePlan).toHaveBeenCalledWith(
+        expect.objectContaining({ quantity: 4 }),
+      );
+    });
+
+    it("does not contact the provider when reading memberships fails", async () => {
+      const spies: ReactivationSpies = setupReactivation({
+        project: fakeReactivationProject({
+          paymentProviderSubscriptionSeats: null,
+        }),
+      });
+      const failure: Error = new Error("Membership lookup unavailable");
+      spies.getUniqueTeamMemberCountInProject.mockRejectedValue(failure);
+
+      await expect(
+        ProjectService.reactiveSubscription(PROJECT_ID),
+      ).rejects.toThrow(failure);
+
+      expect(spies.changePlan).not.toHaveBeenCalled();
+      expect(spies.getSubscriptionStatus).not.toHaveBeenCalled();
+      expect(spies.updateOneById).not.toHaveBeenCalled();
+    });
+
+    it.each([null, undefined])(
+      "rejects a project without members when acknowledged seats are %s",
+      async (seats: null | undefined) => {
+        const spies: ReactivationSpies = setupReactivation({
+          project: fakeReactivationProject({
+            paymentProviderSubscriptionSeats: seats,
+          }),
+        });
+        spies.getUniqueTeamMemberCountInProject.mockResolvedValue(0);
+
+        await expect(
+          ProjectService.reactiveSubscription(PROJECT_ID),
+        ).rejects.toThrow("Payment Provider subscription seats not found");
+
+        expect(spies.changePlan).not.toHaveBeenCalled();
+        expect(spies.updateOneById).not.toHaveBeenCalled();
+      },
+    );
+
+    it("preserves the existing rejection of an acknowledged zero count", async () => {
+      const spies: ReactivationSpies = setupReactivation({
+        project: fakeReactivationProject({
+          paymentProviderSubscriptionSeats: 0,
+        }),
+      });
+
+      await expect(
+        ProjectService.reactiveSubscription(PROJECT_ID),
+      ).rejects.toThrow("Payment Provider subscription seats not found");
+
+      expect(spies.getUniqueTeamMemberCountInProject).not.toHaveBeenCalled();
+      expect(spies.changePlan).not.toHaveBeenCalled();
+      expect(spies.updateOneById).not.toHaveBeenCalled();
     });
   });
 

--- a/Common/Tests/Server/Services/ProjectServiceSubscriptionSeats.test.ts
+++ b/Common/Tests/Server/Services/ProjectServiceSubscriptionSeats.test.ts
@@ -56,8 +56,10 @@ describe("ProjectService.updateSubscriptionSeats", () => {
 
     await expect(updateSeats(4)).resolves.toBe(1);
 
-    // The normal update service applies predicates to a SELECT, then updates
-    // by id alone. They must reach repository.update in this same statement.
+    /*
+     * The normal update service applies predicates to a SELECT, then updates
+     * by id alone. They must reach repository.update in this same statement.
+     */
     expect(update).toHaveBeenCalledTimes(1);
     expect(update).toHaveBeenCalledWith(
       {

--- a/Common/Tests/Server/Services/ProjectServiceSubscriptionSeats.test.ts
+++ b/Common/Tests/Server/Services/ProjectServiceSubscriptionSeats.test.ts
@@ -1,0 +1,132 @@
+import Project from "../../../Models/DatabaseModels/Project";
+import ProjectService from "../../../Server/Services/ProjectService";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, describe, expect, it } from "@jest/globals";
+import { IsNull, Repository, UpdateResult } from "typeorm";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const SUBSCRIPTION_ID: string = "sub_seats_123";
+const PLAN_ID: string = "price_growth_123";
+
+interface SeatUpdateData {
+  paymentProviderSubscriptionSeats: number | (() => string);
+  version: () => string;
+}
+
+function setupRepository(affected: number | undefined = 1): jest.Mock {
+  const update: jest.Mock = jest.fn().mockResolvedValue({
+    affected,
+    generatedMaps: [],
+    raw: [],
+  } as UpdateResult);
+
+  jest.spyOn(ProjectService, "getRepository").mockReturnValue({
+    update,
+  } as unknown as Repository<Project>);
+
+  return update;
+}
+
+async function updateSeats(seats: number | null): Promise<number> {
+  return ProjectService.updateSubscriptionSeats({
+    projectId: PROJECT_ID,
+    subscriptionId: SUBSCRIPTION_ID,
+    planId: PLAN_ID,
+    seats,
+  });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("ProjectService.updateSubscriptionSeats", () => {
+  it("guards the actual write by project, subscription, plan and deletion state", async () => {
+    const update: jest.Mock = setupRepository();
+    const findOneById: jest.SpyInstance = jest.spyOn(
+      ProjectService,
+      "findOneById",
+    );
+    const updateOneBy: jest.SpyInstance = jest.spyOn(
+      ProjectService,
+      "updateOneBy",
+    );
+
+    await expect(updateSeats(4)).resolves.toBe(1);
+
+    // The normal update service applies predicates to a SELECT, then updates
+    // by id alone. They must reach repository.update in this same statement.
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(
+      {
+        _id: PROJECT_ID.toString(),
+        paymentProviderSubscriptionId: SUBSCRIPTION_ID,
+        paymentProviderPlanId: PLAN_ID,
+        deletedAt: IsNull(),
+      },
+      {
+        paymentProviderSubscriptionSeats: 4,
+        version: expect.any(Function),
+      },
+    );
+    const data: SeatUpdateData = update.mock.calls[0]![1] as SeatUpdateData;
+    expect(data.version()).toBe('"version" + 1');
+    expect(findOneById).not.toHaveBeenCalled();
+    expect(updateOneBy).not.toHaveBeenCalled();
+  });
+
+  it("writes the null marker on every retry even when it is already null", async () => {
+    const update: jest.Mock = setupRepository();
+
+    await expect(updateSeats(null)).resolves.toBe(1);
+    await expect(updateSeats(null)).resolves.toBe(1);
+
+    expect(update).toHaveBeenCalledTimes(2);
+    for (const call of update.mock.calls) {
+      const data: SeatUpdateData = call[1] as SeatUpdateData;
+      const value: number | (() => string) =
+        data.paymentProviderSubscriptionSeats;
+      expect(typeof value).toBe("function");
+      expect((value as () => string)()).toBe("NULL");
+    }
+  });
+
+  it("acknowledges zero seats without converting it to the null marker", async () => {
+    const update: jest.Mock = setupRepository();
+
+    await expect(updateSeats(0)).resolves.toBe(1);
+
+    expect(update).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ paymentProviderSubscriptionSeats: 0 }),
+    );
+  });
+
+  it.each([null, 4])(
+    "returns zero when the guarded write of %s seats no longer matches",
+    async (seats: number | null) => {
+      const update: jest.Mock = setupRepository(0);
+
+      await expect(updateSeats(seats)).resolves.toBe(0);
+
+      expect(update).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("does not claim success when the driver does not report an affected count", async () => {
+    const update: jest.Mock = setupRepository();
+    update.mockResolvedValue({ generatedMaps: [], raw: [] } as UpdateResult);
+
+    await expect(updateSeats(null)).resolves.toBe(0);
+  });
+
+  it("propagates a failed write so the caller cannot proceed as if it invalidated seats", async () => {
+    const update: jest.Mock = setupRepository();
+    const failure: Error = new Error("Project update unavailable");
+    update.mockRejectedValue(failure);
+
+    await expect(updateSeats(null)).rejects.toThrow(failure);
+  });
+});

--- a/Common/Tests/Server/Services/TeamMemberAutoAcceptInvitation.test.ts
+++ b/Common/Tests/Server/Services/TeamMemberAutoAcceptInvitation.test.ts
@@ -196,6 +196,9 @@ beforeEach(() => {
 
   // No existing membership - the duplicate-invite guard at the end of the hook.
   jest.spyOn(TeamMemberService, "findOneBy").mockResolvedValue(null);
+  jest
+    .spyOn(TeamMemberService, "getUniqueTeamMemberCountInProject")
+    .mockResolvedValue(0);
 
   jest
     .spyOn(ProjectService, "findOneById")

--- a/Common/Tests/Server/Services/TeamMemberBillingSeatSync.test.ts
+++ b/Common/Tests/Server/Services/TeamMemberBillingSeatSync.test.ts
@@ -1,0 +1,758 @@
+import Project from "../../../Models/DatabaseModels/Project";
+import Team from "../../../Models/DatabaseModels/Team";
+import TeamMember from "../../../Models/DatabaseModels/TeamMember";
+import User from "../../../Models/DatabaseModels/User";
+import * as EnvironmentConfig from "../../../Server/EnvironmentConfig";
+import Semaphore, {
+  SemaphoreMutex,
+} from "../../../Server/Infrastructure/Semaphore";
+import AuditLogService from "../../../Server/Services/AuditLogService";
+import BillingService from "../../../Server/Services/BillingService";
+import ProjectSCIMService from "../../../Server/Services/ProjectSCIMService";
+import ProjectService from "../../../Server/Services/ProjectService";
+import TeamMemberService from "../../../Server/Services/TeamMemberService";
+import TeamPermissionService from "../../../Server/Services/TeamPermissionService";
+import TeamService from "../../../Server/Services/TeamService";
+import UserNotificationRuleService from "../../../Server/Services/UserNotificationRuleService";
+import UserNotificationSettingService from "../../../Server/Services/UserNotificationSettingService";
+import UserService from "../../../Server/Services/UserService";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import { OnCreate, OnDelete } from "../../../Server/Types/Database/Hooks";
+import ModelPermission from "../../../Server/Types/Database/Permissions/Index";
+import Errors from "../../../Server/Utils/Errors";
+import logger from "../../../Server/Utils/Logger";
+import ProductAnalytics from "../../../Server/Utils/ProductAnalytics";
+import SubscriptionPlan, {
+  PlanType,
+} from "../../../Types/Billing/SubscriptionPlan";
+import Email from "../../../Types/Email";
+import ObjectID from "../../../Types/ObjectID";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+jest.mock("../../../Server/EnvironmentConfig", () => {
+  const config: Record<string, unknown> = {
+    __esModule: true,
+    ...jest.requireActual("../../../Server/EnvironmentConfig"),
+  };
+
+  Object.defineProperty(config, "IsBillingEnabled", {
+    configurable: true,
+    enumerable: true,
+    get: (): boolean => {
+      return true;
+    },
+  });
+
+  return config;
+});
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const TEAM_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+const USER_ID: ObjectID = new ObjectID("33333333-3333-4333-8333-333333333333");
+const MEMBER_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const SUBSCRIPTION_ID: string = "sub_team_members";
+const PLAN_ID: string = "price_growth_monthly";
+
+function member(): TeamMember {
+  const item: TeamMember = new TeamMember(MEMBER_ID);
+  item.projectId = PROJECT_ID;
+  item.teamId = TEAM_ID;
+  item.userId = USER_ID;
+  item.hasAcceptedInvitation = false;
+  return item;
+}
+
+function invitation(): CreateBy<TeamMember> {
+  return {
+    data: member(),
+    props: { isRoot: true, tenantId: PROJECT_ID },
+  };
+}
+
+function callHook(name: string, ...args: Array<unknown>): Promise<unknown> {
+  const service: Record<
+    string,
+    (...values: Array<unknown>) => Promise<unknown>
+  > = TeamMemberService as unknown as Record<
+    string,
+    (...values: Array<unknown>) => Promise<unknown>
+  >;
+  return service[name]!.apply(TeamMemberService, args);
+}
+
+function rateLimitError(): Error {
+  return Object.assign(new Error("Too many requests to the billing provider"), {
+    statusCode: 429,
+    type: "StripeRateLimitError",
+  });
+}
+
+let project: Project;
+let lockSpy: jest.SpyInstance;
+let releaseSpy: jest.SpyInstance;
+let projectReadSpy: jest.SpyInstance;
+let projectWriteSpy: jest.SpyInstance;
+let memberCountSpy: jest.SpyInstance;
+let billingSpy: jest.SpyInstance;
+let errorSpy: jest.SpyInstance;
+let mutex: SemaphoreMutex;
+
+interface SeatUpdate {
+  projectId: ObjectID;
+  subscriptionId: string;
+  planId: string;
+  seats: number | null;
+}
+
+async function applySeatUpdate(update: SeatUpdate): Promise<number> {
+  if (
+    update.subscriptionId !== project.paymentProviderSubscriptionId ||
+    update.planId !== project.paymentProviderPlanId
+  ) {
+    return 0;
+  }
+  project.setColumnValue("paymentProviderSubscriptionSeats", update.seats);
+  return 1;
+}
+
+beforeEach(() => {
+  project = new Project(PROJECT_ID);
+  project.paymentProviderSubscriptionId = SUBSCRIPTION_ID;
+  project.paymentProviderPlanId = PLAN_ID;
+  project.paymentProviderSubscriptionSeats = 3;
+  project.seatLimit = 10;
+
+  mutex = {} as SemaphoreMutex;
+  lockSpy = jest.spyOn(Semaphore, "lock").mockResolvedValue(mutex);
+  releaseSpy = jest.spyOn(Semaphore, "release").mockResolvedValue(undefined);
+  projectReadSpy = jest
+    .spyOn(ProjectService, "findOneById")
+    .mockImplementation(async (): Promise<Project> => {
+      return Object.assign(new Project(PROJECT_ID), project);
+    });
+  projectWriteSpy = jest
+    .spyOn(ProjectService, "updateSubscriptionSeats")
+    .mockImplementation(applySeatUpdate as never);
+  memberCountSpy = jest
+    .spyOn(TeamMemberService, "getUniqueTeamMemberCountInProject")
+    .mockResolvedValue(4);
+  billingSpy = jest
+    .spyOn(BillingService, "changeQuantity")
+    .mockResolvedValue(undefined);
+  errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
+  jest
+    .spyOn(SubscriptionPlan, "getSubscriptionPlanById")
+    .mockReturnValue(
+      new SubscriptionPlan(PLAN_ID, "price_yearly", "Growth", 20, 200, 1, 14),
+    );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("TeamMemberService billing seat reconciliation", () => {
+  test("acknowledges the distinct membership count only after the provider succeeds", async () => {
+    await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+      PROJECT_ID,
+    );
+
+    expect(billingSpy).toHaveBeenCalledWith(SUBSCRIPTION_ID, 4);
+    expect(projectWriteSpy).toHaveBeenNthCalledWith(1, {
+      projectId: PROJECT_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      planId: PLAN_ID,
+      seats: null,
+    });
+    expect(projectWriteSpy).toHaveBeenNthCalledWith(2, {
+      projectId: PROJECT_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      planId: PLAN_ID,
+      seats: 4,
+    });
+    expect(projectWriteSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      billingSpy.mock.invocationCallOrder[0]!,
+    );
+    expect(billingSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      projectWriteSpy.mock.invocationCallOrder[1]!,
+    );
+    expect(lockSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: PROJECT_ID.toString(),
+        namespace: "team-member-subscription-seats",
+      }),
+    );
+    expect(lockSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      projectReadSpy.mock.invocationCallOrder[0]!,
+    );
+    expect(releaseSpy).toHaveBeenCalledWith(mutex);
+  });
+
+  test("a provider 429 leaves the count uncertain and remains retryable", async () => {
+    const error: Error = rateLimitError();
+    billingSpy.mockRejectedValueOnce(error);
+
+    await expect(
+      TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+        PROJECT_ID,
+      ),
+    ).rejects.toBe(error);
+
+    expect(projectWriteSpy).toHaveBeenCalledTimes(1);
+    expect(project.paymentProviderSubscriptionSeats).toBeNull();
+    expect(releaseSpy).toHaveBeenCalledWith(mutex);
+
+    await expect(
+      TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+        PROJECT_ID,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(billingSpy).toHaveBeenCalledTimes(2);
+    expect(billingSpy).toHaveBeenNthCalledWith(2, SUBSCRIPTION_ID, 4);
+    expect(projectWriteSpy).toHaveBeenCalledTimes(3);
+    expect(project.paymentProviderSubscriptionSeats).toBe(4);
+    expect(releaseSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("retries if recording a successful provider change fails", async () => {
+    const error: Error = new Error("Database temporarily unavailable");
+    projectWriteSpy
+      .mockImplementationOnce(applySeatUpdate)
+      .mockRejectedValueOnce(error);
+
+    await expect(
+      TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+        PROJECT_ID,
+      ),
+    ).rejects.toBe(error);
+    await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+      PROJECT_ID,
+    );
+
+    expect(billingSpy).toHaveBeenCalledTimes(2);
+    expect(projectWriteSpy).toHaveBeenCalledTimes(4);
+    expect(releaseSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("reconciles a partially applied provider update even after the membership count returns to its old value", async () => {
+    let providerSeats: number = 3;
+    billingSpy.mockImplementationOnce(
+      async (_subscriptionId: string, seats: number): Promise<void> => {
+        providerSeats = seats;
+        throw rateLimitError();
+      },
+    );
+    await expect(
+      TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+        PROJECT_ID,
+      ),
+    ).rejects.toThrow();
+    expect(providerSeats).toBe(4);
+    expect(project.paymentProviderSubscriptionSeats).toBeNull();
+
+    memberCountSpy.mockResolvedValue(3);
+    billingSpy.mockImplementation(
+      async (_subscriptionId: string, seats: number): Promise<void> => {
+        providerSeats = seats;
+      },
+    );
+    await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+      PROJECT_ID,
+    );
+
+    expect(billingSpy).toHaveBeenNthCalledWith(2, SUBSCRIPTION_ID, 3);
+    expect(providerSeats).toBe(3);
+    expect(project.paymentProviderSubscriptionSeats).toBe(3);
+  });
+
+  test("does not call the provider if persisting uncertainty fails", async () => {
+    projectWriteSpy.mockRejectedValue(new Error("Database unavailable"));
+
+    await expect(
+      TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+        PROJECT_ID,
+      ),
+    ).rejects.toThrow("Database unavailable");
+
+    expect(billingSpy).not.toHaveBeenCalled();
+    expect(project.paymentProviderSubscriptionSeats).toBe(3);
+    expect(releaseSpy).toHaveBeenCalledWith(mutex);
+  });
+
+  test("does not bill a subscription replaced before the uncertainty marker is saved", async () => {
+    projectWriteSpy.mockImplementationOnce(
+      async (update: SeatUpdate): Promise<number> => {
+        project.paymentProviderSubscriptionId = "sub_replacement";
+        return applySeatUpdate(update);
+      },
+    );
+
+    await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+      PROJECT_ID,
+    );
+
+    expect(billingSpy).not.toHaveBeenCalled();
+    expect(projectWriteSpy).toHaveBeenCalledTimes(1);
+    expect(project.paymentProviderSubscriptionSeats).toBe(3);
+    expect(releaseSpy).toHaveBeenCalledWith(mutex);
+  });
+
+  test("does not acknowledge seats against a subscription replaced during the provider call", async () => {
+    billingSpy.mockImplementationOnce(async (): Promise<void> => {
+      project.paymentProviderSubscriptionId = "sub_replacement";
+      project.paymentProviderSubscriptionSeats = 1;
+    });
+
+    await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+      PROJECT_ID,
+    );
+
+    expect(billingSpy).toHaveBeenCalledWith(SUBSCRIPTION_ID, 4);
+    expect(project.paymentProviderSubscriptionId).toBe("sub_replacement");
+    expect(project.paymentProviderSubscriptionSeats).toBe(1);
+    expect(releaseSpy).toHaveBeenCalledWith(mutex);
+  });
+
+  test.each([0, 4])(
+    "does not contact the provider when %i seats are already acknowledged",
+    async (count: number) => {
+      project.paymentProviderSubscriptionSeats = count;
+      memberCountSpy.mockResolvedValue(count);
+
+      await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+        PROJECT_ID,
+      );
+
+      expect(billingSpy).not.toHaveBeenCalled();
+      expect(projectWriteSpy).not.toHaveBeenCalled();
+      expect(releaseSpy).toHaveBeenCalledWith(mutex);
+    },
+  );
+
+  test.each([0, 2, 8])(
+    "synchronizes changed counts including removals and zero (%i seats)",
+    async (count: number) => {
+      memberCountSpy.mockResolvedValue(count);
+
+      await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+        PROJECT_ID,
+      );
+
+      expect(billingSpy).toHaveBeenCalledWith(SUBSCRIPTION_ID, count);
+      expect(projectWriteSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          seats: count,
+        }),
+      );
+    },
+  );
+
+  test("an unknown acknowledged count is synchronized", async () => {
+    project.paymentProviderSubscriptionSeats = undefined;
+
+    await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+      PROJECT_ID,
+    );
+
+    expect(billingSpy).toHaveBeenCalledWith(SUBSCRIPTION_ID, 4);
+  });
+
+  test("self-hosted installations do not acquire a lock or access billing data", async () => {
+    jest
+      .spyOn(EnvironmentConfig, "IsBillingEnabled", "get")
+      .mockReturnValue(false);
+
+    await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+      PROJECT_ID,
+    );
+
+    expect(lockSpy).not.toHaveBeenCalled();
+    expect(projectReadSpy).not.toHaveBeenCalled();
+    expect(memberCountSpy).not.toHaveBeenCalled();
+    expect(billingSpy).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    "missing project",
+    "missing subscription",
+    "missing plan",
+    "unknown plan",
+  ])("releases the lock without billing for %s", async (reason: string) => {
+    if (reason === "missing project") {
+      projectReadSpy.mockResolvedValue(null);
+    } else if (reason === "missing subscription") {
+      project.paymentProviderSubscriptionId = undefined;
+    } else if (reason === "missing plan") {
+      project.paymentProviderPlanId = undefined;
+    } else {
+      jest
+        .spyOn(SubscriptionPlan, "getSubscriptionPlanById")
+        .mockReturnValue(undefined);
+    }
+
+    await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+      PROJECT_ID,
+    );
+
+    expect(memberCountSpy).not.toHaveBeenCalled();
+    expect(billingSpy).not.toHaveBeenCalled();
+    expect(projectWriteSpy).not.toHaveBeenCalled();
+    expect(releaseSpy).toHaveBeenCalledWith(mutex);
+  });
+
+  test.each(["project", "members"])(
+    "releases the lock when reading %s fails",
+    async (read: string) => {
+      const error: Error = new Error("Database read failed");
+      (read === "project" ? projectReadSpy : memberCountSpy).mockRejectedValue(
+        error,
+      );
+
+      await expect(
+        TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+          PROJECT_ID,
+        ),
+      ).rejects.toBe(error);
+
+      expect(billingSpy).not.toHaveBeenCalled();
+      expect(releaseSpy).toHaveBeenCalledWith(mutex);
+    },
+  );
+
+  test("a lock timeout performs no reads or provider writes and is retryable", async () => {
+    const error: Error = new Error("Lock acquisition timed out");
+    lockSpy.mockRejectedValue(error);
+
+    await expect(
+      TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+        PROJECT_ID,
+      ),
+    ).rejects.toBe(error);
+
+    expect(projectReadSpy).not.toHaveBeenCalled();
+    expect(billingSpy).not.toHaveBeenCalled();
+    expect(releaseSpy).not.toHaveBeenCalled();
+  });
+
+  test("concurrent request and worker calls read fresh counts in lock order", async () => {
+    let previousLock: Promise<void> = Promise.resolve();
+    lockSpy.mockImplementation(async (): Promise<SemaphoreMutex> => {
+      const waitForPrevious: Promise<void> = previousLock;
+      let unlock: () => void = (): void => {};
+      previousLock = new Promise<void>((resolve: () => void) => {
+        unlock = resolve;
+      });
+      await waitForPrevious;
+      return {
+        release: async (): Promise<void> => {
+          unlock();
+        },
+      } as SemaphoreMutex;
+    });
+    releaseSpy.mockImplementation(
+      async (heldMutex: SemaphoreMutex): Promise<void> => {
+        await heldMutex.release();
+      },
+    );
+
+    let actualCount: number = 4;
+    memberCountSpy.mockImplementation(async (): Promise<number> => {
+      return actualCount;
+    });
+
+    let firstProviderCallStarted: () => void = (): void => {};
+    const firstProviderCall: Promise<void> = new Promise<void>(
+      (resolve: () => void) => {
+        firstProviderCallStarted = resolve;
+      },
+    );
+    let finishFirstProviderCall: () => void = (): void => {};
+    const providerGate: Promise<void> = new Promise<void>(
+      (resolve: () => void) => {
+        finishFirstProviderCall = resolve;
+      },
+    );
+    billingSpy.mockImplementationOnce(async (): Promise<void> => {
+      firstProviderCallStarted();
+      await providerGate;
+    });
+
+    const firstSync: Promise<void> =
+      TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+        PROJECT_ID,
+      );
+    await firstProviderCall;
+    actualCount = 5;
+    const secondSync: Promise<void> =
+      TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+        PROJECT_ID,
+      );
+
+    expect(projectReadSpy).toHaveBeenCalledTimes(1);
+    expect(memberCountSpy).toHaveBeenCalledTimes(1);
+    finishFirstProviderCall();
+    await Promise.all([firstSync, secondSync]);
+
+    expect(billingSpy).toHaveBeenNthCalledWith(1, SUBSCRIPTION_ID, 4);
+    expect(billingSpy).toHaveBeenNthCalledWith(2, SUBSCRIPTION_ID, 5);
+    expect(project.paymentProviderSubscriptionSeats).toBe(5);
+    expect(releaseSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("the real member count includes pending invitations and deduplicates people across teams", async () => {
+    memberCountSpy.mockRestore();
+    const accepted: TeamMember = member();
+    accepted.hasAcceptedInvitation = true;
+    const secondTeam: TeamMember = member();
+    secondTeam.teamId = ObjectID.generate();
+    const pending: TeamMember = member();
+    pending.userId = ObjectID.generate();
+    const missingUser: TeamMember = member();
+    missingUser.userId = undefined;
+    jest
+      .spyOn(TeamMemberService, "findBy")
+      .mockResolvedValue([accepted, secondTeam, pending, missingUser]);
+
+    await TeamMemberService.updateSubscriptionSeatsByUniqueTeamMembersInProject(
+      PROJECT_ID,
+    );
+
+    expect(billingSpy).toHaveBeenCalledWith(SUBSCRIPTION_ID, 2);
+    expect(TeamMemberService.findBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: { projectId: PROJECT_ID },
+        props: { isRoot: true },
+      }),
+    );
+  });
+});
+
+describe("completed membership writes during a billing outage", () => {
+  beforeEach(() => {
+    jest.spyOn(TeamMemberService, "refreshTokens").mockResolvedValue(undefined);
+    jest.spyOn(ProductAnalytics, "captureForUser").mockImplementation(() => {});
+    jest.spyOn(TeamMemberService, "findOneBy").mockResolvedValue(null);
+    jest
+      .spyOn(TeamMemberService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0));
+    jest.spyOn(TeamService, "findOneBy").mockResolvedValue(new Team(TEAM_ID));
+    jest
+      .spyOn(TeamPermissionService, "assertCanGrantTeamPermissions")
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(ProjectSCIMService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0));
+    jest
+      .spyOn(
+        UserNotificationSettingService,
+        "addDefaultNotificationSettingsForUser",
+      )
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(UserNotificationRuleService, "addDefaultNotificationRuleForUser")
+      .mockResolvedValue(undefined);
+  });
+
+  test("returns the saved pending invitation even when the provider returns 429", async () => {
+    const error: Error = rateLimitError();
+    billingSpy.mockRejectedValue(error);
+    const saved: TeamMember = member();
+    const onCreate: OnCreate<TeamMember> = {
+      createBy: invitation(),
+      carryForward: null,
+    };
+
+    await expect(callHook("onCreateSuccess", onCreate, saved)).resolves.toBe(
+      saved,
+    );
+
+    expect(saved.hasAcceptedInvitation).toBe(false);
+    expect(projectWriteSpy).toHaveBeenCalledTimes(1);
+    expect(project.paymentProviderSubscriptionSeats).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith(error, {
+      projectId: PROJECT_ID.toString(),
+    });
+    expect(TeamMemberService.refreshTokens).toHaveBeenCalledWith(
+      USER_ID,
+      PROJECT_ID,
+    );
+    expect(ProductAnalytics.captureForUser).toHaveBeenCalled();
+  });
+
+  test("a Redis outage also leaves the committed invitation successful", async () => {
+    lockSpy.mockRejectedValue(new Error("Redis client is not connected"));
+    const saved: TeamMember = member();
+
+    await expect(
+      callHook(
+        "onCreateSuccess",
+        { createBy: invitation(), carryForward: null },
+        saved,
+      ),
+    ).resolves.toBe(saved);
+
+    expect(billingSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  test("billing failure does not skip defaults for an automatically accepted member", async () => {
+    billingSpy.mockRejectedValue(rateLimitError());
+    const saved: TeamMember = member();
+    saved.hasAcceptedInvitation = true;
+    const user: User = new User(USER_ID);
+    user.email = new Email("member@example.com");
+    user.isEmailVerified = true;
+    jest.spyOn(UserService, "findOneById").mockResolvedValue(user);
+
+    await expect(
+      callHook(
+        "onCreateSuccess",
+        { createBy: invitation(), carryForward: null },
+        saved,
+      ),
+    ).resolves.toBe(saved);
+
+    expect(
+      UserNotificationSettingService.addDefaultNotificationSettingsForUser,
+    ).toHaveBeenCalledWith(USER_ID, PROJECT_ID);
+    expect(
+      UserNotificationRuleService.addDefaultNotificationRuleForUser,
+    ).toHaveBeenCalledWith(PROJECT_ID, USER_ID, user.email);
+  });
+
+  test("billing failure does not stop removal cleanup or change a successful delete result", async () => {
+    billingSpy.mockRejectedValue(rateLimitError());
+    jest
+      .spyOn(TeamMemberService, "cleanupOnCallAssignmentsIfUserLeftProject")
+      .mockResolvedValue(null);
+    jest
+      .spyOn(
+        UserNotificationSettingService,
+        "removeDefaultNotificationSettingsForUser",
+      )
+      .mockResolvedValue(undefined);
+    const onDelete: OnDelete<TeamMember> = {
+      deleteBy: {
+        query: { _id: MEMBER_ID },
+        props: { isRoot: true },
+        limit: 1,
+        skip: 0,
+      },
+      carryForward: [member()],
+    };
+
+    await expect(callHook("onDeleteSuccess", onDelete)).resolves.toBe(onDelete);
+
+    expect(
+      TeamMemberService.cleanupOnCallAssignmentsIfUserLeftProject,
+    ).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      userId: USER_ID,
+      hadAcceptedMembership: false,
+    });
+    expect(
+      UserNotificationSettingService.removeDefaultNotificationSettingsForUser,
+    ).toHaveBeenCalledWith(USER_ID, PROJECT_ID);
+  });
+
+  test("the complete create pipeline returns the committed row after a provider 429", async () => {
+    // Keep DatabaseService.create, validation, and both membership hooks real.
+    // Only persistence and other external side effects are replaced.
+    const persisted: Array<TeamMember> = [];
+    const save: jest.Mock = jest.fn(
+      async (data: TeamMember): Promise<TeamMember> => {
+        persisted.push(data);
+        return data;
+      },
+    );
+    jest
+      .spyOn(TeamMemberService, "getRepository")
+      .mockReturnValue({ save } as never);
+    jest
+      .spyOn(TeamMemberService, "onTriggerRealtime")
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(TeamMemberService, "onTriggerWorkflow")
+      .mockResolvedValue(undefined);
+    jest.spyOn(AuditLogService, "recordCreate").mockResolvedValue(undefined);
+    jest
+      .spyOn(ModelPermission, "checkCreatePermissions")
+      .mockReturnValue(undefined);
+    billingSpy.mockImplementation(async (): Promise<void> => {
+      expect(persisted).toHaveLength(1);
+      throw rateLimitError();
+    });
+
+    const saved: TeamMember = await TeamMemberService.create(invitation());
+
+    expect(saved).toBe(persisted[0]);
+    expect(saved.id?.toString()).toBe(MEMBER_ID.toString());
+    expect(saved.userId?.toString()).toBe(USER_ID.toString());
+    expect(saved.hasAcceptedInvitation).toBe(false);
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(billingSpy).toHaveBeenCalledTimes(1);
+    expect(projectWriteSpy).toHaveBeenCalledTimes(1);
+    expect(project.paymentProviderSubscriptionSeats).toBeNull();
+    expect(TeamMemberService.onTriggerRealtime).toHaveBeenCalled();
+
+    // A retry sees the saved row and retains the normal duplicate guard.
+    jest.spyOn(TeamMemberService, "findOneBy").mockResolvedValue(saved);
+    await expect(TeamMemberService.create(invitation())).rejects.toThrow(
+      Errors.TeamMemberService.ALREADY_INVITED,
+    );
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([undefined, null, 0, 2])(
+    "enforces the real seat limit when acknowledged seats are stale (%s)",
+    async (acknowledged: number | null | undefined) => {
+      project.seatLimit = 4;
+      project.setColumnValue("paymentProviderSubscriptionSeats", acknowledged);
+
+      await expect(callHook("onBeforeCreate", invitation())).rejects.toThrow(
+        Errors.TeamMemberService.LIMIT_REACHED,
+      );
+
+      expect(memberCountSpy).toHaveBeenCalledWith(PROJECT_ID);
+      expect(billingSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  test("allows an invitation below the real limit when old billing seats exceed it", async () => {
+    project.seatLimit = 5;
+    project.paymentProviderSubscriptionSeats = 8;
+
+    await expect(callHook("onBeforeCreate", invitation())).resolves.toEqual({
+      createBy: expect.any(Object),
+      carryForward: null,
+    });
+  });
+
+  test("enforces the free-plan limit from persisted members when billing seats are missing", async () => {
+    project.paymentProviderSubscriptionSeats = undefined;
+    memberCountSpy.mockResolvedValue(1);
+    const createBy: CreateBy<TeamMember> = invitation();
+    createBy.props.currentPlan = PlanType.Free;
+
+    await expect(callHook("onBeforeCreate", createBy)).rejects.toThrow(
+      Errors.TeamMemberService.LIMIT_REACHED_FOR_FREE_PLAN,
+    );
+  });
+
+  test("allows the first free-plan member even when the cached billing count is stale", async () => {
+    memberCountSpy.mockResolvedValue(0);
+    const createBy: CreateBy<TeamMember> = invitation();
+    createBy.props.currentPlan = PlanType.Free;
+
+    await expect(callHook("onBeforeCreate", createBy)).resolves.toEqual({
+      createBy,
+      carryForward: null,
+    });
+  });
+});

--- a/Common/Tests/Server/Services/TeamMemberBillingSeatSync.test.ts
+++ b/Common/Tests/Server/Services/TeamMemberBillingSeatSync.test.ts
@@ -32,9 +32,11 @@ import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
 
 jest.mock("../../../Server/EnvironmentConfig", () => {
   const config: Record<string, unknown> = {
-    __esModule: true,
     ...jest.requireActual("../../../Server/EnvironmentConfig"),
   };
+
+  // Preserve the configurable getter when TypeScript imports this namespace.
+  Object.defineProperty(config, "__esModule", { value: true });
 
   Object.defineProperty(config, "IsBillingEnabled", {
     configurable: true,
@@ -662,8 +664,10 @@ describe("completed membership writes during a billing outage", () => {
   });
 
   test("the complete create pipeline returns the committed row after a provider 429", async () => {
-    // Keep DatabaseService.create, validation, and both membership hooks real.
-    // Only persistence and other external side effects are replaced.
+    /*
+     * Keep DatabaseService.create, validation, and both membership hooks real.
+     * Only persistence and other external side effects are replaced.
+     */
     const persisted: Array<TeamMember> = [];
     const save: jest.Mock = jest.fn(
       async (data: TeamMember): Promise<TeamMember> => {

--- a/Common/Tests/Server/Services/TeamMemberInviteRegistrationToken.test.ts
+++ b/Common/Tests/Server/Services/TeamMemberInviteRegistrationToken.test.ts
@@ -138,6 +138,9 @@ beforeEach(() => {
 
   // No existing membership - the duplicate-invite guard at the end of the hook.
   jest.spyOn(TeamMemberService, "findOneBy").mockResolvedValue(null);
+  jest
+    .spyOn(TeamMemberService, "getUniqueTeamMemberCountInProject")
+    .mockResolvedValue(0);
 
   jest
     .spyOn(ProjectService, "findOneById")


### PR DESCRIPTION
Inviting a user could save the membership and then return a generic server error when Stripe rate-limited the follow-up seat update. The test environment had a pending invitation despite HTTP 500, with four members and only three acknowledged billing seats.

Completed membership writes now return successfully if billing synchronization fails. The existing worker reconciles subscribed projects every 15 minutes and isolates failures between projects. Seat limits use actual memberships while synchronization is pending.

Synchronization is serialized per project. An atomic conditional update marks the acknowledged count unknown before contacting Stripe, so partial provider success remains retryable and cannot overwrite a replacement subscription. Subscription reactivation can recover the count from memberships.

Validation:
- 133 focused tests passed: 125 across six Common suites and eight worker registration/reconciliation tests.
- Coverage includes the full membership-create pipeline, provider failures and retries, partial success, concurrent synchronization, subscription replacement, quotas, removal cleanup, and reactivation. The 35 billing cases and eight worker cases also passed after the final test edits.
- The create-pipeline regression also fails against the original service with the injected Stripe 429 after persistence, then passes against the fix.
- Root `npm run fix` passed for all nine changed files using the repository's type-aware rules. `git diff --check` passed.
- `npm run compile -- --noEmit` passed in Common and App. GitHub's compilation and lint jobs are still queued.
- Live Kubernetes/database/provider checks confirmed the saved invitation, HTTP 500, stale seat count, and Stripe HTTP 429. Chrome interaction was blocked by an app authentication error. No deployment was performed.
