### PR TITLE
fix(workflow): stop leaking secret variables through schedule errors

### DIFF
--- a/App/FeatureSet/Workflow/Services/QueueWorkflow.ts
+++ b/App/FeatureSet/Workflow/Services/QueueWorkflow.ts
@@ -19,6 +19,11 @@ import logger from "Common/Server/Utils/Logger";
 import Workflow from "Common/Models/DatabaseModels/Workflow";
 import WorkflowLog from "Common/Models/DatabaseModels/WorkflowLog";
 import WorkflowVariable from "Common/Models/DatabaseModels/WorkflowVariable";
+import {
+  getSecretValuesForRedaction,
+  getSecretWorkflowVariableValues,
+  redactSecretsFromString,
+} from "../Utils/SecretRedaction";
 
 export default class QueueWorkflow {
   public static async removeWorkflow(workflowId: ObjectID): Promise<void> {
@@ -300,6 +305,8 @@ export default class QueueWorkflow {
         select: {
           name: true,
           content: true,
+          // Needed to scrub secrets out of the schedule error below.
+          isSecret: true,
         },
         skip: 0,
         limit: LIMIT_PER_PROJECT,
@@ -316,6 +323,8 @@ export default class QueueWorkflow {
         select: {
           name: true,
           content: true,
+          // Needed to scrub secrets out of the schedule error below.
+          isSecret: true,
         },
         skip: 0,
         limit: LIMIT_PER_PROJECT,
@@ -345,6 +354,7 @@ export default class QueueWorkflow {
       rawSchedule,
       localVariableMap,
       globalVariableMap,
+      getSecretWorkflowVariableValues([...localVariables, ...globalVariables]),
     );
   }
 
@@ -357,12 +367,44 @@ export default class QueueWorkflow {
    * Returns the concrete cron on success, or a human-readable `error` when the
    * pattern is still unresolved (a referenced variable is missing) or is not a
    * valid cron expression.
+   *
+   * `secretValues` are the contents of the secret workflow variables in scope.
+   * The returned `error` quotes the resolved schedule, and the caller writes it
+   * straight into a WorkflowLog row that anyone with workflow read permission
+   * can read — so a secret substituted into the schedule would otherwise be
+   * published in plaintext by the act of being invalid. They are scrubbed from
+   * the message the same way RunWorkflow scrubs the run log. The returned
+   * `cron` is never scrubbed: it is handed to BullMQ, not to a reader.
+   *
+   * A very short secret ("0", say) will also blank out innocent occurrences of
+   * that text in the message. A mangled error beats a leaked secret, and this
+   * matches how the run log has always behaved.
    */
   public static buildScheduleCronFromVariables(
     rawSchedule: string,
     localVariables: Record<string, string>,
     globalVariables: Record<string, string>,
+    secretValues: Array<string> = [],
   ): { cron: string; error: string | null } {
+    /*
+     * Normalized here rather than at the call site so a unit test (and any
+     * future caller) can pass raw values in any order and still get the
+     * longest-first ordering overlapping secrets depend on.
+     */
+    const secrets: Array<string> = getSecretValuesForRedaction(secretValues);
+
+    type FailureFunction = (
+      cron: string,
+      error: string,
+    ) => { cron: string; error: string | null };
+
+    const failure: FailureFunction = (
+      cron: string,
+      error: string,
+    ): { cron: string; error: string | null } => {
+      return { cron: cron, error: redactSecretsFromString(error, secrets) };
+    };
+
     const storageMap: {
       local: { variables: Record<string, string> };
       global: { variables: Record<string, string> };
@@ -381,19 +423,19 @@ export default class QueueWorkflow {
       );
     } catch (err) {
       logger.error(err);
-      return {
-        cron: rawSchedule,
-        error: `Failed to resolve schedule variables for "${rawSchedule}".`,
-      };
+      return failure(
+        rawSchedule,
+        `Failed to resolve schedule variables for "${rawSchedule}".`,
+      );
     }
 
     resolved = (resolved || "").toString().trim();
 
     if (CronTab.isVariableExpression(resolved)) {
-      return {
-        cron: resolved,
-        error: `The schedule "${rawSchedule}" references a variable that could not be resolved. Make sure the referenced workflow or global variable exists and contains a valid cron expression.`,
-      };
+      return failure(
+        resolved,
+        `The schedule "${rawSchedule}" references a variable that could not be resolved. Make sure the referenced workflow or global variable exists and contains a valid cron expression.`,
+      );
     }
 
     const validationError: string | null = CronTab.getValidationError(resolved);
@@ -402,10 +444,10 @@ export default class QueueWorkflow {
       const resolvedNote: string =
         resolved === rawSchedule ? "" : ` (resolved to "${resolved}")`;
 
-      return {
-        cron: resolved,
-        error: `The schedule "${rawSchedule}"${resolvedNote} is not a valid cron expression. ${validationError}`,
-      };
+      return failure(
+        resolved,
+        `The schedule "${rawSchedule}"${resolvedNote} is not a valid cron expression. ${validationError}`,
+      );
     }
 
     return {

--- a/App/FeatureSet/Workflow/Services/RunWorkflow.ts
+++ b/App/FeatureSet/Workflow/Services/RunWorkflow.ts
@@ -48,10 +48,15 @@ import VMAPI from "Common/Server/Utils/VM/VMAPI";
 import Workflow from "Common/Models/DatabaseModels/Workflow";
 import WorkflowLog from "Common/Models/DatabaseModels/WorkflowLog";
 import WorkflowVariable from "Common/Models/DatabaseModels/WorkflowVariable";
+import {
+  WORKFLOW_LOG_REDACTED_VALUE,
+  getSecretWorkflowVariableValues,
+  redactSecretsFromString,
+} from "../Utils/SecretRedaction";
 
 const AllComponents: Dictionary<ComponentMetadata> = loadAllComponentMetadata();
 
-export const WORKFLOW_LOG_REDACTED_VALUE: string = "[REDACTED]";
+export { WORKFLOW_LOG_REDACTED_VALUE };
 
 type SensitiveWorkflowField =
   | Pick<Argument, "id" | "isSensitive">
@@ -85,68 +90,6 @@ export function redactSensitiveComponentValuesForLogs(
 
   return loggableValues;
 }
-
-type GetSecretWorkflowVariableValuesFunction = (
-  variables: Array<WorkflowVariable>,
-) => Array<string>;
-
-/**
- * Build the replacement list once, with overlapping secrets ordered safely.
- *
- * A secret of `token` must not run before `token-with-suffix`, or the first
- * replacement leaves `-with-suffix` behind in the log. Empty values are
- * excluded because every string contains the empty string.
- */
-const getSecretWorkflowVariableValues: GetSecretWorkflowVariableValuesFunction =
-  (variables: Array<WorkflowVariable>): Array<string> => {
-    const values: Array<string> = variables
-      .filter((variable: WorkflowVariable) => {
-        const isSecret: unknown = variable.isSecret;
-
-        return (
-          (isSecret === true || isSecret === "true") &&
-          typeof variable.content === "string" &&
-          variable.content.length > 0
-        );
-      })
-      .map((variable: WorkflowVariable) => {
-        return variable.content as string;
-      });
-
-    return Array.from(new Set(values)).sort((first: string, second: string) => {
-      return second.length - first.length;
-    });
-  };
-
-type RedactSecretsFromStringFunction = (
-  value: string,
-  secrets: Array<string>,
-) => string;
-
-const redactSecretsFromString: RedactSecretsFromStringFunction = (
-  value: string,
-  secrets: Array<string>,
-): string => {
-  if (!value || secrets.length === 0) {
-    return value;
-  }
-
-  const escapedSecrets: Array<string> = secrets.map((secret: string) => {
-    return secret.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  });
-
-  /*
-   * One global expression replaces every occurrence without processing the
-   * replacement marker again. The alternatives are longest-first from
-   * getSecretWorkflowVariableValues, which prevents a shorter overlapping
-   * secret from exposing the tail of a longer one.
-   */
-  const secretPattern: RegExp = new RegExp(escapedSecrets.join("|"), "g");
-
-  return value.replace(secretPattern, () => {
-    return WORKFLOW_LOG_REDACTED_VALUE;
-  });
-};
 
 type RedactSecretValuesFunction = (
   value: JSONValue,

--- a/App/FeatureSet/Workflow/Utils/SecretRedaction.ts
+++ b/App/FeatureSet/Workflow/Utils/SecretRedaction.ts
@@ -1,0 +1,99 @@
+import WorkflowVariable from "Common/Models/DatabaseModels/WorkflowVariable";
+
+/**
+ * Redaction of workflow-variable secrets out of anything that gets persisted
+ * to a WorkflowLog row.
+ *
+ * This lives outside RunWorkflow because the run log is not the only writer:
+ * QueueWorkflow writes a log row of its own when a scheduled workflow cannot
+ * be registered, and that message quotes the resolved schedule — which can be
+ * the plaintext of a secret variable. Both writers must scrub the same values
+ * the same way, and RunWorkflow already imports QueueWorkflow, so the shared
+ * helpers cannot live in either service.
+ */
+
+export const WORKFLOW_LOG_REDACTED_VALUE: string = "[REDACTED]";
+
+type GetSecretValuesForRedactionFunction = (
+  values: Array<string | undefined | null>,
+) => Array<string>;
+
+/**
+ * Build the replacement list once, with overlapping secrets ordered safely.
+ *
+ * A secret of `token` must not run before `token-with-suffix`, or the first
+ * replacement leaves `-with-suffix` behind in the log. Empty values are
+ * excluded because every string contains the empty string.
+ */
+export const getSecretValuesForRedaction: GetSecretValuesForRedactionFunction =
+  (values: Array<string | undefined | null>): Array<string> => {
+    const definedValues: Array<string> = values.filter(
+      (value: string | undefined | null): value is string => {
+        return typeof value === "string" && value.length > 0;
+      },
+    );
+
+    return Array.from(new Set(definedValues)).sort(
+      (first: string, second: string) => {
+        return second.length - first.length;
+      },
+    );
+  };
+
+type GetSecretWorkflowVariableValuesFunction = (
+  variables: Array<WorkflowVariable>,
+) => Array<string>;
+
+/**
+ * The secret contents of the supplied variables, ready to hand to
+ * `redactSecretsFromString`.
+ *
+ * `isSecret` is declared as a string on the model but arrives as a real
+ * boolean from the database, so both are accepted. A variable whose `isSecret`
+ * was not selected reads as undefined and is treated as not secret — every
+ * caller must therefore select the column.
+ */
+export const getSecretWorkflowVariableValues: GetSecretWorkflowVariableValuesFunction =
+  (variables: Array<WorkflowVariable>): Array<string> => {
+    return getSecretValuesForRedaction(
+      variables
+        .filter((variable: WorkflowVariable) => {
+          const isSecret: unknown = variable.isSecret;
+
+          return isSecret === true || isSecret === "true";
+        })
+        .map((variable: WorkflowVariable) => {
+          return variable.content as string;
+        }),
+    );
+  };
+
+type RedactSecretsFromStringFunction = (
+  value: string,
+  secrets: Array<string>,
+) => string;
+
+export const redactSecretsFromString: RedactSecretsFromStringFunction = (
+  value: string,
+  secrets: Array<string>,
+): string => {
+  if (!value || secrets.length === 0) {
+    return value;
+  }
+
+  const escapedSecrets: Array<string> = secrets.map((secret: string) => {
+    return secret.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  });
+
+  /*
+   * One global expression replaces every occurrence without processing the
+   * replacement marker again. The alternatives are longest-first from
+   * getSecretValuesForRedaction, which prevents a shorter overlapping secret
+   * from exposing the tail of a longer one.
+   */
+  const secretPattern: RegExp = new RegExp(escapedSecrets.join("|"), "g");
+
+  return value.replace(secretPattern, () => {
+    return WORKFLOW_LOG_REDACTED_VALUE;
+  });
+};

--- a/App/Tests/FeatureSet/Workflow/QueueWorkflowScheduleSecrets.test.ts
+++ b/App/Tests/FeatureSet/Workflow/QueueWorkflowScheduleSecrets.test.ts
@@ -1,0 +1,435 @@
+/*
+ * A scheduled workflow whose "Schedule at" references a workflow variable has
+ * that variable substituted at registration time, because BullMQ needs a
+ * concrete cron. When the result is not a valid cron, QueueWorkflow quotes it
+ * back in an error and writes that error into a WorkflowLog row — a row any
+ * member with workflow read permission can open.
+ *
+ * If the referenced variable is marked Secret, that quoted value is the
+ * secret's plaintext. These tests hold the line the run log already holds:
+ * the secret never reaches the persisted output.
+ */
+
+import Workflow from "Common/Models/DatabaseModels/Workflow";
+import WorkflowLog from "Common/Models/DatabaseModels/WorkflowLog";
+import WorkflowVariable from "Common/Models/DatabaseModels/WorkflowVariable";
+import Queue from "Common/Server/Infrastructure/Queue";
+import ProjectService from "Common/Server/Services/ProjectService";
+import WorkflowLogService from "Common/Server/Services/WorkflowLogService";
+import WorkflowService from "Common/Server/Services/WorkflowService";
+import WorkflowVariableService from "Common/Server/Services/WorkflowVariableService";
+import logger from "Common/Server/Utils/Logger";
+import ObjectID from "Common/Types/ObjectID";
+import WorkflowStatus from "Common/Types/Workflow/WorkflowStatus";
+import QueueWorkflow from "../../../FeatureSet/Workflow/Services/QueueWorkflow";
+import { WORKFLOW_LOG_REDACTED_VALUE } from "../../../FeatureSet/Workflow/Utils/SecretRedaction";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+const WORKFLOW_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const PROJECT_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+
+interface RecordedSpy {
+  mock: { calls: Array<Array<unknown>> };
+}
+
+type VariableFunction = (params: {
+  name: string;
+  content: string;
+  isSecret?: boolean | string | undefined;
+}) => WorkflowVariable;
+
+const variable: VariableFunction = (params: {
+  name: string;
+  content: string;
+  isSecret?: boolean | string | undefined;
+}): WorkflowVariable => {
+  const workflowVariable: WorkflowVariable = new WorkflowVariable();
+  workflowVariable.name = params.name;
+  workflowVariable.content = params.content;
+
+  if (params.isSecret !== undefined) {
+    workflowVariable.isSecret = params.isSecret as string;
+  }
+
+  return workflowVariable;
+};
+
+interface PreparedQueue {
+  createLogSpy: RecordedSpy;
+  findVariablesSpy: RecordedSpy;
+}
+
+type PrepareFunction = (params: {
+  localVariables: Array<WorkflowVariable>;
+  globalVariables?: Array<WorkflowVariable> | undefined;
+}) => PreparedQueue;
+
+/**
+ * Stand the enqueue path up far enough to reach the schedule-resolution
+ * failure: an enabled workflow, its variables, and a capturable log writer.
+ * The failure returns before the plan check and before BullMQ is touched, so
+ * nothing further needs mocking.
+ */
+const prepareQueue: PrepareFunction = (params: {
+  localVariables: Array<WorkflowVariable>;
+  globalVariables?: Array<WorkflowVariable> | undefined;
+}): PreparedQueue => {
+  const workflowRow: Workflow = new Workflow();
+  workflowRow.isEnabled = true;
+  workflowRow.projectId = PROJECT_ID;
+
+  jest
+    .spyOn(WorkflowService as never, "findOneById")
+    .mockResolvedValue(workflowRow as never);
+
+  const findVariablesSpy: RecordedSpy = jest
+    .spyOn(WorkflowVariableService as never, "findBy")
+    .mockImplementation(((findParams: {
+      query: { workflowId?: unknown };
+    }): Promise<Array<WorkflowVariable>> => {
+      /*
+       * Local variables are queried by workflowId; the global query looks for
+       * rows whose workflowId is null, which arrives here as a QueryHelper
+       * instance rather than an ObjectID.
+       */
+      const isLocalQuery: boolean =
+        findParams.query.workflowId instanceof ObjectID;
+
+      return Promise.resolve(
+        isLocalQuery ? params.localVariables : params.globalVariables || [],
+      );
+    }) as never) as unknown as RecordedSpy;
+
+  const createLogSpy: RecordedSpy = jest
+    .spyOn(WorkflowLogService as never, "create")
+    .mockResolvedValue(new WorkflowLog() as never) as unknown as RecordedSpy;
+
+  return { createLogSpy: createLogSpy, findVariablesSpy: findVariablesSpy };
+};
+
+type PersistedLogFunction = (createLogSpy: RecordedSpy) => WorkflowLog;
+
+const lastPersistedLog: PersistedLogFunction = (
+  createLogSpy: RecordedSpy,
+): WorkflowLog => {
+  const lastCall: unknown =
+    createLogSpy.mock.calls[createLogSpy.mock.calls.length - 1]?.[0];
+
+  return (lastCall as { data: WorkflowLog }).data;
+};
+
+type EnqueueFunction = (scheduleAt: string) => Promise<void>;
+
+const enqueueScheduled: EnqueueFunction = async (
+  scheduleAt: string,
+): Promise<void> => {
+  await QueueWorkflow.addWorkflowToQueue(
+    { workflowId: WORKFLOW_ID, returnValues: {} },
+    scheduleAt,
+  );
+};
+
+describe("QueueWorkflow schedule errors do not leak secret variables", () => {
+  let loggedErrors: Array<unknown> = [];
+
+  beforeEach(() => {
+    loggedErrors = [];
+    jest.spyOn(logger, "error").mockImplementation(((
+      message: unknown,
+    ): void => {
+      loggedErrors.push(message);
+    }) as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("selects isSecret when reading the variables it resolves the schedule from", async () => {
+    const { findVariablesSpy } = prepareQueue({
+      /*
+       * Invalid on purpose: the run returns after writing the error log,
+       * before anything that would need a queue or a plan.
+       */
+      localVariables: [variable({ name: "schedule", content: "nope" })],
+    });
+
+    await enqueueScheduled("{{local.variables.schedule}}");
+
+    expect(findVariablesSpy.mock.calls.length).toBe(2);
+
+    for (const call of findVariablesSpy.mock.calls) {
+      const select: Record<string, unknown> = (
+        call[0] as { select: Record<string, unknown> }
+      ).select;
+
+      // Without this column every variable reads as non-secret and nothing is redacted.
+      expect(select["isSecret"]).toBe(true);
+    }
+  });
+
+  test("a secret local variable that is not a valid cron never reaches the workflow log", async () => {
+    const { createLogSpy } = prepareQueue({
+      localVariables: [
+        variable({
+          name: "schedule",
+          content: "sk-live-super-secret-value",
+          isSecret: true,
+        }),
+      ],
+    });
+
+    await enqueueScheduled("{{local.variables.schedule}}");
+
+    const persistedLog: WorkflowLog = lastPersistedLog(createLogSpy);
+
+    expect(persistedLog.workflowStatus).toBe(WorkflowStatus.Error);
+    expect(JSON.stringify(persistedLog)).not.toContain(
+      "sk-live-super-secret-value",
+    );
+    expect(persistedLog.logs).toContain(WORKFLOW_LOG_REDACTED_VALUE);
+    // The operator still learns which workflow setting is broken.
+    expect(persistedLog.logs).toContain("{{local.variables.schedule}}");
+    expect(persistedLog.logs).toContain("not a valid cron expression");
+  });
+
+  test("a secret global variable is redacted the same way", async () => {
+    const { createLogSpy } = prepareQueue({
+      localVariables: [],
+      globalVariables: [
+        variable({
+          name: "cron",
+          content: "not-a-cron-global-secret",
+          isSecret: true,
+        }),
+      ],
+    });
+
+    await enqueueScheduled("{{global.variables.cron}}");
+
+    expect(JSON.stringify(lastPersistedLog(createLogSpy))).not.toContain(
+      "not-a-cron-global-secret",
+    );
+  });
+
+  test('isSecret arriving as the string "true" is redacted too', async () => {
+    const { createLogSpy } = prepareQueue({
+      localVariables: [
+        variable({
+          name: "schedule",
+          content: "string-flagged-secret",
+          isSecret: "true",
+        }),
+      ],
+    });
+
+    await enqueueScheduled("{{local.variables.schedule}}");
+
+    expect(JSON.stringify(lastPersistedLog(createLogSpy))).not.toContain(
+      "string-flagged-secret",
+    );
+  });
+
+  test("a secret substituted into part of a cron is redacted", async () => {
+    const { createLogSpy } = prepareQueue({
+      localVariables: [
+        variable({
+          name: "hours",
+          content: "secret-hours-value",
+          isSecret: true,
+        }),
+      ],
+    });
+
+    await enqueueScheduled("0 */{{local.variables.hours}} * * *");
+
+    expect(JSON.stringify(lastPersistedLog(createLogSpy))).not.toContain(
+      "secret-hours-value",
+    );
+  });
+
+  test("the server log line is redacted as well as the database row", async () => {
+    prepareQueue({
+      localVariables: [
+        variable({
+          name: "schedule",
+          content: "leaky-secret-in-server-log",
+          isSecret: true,
+        }),
+      ],
+    });
+
+    await enqueueScheduled("{{local.variables.schedule}}");
+
+    expect(loggedErrors.length).toBeGreaterThan(0);
+    expect(JSON.stringify(loggedErrors)).not.toContain(
+      "leaky-secret-in-server-log",
+    );
+  });
+
+  test("a non-secret variable is still quoted back so the error stays useful", async () => {
+    const { createLogSpy } = prepareQueue({
+      localVariables: [
+        variable({ name: "schedule", content: "every-monday-please" }),
+      ],
+    });
+
+    await enqueueScheduled("{{local.variables.schedule}}");
+
+    expect(lastPersistedLog(createLogSpy).logs).toContain(
+      "every-monday-please",
+    );
+  });
+
+  test("a valid secret cron schedules the job and writes no error log", async () => {
+    const { createLogSpy } = prepareQueue({
+      localVariables: [
+        variable({ name: "schedule", content: "0 */6 * * *", isSecret: true }),
+      ],
+    });
+
+    const addJobSpy: RecordedSpy = jest
+      .spyOn(Queue as never, "addJob")
+      .mockResolvedValue({} as never) as unknown as RecordedSpy;
+
+    jest
+      .spyOn(ProjectService as never, "getCurrentPlan")
+      .mockResolvedValue({ plan: null, isSubscriptionUnpaid: false } as never);
+
+    await enqueueScheduled("{{local.variables.schedule}}");
+
+    expect(createLogSpy.mock.calls.length).toBe(0);
+    expect(addJobSpy.mock.calls.length).toBe(1);
+
+    /*
+     * The cron itself is deliberately NOT redacted — it goes to BullMQ, which
+     * needs the real pattern, not to anything a reader sees.
+     */
+    const options: { scheduleAt?: string } = addJobSpy.mock.calls[0]?.[4] as {
+      scheduleAt?: string;
+    };
+
+    expect(options.scheduleAt).toBe("0 */6 * * *");
+  });
+});
+
+/*
+ * The pure resolver, exercised directly for the cases that are awkward to set
+ * up through the database: overlapping secrets, regex metacharacters, and the
+ * ordering guarantee redaction depends on.
+ */
+describe("QueueWorkflow.buildScheduleCronFromVariables secret redaction", () => {
+  test("redacts the secret but keeps the concrete cron for the scheduler", () => {
+    const result: { cron: string; error: string | null } =
+      QueueWorkflow.buildScheduleCronFromVariables(
+        "{{local.variables.schedule}}",
+        { schedule: "totally-not-a-cron" },
+        {},
+        ["totally-not-a-cron"],
+      );
+
+    expect(result.error).not.toContain("totally-not-a-cron");
+    expect(result.error).toContain(WORKFLOW_LOG_REDACTED_VALUE);
+    expect(result.cron).toBe("totally-not-a-cron");
+  });
+
+  test("redacts overlapping secrets regardless of the order they are passed in", () => {
+    const result: { cron: string; error: string | null } =
+      QueueWorkflow.buildScheduleCronFromVariables(
+        "{{local.variables.schedule}}",
+        { schedule: "token-with-suffix token" },
+        {},
+        // Deliberately shortest-first: the resolver must reorder these.
+        ["token", "token-with-suffix"],
+      );
+
+    expect(result.error).not.toContain("token");
+    expect(result.error).not.toContain("with-suffix");
+    expect(result.error).toContain(
+      `${WORKFLOW_LOG_REDACTED_VALUE} ${WORKFLOW_LOG_REDACTED_VALUE}`,
+    );
+  });
+
+  test("redacts a secret containing regex metacharacters", () => {
+    const result: { cron: string; error: string | null } =
+      QueueWorkflow.buildScheduleCronFromVariables(
+        "{{local.variables.schedule}}",
+        { schedule: "a.*b(c)+[d]$" },
+        {},
+        ["a.*b(c)+[d]$"],
+      );
+
+    expect(result.error).not.toContain("a.*b(c)+[d]$");
+    expect(result.error).toContain(WORKFLOW_LOG_REDACTED_VALUE);
+  });
+
+  test("redacts a secret from the global scope", () => {
+    const result: { cron: string; error: string | null } =
+      QueueWorkflow.buildScheduleCronFromVariables(
+        "{{global.variables.cron}}",
+        {},
+        { cron: "global-secret-cron" },
+        ["global-secret-cron"],
+      );
+
+    expect(result.error).not.toContain("global-secret-cron");
+  });
+
+  test("an empty secret does not turn the whole message into redaction markers", () => {
+    const result: { cron: string; error: string | null } =
+      QueueWorkflow.buildScheduleCronFromVariables("60 * * * *", {}, {}, [""]);
+
+    expect(result.error).toContain("60 * * * *");
+    expect(result.error).not.toContain(WORKFLOW_LOG_REDACTED_VALUE);
+  });
+
+  test("with no secrets the message is unchanged", () => {
+    const result: { cron: string; error: string | null } =
+      QueueWorkflow.buildScheduleCronFromVariables(
+        "{{local.variables.schedule}}",
+        { schedule: "plain-invalid" },
+        {},
+        [],
+      );
+
+    expect(result.error).toContain("plain-invalid");
+    expect(result.error).not.toContain(WORKFLOW_LOG_REDACTED_VALUE);
+  });
+
+  test("redacts a secret out of the unresolved-variable error too", () => {
+    const result: { cron: string; error: string | null } =
+      QueueWorkflow.buildScheduleCronFromVariables(
+        "{{local.variables.missing}}",
+        {},
+        {},
+        ["{{local.variables.missing}}"],
+      );
+
+    expect(result.error).not.toContain("{{local.variables.missing}}");
+    expect(result.error).toContain("could not be resolved");
+  });
+
+  test("a valid resolved cron returns no error to redact", () => {
+    const result: { cron: string; error: string | null } =
+      QueueWorkflow.buildScheduleCronFromVariables(
+        "{{local.variables.schedule}}",
+        { schedule: "0 */6 * * *" },
+        {},
+        ["0 */6 * * *"],
+      );
+
+    expect(result.error).toBeNull();
+    expect(result.cron).toBe("0 */6 * * *");
+  });
+});

--- a/App/Tests/FeatureSet/Workflow/SecretRedaction.test.ts
+++ b/App/Tests/FeatureSet/Workflow/SecretRedaction.test.ts
@@ -1,0 +1,138 @@
+/*
+ * The redaction helpers shared by the two writers of WorkflowLog: the runner
+ * (RunWorkflow.cleanLogs) and the scheduler (QueueWorkflow's schedule errors).
+ * They used to live inside RunWorkflow, where the scheduler could not reach
+ * them — which is how the scheduler came to log secrets in plaintext.
+ */
+
+import WorkflowVariable from "Common/Models/DatabaseModels/WorkflowVariable";
+import {
+  WORKFLOW_LOG_REDACTED_VALUE,
+  getSecretValuesForRedaction,
+  getSecretWorkflowVariableValues,
+  redactSecretsFromString,
+} from "../../../FeatureSet/Workflow/Utils/SecretRedaction";
+import { describe, expect, test } from "@jest/globals";
+
+type VariableFunction = (
+  content: string,
+  isSecret?: boolean | string | undefined,
+) => WorkflowVariable;
+
+const variable: VariableFunction = (
+  content: string,
+  isSecret?: boolean | string | undefined,
+): WorkflowVariable => {
+  const workflowVariable: WorkflowVariable = new WorkflowVariable();
+  workflowVariable.name = "variable";
+  workflowVariable.content = content;
+  workflowVariable.isSecret = isSecret as string;
+
+  return workflowVariable;
+};
+
+describe("getSecretValuesForRedaction", () => {
+  test("orders longest first so an overlapping shorter secret cannot expose a tail", () => {
+    expect(
+      getSecretValuesForRedaction(["token", "token-with-suffix", "tok"]),
+    ).toEqual(["token-with-suffix", "token", "tok"]);
+  });
+
+  test("drops empty and missing values", () => {
+    expect(getSecretValuesForRedaction(["", undefined, null, "real"])).toEqual([
+      "real",
+    ]);
+  });
+
+  test("de-duplicates repeated values", () => {
+    expect(getSecretValuesForRedaction(["same", "same"])).toEqual(["same"]);
+  });
+
+  test("returns an empty list for no input", () => {
+    expect(getSecretValuesForRedaction([])).toEqual([]);
+  });
+});
+
+describe("getSecretWorkflowVariableValues", () => {
+  test("collects variables flagged with a boolean true", () => {
+    expect(getSecretWorkflowVariableValues([variable("secret", true)])).toEqual(
+      ["secret"],
+    );
+  });
+
+  test('collects variables flagged with the string "true"', () => {
+    expect(
+      getSecretWorkflowVariableValues([variable("secret", "true")]),
+    ).toEqual(["secret"]);
+  });
+
+  test("ignores variables that are not secret", () => {
+    expect(
+      getSecretWorkflowVariableValues([
+        variable("public", false),
+        variable("also-public", "false"),
+        variable("unflagged"),
+      ]),
+    ).toEqual([]);
+  });
+
+  test("ignores a secret with no content", () => {
+    expect(getSecretWorkflowVariableValues([variable("", true)])).toEqual([]);
+  });
+
+  test("treats an unselected isSecret column as not secret", () => {
+    /*
+     * Reading the column is the caller's responsibility. This is exactly the
+     * bug being fixed: a query that omits isSecret redacts nothing at all.
+     */
+    const unselected: WorkflowVariable = new WorkflowVariable();
+    unselected.content = "would-not-be-redacted";
+
+    expect(getSecretWorkflowVariableValues([unselected])).toEqual([]);
+  });
+});
+
+describe("redactSecretsFromString", () => {
+  test("replaces every occurrence of a secret", () => {
+    expect(redactSecretsFromString("a secret b secret", ["secret"])).toBe(
+      `a ${WORKFLOW_LOG_REDACTED_VALUE} b ${WORKFLOW_LOG_REDACTED_VALUE}`,
+    );
+  });
+
+  test("does not leave the tail of a longer overlapping secret behind", () => {
+    const secrets: Array<string> = getSecretValuesForRedaction([
+      "token",
+      "token-with-suffix",
+    ]);
+
+    expect(redactSecretsFromString("token-with-suffix", secrets)).toBe(
+      WORKFLOW_LOG_REDACTED_VALUE,
+    );
+  });
+
+  test("treats regex metacharacters in a secret literally", () => {
+    expect(redactSecretsFromString("value a.*b here", ["a.*b"])).toBe(
+      `value ${WORKFLOW_LOG_REDACTED_VALUE} here`,
+    );
+    // The pattern must not match text it only matches when read as a regex.
+    expect(redactSecretsFromString("value aXXXb here", ["a.*b"])).toBe(
+      "value aXXXb here",
+    );
+  });
+
+  test("does not re-process the replacement marker", () => {
+    expect(redactSecretsFromString("keep REDACTED", ["REDACTED"])).toBe(
+      `keep ${WORKFLOW_LOG_REDACTED_VALUE}`,
+    );
+  });
+
+  test("returns the value untouched when there are no secrets", () => {
+    expect(redactSecretsFromString("nothing to hide", [])).toBe(
+      "nothing to hide",
+    );
+  });
+
+  test("handles an empty value", () => {
+    expect(redactSecretsFromString("", ["secret"])).toBe("");
+  });
+});

--- a/Common/Models/DatabaseModels/WorkflowVariable.ts
+++ b/Common/Models/DatabaseModels/WorkflowVariable.ts
@@ -346,9 +346,9 @@ export default class WorkflowVariable extends BaseModel {
     ],
     /*
      * Same list as name, description and content. isSecret decides one thing
-     * only - whether RunWorkflow redacts this variable's value out of the run
-     * logs (getSecretWorkflowVariableValues in
-     * App/FeatureSet/Workflow/Services/RunWorkflow.ts). It is not an encryption
+     * only - whether this variable's value is redacted out of the logs a
+     * workflow writes (getSecretWorkflowVariableValues in
+     * App/FeatureSet/Workflow/Utils/SecretRedaction.ts). It is not an encryption
      * switch and nothing is re-encrypted when it flips, so leaving it
      * create-only bought no safety in the direction that matters: it only meant
      * a variable saved without the toggle kept leaking its value into every run


### PR DESCRIPTION
## The leak

A scheduled workflow's **Schedule at** value can reference a workflow variable — `{{local.variables.schedule}}`, `0 */{{global.variables.hours}} * * *`. BullMQ needs a concrete cron to register the repeatable job, so `QueueWorkflow` substitutes those variables at registration time rather than at run time.

When the substituted value isn't a valid cron, the error quotes it back:

```
The schedule "{{local.variables.schedule}}" (resolved to "sk-live-…") is not a valid cron expression.
```

and `addWorkflowToQueue` writes that string verbatim into a `WorkflowLog` row — readable by anyone with workflow read permission, and repeated into the server log.

If the referenced variable is marked **Secret**, that quoted value is its plaintext.

**Reproduce:** create a workflow variable marked Secret whose content is not a valid cron, point a workflow's schedule at it, enqueue the workflow. The secret is in that workflow's run log.

`RunWorkflow` has always redacted secret variable values (`cleanLogs` → `getSecretWorkflowVariableValues`), but those helpers were module-private, and the query behind schedule resolution selected only `name` and `content` — it never read `isSecret`, so the queue path had nothing to redact with even if it had wanted to.

Pre-existing, and independent of the workflow-variable editing work in #3717, which deliberately left this alone to stay scoped.

## The fix

- **`App/FeatureSet/Workflow/Utils/SecretRedaction.ts`** (new) — `WORKFLOW_LOG_REDACTED_VALUE`, `getSecretWorkflowVariableValues` and `redactSecretsFromString`, lifted verbatim out of `RunWorkflow`. They have to live outside both services: `RunWorkflow` already imports `QueueWorkflow`. Ordering (longest secret first, so an overlapping shorter one can't expose a tail) is split out as `getSecretValuesForRedaction` so a caller holding raw strings gets the same guarantee.
- **`QueueWorkflow.resolveScheduleCron`** now selects `isSecret` on both the local and global variable queries, and hands the secret values to the resolver.
- **`QueueWorkflow.buildScheduleCronFromVariables`** takes those values and scrubs them out of every error it returns. The returned `cron` is deliberately *not* scrubbed — it goes to BullMQ, which needs the real pattern, not to a reader.
- `RunWorkflow` keeps re-exporting `WORKFLOW_LOG_REDACTED_VALUE`; its behavior is unchanged.

Known trade-off, same one the run log has always made: a one-character secret ("0") will also blank out innocent occurrences of that text in the message. A mangled error beats a leaked secret.

## Tests

`App/Tests/FeatureSet/Workflow/QueueWorkflowScheduleSecrets.test.ts` — drives `addWorkflowToQueue` and asserts against the persisted `WorkflowLog`, following the "the secret never appears anywhere in the persisted output" pattern from `RunWorkflowStepTrace.test.ts`:

- the regression itself: a Secret local variable that isn't a valid cron never reaches the log row
- same for a Secret global variable, for `isSecret` arriving as the string `"true"`, and for a secret substituted into *part* of a cron
- the `logger.error` line is redacted too, not just the database row
- `isSecret` is selected on both variable queries — this one fails outright if the select regresses
- the error stays useful: a **non-secret** variable is still quoted back verbatim
- a valid secret cron schedules normally, writes no error log, and reaches `Queue.addJob` **unredacted**

plus direct coverage of the resolver for the cases that are awkward to stage through the database: overlapping secrets passed shortest-first, regex metacharacters, empty secrets, no secrets, and the unresolved-variable branch.

`App/Tests/FeatureSet/Workflow/SecretRedaction.test.ts` — the shared helpers on their own: ordering, de-duplication, empty/missing values, boolean vs string `isSecret`, literal treatment of regex metacharacters, no re-processing of the replacement marker, and — pinning the bug — that a variable whose `isSecret` was never selected reads as not-secret and is redacted by nothing.

## Verification

- `App/Tests/FeatureSet/Workflow` — **10 suites, 172 tests, all passing** (includes the existing `QueueWorkflow`, `RunWorkflow` and `RunWorkflowStepTrace` suites, unchanged).
- `eslint --fix` clean on every touched file.
- `tsc --noEmit` reports nothing in the touched files.