### PR TITLE
Fix delete account card spacing

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Global/UserProfile/DeleteAccount.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Global/UserProfile/DeleteAccount.tsx
@@ -139,6 +139,7 @@ const DeleteAccount: FunctionComponent<
           type={AlertType.DANGER}
           strongTitle="DANGER ZONE"
           title="Deleting your account is permanent and cannot be undone. All your personal data will be removed."
+          className="mb-5"
         />
 
         {isLoading && <ComponentLoader />}

--- a/Common/Tests/App/Dashboard/WorkflowVariablesTable.test.tsx
+++ b/Common/Tests/App/Dashboard/WorkflowVariablesTable.test.tsx
@@ -287,9 +287,7 @@ function makeVariable(
   return variable;
 }
 
-function openUpdateContentModal(
-  variable?: WorkflowVariable | undefined,
-): void {
+function openUpdateContentModal(variable?: WorkflowVariable | undefined): void {
   act(() => {
     updateContentButton().onClick(
       variable || makeVariable(),

--- a/Common/Tests/Server/Services/WorkflowVariableRenameUniqueness.test.ts
+++ b/Common/Tests/Server/Services/WorkflowVariableRenameUniqueness.test.ts
@@ -43,9 +43,7 @@ const WORKFLOW_ID: ObjectID = new ObjectID(
 const VARIABLE_ID: ObjectID = new ObjectID(
   "aaaa3333-3333-4333-8333-333333333333",
 );
-const USER_ID: ObjectID = new ObjectID(
-  "aaaa5555-5555-4555-8555-555555555555",
-);
+const USER_ID: ObjectID = new ObjectID("aaaa5555-5555-4555-8555-555555555555");
 const OTHER_VARIABLE_ID: ObjectID = new ObjectID(
   "aaaa4444-4444-4444-8444-444444444444",
 );

--- a/Common/Tests/Server/Utils/Monitor/MonitorRootCauseTargetResolution.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorRootCauseTargetResolution.test.ts
@@ -345,7 +345,7 @@ describe("Root cause Attempts line", () => {
      * unreported count must not be rendered as a real one.
      */
     expect(context).not.toContain("- Attempts:");
-    expect(/^- Attempts:/m.test(context)).toBe(false);
+    expect(new RegExp("^- Attempts:", "m").test(context)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- add spacing below the delete-account danger alert so it no longer touches the following card
- keep root lint/fix output clean with minimal formatter/lint cleanup in existing tests

## Validation
- `npm run fix`
- `npm run compile` in `App/FeatureSet/Dashboard` (fails on existing unrelated Dashboard type/module errors in metrics/on-call files and shared dependency resolution)
