### PR TITLE
Make shared pencil icons smaller and wider

### DIFF
--- a/Common/Tests/UI/Components/IconOpticalSize.test.tsx
+++ b/Common/Tests/UI/Components/IconOpticalSize.test.tsx
@@ -6,28 +6,10 @@ import { render } from "@testing-library/react";
 import React from "react";
 
 /*
- * WHY THIS FILE EXISTS
- *
- * Every icon in Icon.tsx is hand-written path data in one long if/else chain,
- * and they all share a 24x24 viewBox. The viewBox is not what the eye
- * measures, though - the INK is. An icon whose drawing runs corner to corner
- * reads as bigger than one that sits inside a keyline square, at the same
- * nominal size, on the same row, in the same button.
- *
- * That is what happened to the pencil. Heroicons' pencil is a single unbroken
- * diagonal spanning the full box, so its ink ran ~25 units tip to eraser
- * while the Trash and List it sits beside in a table row's action buttons run
- * ~20. Rendered by Button at 20px (Button.tsx pins the icon to `w-5 h-5`), the
- * pencil drew a stroke longer than the box it was sized into, and looked a
- * size larger than every button next to it (OneUptime issue #3444's
- * screenshot).
- *
- * A path string pinned by equality would catch a revert and nothing else - it
- * says nothing about WHY the string is what it is, and it goes stale the
- * moment anyone redraws the glyph for an unrelated reason. So this measures
- * the geometry instead: the pencil's ink must stay in the same size class as
- * the icons it is rendered beside. Redraw the pencil however you like; it just
- * may not go back to overshooting its neighbours.
+ * Edit and Pencil share a diagonal glyph. A uniform reduction made the old
+ * pencil shorter but also left a thin barrel that disappeared at button size.
+ * These geometry checks protect both dimensions: a compact outline and enough
+ * width to remain legible, without tying future redraws to an exact path.
  */
 
 /*
@@ -59,13 +41,10 @@ interface Point {
  * The vertices of an SVG path: every on-path point the path data names, in
  * user units.
  *
- * Deliberately vertices and not a true outline. Curves and arcs bulge past
- * their endpoints - the pencil's eraser cap is a semicircle that reaches
- * ~0.4 units beyond its own arc endpoint - so this under-measures every icon
- * by a fraction of a unit. That is fine and it is why the comparison below is
- * relative: every icon is measured the same way, so the bias cancels, and the
- * question being asked ("is the pencil in the same size class as the trash
- * can") is not sensitive to a rounding of a stroke width.
+ * Deliberately vertices and not a true outline. Curves and arcs extend past
+ * their endpoints, especially the pencil's rounded cap. These measurements
+ * protect proportions in the path data; browser checks cover the rendered
+ * outline and alignment. Bounds below allow for the cap being omitted here.
  *
  * Control points of curves are skipped rather than treated as vertices: they
  * routinely sit outside the drawn shape and would report ink that is not
@@ -258,6 +237,22 @@ const measurePath: MeasurePathFunction = (pathData: string): number => {
   return longestSpan(parsePathVertices(pathData));
 };
 
+// Project onto the axis perpendicular to the pencil's 45-degree barrel.
+// Its axis-aligned bounding box cannot distinguish a wide pencil from a line.
+type DiagonalWidthFunction = (vertices: Array<Point>) => number;
+
+const diagonalWidth: DiagonalWidthFunction = (
+  vertices: Array<Point>,
+): number => {
+  const transverseCoordinates: Array<number> = vertices.map((point: Point) => {
+    return (point.x + point.y) / Math.SQRT2;
+  });
+
+  return (
+    Math.max(...transverseCoordinates) - Math.min(...transverseCoordinates)
+  );
+};
+
 // The same measurement, for an icon rendered by the component under test.
 type InkExtentFunction = (icon: IconProp) => number;
 
@@ -282,6 +277,11 @@ const inkExtent: InkExtentFunction = (icon: IconProp): number => {
 const OVERSIZED_HEROICONS_PENCIL: string =
   "M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125";
 
+// The previous 80% pencil had an approximately three-unit barrel. Keeping it
+// as a control proves that length checks alone do not prevent this regression.
+const NARROW_PENCIL: string =
+  "M15.89 5.99l1.35-1.35a1.5 1.5 0 112.122 2.122L7.866 18.256a3.6 3.6 0 01-1.518.904l-2.148.64.64-2.148a3.6 3.6 0 01.904-1.518L15.89 5.99zm0 0L18 8.1";
+
 describe("path measurement", () => {
   /*
    * Every assertion in the suite below is only as good as the parser, and a
@@ -295,6 +295,14 @@ describe("path measurement", () => {
 
     // "M12 4.5v15m7.5-7.5h-15" - a plus with 15-unit arms.
     expect(measurePath("M12 4.5v15m7.5-7.5h-15")).toBeCloseTo(15, 2);
+  });
+
+  it("measures width perpendicular to a diagonal instead of its bounding box", () => {
+    const diagonal: Array<Point> = parsePathVertices("M0 8L8 0");
+    const wideDiagonal: Array<Point> = parsePathVertices("M0 4L4 0L8 4L4 8Z");
+
+    expect(diagonalWidth(diagonal)).toBeCloseTo(0, 6);
+    expect(diagonalWidth(wideDiagonal)).toBeCloseTo(4 * Math.SQRT2, 6);
   });
 
   it("reads arc flags that are packed against their coordinates", () => {
@@ -330,8 +338,9 @@ describe("Icon optical size", () => {
      */
     expect(pencil).toBeLessThanOrEqual(trash * 1.05);
 
-    // And not shrunk into a different size class either.
-    expect(pencil).toBeGreaterThanOrEqual(list * 0.9);
+    // A compact pencil still needs to be legible. Its rounded cap extends
+    // past these vertices, so allow more inset than for an upright glyph.
+    expect(pencil).toBeGreaterThanOrEqual(list * 0.8);
   });
 
   it("would fail for the stock Heroicons pencil", () => {
@@ -340,6 +349,37 @@ describe("Icon optical size", () => {
 
     // The regression this test exists for: 25 units of ink against the bin's 20.
     expect(stock).toBeGreaterThan(trash * 1.2);
+  });
+
+  it.each([IconProp.Pencil, IconProp.Edit])(
+    "%s has a wider barrel and a shorter outline than the previous pencil",
+    (icon: IconProp) => {
+      const vertices: Array<Point> = getIconPaths(icon).flatMap(
+        (pathData: string) => {
+          return parsePathVertices(pathData);
+        },
+      );
+      const width: number = diagonalWidth(vertices);
+      const length: number = longestSpan(vertices);
+
+      // At 20px, this leaves a visible barrel interior even after the 1.5-unit
+      // outline is drawn. A width ceiling preserves the familiar pencil shape.
+      expect(width).toBeGreaterThanOrEqual(4.5);
+      expect(width).toBeLessThanOrEqual(6.5);
+      expect(length / width).toBeGreaterThanOrEqual(2.5);
+      expect(length / width).toBeLessThanOrEqual(4);
+      expect(length).toBeLessThanOrEqual(measurePath(NARROW_PENCIL) * 0.85);
+    },
+  );
+
+  it("rejects the previous narrow pencil even though it passed the size checks", () => {
+    const vertices: Array<Point> = parsePathVertices(NARROW_PENCIL);
+    const width: number = diagonalWidth(vertices);
+    const length: number = longestSpan(vertices);
+
+    expect(length).toBeLessThanOrEqual(inkExtent(IconProp.Trash) * 1.05);
+    expect(width).toBeLessThan(4.5);
+    expect(length / width).toBeGreaterThan(4);
   });
 
   it("draws the same pencil for Pencil and Edit", () => {

--- a/Common/Tests/UI/Components/IconOpticalSize.test.tsx
+++ b/Common/Tests/UI/Components/IconOpticalSize.test.tsx
@@ -237,8 +237,10 @@ const measurePath: MeasurePathFunction = (pathData: string): number => {
   return longestSpan(parsePathVertices(pathData));
 };
 
-// Project onto the axis perpendicular to the pencil's 45-degree barrel.
-// Its axis-aligned bounding box cannot distinguish a wide pencil from a line.
+/*
+ * Project onto the axis perpendicular to the pencil's 45-degree barrel.
+ * Its axis-aligned bounding box cannot distinguish a wide pencil from a line.
+ */
 type DiagonalWidthFunction = (vertices: Array<Point>) => number;
 
 const diagonalWidth: DiagonalWidthFunction = (
@@ -277,8 +279,10 @@ const inkExtent: InkExtentFunction = (icon: IconProp): number => {
 const OVERSIZED_HEROICONS_PENCIL: string =
   "M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125";
 
-// The previous 80% pencil had an approximately three-unit barrel. Keeping it
-// as a control proves that length checks alone do not prevent this regression.
+/*
+ * The previous 80% pencil had an approximately three-unit barrel. Keeping it
+ * as a control proves that length checks alone do not prevent this regression.
+ */
 const NARROW_PENCIL: string =
   "M15.89 5.99l1.35-1.35a1.5 1.5 0 112.122 2.122L7.866 18.256a3.6 3.6 0 01-1.518.904l-2.148.64.64-2.148a3.6 3.6 0 01.904-1.518L15.89 5.99zm0 0L18 8.1";
 
@@ -338,8 +342,10 @@ describe("Icon optical size", () => {
      */
     expect(pencil).toBeLessThanOrEqual(trash * 1.05);
 
-    // A compact pencil still needs to be legible. Its rounded cap extends
-    // past these vertices, so allow more inset than for an upright glyph.
+    /*
+     * A compact pencil still needs to be legible. Its rounded cap extends
+     * past these vertices, so allow more inset than for an upright glyph.
+     */
     expect(pencil).toBeGreaterThanOrEqual(list * 0.8);
   });
 
@@ -362,8 +368,10 @@ describe("Icon optical size", () => {
       const width: number = diagonalWidth(vertices);
       const length: number = longestSpan(vertices);
 
-      // At 20px, this leaves a visible barrel interior even after the 1.5-unit
-      // outline is drawn. A width ceiling preserves the familiar pencil shape.
+      /*
+       * At 20px, this leaves a visible barrel interior even after the 1.5-unit
+       * outline is drawn. A width ceiling preserves the familiar pencil shape.
+       */
       expect(width).toBeGreaterThanOrEqual(4.5);
       expect(width).toBeLessThanOrEqual(6.5);
       expect(length / width).toBeGreaterThanOrEqual(2.5);

--- a/Common/Tests/UI/Components/PencilButton.test.tsx
+++ b/Common/Tests/UI/Components/PencilButton.test.tsx
@@ -49,9 +49,11 @@ describe.each([IconProp.Edit, IconProp.Pencil])(
         const svg: SVGSVGElement | null = button.querySelector("svg");
         const path: SVGPathElement | null = button.querySelector("path");
 
-        // Centering matters when a mobile label has a 24px line height and the
-        // icon occupies 20px. jsdom cannot lay out these boxes; the shared class
-        // is the CSS contract also exercised by the browser regression.
+        /*
+         * Centering matters when a mobile label has a 24px line height and the
+         * icon occupies 20px. jsdom cannot lay out these boxes; the shared class
+         * is the CSS contract also exercised by the browser regression.
+         */
         expect(button).toHaveClass("items-center");
         expect(button).toBeEnabled();
         expect(svg).toHaveClass("w-5", "h-5");

--- a/Common/Tests/UI/Components/PencilButton.test.tsx
+++ b/Common/Tests/UI/Components/PencilButton.test.tsx
@@ -1,0 +1,209 @@
+import IconProp from "../../../Types/Icon/IconProp";
+import Button, {
+  ButtonSize,
+  ButtonStyleType,
+} from "../../../UI/Components/Button/Button";
+import { describe, expect, it, jest } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const BUTTON_STYLES: Array<[string, ButtonStyleType]> = Object.keys(
+  ButtonStyleType,
+)
+  .filter((key: string) => {
+    return isNaN(Number(key));
+  })
+  .map((key: string) => {
+    return [key, ButtonStyleType[key as keyof typeof ButtonStyleType]] as [
+      string,
+      ButtonStyleType,
+    ];
+  });
+
+const BUTTON_SIZES: Array<[string, ButtonSize]> = [
+  ["extra small", ButtonSize.ExtraSmall],
+  ["small", ButtonSize.Small],
+  ["normal", ButtonSize.Normal],
+  ["large", ButtonSize.Large],
+];
+
+/*
+ * Render the real Button -> Icon stack. The glyph's proportions are covered
+ * by IconOpticalSize; these checks protect the space and alignment around it
+ * and the edit action that users reach through each button variant.
+ */
+describe.each([IconProp.Edit, IconProp.Pencil])(
+  "%s buttons",
+  (icon: IconProp) => {
+    it.each(BUTTON_STYLES)(
+      "centers the icon and preserves its accessible name in the %s style",
+      (_name: string, buttonStyle: ButtonStyleType) => {
+        render(
+          <Button title="Edit Project" icon={icon} buttonStyle={buttonStyle} />,
+        );
+
+        const button: HTMLElement = screen.getByRole("button", {
+          name: "Edit Project",
+        });
+        const svg: SVGSVGElement | null = button.querySelector("svg");
+        const path: SVGPathElement | null = button.querySelector("path");
+
+        // Centering matters when a mobile label has a 24px line height and the
+        // icon occupies 20px. jsdom cannot lay out these boxes; the shared class
+        // is the CSS contract also exercised by the browser regression.
+        expect(button).toHaveClass("items-center");
+        expect(button).toBeEnabled();
+        expect(svg).toHaveClass("w-5", "h-5");
+        expect(svg).toHaveAttribute("viewBox", "0 0 24 24");
+        expect(svg).toHaveAttribute("stroke-width", "1.5");
+        expect(svg).toHaveAttribute("stroke", "currentColor");
+        expect(svg).toHaveAttribute("aria-hidden", "true");
+        expect(path).toHaveAttribute("stroke-linecap", "round");
+        expect(path).toHaveAttribute("stroke-linejoin", "round");
+        expect(screen.queryByRole("img")).not.toBeInTheDocument();
+
+        if (
+          buttonStyle === ButtonStyleType.ICON ||
+          buttonStyle === ButtonStyleType.ICON_LIGHT
+        ) {
+          expect(svg).toHaveClass("m-1");
+          expect(button).toHaveAttribute("aria-label", "Edit Project");
+        } else {
+          expect(svg).toHaveClass("mr-1");
+        }
+
+        if (buttonStyle === ButtonStyleType.ICON) {
+          expect(button).not.toHaveTextContent("Edit Project");
+        } else {
+          expect(button).toHaveTextContent("Edit Project");
+        }
+      },
+    );
+
+    it.each(BUTTON_SIZES)(
+      "retains the icon footprint and padding in a %s button",
+      (_name: string, buttonSize: ButtonSize) => {
+        render(
+          <Button title="Edit Project" icon={icon} buttonSize={buttonSize} />,
+        );
+
+        const button: HTMLElement = screen.getByRole("button", {
+          name: "Edit Project",
+        });
+
+        expect(button).toHaveClass(...buttonSize.split(" "), "items-center");
+        expect(button.querySelector("svg")).toHaveClass("w-5", "h-5", "mr-1");
+      },
+    );
+
+    it.each([ButtonStyleType.NORMAL, ButtonStyleType.ICON])(
+      "invokes edit once when the pencil is clicked in style %s",
+      (buttonStyle: ButtonStyleType) => {
+        const onClick: ReturnType<typeof jest.fn> = jest.fn();
+        render(
+          <Button
+            title="Edit Project"
+            icon={icon}
+            buttonStyle={buttonStyle}
+            onClick={onClick}
+          />,
+        );
+
+        const button: HTMLElement = screen.getByRole("button", {
+          name: "Edit Project",
+        });
+        const path: SVGPathElement | null = button.querySelector("path");
+
+        expect(path).not.toBeNull();
+        fireEvent.click(path as SVGPathElement);
+        expect(onClick).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it.each([ButtonStyleType.NORMAL, ButtonStyleType.ICON])(
+      "keeps a disabled edit action inert in style %s",
+      (buttonStyle: ButtonStyleType) => {
+        const onClick: ReturnType<typeof jest.fn> = jest.fn();
+        render(
+          <Button
+            title="Edit Project"
+            icon={icon}
+            buttonStyle={buttonStyle}
+            disabled={true}
+            onClick={onClick}
+          />,
+        );
+
+        const button: HTMLElement = screen.getByRole("button", {
+          name: "Edit Project",
+        });
+        const path: SVGPathElement | null = button.querySelector("path");
+
+        expect(button).toBeDisabled();
+        expect(button).toHaveAttribute("aria-disabled", "true");
+        expect(path).not.toBeNull();
+        fireEvent.click(path as SVGPathElement);
+        expect(onClick).not.toHaveBeenCalled();
+      },
+    );
+
+    it("replaces the pencil with a centered spinner while an edit action loads", () => {
+      const onClick: ReturnType<typeof jest.fn> = jest.fn();
+      const { rerender } = render(
+        <Button title="Edit Project" icon={icon} onClick={onClick} />,
+      );
+      const button: HTMLElement = screen.getByRole("button", {
+        name: "Edit Project",
+      });
+
+      expect(button.querySelector("svg")).not.toHaveClass("animate-spin");
+
+      rerender(
+        <Button
+          title="Edit Project"
+          icon={icon}
+          isLoading={true}
+          onClick={onClick}
+        />,
+      );
+
+      expect(button).toBeDisabled();
+      expect(button).toHaveClass("items-center");
+      expect(button.querySelectorAll("svg")).toHaveLength(1);
+      expect(button.querySelector("svg")).toHaveClass(
+        "animate-spin",
+        "w-5",
+        "h-5",
+      );
+      fireEvent.click(button);
+      expect(onClick).not.toHaveBeenCalled();
+
+      rerender(<Button title="Edit Project" icon={icon} onClick={onClick} />);
+
+      expect(button).toBeEnabled();
+      expect(button.querySelectorAll("svg")).toHaveLength(1);
+      expect(button.querySelector("svg")).not.toHaveClass("animate-spin");
+      fireEvent.click(button);
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("retains an explicit accessible name for an icon-only edit action", () => {
+      render(
+        <Button
+          icon={icon}
+          buttonStyle={ButtonStyleType.ICON}
+          title="Edit"
+          ariaLabel="Rename project"
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Rename project" }),
+      ).toBeEnabled();
+      expect(
+        screen.queryByRole("button", { name: "Edit" }),
+      ).not.toBeInTheDocument();
+    });
+  },
+);

--- a/Common/UI/Components/Button/Button.tsx
+++ b/Common/UI/Components/Button/Button.tsx
@@ -183,7 +183,7 @@ const Button: FunctionComponent<ComponentProps> = ({
 
   if (buttonStyle === ButtonStyleType.SECONDARY) {
     loadingIconClassName += ` text-indigo-500`;
-    buttonStyleCssClass = `inline-flex items-center rounded-md border border-transparent ${
+    buttonStyleCssClass = `inline-flex rounded-md border border-transparent ${
       disabled ? "bg-indigo-300" : "bg-indigo-100 hover:bg-indigo-200"
     } text-sm font-medium text-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`;
   }

--- a/Common/UI/Components/Button/Button.tsx
+++ b/Common/UI/Components/Button/Button.tsx
@@ -245,6 +245,9 @@ const Button: FunctionComponent<ComponentProps> = ({
     }   focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2 md:mt-0 md:ml-3 md:w-auto md:text-sm`;
   }
 
+  // Center the icon against both desktop and taller mobile label lines.
+  buttonStyleCssClass += ` items-center`;
+
   /*
    * The one shared point every variant funnels through: hover/focus colour
    * changes ease in instead of snapping, at the same 150ms the other

--- a/Common/UI/Components/Icon/Icon.tsx
+++ b/Common/UI/Components/Icon/Icon.tsx
@@ -389,47 +389,13 @@ const Icon: FunctionComponent<ComponentProps> = ({
       />,
     );
   } else if (icon === IconProp.Pencil || icon === IconProp.Edit) {
-    /*
-     * Edit is a pencil, and nothing else. It used to be a pencil drawn over a
-     * document outline, which at the 16px this icon is actually rendered at
-     * almost everywhere collapsed into a grey box with a diagonal through it -
-     * legible as "some kind of file thing", not as "change this". The pencil
-     * alone is what everybody already reads as edit, and it survives being
-     * small. IconProp.PencilSquare still draws the composite for the handful of
-     * places that want it.
-     *
-     * DRAWN AT 80% OF THE UPSTREAM HEROICON, and that is the whole point of
-     * this path existing rather than the stock one.
-     *
-     * Every icon here shares a 24x24 box, but the eye does not measure the
-     * box - it measures the ink. Heroicons' pencil is one unbroken diagonal
-     * from corner to corner, so its ink ran 26.8 units end to end: the
-     * longest stroke of any icon in this file, against a median of 21 and
-     * against the 20.5 of the Trash and the 19.9 of the List it sits beside
-     * in a table row. At the 20px a Button renders it at, that is a 22px
-     * stroke inside a 20px box - it overshot the cap height of its own label
-     * and read as a size larger than every button next to it.
-     *
-     * (Those figures are the longest distance across each glyph's drawn ink,
-     * with arcs and curves sampled. Common/Tests/UI/Components/
-     * IconOpticalSize.test.tsx measures the same quantity from the path
-     * VERTICES alone, which under-reads every icon by a fraction of a unit -
-     * so its numbers are smaller than these and its comparison is relative
-     * rather than absolute.)
-     *
-     * Scaling by 0.8 about the centre of the box brings the ink to 21.4 -
-     * between Trash and Copy, at the median - while keeping the glyph
-     * itself untouched: a uniform scale preserves the arc flags, the 45
-     * degree barrel, and the tangency of the nib and eraser arcs. The
-     * numbers stay exact (radii 1.5 and 3.6, tip at 4.2 19.8), and the
-     * stroke width deliberately does NOT scale, so the pencil keeps the same
-     * weight as its neighbours instead of thinning out.
-     */
+    // A short, wide barrel keeps the pencil legible beside button labels and
+    // table actions. Keep the shared stroke weight and 24px box for both aliases.
     return getSvgWrapper(
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
-        d="M15.89 5.99l1.35-1.35a1.5 1.5 0 112.122 2.122L7.866 18.256a3.6 3.6 0 01-1.518.904l-2.148.64.64-2.148a3.6 3.6 0 01.904-1.518L15.89 5.99zm0 0L18 8.1"
+        d="M14.5 5.5a2.828 2.828 0 0 1 4 4L10 18l-5 1 1-5 8.5-8.5ZM13 7l4 4"
       />,
     );
   } else if (icon === IconProp.Equals) {

--- a/Common/UI/Components/Icon/Icon.tsx
+++ b/Common/UI/Components/Icon/Icon.tsx
@@ -389,8 +389,10 @@ const Icon: FunctionComponent<ComponentProps> = ({
       />,
     );
   } else if (icon === IconProp.Pencil || icon === IconProp.Edit) {
-    // A short, wide barrel keeps the pencil legible beside button labels and
-    // table actions. Keep the shared stroke weight and 24px box for both aliases.
+    /*
+     * A short, wide barrel keeps the pencil legible beside button labels and
+     * table actions. Keep the shared stroke weight and 24px box for both aliases.
+     */
     return getSvgWrapper(
       <path
         strokeLinecap="round"

--- a/E2E/PencilButton/BrowserFixture.spec.ts
+++ b/E2E/PencilButton/BrowserFixture.spec.ts
@@ -1,0 +1,194 @@
+import { Locator, Page, TestInfo, expect, test } from "@playwright/test";
+
+interface Alignment {
+  iconWidth: number;
+  iconHeight: number;
+  iconCenterOffset: number;
+  labelCenterOffset: number;
+  labelGap: number;
+}
+
+const alignment: (button: Locator) => Promise<Alignment> = async (
+  button: Locator,
+): Promise<Alignment> => {
+  return button.evaluate((element: HTMLButtonElement): Alignment => {
+    const svg: SVGSVGElement = element.querySelector("svg")!;
+    const icon: DOMRect = svg.getBoundingClientRect();
+    const bounds: DOMRect = element.getBoundingClientRect();
+    const label: ChildNode | undefined = Array.from(element.childNodes).find(
+      (node: ChildNode): boolean => {
+        return (
+          node.nodeType === Node.TEXT_NODE && Boolean(node.textContent?.trim())
+        );
+      },
+    );
+    const range: Range = document.createRange();
+    range.selectNode(label!);
+    const text: DOMRect = range.getBoundingClientRect();
+    return {
+      iconWidth: icon.width,
+      iconHeight: icon.height,
+      iconCenterOffset:
+        icon.y + icon.height / 2 - (bounds.y + bounds.height / 2),
+      labelCenterOffset: icon.y + icon.height / 2 - (text.y + text.height / 2),
+      labelGap: text.x - icon.right,
+    };
+  });
+};
+
+test.beforeEach(async ({ page }: { page: Page }) => {
+  await page.goto("/");
+  await expect(page.getByTestId("edit-project")).toBeVisible();
+  await expect(page.getByTestId("edit-project").locator("svg")).toHaveCSS(
+    "width",
+    "20px",
+  );
+});
+
+test("all labeled variants and sizes center the pencil without changing its button slot", async ({
+  page,
+}: {
+  page: Page;
+}) => {
+  const buttons: Locator = page.locator(
+    '[data-testid="edit-project"], [data-testid^="variant-"], [data-testid^="size-"]',
+  );
+  expect(await buttons.count()).toBe(24);
+  for (const button of await buttons.all()) {
+    const name: string | null = await button.getAttribute("data-testid");
+    const result: Alignment = await alignment(button);
+    expect(result.iconWidth, name || "icon width").toBe(20);
+    expect(result.iconHeight, name || "icon height").toBe(20);
+    expect(
+      Math.abs(result.iconCenterOffset),
+      `${name}: button center`,
+    ).toBeLessThanOrEqual(0.25);
+    expect(
+      Math.abs(result.labelCenterOffset),
+      `${name}: text center`,
+    ).toBeLessThanOrEqual(1.5);
+    expect(result.labelGap, `${name}: label gap`).toBeGreaterThanOrEqual(4);
+    await expect(button.locator("svg")).toHaveAttribute("aria-hidden", "true");
+  }
+  expect(
+    await page.evaluate((): number => {
+      return document.documentElement.scrollWidth - window.innerWidth;
+    }),
+  ).toBeLessThanOrEqual(0);
+});
+
+test("pencil is visibly wider and shorter while both aliases and all sizes share the same geometry", async ({
+  page,
+}: {
+  page: Page;
+}) => {
+  const pencil: Locator = page.getByTestId("edit-project").locator("svg path");
+  const edit: Locator = page.getByTestId("variant-NORMAL").locator("svg path");
+  expect(await pencil.getAttribute("d")).toBe(await edit.getAttribute("d"));
+  const geometry: {
+    width: number;
+    length: number;
+    x: number;
+    y: number;
+    right: number;
+    bottom: number;
+  } = await pencil.evaluate((path: SVGPathElement) => {
+    const bounds: DOMRect = path.getBBox();
+    const perimeter: number = path.getTotalLength();
+    const along: number[] = [];
+    const across: number[] = [];
+    // Project the actual rendered outline onto the pencil's diagonal axes.
+    for (let index: number = 0; index <= 1000; index++) {
+      const point: DOMPoint = path.getPointAtLength((perimeter * index) / 1000);
+      along.push((point.x - point.y) / Math.SQRT2);
+      across.push((point.x + point.y) / Math.SQRT2);
+    }
+    return {
+      width: Math.max(...across) - Math.min(...across),
+      length: Math.max(...along) - Math.min(...along),
+      x: bounds.x,
+      y: bounds.y,
+      right: bounds.x + bounds.width,
+      bottom: bounds.y + bounds.height,
+    };
+  });
+  // The previous narrow pencil measured 3 units wide and 21.4 units long.
+  expect(geometry.width).toBeGreaterThan(5);
+  expect(geometry.length).toBeLessThan(20);
+  expect(geometry.length / geometry.width).toBeLessThan(4);
+  expect(geometry.x).toBeGreaterThan(4);
+  expect(geometry.y).toBeGreaterThan(4);
+  expect(geometry.right).toBeLessThan(20);
+  expect(geometry.bottom).toBeLessThan(20);
+  const sizes: number[] = [];
+  for (const svg of await page.locator('[data-testid^="standalone-"]').all()) {
+    sizes.push(
+      await svg.evaluate((element: SVGSVGElement): number => {
+        return element.getBoundingClientRect().width;
+      }),
+    );
+    expect(await svg.locator("path").getAttribute("d")).toBe(
+      await pencil.getAttribute("d"),
+    );
+  }
+  expect(sizes).toEqual([16, 20, 24]);
+});
+
+test("labeled and icon-only edit actions remain accessible to pointer and keyboard users", async ({
+  page,
+}: {
+  page: Page;
+}) => {
+  const project: Locator = page.getByRole("button", {
+    name: "Edit Project",
+    exact: true,
+  });
+  await project.click();
+  await project.focus();
+  await page.keyboard.press("Enter");
+  await page.keyboard.press("Space");
+  await expect(page.getByRole("status")).toHaveText("Edits requested: 3");
+  for (const name of ["ICON", "ICON_LIGHT"]) {
+    const button: Locator = page.getByRole("button", {
+      name: `Edit ${name}`,
+      exact: true,
+    });
+    await expect(button).toHaveText("");
+    const offset: number = await button.evaluate(
+      (element: HTMLButtonElement): number => {
+        const buttonBounds: DOMRect = element.getBoundingClientRect();
+        const iconBounds: DOMRect = element
+          .querySelector("svg")!
+          .getBoundingClientRect();
+        return Math.abs(
+          iconBounds.y +
+            iconBounds.height / 2 -
+            (buttonBounds.y + buttonBounds.height / 2),
+        );
+      },
+    );
+    expect(offset).toBeLessThanOrEqual(0.25);
+    await button.focus();
+    await page.keyboard.press("Enter");
+  }
+  await expect(page.getByRole("status")).toHaveText("Edits requested: 5");
+  await expect(
+    page.getByRole("button", { name: "Disabled edit" }),
+  ).toBeDisabled();
+});
+
+test("captures the project action and button variants for visual review", async ({
+  page,
+}: { page: Page }, testInfo: TestInfo) => {
+  await page
+    .getByTestId("project-card")
+    .screenshot({ path: testInfo.outputPath("edit-project.png") });
+  await page.screenshot({
+    path: testInfo.outputPath("pencil-buttons.png"),
+    fullPage: true,
+  });
+  await testInfo.attach("Edit Project", {
+    path: testInfo.outputPath("edit-project.png"),
+    contentType: "image/png",
+  });
+});

--- a/E2E/PencilButton/Fixture/Fixture.js
+++ b/E2E/PencilButton/Fixture/Fixture.js
@@ -1,0 +1,106 @@
+import React, { useState } from "react";
+import { createRoot } from "react-dom/client";
+import i18next from "i18next";
+import { initReactI18next } from "react-i18next";
+import Button, {
+  ButtonSize,
+  ButtonStyleType,
+} from "Common/UI/Components/Button/Button";
+import Icon, { SizeProp } from "Common/UI/Components/Icon/Icon";
+import IconProp from "Common/Types/Icon/IconProp";
+import "Common/UI/Styles/Theme.css";
+
+await i18next.use(initReactI18next).init({
+  lng: "en",
+  fallbackLng: "en",
+  resources: { en: { translation: {} } },
+  interpolation: { escapeValue: false },
+});
+
+const variants = Object.keys(ButtonStyleType).filter(
+  (name) =>
+    Number.isNaN(Number(name)) && !["ICON", "ICON_LIGHT"].includes(name),
+);
+
+function Fixture() {
+  const [clicks, setClicks] = useState(0);
+  return (
+    <main className="mx-auto max-w-5xl space-y-6 p-6 text-gray-700">
+      <section
+        data-testid="project-card"
+        className="rounded-xl border border-gray-200 bg-white"
+      >
+        <div className="flex flex-wrap items-center justify-between gap-4 border-b border-gray-200 p-6">
+          <h1 className="text-xl font-semibold">Project details</h1>
+          <Button
+            title="Edit Project"
+            icon={IconProp.Pencil}
+            dataTestId="edit-project"
+            onClick={() => setClicks((count) => count + 1)}
+          />
+        </div>
+        <p className="p-6 text-sm text-gray-500">Production workspace</p>
+      </section>
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+        {variants.map((name) => (
+          <div
+            key={name}
+            className="rounded-lg border border-gray-200 bg-white p-3"
+          >
+            <h2 className="mb-3 text-xs text-gray-500">{name}</h2>
+            <Button
+              title="Edit"
+              icon={IconProp.Edit}
+              buttonStyle={ButtonStyleType[name]}
+              dataTestId={`variant-${name}`}
+            />
+          </div>
+        ))}
+        {["NORMAL", "OUTLINE"].flatMap((name) =>
+          Object.keys(ButtonSize).map((size) => (
+            <div
+              key={`${name}-${size}`}
+              className="rounded-lg border border-gray-200 bg-white p-3"
+            >
+              <h2 className="mb-3 text-xs text-gray-500">
+                {name} · {size}
+              </h2>
+              <Button
+                title="Edit"
+                icon={IconProp.Pencil}
+                buttonStyle={ButtonStyleType[name]}
+                buttonSize={ButtonSize[size]}
+                dataTestId={`size-${name}-${size}`}
+              />
+            </div>
+          )),
+        )}
+      </section>
+      <section className="flex flex-wrap items-center gap-6 rounded-lg border border-gray-200 bg-white p-4">
+        {["ICON", "ICON_LIGHT"].map((name) => (
+          <Button
+            key={name}
+            icon={IconProp.Edit}
+            ariaLabel={`Edit ${name}`}
+            buttonStyle={ButtonStyleType[name]}
+            dataTestId={`icon-${name}`}
+            onClick={() => setClicks((count) => count + 1)}
+          />
+        ))}
+        {[SizeProp.Regular, SizeProp.Five, SizeProp.Large].map((size) => (
+          <Icon
+            key={size}
+            icon={IconProp.Pencil}
+            className="text-indigo-600"
+            size={size}
+            data-testid={`standalone-${size}`}
+          />
+        ))}
+        <Button title="Disabled edit" icon={IconProp.Pencil} disabled />
+      </section>
+      <p role="status">Edits requested: {clicks}</p>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")).render(<Fixture />);

--- a/E2E/PencilButton/Fixture/server.js
+++ b/E2E/PencilButton/Fixture/server.js
@@ -1,0 +1,70 @@
+/* Render production Button/Icon components with the app's bundled Tailwind. */
+const fs = require("fs");
+const http = require("http");
+const path = require("path");
+const { createConfig } = require("../../../Common/UI/esbuild-config.js");
+const esbuild = require("../../../Common/node_modules/esbuild");
+
+const repository = path.resolve(__dirname, "../../..");
+const output = path.join(repository, "output/playwright/pencil-button/fixture");
+const port = 4208;
+const config = createConfig({
+  serviceName: "pencil-button-fixture",
+  publicPath: "/dist/",
+  entryPoint: path.join(__dirname, "Fixture.js"),
+  outdir: output,
+  additionalAlias: {
+    Common: path.join(repository, "Common"),
+    react: path.join(repository, "Common/node_modules/react"),
+    "react-dom": path.join(repository, "Common/node_modules/react-dom"),
+  },
+});
+config.target = "es2022";
+config.loader[".js"] = "jsx";
+config.sourcemap = false;
+config.minify = false;
+config.logLevel = "warning";
+
+const tailwind = path.join(
+  repository,
+  "Common/Server/Static/Vendor/tailwind/tailwind-3.4.5.js",
+);
+const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Pencil button regression fixture</title><script>window.process={env:{HOST:"localhost",HTTP_PROTOCOL:"http",BILLING_ENABLED:"false",VERSION:"1.0.0",NODE_ENV:"development"}};window.global=window;</script><script src="/tailwind.js"></script></head><body class="bg-gray-50"><div id="root"></div><script type="module" src="/dist/Fixture.js"></script></body></html>`;
+
+async function main() {
+  fs.mkdirSync(output, { recursive: true });
+  await esbuild.build(config);
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url, `http://127.0.0.1:${port}`);
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader(
+      "Content-Security-Policy",
+      "connect-src 'self'; font-src 'self' data:;",
+    );
+    if (url.pathname === "/tailwind.js") {
+      response.setHeader("Content-Type", "application/javascript");
+      fs.createReadStream(tailwind).pipe(response);
+      return;
+    }
+    if (url.pathname.startsWith("/dist/")) {
+      const file = path.resolve(output, url.pathname.slice(6));
+      if (!file.startsWith(output + path.sep) || !fs.existsSync(file)) {
+        response.writeHead(404).end();
+        return;
+      }
+      response.setHeader("Content-Type", "application/javascript");
+      fs.createReadStream(file).pipe(response);
+      return;
+    }
+    response.setHeader("Content-Type", "text/html");
+    response.end(html);
+  });
+  server.listen(port, "127.0.0.1");
+  process.on("SIGTERM", () => server.close());
+  process.on("SIGINT", () => server.close());
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/E2E/README.md
+++ b/E2E/README.md
@@ -166,3 +166,17 @@ npx playwright install-deps
 ```bash
 npm run clear-modules
 ```
+
+## Pencil button UI regression tests
+
+Run the shared pencil icon and button checks without starting the app or database:
+
+```bash
+cd E2E
+npm run test-pencil-button-ui
+```
+
+The fixture renders the production components with the shared theme and bundled
+Tailwind. Desktop and mobile checks cover the pencil's proportions, label
+alignment, button sizes, and keyboard activation. Screenshots and failure traces
+are written to `output/playwright/pencil-button/test-results/` at the repository root.

--- a/E2E/package.json
+++ b/E2E/package.json
@@ -15,6 +15,7 @@
     "clear-modules": "rm -rf node_modules && rm package-lock.json && npm install",
     "compile": "tsc",
     "debug-tests": "playwright test --debug",
+    "test-pencil-button-ui": "playwright test --config playwright.pencil-button.config.ts",
     "test-topology-ui": "playwright test --config playwright.topology.config.ts",
     "test-discovery-ui": "playwright test --config playwright.discovery.config.ts",
     "test-label-rule-transfer": "playwright test --config playwright.label-rules.config.ts",

--- a/E2E/playwright.pencil-button.config.ts
+++ b/E2E/playwright.pencil-button.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "path";
+
+export default defineConfig({
+  testDir: "./PencilButton",
+  testMatch: "BrowserFixture.spec.ts",
+  timeout: 60000,
+  expect: { timeout: 10000 },
+  workers: 1,
+  retries: 0,
+  reporter: "list",
+  outputDir: "../output/playwright/pencil-button/test-results",
+  use: {
+    baseURL: "http://127.0.0.1:4208",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "desktop",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 1100 },
+      },
+    },
+    { name: "mobile", use: { ...devices["Pixel 7"] } },
+  ],
+  webServer: {
+    command: "node PencilButton/Fixture/server.js",
+    cwd: path.resolve(__dirname),
+    url: "http://127.0.0.1:4208",
+    reuseExistingServer: false,
+    timeout: 120000,
+  },
+});


### PR DESCRIPTION
Edit buttons such as **Edit Project** used a long, narrow pencil that looked oversized beside their labels. Redraw the shared `Edit` / `Pencil` glyph with a shorter outline and a wider barrel, retaining the existing SVG box, stroke weight, and button spacing. Center shared button contents vertically so the icon also aligns with taller mobile text lines.

Regression coverage measures pencil proportions against the previous narrow glyph and exercises both aliases through the real Button/Icon components across styles, sizes, accessibility, clicks, disabled states, and loading states. A browser fixture uses the production components, shared theme, and bundled Tailwind to verify desktop/mobile geometry and alignment and capture screenshots.

Validation:
- All 182 focused unit/integration tests passed with the default type-aware Jest configuration (Icon, IconOpticalSize, PencilButton, Button, and DisabledButtonTooltip).
- All 8 desktop/mobile browser tests passed (`cd E2E && npm run test-pencil-button-ui`).
- Browser test lint and changed-file formatting passed.
- `npm run compile` passed in both Common and E2E.
- Root `npm run fix` passed across all 10,091 files; its final changes only normalized comment formatting.

The configured development app returned HTTP 502; browser verification used the isolated fixture built from this worktree. Screenshots are generated under `output/playwright/pencil-button/test-results/`.
