### PR TITLE
fix(dashboard): remove network topology guidance banner

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyExplorer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyExplorer.tsx
@@ -746,52 +746,6 @@ const NetworkTopologyExplorer: FunctionComponent<ComponentProps> = (
           <></>
         )}
 
-        <div
-          className="mb-5 grid gap-3 rounded-xl border border-indigo-100 bg-indigo-50 p-4 sm:grid-cols-3"
-          data-testid="topology-hierarchy-guide"
-        >
-          {[
-            {
-              step: "1",
-              title: "Choose a site",
-              description: "Open a location to explore the sites inside it.",
-            },
-            {
-              step: "2",
-              title: "Follow the network",
-              description: "At the last level, see how its devices connect.",
-            },
-            {
-              step: "3",
-              title: "Find the problem",
-              description:
-                "Filter by health, then select a device for details.",
-            },
-          ].map(
-            (item: {
-              step: string;
-              title: string;
-              description: string;
-            }): ReactElement => {
-              return (
-                <div key={item.step} className="flex items-start gap-3">
-                  <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-white text-xs font-semibold text-indigo-600">
-                    {item.step}
-                  </span>
-                  <div>
-                    <p className="text-sm font-medium text-indigo-900">
-                      {translateString(item.title) || item.title}
-                    </p>
-                    <p className="mt-1 text-xs leading-5 text-indigo-700">
-                      {translateString(item.description) || item.description}
-                    </p>
-                  </div>
-                </div>
-              );
-            },
-          )}
-        </div>
-
         <div className="mb-4 flex flex-col gap-3">
           <div className="flex flex-col gap-3 md:flex-row md:items-center">
             <div className="md:w-72">

--- a/E2E/Topology/TopologyExperience.spec.ts
+++ b/E2E/Topology/TopologyExperience.spec.ts
@@ -218,6 +218,11 @@ test("network sites lead to a real device map with recoverable progressive contr
 }) => {
   await openView(page, "Network");
   await expect(page.getByTestId("topology-hierarchy-grid")).toBeVisible();
+  await expect(page.getByTestId("topology-hierarchy-guide")).toHaveCount(0);
+  await expect(
+    page.getByText(/^(Choose a site|Follow the network|Find the problem)$/),
+  ).toHaveCount(0);
+  await expect(page.getByTestId("topology-hierarchy-search")).toBeVisible();
   await screenshot(page, "network-sites-synthetic");
   await page.getByTestId("site-card-london").click();
   await expect(


### PR DESCRIPTION
Remove the three-step guidance banner (Choose a site, Follow the network, Find the problem) from the shared network topology explorer. Site search, health filters, and navigation remain available directly beneath the description.

The browser regression checks that the banner is absent, search remains visible, and users can still drill into a site and interact with its device map. The assertion was verified to fail against the original banner.

Validation:
- Focused network topology and phone-layout browser checks: 2 passed.
- Network topology explorer invariant suite: 44 passed.
- E2E `npm run compile`: passed.
- Root `npm run fix`, scoped to the two changed files: passed.
- Dashboard `npm run compile`: passed.
