### PR TITLE
fix(docs): keep sidebar icons matched to their categories

### DIFF
--- a/App/FeatureSet/Docs/Utils/I18n.ts
+++ b/App/FeatureSet/Docs/Utils/I18n.ts
@@ -134,6 +134,7 @@ export const getLocalizedNav: (lang: string) => LocalizedNavGroup[] = (
   const t: TranslateFn = makeT(lang);
   return DocsNav.map((group: NavGroup): LocalizedNavGroup => {
     return {
+      key: group.title,
       title: t(`navGroups.${group.title}`),
       links: group.links.map((link: NavLink): LocalizedNavLink => {
         return {

--- a/App/FeatureSet/Docs/Utils/Nav.ts
+++ b/App/FeatureSet/Docs/Utils/Nav.ts
@@ -10,16 +10,15 @@ export interface NavGroup {
   links: NavLink[];
 }
 
-/*
- * Localized variants used at render time. The shape matches NavGroup/NavLink
- * so EJS templates do not need to change.
- */
+// Localized variants used at render time.
 export interface LocalizedNavLink {
   title: string;
   url: string;
 }
 
 export interface LocalizedNavGroup {
+  // Canonical English title, preserved for icon lookup across languages.
+  key: string;
   title: string;
   links: LocalizedNavLink[];
 }

--- a/App/FeatureSet/Docs/Views/Partials/Nav.ejs
+++ b/App/FeatureSet/Docs/Views/Partials/Nav.ejs
@@ -5,42 +5,43 @@
  * aria-controls points at exactly one list.
  */
 var idPrefix = typeof navIdPrefix !== 'undefined' && navIdPrefix ? navIdPrefix : 'nav';
-// Map category icons by the canonical English title. We look up using the
-// `key` we attach to each localized group below — that key is the original
-// English title so icons stay stable across languages.
+// Each localized group retains its canonical English key, so icons stay
+// associated with their category across languages and navigation changes.
 var categoryIcons = {
     'Introduction': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>',
     'Installation': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>',
     'Mobile & Desktop Apps': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/>',
     'Configuration': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>',
-    'Monitor': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>',
-    'Telemetry': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>',
-    'AI': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>',
-    'On Call': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>',
-    'Probe': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/>',
     'Emails': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>',
     'Identity': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>',
-    'Status Pages': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>',
-    'Workspace Connections': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>',
+    'Users & Permissions': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2m20 0v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/><circle cx="9" cy="7" r="4" stroke-width="2"/>',
     'Terraform Provider': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>',
     'CLI': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>',
+    'Monitor': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>',
+    'SLOs': '<circle cx="12" cy="12" r="9" stroke-width="2"/><circle cx="12" cy="12" r="5" stroke-width="2"/><circle cx="12" cy="12" r="1" stroke-width="2"/>',
+    'Incidents': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v4m0 4h.01M10.27 4a2 2 0 013.46 0l8 14A2 2 0 0120 21H4a2 2 0 01-1.73-3l8-14z"/>',
+    'On Call': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>',
+    'Runbooks': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v16m0-16C9 3 5 3 2 4v16c3-1 7-1 10 1m0-16c3-2 7-2 10-1v16c-3-1-7-1-10 1"/>',
+    'Workflows': '<rect x="9" y="2" width="6" height="6" rx="1" stroke-width="2"/><rect x="2" y="16" width="6" height="6" rx="1" stroke-width="2"/><rect x="16" y="16" width="6" height="6" rx="1" stroke-width="2"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m-7 4v-4h14v4"/>',
+    'Dashboards': '<rect x="3" y="3" width="7" height="7" rx="1" stroke-width="2"/><rect x="14" y="3" width="7" height="7" rx="1" stroke-width="2"/><rect x="3" y="14" width="7" height="7" rx="1" stroke-width="2"/><rect x="14" y="14" width="7" height="7" rx="1" stroke-width="2"/>',
+    'Status Pages': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>',
+    'Workspace Connections': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>',
+    'Integrations': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 3v5m8-5v5M6 8h12v4a6 6 0 01-12 0V8zm6 10v4"/>',
+    'Probe': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/>',
+    'Inventory': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3l9 5v8l-9 5-9-5V8l9-5zm0 10v8M3 8l9 5 9-5M7.5 5.5l9 5"/>',
+    'Telemetry': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>',
+    'Real User Monitoring': '<rect x="2" y="3" width="20" height="18" rx="2" stroke-width="2"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2 7h20M8 18a4 4 0 018 0"/><circle cx="12" cy="12" r="2" stroke-width="2"/>',
+    'AI': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>',
     'API Reference': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>',
     'Self Hosted': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/>'
 };
 var defaultIcon = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>';
-// Stable English category keys, in nav order. The localized `nav` array is
-// rendered in the same order, so we can look up the icon by index.
-var navKeys = [
-    'Introduction','Installation','Mobile & Desktop Apps','Configuration','Emails','Identity',
-    'Terraform Provider','CLI','Monitor','On Call','Status Pages','Workspace Connections','Probe',
-    'Telemetry','AI','API Reference','Self Hosted'
-];
 %>
 <nav class="docs-nav text-sm" data-docs-nav aria-label="<%= t('ui.documentation') %>">
     <ul role="list" class="space-y-px">
         <% for(var i=0; i<nav.length; i++) {
             var isActiveCategory = category && category.title === nav[i].title;
-            var catIcon = categoryIcons[navKeys[i]] || defaultIcon;
+            var catIcon = Object.prototype.hasOwnProperty.call(categoryIcons, nav[i].key) ? categoryIcons[nav[i].key] : defaultIcon;
             var listId = idPrefix + '-group-' + i;
         %>
         <li class="docs-nav__group">
@@ -63,7 +64,7 @@ var navKeys = [
                         %>
                         <li>
                             <a class="docs-nav__link <%= isActiveLink ? 'is-active' : '' %>"
-                               <%= isActiveLink ? 'aria-current="page" data-nav-active' : '' %>
+                               <%- isActiveLink ? 'aria-current="page" data-nav-active' : '' %>
                                href="<%- nav[i].links[j].url -%>">
                                 <%- nav[i].links[j].title -%>
                             </a>

--- a/App/Tests/FeatureSet/Docs/NavigationIcons.test.ts
+++ b/App/Tests/FeatureSet/Docs/NavigationIcons.test.ts
@@ -1,0 +1,353 @@
+import DocsNav, {
+  LocalizedNavGroup,
+  NavGroup,
+  NavLink,
+} from "../../../FeatureSet/Docs/Utils/Nav";
+import {
+  getLocalizedNav,
+  localizeDocsUrl,
+  makeT,
+  SUPPORTED_DOCS_LANGUAGE_CODES,
+  SUPPORTED_DOCS_LANGUAGES,
+} from "../../../FeatureSet/Docs/Utils/I18n";
+import { beforeAll, describe, expect, it } from "@jest/globals";
+import ejs from "ejs";
+import path from "path";
+
+const VIEWS_ROOT: string = path.resolve(
+  __dirname,
+  "../../../FeatureSet/Docs/Views",
+);
+
+interface RenderedGroup {
+  title: string;
+  icon: string;
+  svg: string;
+  button: string;
+}
+
+/*
+ * Read the actual rendered buttons, rather than inspecting the template's
+ * icon map. A complete map still renders the wrong icons if its lookup uses
+ * the group's position or translated title.
+ */
+function renderedGroups(html: string): RenderedGroup[] {
+  return Array.from(
+    html.matchAll(/<button\b[^>]*\bdata-nav-toggle\b[^>]*>[\s\S]*?<\/button>/g),
+    (match: RegExpMatchArray): RenderedGroup => {
+      const button: string = match[0];
+      const svg: RegExpMatchArray | null = button.match(
+        /<svg\b[^>]*class="docs-nav__icon"[^>]*>([\s\S]*?)<\/svg>/,
+      );
+      const title: RegExpMatchArray | null = button.match(
+        /<span\b[^>]*class="flex-1 truncate"[^>]*>([\s\S]*?)<\/span>/,
+      );
+      expect(svg).not.toBeNull();
+      expect(title).not.toBeNull();
+      return {
+        title: title![1]!.trim(),
+        icon: svg![1]!.trim(),
+        svg: svg![0],
+        button: button,
+      };
+    },
+  );
+}
+
+async function renderNav(
+  nav: LocalizedNavGroup[],
+  lang: string = "en",
+): Promise<string> {
+  return ejs.renderFile(path.join(VIEWS_ROOT, "Partials/Nav.ejs"), {
+    nav: nav,
+    category: null,
+    link: null,
+    t: makeT(lang),
+    lang: lang,
+  });
+}
+
+const UNKNOWN_GROUP: LocalizedNavGroup = {
+  key: "Future Documentation Category",
+  title: "Future Documentation Category",
+  links: [],
+};
+
+let englishNav: LocalizedNavGroup[];
+let englishGroups: RenderedGroup[];
+let iconsByKey: Map<string, string>;
+let fallbackIcon: string;
+
+beforeAll(async () => {
+  englishNav = getLocalizedNav("en");
+  englishGroups = renderedGroups(await renderNav(englishNav));
+  expect(englishGroups).toHaveLength(DocsNav.length);
+  iconsByKey = new Map(
+    englishNav.map((group: LocalizedNavGroup, index: number) => {
+      return [group.key, englishGroups[index]!.icon];
+    }),
+  );
+  fallbackIcon = renderedGroups(await renderNav([UNKNOWN_GROUP]))[0]!.icon;
+});
+
+describe("canonical navigation identity", () => {
+  it.each(SUPPORTED_DOCS_LANGUAGE_CODES)(
+    "preserves each category's English key while localizing %s",
+    (lang: string) => {
+      const localized: LocalizedNavGroup[] = getLocalizedNav(lang);
+      const t: ReturnType<typeof makeT> = makeT(lang);
+      expect(
+        localized.map((group: LocalizedNavGroup) => {
+          return group.key;
+        }),
+      ).toEqual(
+        DocsNav.map((group: NavGroup) => {
+          return group.title;
+        }),
+      );
+      localized.forEach((group: LocalizedNavGroup, index: number) => {
+        const canonical: NavGroup = DocsNav[index]!;
+        expect(group.title).toBe(t(`navGroups.${canonical.title}`));
+        expect(group.links).toEqual(
+          canonical.links.map((link: NavLink) => {
+            return {
+              title: t(`navLinks.${link.title}`),
+              url: localizeDocsUrl(link.url, lang),
+            };
+          }),
+        );
+      });
+    },
+  );
+
+  it("falls back to English without losing category identity", () => {
+    expect(getLocalizedNav("unsupported-language")).toEqual(englishNav);
+  });
+});
+
+describe("category icons", () => {
+  it.each(
+    DocsNav.map((group: NavGroup) => {
+      return group.title;
+    }),
+  )("renders a dedicated icon for %s", (key: string) => {
+    const icon: string | undefined = iconsByKey.get(key);
+    expect(icon).toBeDefined();
+    expect(icon).toMatch(
+      /<(?:path|circle|rect|line|polyline|polygon|ellipse)\b/,
+    );
+    expect(icon).not.toBe(fallbackIcon);
+  });
+
+  it("gives every current category a distinct icon", () => {
+    expect(
+      new Set(
+        englishGroups.map((group: RenderedGroup) => {
+          return group.icon;
+        }),
+      ).size,
+    ).toBe(DocsNav.length);
+  });
+
+  it.each([
+    ["CLI", "M8 9l3 3-3 3m5 0h3"],
+    ["Monitor", "M9 19v-6a2 2 0 00-2-2"],
+    ["On Call", "M3 5a2 2 0 012-2h3.28"],
+    ["Workspace Connections", "M13.828 10.172a4 4 0 00-5.656 0"],
+    ["API Reference", "M10 20l4-16m4 4l4 4-4 4"],
+    ["Self Hosted", "M5 12h14M5 12a2 2 0 01-2-2"],
+  ])(
+    "keeps the established icon associated with %s",
+    (key: string, pathData: string) => {
+      expect(iconsByKey.get(key)).toContain(pathData);
+    },
+  );
+
+  it("keeps icons decorative and compatible with both themes", () => {
+    for (const group of englishGroups) {
+      expect(group.svg).toContain('aria-hidden="true"');
+      expect(group.svg).toContain('viewBox="0 0 24 24"');
+      expect(group.svg).toContain('fill="none"');
+      expect(group.svg).toContain('stroke="currentColor"');
+    }
+  });
+
+  it.each(SUPPORTED_DOCS_LANGUAGE_CODES)(
+    "renders the same category icons with %s labels",
+    async (lang: string) => {
+      const nav: LocalizedNavGroup[] = getLocalizedNav(lang);
+      const groups: RenderedGroup[] = renderedGroups(
+        await renderNav(nav, lang),
+      );
+      expect(groups).toHaveLength(nav.length);
+      groups.forEach((group: RenderedGroup, index: number) => {
+        expect(group.title).toBe(nav[index]!.title);
+        expect(group.icon).toBe(iconsByKey.get(nav[index]!.key));
+      });
+    },
+  );
+});
+
+describe("navigation changes", () => {
+  it.each(["reversed", "filtered", "inserted category"])(
+    "keeps category icons stable when navigation is %s",
+    async (scenario: string) => {
+      let nav: LocalizedNavGroup[] = [...englishNav];
+      if (scenario === "reversed") {
+        nav.reverse();
+      } else if (scenario === "filtered") {
+        nav = nav.filter((_group: LocalizedNavGroup, index: number) => {
+          return index % 2 === 1;
+        });
+      } else {
+        nav.splice(3, 0, UNKNOWN_GROUP);
+      }
+      const groups: RenderedGroup[] = renderedGroups(await renderNav(nav));
+      expect(groups).toHaveLength(nav.length);
+      groups.forEach((group: RenderedGroup, index: number) => {
+        const category: LocalizedNavGroup = nav[index]!;
+        expect(group.title).toBe(category.title);
+        expect(group.icon).toBe(
+          category.key === UNKNOWN_GROUP.key
+            ? fallbackIcon
+            : iconsByKey.get(category.key),
+        );
+      });
+    },
+  );
+
+  it("uses the stable key even if translated category labels coincide", async () => {
+    const nav: LocalizedNavGroup[] = englishNav.map(
+      (group: LocalizedNavGroup) => {
+        return { ...group, title: "Shared translated label" };
+      },
+    );
+    const groups: RenderedGroup[] = renderedGroups(await renderNav(nav));
+    expect(
+      groups.map((group: RenderedGroup) => {
+        return group.icon;
+      }),
+    ).toEqual(
+      englishGroups.map((group: RenderedGroup) => {
+        return group.icon;
+      }),
+    );
+  });
+
+  it("uses the document fallback for an unknown key with a known title", async () => {
+    const groups: RenderedGroup[] = renderedGroups(
+      await renderNav([{ ...UNKNOWN_GROUP, title: "Monitor" }]),
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.icon).toContain("M9 12h6m-6 4h6");
+    expect(groups[0]!.icon).toBe(fallbackIcon);
+    expect(groups[0]!.icon).not.toBe(iconsByKey.get("Monitor"));
+  });
+
+  it("renders an empty navigation without inventing a category", async () => {
+    expect(renderedGroups(await renderNav([]))).toEqual([]);
+  });
+
+  it.each(["__proto__", "constructor", "toString"])(
+    "uses the fallback for the inherited object key %s",
+    async (key: string) => {
+      const groups: RenderedGroup[] = renderedGroups(
+        await renderNav([{ ...UNKNOWN_GROUP, key: key }]),
+      );
+      expect(groups).toHaveLength(1);
+      expect(groups[0]!.icon).toBe(fallbackIcon);
+    },
+  );
+});
+
+describe.each(["en", "de", "fa"])("full docs page in %s", (lang: string) => {
+  let html: string;
+  let nav: LocalizedNavGroup[];
+  let activeCategory: LocalizedNavGroup;
+  let navigationRegions: string[];
+
+  beforeAll(async () => {
+    nav = getLocalizedNav(lang);
+    activeCategory = nav.find((group: LocalizedNavGroup) => {
+      return group.key === "Telemetry";
+    })!;
+    html = await ejs.renderFile(path.join(VIEWS_ROOT, "Index.ejs"), {
+      nav: nav,
+      category: activeCategory,
+      link: activeCategory.links[0],
+      t: makeT(lang),
+      lang: lang,
+      supportedLanguages: SUPPORTED_DOCS_LANGUAGES,
+      content: "<p>Documentation page content.</p>",
+      githubPath: "telemetry/index",
+      currentPath: activeCategory.links[0]!.url,
+      enableGoogleTagManager: false,
+    });
+    navigationRegions = Array.from(
+      html.matchAll(/<nav\b[^>]*\bdata-docs-nav\b[^>]*>[\s\S]*?<\/nav>/g),
+      (match: RegExpMatchArray): string => {
+        return match[0];
+      },
+    );
+  });
+
+  it("renders matching dedicated icons in the mobile drawer and desktop sidebar", () => {
+    expect(navigationRegions).toHaveLength(2);
+    for (const region of navigationRegions) {
+      const groups: RenderedGroup[] = renderedGroups(region);
+      expect(groups).toHaveLength(nav.length);
+      for (const [index, group] of groups.entries()) {
+        expect(group.title).toBe(nav[index]!.title);
+        expect(group.icon).toBe(iconsByKey.get(nav[index]!.key));
+        expect(group.icon).not.toBe(fallbackIcon);
+      }
+    }
+  });
+
+  it("retains the active category and localized current-page link in both menus", () => {
+    for (const region of navigationRegions) {
+      const activeGroups: RenderedGroup[] = renderedGroups(region).filter(
+        (group: RenderedGroup): boolean => {
+          return group.button.includes('aria-expanded="true"');
+        },
+      );
+      expect(activeGroups).toHaveLength(1);
+      expect(activeGroups[0]!.title).toBe(activeCategory.title);
+      expect(activeGroups[0]!.button).toContain("is-current");
+
+      const activeLinks: RegExpMatchArray[] = Array.from(
+        region.matchAll(/<a\b[^>]*aria-current="page"[^>]*>[\s\S]*?<\/a>/g),
+      );
+      expect(activeLinks).toHaveLength(1);
+      expect(activeLinks[0]![0]).toContain("is-active");
+      expect(activeLinks[0]![0]).toContain("data-nav-active");
+      expect(activeLinks[0]![0]).toContain(
+        `href="${activeCategory.links[0]!.url}"`,
+      );
+      expect(activeLinks[0]![0]).toContain(activeCategory.links[0]!.title);
+    }
+  });
+
+  it("keeps each category toggle connected to a unique list", () => {
+    const controls: string[] = renderedGroups(html).map(
+      (group: RenderedGroup) => {
+        return group.button.match(/aria-controls="([^"]+)"/)![1]!;
+      },
+    );
+    expect(controls).toHaveLength(nav.length * 2);
+    expect(new Set(controls).size).toBe(controls.length);
+    expect(
+      controls.some((id: string) => {
+        return id.startsWith("drawer-group-");
+      }),
+    ).toBe(true);
+    expect(
+      controls.some((id: string) => {
+        return id.startsWith("sidebar-group-");
+      }),
+    ).toBe(true);
+    for (const id of controls) {
+      expect(html.split(`id="${id}"`)).toHaveLength(2);
+    }
+  });
+});

--- a/E2E/Tests/Docs/NavigationIcons.spec.ts
+++ b/E2E/Tests/Docs/NavigationIcons.spec.ts
@@ -1,0 +1,226 @@
+import { BASE_URL } from "../../Config";
+import DocsNav, { NavGroup } from "../../../App/FeatureSet/Docs/Utils/Nav";
+import English from "../../../App/FeatureSet/Docs/Locales/en.json";
+import French from "../../../App/FeatureSet/Docs/Locales/fr.json";
+import { Locator, Page, expect, test } from "@playwright/test";
+import URL from "Common/Types/API/URL";
+
+interface DocsLocale {
+  ui: {
+    documentation: string;
+    openNavigation: string;
+    closeNavigation: string;
+    switchLanguage: string;
+    toggleTheme: string;
+  };
+  navGroups: { [key: string]: string };
+  navLinks: { [key: string]: string };
+}
+
+interface ToggleTarget {
+  title: string;
+  controls: string | null;
+  matchingLists: number;
+  insideGroup: boolean;
+}
+
+const locales: { [key: string]: DocsLocale } = { en: English, fr: French };
+
+function docsUrl(language: string, path: string): string {
+  return URL.fromString(BASE_URL.toString())
+    .addRoute(`/docs/${language}/${path}`)
+    .toString();
+}
+
+async function iconShapes(nav: Locator): Promise<string[]> {
+  return nav.locator(".docs-nav__icon").evaluateAll((icons: Element[]) => {
+    return icons.map((icon: Element): string => {
+      return icon.innerHTML.replace(/\s+/g, " ").trim();
+    });
+  });
+}
+
+async function expectNavigation(
+  page: Page,
+  nav: Locator,
+  locale: DocsLocale,
+): Promise<string[]> {
+  await expect(nav).toBeVisible();
+  await expect(nav.getByRole("button")).toHaveCount(DocsNav.length);
+  await expect(nav.getByRole("button")).toHaveText(
+    DocsNav.map((group: NavGroup): string => {
+      return locale.navGroups[group.title] || group.title;
+    }),
+  );
+  await expect(nav.locator('.docs-nav__icon[aria-hidden="true"]')).toHaveCount(
+    DocsNav.length,
+  );
+
+  const shapes: string[] = await iconShapes(nav);
+  expect(shapes).toHaveLength(DocsNav.length);
+  expect(
+    shapes.every((shape: string): boolean => {
+      return shape.length > 0;
+    }),
+  ).toBe(true);
+  // The old positional lookup reused the same fallback for the final groups.
+  expect(new Set(shapes).size).toBe(DocsNav.length);
+
+  const targets: ToggleTarget[] = await page
+    .locator("[data-docs-nav] [data-nav-toggle]")
+    .evaluateAll((buttons: Element[]): ToggleTarget[] => {
+      const lists: Element[] = Array.from(
+        document.querySelectorAll(".docs-nav__links[id]"),
+      );
+      return buttons.map((button: Element): ToggleTarget => {
+        const controls: string | null = button.getAttribute("aria-controls");
+        const matchingLists: Element[] = lists.filter(
+          (list: Element): boolean => {
+            return list.id === controls;
+          },
+        );
+        return {
+          title: button.textContent?.trim() || "",
+          controls,
+          matchingLists: matchingLists.length,
+          insideGroup:
+            matchingLists.length === 1 &&
+            matchingLists[0]?.parentElement === button.parentElement,
+        };
+      });
+    });
+
+  expect(targets).toHaveLength(DocsNav.length * 2);
+  for (const target of targets) {
+    expect(target.controls, target.title).toBeTruthy();
+    expect(target.matchingLists, target.title).toBe(1);
+    expect(target.insideGroup, target.title).toBe(true);
+  }
+  return shapes;
+}
+
+test.describe("Docs: category icons", () => {
+  test.use({ colorScheme: "light" });
+
+  for (const language of ["en", "fr"]) {
+    for (const mobile of [false, true]) {
+      test(`${language} ${mobile ? "mobile drawer" : "desktop sidebar"} keeps distinct icons through navigation`, async ({
+        page,
+      }: {
+        page: Page;
+      }) => {
+        const locale: DocsLocale = locales[language]!;
+        await page.setViewportSize(
+          mobile ? { width: 390, height: 844 } : { width: 1440, height: 1000 },
+        );
+        const response: Awaited<ReturnType<Page["goto"]>> = await page.goto(
+          docsUrl("en", "introduction/getting-started"),
+        );
+        expect(response?.status()).toBe(200);
+
+        const sidebar: Locator = page.locator(
+          "#docs-sidebar-scroll [data-docs-nav]",
+        );
+        const drawer: Locator = page.locator("#docs-mobile-drawer");
+        const drawerNav: Locator = drawer.locator("[data-docs-nav]");
+        const englishShapes: string[] = await iconShapes(sidebar);
+
+        if (language !== "en") {
+          if (mobile) {
+            await page
+              .getByRole("button", { name: English.ui.openNavigation })
+              .click();
+          }
+          await (mobile ? drawer : page)
+            .getByRole("combobox", { name: English.ui.switchLanguage })
+            .selectOption(language);
+          await expect(page).toHaveURL(
+            docsUrl(language, "introduction/getting-started"),
+          );
+          await page.waitForLoadState("load");
+        }
+        await expect(page.locator("html")).toHaveAttribute("lang", language);
+
+        const openNavigation: Locator = page.getByRole("button", {
+          name: locale.ui.openNavigation,
+        });
+        if (mobile) {
+          await expect(openNavigation).toHaveAttribute(
+            "aria-controls",
+            "docs-mobile-drawer",
+          );
+          await openNavigation.click();
+          await expect(openNavigation).toHaveAttribute("aria-expanded", "true");
+          await expect(drawer).toHaveRole("dialog");
+          await expect(drawer).toHaveAccessibleName(locale.ui.documentation);
+          await expect(
+            drawer.getByRole("button", { name: locale.ui.closeNavigation }),
+          ).toBeFocused();
+        }
+
+        const nav: Locator = mobile ? drawerNav : sidebar;
+        const shapes: string[] = await expectNavigation(page, nav, locale);
+        expect(shapes).toEqual(englishShapes);
+        expect(await iconShapes(mobile ? sidebar : drawerNav)).toEqual(shapes);
+
+        await expect(
+          nav.getByRole("button", {
+            name: locale.navGroups["Introduction"]!,
+            exact: true,
+          }),
+        ).toHaveAttribute("aria-expanded", "true");
+        await expect(
+          nav.locator(
+            `a[href="/docs/${language}/introduction/getting-started"]`,
+          ),
+        ).toHaveAttribute("aria-current", "page");
+
+        // Exercise a category at the bottom, where the repeated icons appeared.
+        const selfHosted: Locator = nav.getByRole("button", {
+          name: locale.navGroups["Self Hosted"]!,
+          exact: true,
+        });
+        await selfHosted.click();
+        await expect(selfHosted).toHaveAttribute("aria-expanded", "true");
+        await nav
+          .getByRole("link", {
+            name: locale.navLinks["Slack Integration"]!,
+            exact: true,
+          })
+          .click();
+        await expect(page).toHaveURL(
+          docsUrl(language, "self-hosted/slack-integration"),
+        );
+        await page.waitForLoadState("load");
+
+        if (mobile) {
+          await openNavigation.click();
+        }
+        await expect(selfHosted).toHaveAttribute("aria-expanded", "true");
+        await expect(
+          nav.getByRole("link", {
+            name: locale.navLinks["Slack Integration"]!,
+            exact: true,
+          }),
+        ).toHaveAttribute("aria-current", "page");
+        expect(await iconShapes(nav)).toEqual(shapes);
+
+        if (mobile) {
+          await page.keyboard.press("Escape");
+          await expect(drawer).toBeHidden();
+          await expect(openNavigation).toHaveAttribute(
+            "aria-expanded",
+            "false",
+          );
+          await expect(openNavigation).toBeFocused();
+        } else {
+          await page
+            .getByRole("button", { name: locale.ui.toggleTheme })
+            .click();
+          await expect(page.locator("html")).toHaveClass(/dark/);
+          expect(await iconShapes(nav)).toEqual(shapes);
+        }
+      });
+    }
+  }
+});


### PR DESCRIPTION
The docs sidebar used an outdated 17-entry positional icon lookup for 26 navigation categories. That shifted icons onto the wrong labels and gave the final nine categories the same document icon.

Preserve the canonical category key through localization, use it for icon lookup, and provide a distinct icon for every current category. Also correct the active-link HTML so aria-current="page" is emitted as a valid attribute.

Validation:
- 87 Jest regression/rendering tests pass, covering all 26 categories, all 17 locales, reordered/filtered/inserted categories, safe fallback, and desktop/mobile layouts.
- Confirmed six semantic icon regression cases fail against the original template.
- Four Chromium and four Firefox browser scenarios verified across English/French and desktop/mobile, including language switching, active links, and theme/drawer behavior. The Firefox English mobile case passed unchanged on rerun after a timeout while closing the drawer.
- Focused strict TypeScript compilation of the changed docs code and tests passes; full E2E `npm run compile` passes.
- Repository lint rules pass for all changed TypeScript files; EJS syntax validation and `git diff --check` pass. Root `npm run fix` was run, with final lint validation scoped to the changed files.

Browser checks use an isolated server with the real docs routes, templates, content, and shared assets. The configured local host returned 502. Full App compilation was attempted but did not complete locally under the current machine load.
