### PR TITLE
Fix security settings layout and add self-service two-factor controls

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/TwoFactorAuth/TwoFactorStatus.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/TwoFactorAuth/TwoFactorStatus.tsx
@@ -16,7 +16,9 @@ const TwoFactorStatus: FunctionComponent = (): ReactElement => {
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
   const [loadError, setLoadError] = React.useState<string>("");
   const [refresh, setRefresh] = React.useState<number>(0);
-  const [showEnableModal, setShowEnableModal] = React.useState<boolean>(false);
+  const [pendingStatus, setPendingStatus] = React.useState<boolean | null>(
+    null,
+  );
   const [isSaving, setIsSaving] = React.useState<boolean>(false);
   const [saveError, setSaveError] = React.useState<string>("");
   const saving: React.MutableRefObject<boolean> = React.useRef<boolean>(false);
@@ -61,8 +63,8 @@ const TwoFactorStatus: FunctionComponent = (): ReactElement => {
     };
   }, [refresh]);
 
-  const enable: () => Promise<void> = async (): Promise<void> => {
-    if (saving.current) {
+  const updateStatus: () => Promise<void> = async (): Promise<void> => {
+    if (saving.current || pendingStatus === null) {
       return;
     }
 
@@ -73,10 +75,10 @@ const TwoFactorStatus: FunctionComponent = (): ReactElement => {
       await ModelAPI.updateById<User>({
         modelType: User,
         id: UserUtil.getUserId(),
-        data: { enableTwoFactorAuth: true },
+        data: { enableTwoFactorAuth: pendingStatus },
       });
-      setIsEnabled(true);
-      setShowEnableModal(false);
+      setIsEnabled(pendingStatus);
+      setPendingStatus(null);
     } catch (error) {
       setSaveError(API.getFriendlyMessage(error));
     } finally {
@@ -109,15 +111,17 @@ const TwoFactorStatus: FunctionComponent = (): ReactElement => {
           ) : undefined
         }
         buttons={
-          !isLoading && !loadError && isEnabled === false
+          !isLoading && !loadError && isEnabled !== null
             ? [
                 {
-                  title: "Enable two-factor authentication",
-                  icon: IconProp.ShieldCheck,
+                  title: isEnabled
+                    ? "Turn off two-factor authentication"
+                    : "Enable two-factor authentication",
+                  icon: isEnabled ? IconProp.Lock : IconProp.ShieldCheck,
                   buttonStyle: ButtonStyleType.NORMAL,
                   onClick: () => {
                     setSaveError("");
-                    setShowEnableModal(true);
+                    setPendingStatus(!isEnabled);
                   },
                 },
               ]
@@ -148,17 +152,32 @@ const TwoFactorStatus: FunctionComponent = (): ReactElement => {
             />
             <p className="text-sm leading-6 text-gray-600">
               {isEnabled
-                ? "Use an authenticator app or security key for your second step. An administrator can turn this off for your account."
+                ? "Use an authenticator app or security key for your second step."
                 : "Set up an authenticator app or security key below, then enable two-factor authentication for your account."}
             </p>
           </div>
         )}
       </Card>
-      {showEnableModal && (
+      {pendingStatus !== null && (
         <ConfirmModal
-          title="Enable two-factor authentication?"
-          description="You will need an authenticator app or security key when signing in with a password. If you have not added one yet, you will finish setup at your next sign-in. Once enabled, only an administrator can turn it off."
-          submitButtonText="Enable two-factor authentication"
+          title={
+            pendingStatus
+              ? "Enable two-factor authentication?"
+              : "Turn off two-factor authentication?"
+          }
+          description={
+            pendingStatus
+              ? "You will need an authenticator app or security key when signing in with a password. If you have not added one yet, you will finish setup at your next sign-in."
+              : "You will no longer be asked for a second step when signing in with a password. Your authenticator apps and security keys will stay saved so you can enable it again."
+          }
+          submitButtonText={
+            pendingStatus
+              ? "Enable two-factor authentication"
+              : "Turn off two-factor authentication"
+          }
+          submitButtonType={
+            pendingStatus ? ButtonStyleType.PRIMARY : ButtonStyleType.DANGER
+          }
           isLoading={isSaving}
           disableSubmitButton={isSaving}
           error={saveError || undefined}
@@ -166,11 +185,11 @@ const TwoFactorStatus: FunctionComponent = (): ReactElement => {
             isSaving
               ? undefined
               : () => {
-                  setShowEnableModal(false);
+                  setPendingStatus(null);
                 }
           }
           onSubmit={() => {
-            void enable();
+            void updateStatus();
           }}
         />
       )}

--- a/App/FeatureSet/Dashboard/src/Components/TwoFactorAuth/WebAuthnCredentials.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/TwoFactorAuth/WebAuthnCredentials.tsx
@@ -172,7 +172,7 @@ const WebAuthnCredentials: FunctionComponent<ComponentProps> = (
       setWebAuthnRegistrationSuccess(
         isRegisteringPasskey
           ? "Passkey added. Use it the next time you sign in."
-          : "Security key added. It is ready to use for two-factor authentication.",
+          : null,
       );
       setTableRefreshToggle((previous: string) => {
         return String(Number(previous) + 1);

--- a/App/FeatureSet/Dashboard/src/Components/TwoFactorAuth/WebAuthnCredentials.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/TwoFactorAuth/WebAuthnCredentials.tsx
@@ -224,7 +224,6 @@ const WebAuthnCredentials: FunctionComponent<ComponentProps> = (
           // Credentials created before purposes were recorded stay manageable.
           isPasskey: new EqualToOrNull(props.isPasskey ? "true" : "false"),
         }}
-        selectMoreFields={{ isPasskey: true }}
         onFetchSuccess={(_items: Array<UserWebAuthn>, totalCount: number) => {
           setCredentialCount(totalCount);
         }}
@@ -305,11 +304,6 @@ const WebAuthnCredentials: FunctionComponent<ComponentProps> = (
                   </span>
                   <div className="min-w-0">
                     <p className="font-medium text-gray-900">{item.name}</p>
-                    {item.isPasskey === null || item.isPasskey === undefined ? (
-                      <span className="mt-1 inline-flex rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
-                        Existing credential
-                      </span>
-                    ) : null}
                   </div>
                 </div>
               );

--- a/App/FeatureSet/Dashboard/src/Components/TwoFactorAuth/WebAuthnCredentials.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/TwoFactorAuth/WebAuthnCredentials.tsx
@@ -35,8 +35,6 @@ const WebAuthnCredentials: FunctionComponent<ComponentProps> = (
   const [credentialCount, setCredentialCount] = React.useState<number | null>(
     null,
   );
-  const [hasExistingCredentials, setHasExistingCredentials] =
-    React.useState<boolean>(false);
   const [tableRefreshToggle, setTableRefreshToggle] =
     React.useState<string>("0");
 
@@ -227,13 +225,8 @@ const WebAuthnCredentials: FunctionComponent<ComponentProps> = (
           isPasskey: new EqualToOrNull(props.isPasskey ? "true" : "false"),
         }}
         selectMoreFields={{ isPasskey: true }}
-        onFetchSuccess={(items: Array<UserWebAuthn>, totalCount: number) => {
+        onFetchSuccess={(_items: Array<UserWebAuthn>, totalCount: number) => {
           setCredentialCount(totalCount);
-          setHasExistingCredentials(
-            items.some((item: UserWebAuthn) => {
-              return item.isPasskey === null || item.isPasskey === undefined;
-            }),
-          );
         }}
         isEditable={true}
         editButtonText="Rename"
@@ -257,15 +250,6 @@ const WebAuthnCredentials: FunctionComponent<ComponentProps> = (
             },
           ],
         }}
-        topContent={
-          hasExistingCredentials ? (
-            <p className="border-b border-gray-100 bg-gray-50 px-6 py-3 text-xs leading-5 text-gray-500">
-              Existing credentials appear on both security pages because their
-              original setup type was not recorded. They continue to work as
-              before.
-            </p>
-          ) : undefined
-        }
         noItemsMessage={
           <div className="px-4 py-7 text-center">
             <span className="mx-auto flex h-11 w-11 items-center justify-center rounded-full bg-gray-100 text-gray-500">

--- a/App/FeatureSet/Dashboard/src/Pages/Global/UserProfile/Passkeys.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Global/UserProfile/Passkeys.tsx
@@ -36,7 +36,7 @@ const Passkeys: FunctionComponent<PageComponentProps> = (): ReactElement => {
       ]}
       sideMenu={<SideMenu />}
     >
-      <div className="max-w-6xl">
+      <div className="w-full min-w-0">
         <WebAuthnCredentials
           isPasskey={true}
           onBackupCodes={setEnrolmentBackupCodes}

--- a/App/FeatureSet/Dashboard/src/Pages/Global/UserProfile/TwoFactorAuth.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Global/UserProfile/TwoFactorAuth.tsx
@@ -198,7 +198,7 @@ const TwoFactorAuth: FunctionComponent<
       ]}
       sideMenu={<SideMenu />}
     >
-      <div className="max-w-6xl">
+      <div className="w-full min-w-0">
         <TwoFactorStatus />
         <WebAuthnCredentials
           isPasskey={false}

--- a/Common/Server/Services/UserService.ts
+++ b/Common/Server/Services/UserService.ts
@@ -8,6 +8,7 @@ import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
 import CreateBy from "../Types/Database/CreateBy";
 import UpdateBy from "../Types/Database/UpdateBy";
 import DeleteBy from "../Types/Database/DeleteBy";
+import OwnerOnlyColumnPermission from "../Types/Database/Permissions/OwnerOnlyColumnPermission";
 import Attribution from "../Utils/Attribution";
 import logger, { LogAttributes } from "../Utils/Logger";
 import DatabaseService from "./DatabaseService";
@@ -336,6 +337,14 @@ export class Service extends DatabaseService<Model> {
   protected override async onBeforeUpdate(
     updateBy: UpdateBy<Model>,
   ): Promise<OnUpdate<Model>> {
+    // Reject values that could bypass the exact-false ownership check below.
+    if (
+      updateBy.data.enableTwoFactorAuth !== undefined &&
+      typeof updateBy.data.enableTwoFactorAuth !== "boolean"
+    ) {
+      throw new BadDataException("enableTwoFactorAuth must be a boolean.");
+    }
+
     let carryForward: Array<Model> = [];
 
     if (updateBy.data.password || updateBy.data.email) {
@@ -361,58 +370,22 @@ export class Service extends DatabaseService<Model> {
     }
 
     /*
-     * There used to be a guard here refusing to set `enableTwoFactorAuth` on
-     * an account with no verified authenticator, on the grounds that doing so
-     * locked the user out: login demanded a second factor, found none, and
-     * said "contact your admin".
-     *
-     * That is no longer true, and the guard was the single thing standing in
-     * the way of the feature it appeared to protect. Login now sends an
-     * account in that state through ENROLMENT -- a QR code and a code to type
-     * back -- rather than refusing it (see App/FeatureSet/Identity/API/
-     * Authentication.ts). "Required, nothing set up yet" is therefore an
-     * ordinary, recoverable state, and it is exactly the state an admin
-     * creates on purpose when they mandate two factor auth for somebody who
-     * has never used it.
-     *
-     * Keeping the guard would have meant an admin could only require two
-     * factor auth from users who had already volunteered for it, which is the
-     * opposite of what a mandate is for.
-     *
-     * What replaces it is the guard below, which protects the opposite
-     * direction.
+     * Users may turn off two factor authentication for their own account.
+     * This hook runs before row scoping, so require an exact owner predicate.
+     * Changes to other accounts still use the master-admin endpoints, whose
+     * root writes retain session revocation when enabling the requirement.
      */
-
-    /*
-     * TURNING THE REQUIREMENT OFF IS A MASTER-ADMIN ACTION, NOT A USER ONE.
-     *
-     * `enableTwoFactorAuth` carries `update: [Permission.CurrentUser]` and the
-     * User table's row ACL scopes updates to the caller's own id, so without
-     * this every signed-in user can clear their own flag with an ordinary
-     * `PUT /user/<their own id>` -- and the product ships the button that does
-     * it, at Dashboard > Profile > Two Factor Authentication.
-     *
-     * That makes an admin mandate self-undoing. The admin requires two factor
-     * auth, the user is marched through enrolment at their next sign-in, and
-     * then, from the session they just earned, they switch it straight back
-     * off and delete the factor. The account is password-only again and the
-     * Authentication page reports the mandate as simply absent.
-     *
-     * So: anybody may turn the requirement ON for themselves -- self-service
-     * enrolment is a feature and taking it away would help nobody -- but only
-     * a root caller may turn it OFF. The one root caller is
-     * `setTwoFactorAuthRequired` below, reached through the master-admin
-     * endpoint. A user who wants two factor auth removed now has to ask an
-     * administrator, which is the point of the feature.
-     *
-     * Keyed on `isRoot` rather than on a master-admin check because a master
-     * admin editing their OWN row through the CRUD API is still that user, and
-     * the flag should move through the endpoint that also revokes sessions
-     * either way.
-     */
-    if (updateBy.data.enableTwoFactorAuth === false && !updateBy.props.isRoot) {
+    if (
+      updateBy.data.enableTwoFactorAuth === false &&
+      !updateBy.props.isRoot &&
+      !OwnerOnlyColumnPermission.isQueryPinnedToCurrentUser(
+        Model,
+        updateBy.query,
+        updateBy.props,
+      )
+    ) {
       throw new BadDataException(
-        "Only an administrator can turn off two factor authentication for this account.",
+        "You can only turn off two factor authentication for your own account.",
       );
     }
 

--- a/Common/Tests/App/Dashboard/PasskeySettings.test.tsx
+++ b/Common/Tests/App/Dashboard/PasskeySettings.test.tsx
@@ -373,13 +373,31 @@ describe("Passkey settings registration", () => {
     },
   );
 
-  test("shows a concise empty state for passkeys", () => {
-    renderPage();
-    expect(screen.getByText("No passkeys added yet.")).toBeVisible();
-    expect(
-      screen.queryByText("No passkeys or security keys found."),
-    ).not.toBeInTheDocument();
-  });
+  test.each([true, false])(
+    "shows a concise empty state without the legacy credential notice: passkeys %s",
+    async (isPasskey: boolean) => {
+      mockPasskeyTable([]);
+      renderPage(isPasskey);
+      expect(
+        await screen.findByText(
+          isPasskey ? "No passkeys added yet." : "No security keys added yet.",
+        ),
+      ).toBeVisible();
+      expect(
+        screen.queryByText("No passkeys or security keys found."),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          /Existing credentials appear on both security pages/,
+        ),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", {
+          name: isPasskey ? "Add Passkey" : "Add Security Key",
+        }),
+      ).toBeEnabled();
+    },
+  );
 
   test.each([false, true])(
     "uses the shared table header and standard add action when a saved passkey is present: %s",
@@ -448,25 +466,68 @@ describe("Passkey settings registration", () => {
   );
 
   test.each([true, false])(
-    "keeps existing credentials manageable when their original purpose is unknown: passkeys %s",
+    "omits the legacy notice while keeping mixed saved credentials manageable: passkeys %s",
     async (isPasskey: boolean) => {
       const storedKey: UserWebAuthn = new UserWebAuthn();
       storedKey._id = "44444444-4444-4444-8444-444444444444";
       storedKey.name = "Existing device";
       storedKey.isVerified = true;
-      mockPasskeyTable([storedKey]);
+      const olderKey: UserWebAuthn = UserWebAuthn.fromJSONObject(
+        {
+          _id: "55555555-5555-4555-8555-555555555555",
+          name: "Older device",
+          isVerified: true,
+          isPasskey: null,
+        },
+        UserWebAuthn,
+      );
+      const currentKey: UserWebAuthn = new UserWebAuthn();
+      currentKey._id = "66666666-6666-4666-8666-666666666666";
+      currentKey.name = "New device";
+      currentKey.isVerified = false;
+      currentKey.isPasskey = isPasskey;
+      mockPasskeyTable([storedKey, olderKey, currentKey]);
       renderPage(isPasskey);
       expect(await screen.findByText("Existing device")).toBeVisible();
-      expect(screen.getByText("Existing credential")).toBeVisible();
       expect(
-        screen.getByText(/Existing credentials appear on both security pages/),
-      ).toBeVisible();
+        screen.queryByText(
+          /Existing credentials appear on both security pages/,
+        ),
+      ).not.toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "Rename", exact: true }),
+        screen.queryByText(/They continue to work as before/),
+      ).not.toBeInTheDocument();
+
+      for (const name of ["Existing device", "Older device", "New device"]) {
+        const row: HTMLElement = screen.getByRole("row", {
+          name: new RegExp(name),
+        });
+        expect(within(row).getByText(name)).toBeVisible();
+        expect(
+          within(row).getByRole("button", { name: "Rename", exact: true }),
+        ).toBeEnabled();
+        expect(
+          within(row).getByRole("button", { name: "Delete", exact: true }),
+        ).toBeEnabled();
+        if (name === "New device") {
+          expect(
+            within(row).queryByText("Existing credential"),
+          ).not.toBeInTheDocument();
+          expect(within(row).getByText("Setup incomplete")).toBeVisible();
+        } else {
+          expect(within(row).getByText("Existing credential")).toBeVisible();
+          expect(within(row).getByText("Ready")).toBeVisible();
+        }
+      }
+      expect(
+        screen.getByRole("button", {
+          name: isPasskey ? "Add Passkey" : "Add Security Key",
+        }),
       ).toBeEnabled();
-      expect(
-        screen.getByRole("button", { name: "Delete", exact: true }),
-      ).toBeEnabled();
+      expect(mockCredentialTableProps?.query).toEqual({
+        userId: UserUtil.getUserId(),
+        isPasskey: new EqualToOrNull(isPasskey ? "true" : "false"),
+      });
     },
   );
 

--- a/Common/Tests/App/Dashboard/PasskeySettings.test.tsx
+++ b/Common/Tests/App/Dashboard/PasskeySettings.test.tsx
@@ -466,7 +466,7 @@ describe("Passkey settings registration", () => {
   );
 
   test.each([true, false])(
-    "omits the legacy notice while keeping mixed saved credentials manageable: passkeys %s",
+    "omits legacy notices and badges while keeping mixed saved credentials manageable: passkeys %s",
     async (isPasskey: boolean) => {
       const storedKey: UserWebAuthn = new UserWebAuthn();
       storedKey._id = "44444444-4444-4444-8444-444444444444";
@@ -486,7 +486,11 @@ describe("Passkey settings registration", () => {
       currentKey.name = "New device";
       currentKey.isVerified = false;
       currentKey.isPasskey = isPasskey;
-      mockPasskeyTable([storedKey, olderKey, currentKey]);
+      const namedKey: UserWebAuthn = new UserWebAuthn();
+      namedKey._id = "77777777-7777-4777-8777-777777777777";
+      namedKey.name = "Existing credential";
+      namedKey.isVerified = true;
+      mockPasskeyTable([storedKey, olderKey, currentKey, namedKey]);
       renderPage(isPasskey);
       expect(await screen.findByText("Existing device")).toBeVisible();
       expect(
@@ -498,7 +502,12 @@ describe("Passkey settings registration", () => {
         screen.queryByText(/They continue to work as before/),
       ).not.toBeInTheDocument();
 
-      for (const name of ["Existing device", "Older device", "New device"]) {
+      for (const name of [
+        "Existing device",
+        "Older device",
+        "New device",
+        "Existing credential",
+      ]) {
         const row: HTMLElement = screen.getByRole("row", {
           name: new RegExp(name),
         });
@@ -509,16 +518,20 @@ describe("Passkey settings registration", () => {
         expect(
           within(row).getByRole("button", { name: "Delete", exact: true }),
         ).toBeEnabled();
-        if (name === "New device") {
+        if (name !== "Existing credential") {
           expect(
             within(row).queryByText("Existing credential"),
           ).not.toBeInTheDocument();
+        }
+        if (name === "New device") {
           expect(within(row).getByText("Setup incomplete")).toBeVisible();
         } else {
-          expect(within(row).getByText("Existing credential")).toBeVisible();
           expect(within(row).getByText("Ready")).toBeVisible();
         }
       }
+      expect(
+        screen.getAllByText("Existing credential", { exact: true }),
+      ).toHaveLength(1);
       expect(
         screen.getByRole("button", {
           name: isPasskey ? "Add Passkey" : "Add Security Key",

--- a/Common/Tests/App/Dashboard/PasskeySettings.test.tsx
+++ b/Common/Tests/App/Dashboard/PasskeySettings.test.tsx
@@ -602,16 +602,37 @@ describe("Passkey settings registration", () => {
     ).toHaveTextContent("Passkey added. Use it the next time you sign in.");
   });
 
-  test("registers a security key as a second factor from the two-factor page", async () => {
+  test("registers security keys, closes registration and refreshes the list without a success banner", async () => {
     renderPage(false);
-    await register(false);
-    expect(posted[0]?.data).toEqual({ isPasskey: false });
-    expect(posted[1]?.data).toMatchObject({ name: "My laptop" });
-    expect(
-      screen.getByTestId("passkey-registration-success"),
-    ).toHaveTextContent(
-      "Security key added. It is ready to use for two-factor authentication.",
-    );
+    for (const registrationNumber of [1, 2]) {
+      const refreshBefore: string | null = screen
+        .getByTestId("security-keys-table")
+        .getAttribute("data-refresh");
+      await register(false);
+
+      expect(posted).toHaveLength(registrationNumber * 2);
+      expect(posted[(registrationNumber - 1) * 2]?.data).toEqual({
+        isPasskey: false,
+      });
+      expect(posted[registrationNumber * 2 - 1]?.data).toMatchObject({
+        name: "My laptop",
+      });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("security-keys-table").getAttribute("data-refresh"),
+      ).not.toBe(refreshBefore);
+      expect(
+        screen.queryByTestId("passkey-registration-success"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          "Security key added. It is ready to use for two-factor authentication.",
+        ),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Add Security Key" }),
+      ).toBeEnabled();
+    }
   });
 
   test.each([true, false])(
@@ -623,6 +644,16 @@ describe("Passkey settings registration", () => {
       expect(screen.getByTestId("enrolment-backup-codes")).toHaveTextContent(
         "ABCDE-12345,FGHIJ-67890",
       );
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      if (isPasskey) {
+        expect(
+          screen.getByTestId("passkey-registration-success"),
+        ).toHaveTextContent("Passkey added. Use it the next time you sign in.");
+      } else {
+        expect(
+          screen.queryByTestId("passkey-registration-success"),
+        ).not.toBeInTheDocument();
+      }
     },
   );
 
@@ -658,6 +689,11 @@ describe("Passkey settings registration", () => {
       });
       expect(posted).toHaveLength(3);
       expect(posted[2]?.data).toMatchObject({ name: "My laptop" });
+      if (!isPasskey) {
+        expect(
+          screen.queryByTestId("passkey-registration-success"),
+        ).not.toBeInTheDocument();
+      }
     },
   );
 
@@ -811,49 +847,65 @@ describe("Passkey settings registration", () => {
     ).toHaveTextContent("Passkey added");
   });
 
-  test("keeps verification visible until saving finishes and preserves returned recovery codes", async () => {
-    let finish: ((value: HTTPResponse<JSONObject>) => void) | undefined;
-    jest
-      .spyOn(API, "post")
-      .mockResolvedValueOnce(
-        new HTTPResponse<JSONObject>(200, { options: registrationOptions }, {}),
-      )
-      .mockImplementationOnce(() => {
-        return new Promise<HTTPResponse<JSONObject>>(
-          (resolve: (value: HTTPResponse<JSONObject>) => void) => {
-            finish = resolve;
-          },
+  test.each([true, false])(
+    "keeps verification visible until saving finishes and preserves returned recovery codes: passkey %s",
+    async (isPasskey: boolean) => {
+      let finish: ((value: HTTPResponse<JSONObject>) => void) | undefined;
+      jest
+        .spyOn(API, "post")
+        .mockResolvedValueOnce(
+          new HTTPResponse<JSONObject>(
+            200,
+            { options: registrationOptions },
+            {},
+          ),
+        )
+        .mockImplementationOnce(() => {
+          return new Promise<HTTPResponse<JSONObject>>(
+            (resolve: (value: HTTPResponse<JSONObject>) => void) => {
+              finish = resolve;
+            },
+          );
+        });
+      renderPage(isPasskey);
+      await register(isPasskey);
+      expect(screen.getByRole("status")).toHaveTextContent("Saving your key");
+      expect(
+        screen.queryByRole("button", { name: "Cancel" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Close" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("passkey-registration-success"),
+      ).not.toBeInTheDocument();
+      await keyboard("{Escape}");
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      await act(async () => {
+        finish!(
+          new HTTPResponse<JSONObject>(
+            200,
+            { verified: true, backupCodes: ["ABCDE-12345"] },
+            {},
+          ),
         );
       });
-    renderPage();
-    await register();
-    expect(screen.getByRole("status")).toHaveTextContent("Saving your key");
-    expect(
-      screen.queryByRole("button", { name: "Cancel" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Close" }),
-    ).not.toBeInTheDocument();
-    await keyboard("{Escape}");
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    await act(async () => {
-      finish!(
-        new HTTPResponse<JSONObject>(
-          200,
-          { verified: true, backupCodes: ["ABCDE-12345"] },
-          {},
-        ),
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(screen.getByTestId("enrolment-backup-codes")).toHaveTextContent(
+        "ABCDE-12345",
       );
-    });
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    expect(screen.getByTestId("enrolment-backup-codes")).toHaveTextContent(
-      "ABCDE-12345",
-    );
-    expect(
-      screen.getByTestId("passkey-registration-success"),
-    ).toHaveTextContent("Passkey added");
-  });
+      if (isPasskey) {
+        expect(
+          screen.getByTestId("passkey-registration-success"),
+        ).toHaveTextContent("Passkey added");
+      } else {
+        expect(
+          screen.queryByTestId("passkey-registration-success"),
+        ).not.toBeInTheDocument();
+      }
+    },
+  );
 
   test.each([true, false])(
     "lets the owner rename a key without updating credential or verification fields: passkey %s",

--- a/Common/Tests/App/Dashboard/TwoFactorStatus.test.tsx
+++ b/Common/Tests/App/Dashboard/TwoFactorStatus.test.tsx
@@ -25,22 +25,32 @@ const userWithStatus: (enabled: boolean) => User = (enabled: boolean): User => {
   return user;
 };
 
-const openConfirmation: () => Promise<HTMLElement> =
-  async (): Promise<HTMLElement> => {
-    fireEvent.click(
-      await screen.findByRole("button", {
-        name: "Enable two-factor authentication",
-        exact: true,
-      }),
-    );
-    return screen.getByRole("dialog", {
-      name: "Enable two-factor authentication?",
-    });
-  };
+const actionForStatus: (isEnabled: boolean) => string = (
+  isEnabled: boolean,
+): string => {
+  return isEnabled
+    ? "Turn off two-factor authentication"
+    : "Enable two-factor authentication";
+};
+
+const openConfirmation: (isEnabled?: boolean) => Promise<HTMLElement> = async (
+  isEnabled: boolean = false,
+): Promise<HTMLElement> => {
+  const action: string = actionForStatus(isEnabled);
+  fireEvent.click(
+    await screen.findByRole("button", {
+      name: action,
+      exact: true,
+    }),
+  );
+  return screen.getByRole("dialog", {
+    name: `${action}?`,
+  });
+};
 
 describe("two-factor authentication status", () => {
   let loadStatus: jest.SpyInstance;
-  let enable: jest.SpyInstance;
+  let updateStatus: jest.SpyInstance;
 
   beforeEach(() => {
     jest.spyOn(UserUtil, "getUserId").mockReturnValue(userId);
@@ -52,7 +62,7 @@ describe("two-factor authentication status", () => {
     loadStatus = jest
       .spyOn(ModelAPI, "getItem")
       .mockResolvedValue(userWithStatus(false));
-    enable = jest
+    updateStatus = jest
       .spyOn(ModelAPI, "updateById")
       .mockResolvedValue(new HTTPResponse<JSONObject>(200, {}, {}));
   });
@@ -73,7 +83,7 @@ describe("two-factor authentication status", () => {
 
     expect(screen.queryByTestId("two-factor-status")).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Enable two-factor/ }),
+      screen.queryByRole("button", { name: /Enable|Turn off two-factor/ }),
     ).not.toBeInTheDocument();
     expect(loadStatus).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -92,10 +102,10 @@ describe("two-factor authentication status", () => {
     expect(
       screen.getByRole("button", { name: "Enable two-factor authentication" }),
     ).toBeEnabled();
-    expect(enable).not.toHaveBeenCalled();
+    expect(updateStatus).not.toHaveBeenCalled();
   });
 
-  test("shows enabled status without offering an unsupported self-service disable action", async () => {
+  test("lets the current user turn off enabled two-factor authentication", async () => {
     loadStatus.mockResolvedValue(userWithStatus(true));
     render(<TwoFactorStatus />);
 
@@ -103,12 +113,23 @@ describe("two-factor authentication status", () => {
       "Enabled",
     );
     expect(
-      screen.getByText(/An administrator can turn this off/),
+      screen.getByText(
+        "Use an authenticator app or security key for your second step.",
+      ),
     ).toBeVisible();
     expect(
-      screen.queryByRole("button", { name: /Enable|Disable|Turn off|Edit/i }),
+      screen.getByRole("button", {
+        name: "Turn off two-factor authentication",
+      }),
+    ).toBeEnabled();
+    expect(screen.queryByText(/administrator/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Enable two-factor authentication",
+      }),
     ).not.toBeInTheDocument();
-    expect(enable).not.toHaveBeenCalled();
+    expect(updateStatus).not.toHaveBeenCalled();
   });
 
   test.each(["missing user", "missing setting"])(
@@ -126,126 +147,272 @@ describe("two-factor authentication status", () => {
       ).toBeVisible();
       expect(screen.queryByTestId("two-factor-status")).not.toBeInTheDocument();
       expect(
-        screen.queryByRole("button", { name: /Enable two-factor/ }),
+        screen.queryByRole("button", { name: /Enable|Turn off two-factor/ }),
       ).not.toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled();
     },
   );
 
-  test("recovers from a failed status request without making an account change", async () => {
-    loadStatus.mockRejectedValueOnce(
-      new Error("Unable to load account security"),
-    );
-    render(<TwoFactorStatus />);
+  test.each([false, true])(
+    "recovers from a failed status request without making an account change: enabled %s",
+    async (isEnabled: boolean) => {
+      loadStatus
+        .mockRejectedValueOnce(new Error("Unable to load account security"))
+        .mockResolvedValueOnce(userWithStatus(isEnabled));
+      render(<TwoFactorStatus />);
 
-    expect(
-      await screen.findByText("Unable to load account security"),
-    ).toBeVisible();
-    expect(screen.queryByTestId("two-factor-status")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
-    expect(await screen.findByTestId("two-factor-status")).toHaveTextContent(
-      "Not enabled",
-    );
-    expect(
-      screen.queryByText("Unable to load account security"),
-    ).not.toBeInTheDocument();
-    expect(loadStatus).toHaveBeenCalledTimes(2);
-    expect(enable).not.toHaveBeenCalled();
-  });
+      expect(
+        await screen.findByText("Unable to load account security"),
+      ).toBeVisible();
+      expect(screen.queryByTestId("two-factor-status")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /Enable|Turn off two-factor/ }),
+      ).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+      expect(await screen.findByTestId("two-factor-status")).toHaveTextContent(
+        isEnabled ? "Enabled" : "Not enabled",
+      );
+      expect(
+        screen.getByRole("button", { name: actionForStatus(isEnabled) }),
+      ).toBeEnabled();
+      expect(
+        screen.queryByText("Unable to load account security"),
+      ).not.toBeInTheDocument();
+      expect(loadStatus).toHaveBeenCalledTimes(2);
+      expect(updateStatus).not.toHaveBeenCalled();
+    },
+  );
 
-  test("explains the next sign-in and administrator requirement before enabling, and cancel leaves it unchanged", async () => {
+  test("explains the next sign-in before enabling, and cancel leaves it unchanged", async () => {
     render(<TwoFactorStatus />);
     const dialog: HTMLElement = await openConfirmation();
 
     expect(dialog).toHaveTextContent("finish setup at your next sign-in");
-    expect(dialog).toHaveTextContent("only an administrator can turn it off");
-    expect(enable).not.toHaveBeenCalled();
+    expect(dialog).not.toHaveTextContent(/administrator/i);
+    expect(updateStatus).not.toHaveBeenCalled();
     fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(screen.getByTestId("two-factor-status")).toHaveTextContent(
       "Not enabled",
     );
-    expect(enable).not.toHaveBeenCalled();
+    expect(updateStatus).not.toHaveBeenCalled();
   });
 
-  test("sends one enable request and waits for the server before changing status", async () => {
-    let finish: (() => void) | undefined;
-    enable.mockReturnValue(
-      new Promise<void>((resolve: () => void) => {
-        finish = resolve;
+  test.each(["Cancel", "Escape"])(
+    "explains turning off two-factor authentication and preserves the account when dismissed with %s",
+    async (dismissal: string) => {
+      loadStatus.mockResolvedValue(userWithStatus(true));
+      render(<TwoFactorStatus />);
+      const dialog: HTMLElement = await openConfirmation(true);
+
+      expect(dialog).toHaveTextContent(
+        "You will no longer be asked for a second step when signing in with a password.",
+      );
+      expect(dialog).toHaveTextContent(
+        "Your authenticator apps and security keys will stay saved so you can enable it again.",
+      );
+      expect(dialog).not.toHaveTextContent(/administrator/i);
+      expect(updateStatus).not.toHaveBeenCalled();
+      expect(screen.getByTestId("two-factor-status")).toHaveTextContent(
+        "Enabled",
+      );
+
+      if (dismissal === "Cancel") {
+        fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+      } else {
+        fireEvent.keyDown(dialog, { key: "Escape" });
+      }
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(screen.getByTestId("two-factor-status")).toHaveTextContent(
+        "Enabled",
+      );
+      expect(
+        screen.getByRole("button", {
+          name: "Turn off two-factor authentication",
+        }),
+      ).toBeEnabled();
+      expect(updateStatus).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([false, true])(
+    "sends one confirmed request and waits for the server before changing status: initially enabled %s",
+    async (isEnabled: boolean) => {
+      let finish: (() => void) | undefined;
+      loadStatus.mockResolvedValue(userWithStatus(isEnabled));
+      updateStatus.mockReturnValue(
+        new Promise<void>((resolve: () => void) => {
+          finish = resolve;
+        }),
+      );
+      render(<TwoFactorStatus />);
+      const dialog: HTMLElement = await openConfirmation(isEnabled);
+      const submit: HTMLElement = within(dialog).getByRole("button", {
+        name: actionForStatus(isEnabled),
+      });
+      expect(updateStatus).not.toHaveBeenCalled();
+
+      act(() => {
+        fireEvent.click(submit);
+        fireEvent.click(submit);
+      });
+      expect(updateStatus).toHaveBeenCalledTimes(1);
+      expect(updateStatus).toHaveBeenCalledWith({
+        modelType: User,
+        id: userId,
+        data: { enableTwoFactorAuth: !isEnabled },
+      });
+      expect(submit).toBeDisabled();
+      expect(screen.getByTestId("two-factor-status")).toHaveTextContent(
+        isEnabled ? "Enabled" : "Not enabled",
+      );
+      expect(
+        within(dialog).queryByRole("button", { name: "Cancel" }),
+      ).not.toBeInTheDocument();
+      expect(
+        within(dialog).queryByRole("button", { name: "Close" }),
+      ).not.toBeInTheDocument();
+      fireEvent.keyDown(dialog, { key: "Escape" });
+      expect(dialog).toBeInTheDocument();
+      expect(updateStatus).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        finish!();
+      });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(screen.getByTestId("two-factor-status")).toHaveTextContent(
+        isEnabled ? "Not enabled" : "Enabled",
+      );
+      expect(
+        screen.getByRole("button", { name: actionForStatus(!isEnabled) }),
+      ).toBeEnabled();
+      expect(
+        screen.queryByRole("button", { name: actionForStatus(isEnabled) }),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  test.each([false, true])(
+    "keeps a failed update visible and retries the same requested status: initially enabled %s",
+    async (isEnabled: boolean) => {
+      loadStatus.mockResolvedValue(userWithStatus(isEnabled));
+      updateStatus.mockRejectedValueOnce(
+        new Error("Your account could not be updated"),
+      );
+      render(<TwoFactorStatus />);
+      const dialog: HTMLElement = await openConfirmation(isEnabled);
+      fireEvent.click(
+        within(dialog).getByRole("button", {
+          name: actionForStatus(isEnabled),
+        }),
+      );
+
+      expect(
+        await within(dialog).findByText("Your account could not be updated"),
+      ).toBeVisible();
+      expect(screen.getByTestId("two-factor-status")).toHaveTextContent(
+        isEnabled ? "Enabled" : "Not enabled",
+      );
+      const retry: HTMLElement = within(dialog).getByRole("button", {
+        name: actionForStatus(isEnabled),
+      });
+      expect(retry).toBeEnabled();
+      expect(
+        within(dialog).getByRole("button", { name: "Cancel" }),
+      ).toBeEnabled();
+      fireEvent.click(retry);
+      await screen.findByText(isEnabled ? "Not enabled" : "Enabled", {
+        exact: true,
+      });
+      expect(updateStatus).toHaveBeenCalledTimes(2);
+      for (const call of [1, 2]) {
+        expect(updateStatus).toHaveBeenNthCalledWith(call, {
+          modelType: User,
+          id: userId,
+          data: { enableTwoFactorAuth: !isEnabled },
+        });
+      }
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: actionForStatus(!isEnabled) }),
+      ).toBeEnabled();
+    },
+  );
+
+  test.each([false, true])(
+    "clears a failed update when its confirmation is closed and reopened: initially enabled %s",
+    async (isEnabled: boolean) => {
+      loadStatus.mockResolvedValue(userWithStatus(isEnabled));
+      updateStatus.mockRejectedValueOnce(new Error("Please try again later"));
+      render(<TwoFactorStatus />);
+      const dialog: HTMLElement = await openConfirmation(isEnabled);
+      fireEvent.click(
+        within(dialog).getByRole("button", {
+          name: actionForStatus(isEnabled),
+        }),
+      );
+      expect(
+        await within(dialog).findByText("Please try again later"),
+      ).toBeVisible();
+
+      fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(screen.getByTestId("two-factor-status")).toHaveTextContent(
+        isEnabled ? "Enabled" : "Not enabled",
+      );
+
+      const reopened: HTMLElement = await openConfirmation(isEnabled);
+      expect(
+        within(reopened).queryByText("Please try again later"),
+      ).not.toBeInTheDocument();
+      expect(
+        within(reopened).getByRole("button", {
+          name: actionForStatus(isEnabled),
+        }),
+      ).toBeEnabled();
+      expect(updateStatus).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test("can enable two-factor authentication again after turning it off", async () => {
+    loadStatus.mockResolvedValue(userWithStatus(true));
+    render(<TwoFactorStatus />);
+    const turnOffDialog: HTMLElement = await openConfirmation(true);
+    fireEvent.click(
+      within(turnOffDialog).getByRole("button", {
+        name: "Turn off two-factor authentication",
       }),
     );
-    render(<TwoFactorStatus />);
-    const dialog: HTMLElement = await openConfirmation();
-    const submit: HTMLElement = within(dialog).getByRole("button", {
-      name: "Enable two-factor authentication",
-    });
-
-    act(() => {
-      fireEvent.click(submit);
-      fireEvent.click(submit);
-    });
-    expect(enable).toHaveBeenCalledTimes(1);
-    expect(enable).toHaveBeenCalledWith({
-      modelType: User,
-      id: userId,
-      data: { enableTwoFactorAuth: true },
-    });
-    expect(submit).toBeDisabled();
-    expect(screen.getByTestId("two-factor-status")).toHaveTextContent(
-      "Not enabled",
-    );
-    expect(
-      within(dialog).queryByRole("button", { name: "Cancel" }),
-    ).not.toBeInTheDocument();
-    fireEvent.keyDown(dialog, { key: "Escape" });
-    expect(dialog).toBeInTheDocument();
-
-    await act(async () => {
-      finish!();
-    });
+    await screen.findByText("Not enabled", { exact: true });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    expect(screen.getByTestId("two-factor-status")).toHaveTextContent(
-      "Enabled",
-    );
-    expect(
-      screen.queryByRole("button", {
-        name: "Enable two-factor authentication",
-      }),
-    ).not.toBeInTheDocument();
-  });
 
-  test("keeps a failed update visible and supports retrying in the same confirmation", async () => {
-    enable.mockRejectedValueOnce(
-      new Error("Your account could not be updated"),
-    );
-    render(<TwoFactorStatus />);
-    const dialog: HTMLElement = await openConfirmation();
+    const enableDialog: HTMLElement = await openConfirmation();
+    expect(enableDialog).toHaveTextContent("finish setup at your next sign-in");
+    expect(enableDialog).not.toHaveTextContent(/administrator/i);
     fireEvent.click(
-      within(dialog).getByRole("button", {
-        name: "Enable two-factor authentication",
-      }),
-    );
-
-    expect(
-      await within(dialog).findByText("Your account could not be updated"),
-    ).toBeVisible();
-    expect(screen.getByTestId("two-factor-status")).toHaveTextContent(
-      "Not enabled",
-    );
-    expect(
-      within(dialog).getByRole("button", {
-        name: "Enable two-factor authentication",
-      }),
-    ).toBeEnabled();
-    fireEvent.click(
-      within(dialog).getByRole("button", {
+      within(enableDialog).getByRole("button", {
         name: "Enable two-factor authentication",
       }),
     );
     await screen.findByText("Enabled", { exact: true });
-    expect(enable).toHaveBeenCalledTimes(2);
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(updateStatus).toHaveBeenCalledTimes(2);
+    expect(updateStatus).toHaveBeenNthCalledWith(1, {
+      modelType: User,
+      id: userId,
+      data: { enableTwoFactorAuth: false },
+    });
+    expect(updateStatus).toHaveBeenNthCalledWith(2, {
+      modelType: User,
+      id: userId,
+      data: { enableTwoFactorAuth: true },
+    });
+    expect(
+      screen.getByRole("button", {
+        name: "Turn off two-factor authentication",
+      }),
+    ).toBeEnabled();
   });
 
   test("aborts a status request when the page unmounts", () => {

--- a/Common/Tests/Server/API/UserTwoFactorSelfService.test.ts
+++ b/Common/Tests/Server/API/UserTwoFactorSelfService.test.ts
@@ -1,0 +1,398 @@
+import User from "../../../Models/DatabaseModels/User";
+import UserAPI from "../../../Server/API/UserAPI";
+import MasterAdminAuthorization from "../../../Server/Middleware/MasterAdminAuthorization";
+import UserService from "../../../Server/Services/UserService";
+import FindBy from "../../../Server/Types/Database/FindBy";
+import {
+  ExpressResponse,
+  NextFunction,
+  OneUptimeRequest,
+} from "../../../Server/Utils/Express";
+import JSONWebToken from "../../../Server/Utils/JsonWebToken";
+import Response from "../../../Server/Utils/Response";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import NotAuthenticatedException from "../../../Types/Exception/NotAuthenticatedException";
+import NotAuthorizedException from "../../../Types/Exception/NotAuthorizedException";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import Permission from "../../../Types/Permission";
+import UserType from "../../../Types/UserType";
+import { getJestSpyOn } from "../../Spy";
+import { mockRouter } from "./Helpers";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { FindOperator } from "typeorm";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEmptySuccessResponse: jest.fn(),
+    sendErrorResponse: jest.fn(),
+  };
+});
+
+const OWNER_ID: string = "11111111-1111-4111-8111-111111111111";
+const OTHER_ID: string = "22222222-2222-4222-8222-222222222222";
+const ADMIN_ROUTE: string = "/user/:userId/set-two-factor-auth-required";
+
+interface RequestOptions {
+  id?: string;
+  userType?: UserType;
+  anonymous?: boolean;
+  body?: JSONObject;
+}
+
+/*
+ * Run the real API deserialization, request-to-permission props, service hook,
+ * owner/table/column permissions, scalar update and success response together.
+ * Only the Postgres find/write boundaries and HTTP response transport are
+ * replaced. In particular, neither getDatabaseCommonInteractionProps nor any
+ * permission check is stubbed, so a forged body cannot become caller identity.
+ */
+describe("User two-factor self-service API integration", () => {
+  const rows: Map<string, User> = new Map<string, User>();
+  let api: UserAPI;
+  let find: jest.SpyInstance;
+  let update: jest.Mock;
+  let response: ExpressResponse;
+
+  const requestFor: (data?: RequestOptions) => OneUptimeRequest = (
+    data: RequestOptions = {},
+  ): OneUptimeRequest => {
+    return {
+      params: { id: data.id || OWNER_ID },
+      query: {},
+      headers: {},
+      body: data.body || { data: { enableTwoFactorAuth: false } },
+      userType: data.userType || UserType.User,
+      ...(data.anonymous
+        ? {}
+        : { userAuthorization: { userId: new ObjectID(OWNER_ID) } }),
+      userGlobalAccessPermission: {
+        globalPermissions: data.anonymous ? [] : [Permission.CurrentUser],
+        projectIds: [],
+        _type: "UserGlobalAccessPermission",
+      },
+    } as unknown as OneUptimeRequest;
+  };
+
+  const expectNoWrite: () => void = (): void => {
+    expect(update).not.toHaveBeenCalled();
+    expect(find).not.toHaveBeenCalled();
+    expect(rows.get(OWNER_ID)?.enableTwoFactorAuth).toBe(true);
+    expect(rows.get(OTHER_ID)?.enableTwoFactorAuth).toBe(true);
+    expect(Response.sendEmptySuccessResponse).not.toHaveBeenCalled();
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    mockRouter.routes.length = 0;
+    api = new UserAPI();
+    response = {} as ExpressResponse;
+    rows.clear();
+    for (const id of [OWNER_ID, OTHER_ID]) {
+      const row: User = new User();
+      row._id = id;
+      row.enableTwoFactorAuth = true;
+      rows.set(id, row);
+    }
+
+    find = getJestSpyOn(UserService, "_findBy").mockImplementation(
+      async (data: FindBy<User>): Promise<Array<User>> => {
+        const predicate: unknown = data.query._id;
+        let id: string;
+        if (predicate instanceof FindOperator) {
+          // Ordinary ownership scoping serializes its exact UUID into Raw equality.
+          expect(predicate.getSql?.("_id")).toMatch(/^\(_id = :\w+\)$/);
+          const values: Array<unknown> = Object.values(
+            predicate.objectLiteralParameters || {},
+          );
+          expect(values).toHaveLength(1);
+          id = String(values[0]);
+        } else {
+          id = String(predicate);
+        }
+        const row: User | undefined = rows.get(id);
+        if (!row) {
+          return [];
+        }
+        const snapshot: User = new User();
+        snapshot._id = row._id;
+        snapshot.enableTwoFactorAuth = row.enableTwoFactorAuth;
+        return [snapshot];
+      },
+    );
+    update = jest
+      .fn()
+      .mockImplementation(
+        async (
+          where: { _id: string },
+          data: { enableTwoFactorAuth: boolean },
+        ): Promise<{ affected: number }> => {
+          const row: User | undefined = rows.get(where._id);
+          if (!row) {
+            return { affected: 0 };
+          }
+          row.enableTwoFactorAuth = data.enableTwoFactorAuth;
+          return { affected: 1 };
+        },
+      );
+    getJestSpyOn(UserService, "getRepository").mockReturnValue({ update });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test.each([false, true])(
+    "persists the current user's enableTwoFactorAuth=%s through ordinary CRUD",
+    async (enabled: boolean): Promise<void> => {
+      rows.get(OWNER_ID)!.enableTwoFactorAuth = !enabled;
+      const request: OneUptimeRequest = requestFor({
+        body: { data: { enableTwoFactorAuth: enabled } },
+      });
+
+      await api.updateItem(request, response);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update).toHaveBeenCalledWith(
+        { _id: OWNER_ID },
+        expect.objectContaining({ enableTwoFactorAuth: enabled }),
+      );
+      expect(rows.get(OWNER_ID)?.enableTwoFactorAuth).toBe(enabled);
+      expect(rows.get(OTHER_ID)?.enableTwoFactorAuth).toBe(true);
+      expect(Response.sendEmptySuccessResponse).toHaveBeenCalledWith(
+        request,
+        response,
+      );
+    },
+  );
+
+  test("allows a master admin to turn off their own setting", async () => {
+    await api.updateItem(
+      requestFor({ userType: UserType.MasterAdmin }),
+      response,
+    );
+
+    expect(rows.get(OWNER_ID)?.enableTwoFactorAuth).toBe(false);
+    expect(rows.get(OTHER_ID)?.enableTwoFactorAuth).toBe(true);
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects an anonymous caller even with forged identity and root flags in the body", async () => {
+    await expect(
+      api.updateItem(
+        requestFor({
+          anonymous: true,
+          body: {
+            data: { enableTwoFactorAuth: false },
+            userId: OWNER_ID,
+            userAuthorization: { userId: OWNER_ID },
+            isRoot: true,
+            isMasterAdmin: true,
+          },
+        }),
+        response,
+      ),
+    ).rejects.toThrow(NotAuthenticatedException);
+
+    expectNoWrite();
+  });
+
+  test("a project API caller without user identity cannot turn off a user's setting", async () => {
+    const request: OneUptimeRequest = requestFor({
+      anonymous: true,
+      userType: UserType.API,
+    });
+    request.userGlobalAccessPermission!.globalPermissions.push(
+      Permission.CurrentUser,
+    );
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+
+    expectNoWrite();
+  });
+
+  test.each([UserType.User, UserType.MasterAdmin])(
+    "blocks %s from disabling a foreign account through ordinary CRUD",
+    async (userType: UserType): Promise<void> => {
+      await expect(
+        api.updateItem(requestFor({ id: OTHER_ID, userType }), response),
+      ).rejects.toThrow(
+        "You can only turn off two factor authentication for your own account.",
+      );
+
+      expectNoWrite();
+    },
+  );
+
+  test("foreign self-service enabling still obeys the existing row permissions", async () => {
+    await expect(
+      api.updateItem(
+        requestFor({
+          id: OTHER_ID,
+          body: { data: { enableTwoFactorAuth: true } },
+        }),
+        response,
+      ),
+    ).rejects.toThrow(NotAuthorizedException);
+
+    expectNoWrite();
+  });
+
+  test("body identity, root props and query operators cannot authorize a foreign target", async () => {
+    await expect(
+      api.updateItem(
+        requestFor({
+          id: OTHER_ID,
+          body: {
+            data: { enableTwoFactorAuth: false },
+            userId: OTHER_ID,
+            userAuthorization: { userId: OTHER_ID },
+            props: { userId: OTHER_ID, isRoot: true, ignoreHooks: true },
+            query: { _id: { _type: "NotEqual", value: OWNER_ID } },
+          },
+        }),
+        response,
+      ),
+    ).rejects.toThrow(BadDataException);
+
+    expectNoWrite();
+  });
+
+  test("a userId inside update data cannot impersonate the foreign target's owner", async () => {
+    await expect(
+      api.updateItem(
+        requestFor({
+          id: OTHER_ID,
+          body: { data: { enableTwoFactorAuth: false, userId: OTHER_ID } },
+        }),
+        response,
+      ),
+    ).rejects.toThrow(BadDataException);
+
+    expectNoWrite();
+  });
+
+  test.each([
+    JSON.stringify({ _type: "NotEqual", value: OWNER_ID }),
+    JSON.stringify([OWNER_ID, OTHER_ID]),
+  ])(
+    "rejects an operator-shaped path ID: %s",
+    async (id: string): Promise<void> => {
+      await expect(
+        api.updateItem(requestFor({ id }), response),
+      ).rejects.toThrow(BadDataException);
+
+      expectNoWrite();
+    },
+  );
+
+  test("a body row ID cannot redirect a successful update away from the URL's owner", async () => {
+    await api.updateItem(
+      requestFor({
+        body: { data: { _id: OTHER_ID, enableTwoFactorAuth: false } },
+      }),
+      response,
+    );
+
+    expect(update).toHaveBeenCalledWith(
+      { _id: OWNER_ID },
+      expect.objectContaining({ enableTwoFactorAuth: false }),
+    );
+    expect(rows.get(OWNER_ID)?.enableTwoFactorAuth).toBe(false);
+    expect(rows.get(OTHER_ID)?.enableTwoFactorAuth).toBe(true);
+  });
+
+  test.each([
+    { value: "false", id: OWNER_ID, userType: UserType.User },
+    { value: null, id: OWNER_ID, userType: UserType.User },
+    { value: "false", id: OTHER_ID, userType: UserType.MasterAdmin },
+    { value: null, id: OTHER_ID, userType: UserType.MasterAdmin },
+  ])(
+    "rejects non-boolean $value for $userType targeting $id before persistence",
+    async (data: {
+      value: string | null;
+      id: string;
+      userType: UserType;
+    }): Promise<void> => {
+      await expect(
+        api.updateItem(
+          requestFor({
+            id: data.id,
+            userType: data.userType,
+            body: { data: { enableTwoFactorAuth: data.value } },
+          }),
+          response,
+        ),
+      ).rejects.toThrow(BadDataException);
+
+      expectNoWrite();
+    },
+  );
+
+  test.each([false, true])(
+    "the dedicated administrator endpoint still enforces a master-admin session: %s",
+    async (isMasterAdmin: boolean): Promise<void> => {
+      const route: ReturnType<typeof mockRouter.match> = mockRouter.match(
+        "POST",
+        ADMIN_ROUTE,
+      );
+      expect(route.middleware).toBe(
+        MasterAdminAuthorization.isAuthorizedMasterAdminMiddleware,
+      );
+      const request: OneUptimeRequest = requestFor();
+      request.params = { userId: OTHER_ID };
+      request.body = { isRequired: false };
+      request.headers["authorization"] = `Bearer ${JSONWebToken.signJsonPayload(
+        {
+          userId: OWNER_ID,
+          email: "self-service-test@oneuptime.invalid",
+          name: "Self service test",
+          isMasterAdmin,
+          isGlobalLogin: true,
+        },
+        60,
+      )}`;
+      const next: jest.Mock = jest.fn();
+
+      await route.middleware(request, response, next as NextFunction);
+      if (isMasterAdmin) {
+        expect(next).toHaveBeenCalledWith();
+        await route.handlerFunction(request, response, next as NextFunction);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(Response.sendErrorResponse).not.toHaveBeenCalled();
+        expect(Response.sendEmptySuccessResponse).toHaveBeenCalledWith(
+          request,
+          response,
+        );
+        expect(rows.get(OWNER_ID)?.enableTwoFactorAuth).toBe(true);
+        expect(rows.get(OTHER_ID)?.enableTwoFactorAuth).toBe(false);
+      } else {
+        expect(next).not.toHaveBeenCalled();
+        expect(Response.sendErrorResponse).toHaveBeenCalledWith(
+          request,
+          response,
+          expect.any(NotAuthorizedException),
+        );
+        expectNoWrite();
+      }
+    },
+  );
+});

--- a/Common/Tests/Server/Services/UserEmailChangePasswordResetExpiry.test.ts
+++ b/Common/Tests/Server/Services/UserEmailChangePasswordResetExpiry.test.ts
@@ -454,18 +454,16 @@ describe("UserService.onBeforeUpdate — a password reset link dies with the add
       expect(stubs.findBy).toHaveBeenCalledTimes(1);
     });
 
-    test("turning off two factor auth as a non-root caller is still refused", async () => {
-      /*
-       * The guard that lives immediately after the new code in the same hook.
-       * Cheap to assert here, and it is the thing an edit to this method is
-       * most likely to displace.
-       */
+    test("turning off two factor auth on another account is still refused", async () => {
       await expect(
         userService().onBeforeUpdate(
-          updatePayload({ patch: { enableTwoFactorAuth: false } }),
+          updatePayload({
+            patch: { enableTwoFactorAuth: false },
+            query: { _id: OTHER_USER_ID.toString() },
+          }),
         ),
       ).rejects.toThrow(
-        "Only an administrator can turn off two factor authentication for this account.",
+        "You can only turn off two factor authentication for your own account.",
       );
     });
   });

--- a/Common/Tests/Server/Services/UserTwoFactorAuthAdmin.test.ts
+++ b/Common/Tests/Server/Services/UserTwoFactorAuthAdmin.test.ts
@@ -6,6 +6,9 @@ import UserWebAuthnService from "../../../Server/Services/UserWebAuthnService";
 import UserTwoFactorBackupCodeService from "../../../Server/Services/UserTwoFactorBackupCodeService";
 import logger from "../../../Server/Utils/Logger";
 import User from "../../../Models/DatabaseModels/User";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import NotEqual from "../../../Types/BaseDatabase/NotEqual";
 import ColumnLength from "../../../Types/Database/ColumnLength";
 import LIMIT_MAX from "../../../Types/Database/LimitMax";
 import Email from "../../../Types/Email";
@@ -901,49 +904,215 @@ describe("UserService -- admin-controlled two factor auth", () => {
       ).onBeforeUpdate(updateBy);
     };
 
-    /*
-     * ---------------------------------------------------------------------
-     * The guard that REPLACED the deleted one, and the reason it had to
-     * exist at all.
-     *
-     * `enableTwoFactorAuth` carries `update: [Permission.CurrentUser]`
-     * (Common/Models/DatabaseModels/User.ts) and the User table's row ACL
-     * scopes updates to the caller's own id, so every signed-in user can
-     * write their own copy of this flag through the ordinary CRUD API -- and
-     * the product ships the button that does it, at Dashboard > Profile >
-     * Two Factor Authentication.
-     *
-     * Without the guard the whole feature is self-undoing: the admin requires
-     * two factor auth, the user is marched through enrolment at their next
-     * sign-in, and then from the session they just earned they flip the
-     * toggle back off and delete the factor -- which the removal of the
-     * onBeforeDelete guards now also permits. The account is password-only
-     * again and the Authentication page reports the mandate as simply absent.
-     * ---------------------------------------------------------------------
-     */
-    test("onBeforeUpdate refuses to let a non-root caller turn the requirement OFF", async () => {
+    type InvalidTwoFactorFlag = { label: string; value: unknown };
+    const invalidTwoFactorFlags: Array<InvalidTwoFactorFlag> = [
+      { label: 'the string "false"', value: "false" },
+      { label: 'the string "true"', value: "true" },
+      { label: "an empty string", value: "" },
+      { label: "zero", value: 0 },
+      { label: "one", value: 1 },
+      { label: "null", value: null },
+      { label: "an array", value: [] },
+      { label: "an object", value: {} },
+    ];
+
+    describe.each(["owner", "master admin", "root"])(
+      "%s flag validation",
+      (caller: string): void => {
+        test.each(invalidTwoFactorFlags)(
+          `rejects $label as a two factor auth flag for ${caller}`,
+          async ({ value }: InvalidTwoFactorFlag) => {
+            await expect(
+              callOnBeforeUpdate({
+                query: {
+                  _id: (caller === "owner" ? userId : foundUserId).toString(),
+                },
+                data: { enableTwoFactorAuth: value },
+                props: {
+                  userId: userId,
+                  isMasterAdmin: caller === "master admin",
+                  isRoot: caller === "root",
+                },
+              }),
+            ).rejects.toThrow("enableTwoFactorAuth must be a boolean.");
+          },
+        );
+      },
+    );
+
+    test("rejects a malformed flag before email and password change side effects", async () => {
       await expect(
         callOnBeforeUpdate({
-          query: { _id: userId },
-          data: { enableTwoFactorAuth: false },
-          props: {},
+          query: { _id: userId.toString() },
+          data: {
+            enableTwoFactorAuth: "false",
+            email: new Email("changed@example.com"),
+            password: new HashedString("a new password"),
+          },
+          props: { userId: userId },
         }),
-      ).rejects.toThrow(BadDataException);
+      ).rejects.toThrow("enableTwoFactorAuth must be a boolean.");
+      expect(findBySpy).not.toHaveBeenCalled();
+      expect(updateBySpy).not.toHaveBeenCalled();
+      expect(revokeSessionsSpy).not.toHaveBeenCalled();
     });
 
-    test("the refusal names an administrator, so the user knows who to ask", async () => {
-      /*
-       * The message is the only thing the user sees when the profile toggle
-       * refuses. "Bad data" would send them to support with nothing to say.
-       */
+    test("ignores an undefined flag on an unrelated profile update", async () => {
       await expect(
         callOnBeforeUpdate({
-          query: { _id: userId },
-          data: { enableTwoFactorAuth: false },
-          props: {},
+          query: { _id: userId.toString() },
+          data: { name: "Someone", enableTwoFactorAuth: undefined },
+          props: { userId: userId },
         }),
-      ).rejects.toThrow(/administrator/i);
+      ).resolves.toBeDefined();
     });
+
+    /*
+     * The hook runs before row permissions scope a query. Self-service must
+     * therefore identify exactly the caller's row, including the string id
+     * produced by the real updateOneById path. Query operators may stringify
+     * to the caller's id while selecting other users, so they stay forbidden.
+     */
+    describe.each([false, true])(
+      "self-service ownership (master admin: %s)",
+      (isMasterAdmin: boolean): void => {
+        test.each(["string", "ObjectID"])(
+          `allows the owner to turn off two factor auth with a %s id: master admin ${isMasterAdmin}`,
+          async (idType: string) => {
+            const updateBy: {
+              query: { _id: string | ObjectID };
+              data: { enableTwoFactorAuth: boolean };
+              props: DatabaseCommonInteractionProps;
+              limit: number;
+              skip: number;
+            } = {
+              query: {
+                _id: idType === "string" ? userId.toString() : userId,
+              },
+              data: { enableTwoFactorAuth: false },
+              props: { userId, isMasterAdmin, isRoot: false },
+              limit: 1,
+              skip: 0,
+            };
+
+            const result: { updateBy: unknown; carryForward: Array<User> } =
+              await callOnBeforeUpdate(updateBy);
+
+            expect(result.updateBy).toBe(updateBy);
+            expect(result.carryForward).toEqual([]);
+            expect(findBySpy).not.toHaveBeenCalled();
+            expect(revokeSessionsSpy).not.toHaveBeenCalled();
+            expect(totpDeleteBySpy).not.toHaveBeenCalled();
+            expect(webAuthnDeleteBySpy).not.toHaveBeenCalled();
+          },
+        );
+
+        type RejectedQueryCase = {
+          label: string;
+          query: (ownerId: ObjectID, otherId: ObjectID) => unknown;
+        };
+
+        const rejectedQueries: Array<RejectedQueryCase> = [
+          {
+            label: "another user's string id",
+            query: (_ownerId: ObjectID, otherId: ObjectID): unknown => {
+              return { _id: otherId.toString() };
+            },
+          },
+          {
+            label: "another user's ObjectID",
+            query: (_ownerId: ObjectID, otherId: ObjectID): unknown => {
+              return { _id: otherId };
+            },
+          },
+          {
+            label: "a bulk query with no id",
+            query: (): unknown => {
+              return {};
+            },
+          },
+          {
+            label: "a missing query",
+            query: (): unknown => {
+              return undefined;
+            },
+          },
+          {
+            label: "a null id",
+            query: (): unknown => {
+              return { _id: null };
+            },
+          },
+          {
+            label: "a query array containing the owner",
+            query: (ownerId: ObjectID): unknown => {
+              return [{ _id: ownerId }];
+            },
+          },
+          {
+            label: "a query array containing another account",
+            query: (ownerId: ObjectID, otherId: ObjectID): unknown => {
+              return [{ _id: ownerId }, { _id: otherId }];
+            },
+          },
+          {
+            label: "a NotEqual predicate that stringifies to the owner",
+            query: (ownerId: ObjectID): unknown => {
+              return { _id: new NotEqual(ownerId.toString()) };
+            },
+          },
+          {
+            label: "an Includes predicate containing another account",
+            query: (ownerId: ObjectID, otherId: ObjectID): unknown => {
+              return { _id: new Includes([ownerId, otherId]) };
+            },
+          },
+          {
+            label: "an array of ids",
+            query: (ownerId: ObjectID): unknown => {
+              return { _id: [ownerId] };
+            },
+          },
+          {
+            label: "an object that stringifies to the owner",
+            query: (ownerId: ObjectID): unknown => {
+              return {
+                _id: {
+                  toString: (): string => {
+                    return ownerId.toString();
+                  },
+                },
+              };
+            },
+          },
+        ];
+
+        test.each(rejectedQueries)(
+          `rejects $label when turning off two factor auth: master admin ${isMasterAdmin}`,
+          async ({ query }: RejectedQueryCase) => {
+            await expect(
+              callOnBeforeUpdate({
+                query: query(userId, foundUserId),
+                data: { enableTwoFactorAuth: false },
+                props: { userId, isMasterAdmin },
+                limit: LIMIT_MAX,
+                skip: 0,
+              }),
+            ).rejects.toThrow(BadDataException);
+          },
+        );
+
+        test(`rejects disabling without an authenticated owner: master admin ${isMasterAdmin}`, async () => {
+          await expect(
+            callOnBeforeUpdate({
+              query: { _id: userId.toString() },
+              data: { enableTwoFactorAuth: false },
+              props: { isMasterAdmin },
+            }),
+          ).rejects.toThrow(/your own account/i);
+        });
+      },
+    );
 
     test("a ROOT caller may turn the requirement off -- that is the admin endpoint", async () => {
       /*

--- a/E2E/Tests/Dashboard/SecuritySettingsLayout.spec.ts
+++ b/E2E/Tests/Dashboard/SecuritySettingsLayout.spec.ts
@@ -195,7 +195,7 @@ test.describe("Security settings card layout", () => {
             }
             await expect(
               credentialCard.getByText("Existing credential", { exact: true }),
-            ).toHaveCount(2);
+            ).toHaveCount(0);
             if (settings.route === "two-factor-auth") {
               await expect(page.getByText(authenticatorName)).toBeVisible();
               await expect(

--- a/E2E/Tests/Dashboard/SecuritySettingsLayout.spec.ts
+++ b/E2E/Tests/Dashboard/SecuritySettingsLayout.spec.ts
@@ -1,0 +1,296 @@
+import { BASE_URL } from "../../Config";
+import { registerAndCreateProject } from "./Helpers/ProductOnboarding";
+import {
+  APIResponse,
+  Browser,
+  BrowserContext,
+  BrowserContextOptions,
+  Locator,
+  Page,
+  Route,
+  expect,
+  test,
+} from "@playwright/test";
+
+interface SecurityPage {
+  route: string;
+  title: string;
+  cardTitles: Array<string>;
+  emptyMessage: string;
+}
+
+interface CardLayout {
+  left: number;
+  right: number;
+  width: number;
+  contentLeft: number;
+  contentRight: number;
+  contentWidth: number;
+}
+
+const securityPages: Array<SecurityPage> = [
+  {
+    route: "passkeys",
+    title: "Passkeys",
+    cardTitles: ["Passkeys"],
+    emptyMessage: "No passkeys added yet.",
+  },
+  {
+    route: "two-factor-auth",
+    title: "Security keys",
+    cardTitles: [
+      "Two-factor authentication",
+      "Security keys",
+      "Authenticator apps",
+      "Backup codes",
+    ],
+    emptyMessage: "No security keys added yet.",
+  },
+];
+
+/*
+ * The old 72rem cap was invisible at ordinary laptop sizes. Measure against
+ * the shared Page's available content column at 2560px as well as desktop and
+ * mobile, so shrinking the whole page cannot make a capped card pass.
+ *
+ * Onboarding, navigation, permissions, Page, Card and ModelTable are real.
+ * Populated cases replace only read-only list replies, including both forms
+ * of legacy purpose, without inventing stored authentication material. The
+ * Passkeys account lifecycle spec covers real WebAuthn registration.
+ */
+test.describe("Security settings card layout", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const origin: string = BASE_URL.toString().replace(/\/$/, "");
+  const legacyName: string = "Existing credential from my original laptop";
+  const olderName: string = "Older office security key";
+  const currentName: string = "Current device";
+  const authenticatorName: string = "Work authenticator app";
+  const shared: { page: Page } = { page: undefined as unknown as Page };
+  let context: BrowserContext;
+  let projectId: string = "";
+
+  test.beforeAll(
+    async ({
+      browser,
+      contextOptions,
+    }: {
+      browser: Browser;
+      contextOptions: BrowserContextOptions;
+    }) => {
+      test.setTimeout(300000);
+      context = await browser.newContext({
+        ...contextOptions,
+        viewport: { width: 1440, height: 1000 },
+      });
+      shared.page = await context.newPage();
+      shared.page.setDefaultTimeout(30000);
+      projectId = await registerAndCreateProject({
+        page: shared.page,
+        projectNamePrefix: "E2E security settings layout",
+        enablePaidUsage: false,
+      });
+    },
+  );
+
+  test.afterAll(async () => {
+    try {
+      if (projectId) {
+        const response: APIResponse = await context.request.delete(
+          `${origin}/api/project/${projectId}`,
+          { headers: { tenantid: projectId } },
+        );
+        expect(response.ok(), "Remove the temporary layout project").toBe(true);
+      }
+    } finally {
+      await context?.close();
+    }
+  });
+
+  for (const populated of [false, true]) {
+    for (const settings of securityPages) {
+      test(`${settings.route}: ${populated ? "populated" : "empty"} cards fill the content column on wide desktop, desktop and mobile`, async () => {
+        const page: Page = shared.page;
+        await page.setViewportSize({ width: 1440, height: 1000 });
+
+        if (populated) {
+          await page.route(
+            "**/user-webauthn/get-list*",
+            async (route: Route) => {
+              await route.fulfill({
+                json: {
+                  data: [
+                    {
+                      _id: "11111111-1111-4111-8111-111111111111",
+                      name: legacyName,
+                      isVerified: true,
+                      createdAt: {
+                        _type: "DateTime",
+                        value: "2026-09-10T10:00:00.000Z",
+                      },
+                    },
+                    {
+                      _id: "22222222-2222-4222-8222-222222222222",
+                      name: olderName,
+                      isVerified: true,
+                      isPasskey: null,
+                    },
+                    {
+                      _id: "33333333-3333-4333-8333-333333333333",
+                      name: currentName,
+                      isVerified: true,
+                      isPasskey: settings.route === "passkeys",
+                    },
+                  ],
+                  count: 3,
+                  skip: 0,
+                  limit: 10,
+                },
+              });
+            },
+          );
+          await page.route(
+            "**/user-totp-auth/get-list*",
+            async (route: Route) => {
+              await route.fulfill({
+                json: {
+                  data: [
+                    {
+                      _id: "44444444-4444-4444-8444-444444444444",
+                      name: authenticatorName,
+                      isVerified: false,
+                    },
+                  ],
+                  count: 1,
+                  skip: 0,
+                  limit: 10,
+                },
+              });
+            },
+          );
+        }
+
+        try {
+          await page.goto(`${origin}/dashboard/user-profile/${settings.route}`);
+          const credentialCard: Locator = page.getByTestId("card").filter({
+            has: page.getByRole("heading", {
+              name: settings.title,
+              exact: true,
+            }),
+          });
+          await expect(credentialCard).toBeVisible();
+
+          if (populated) {
+            for (const name of [legacyName, olderName, currentName]) {
+              const row: Locator = credentialCard
+                .getByRole("row")
+                .filter({ hasText: name });
+              await expect(row).toBeVisible();
+              await expect(
+                row.getByRole("button", { name: "Rename", exact: true }),
+              ).toBeEnabled();
+              await expect(
+                row.getByRole("button", { name: "Delete", exact: true }),
+              ).toBeEnabled();
+            }
+            await expect(
+              credentialCard.getByText("Existing credential", { exact: true }),
+            ).toHaveCount(2);
+            if (settings.route === "two-factor-auth") {
+              await expect(page.getByText(authenticatorName)).toBeVisible();
+              await expect(
+                page.getByRole("button", { name: "Finish setup", exact: true }),
+              ).toBeEnabled();
+            }
+          } else {
+            await expect(page.getByText(settings.emptyMessage)).toBeVisible();
+            if (settings.route === "two-factor-auth") {
+              await expect(
+                page.getByText("No authenticator apps added yet."),
+              ).toBeVisible();
+            }
+          }
+
+          let desktopWidth: number = 0;
+          for (const viewport of [
+            { width: 1440, height: 1000 },
+            { width: 2560, height: 1440 },
+            { width: 390, height: 844 },
+          ]) {
+            await page.setViewportSize(viewport);
+            for (const title of settings.cardTitles) {
+              const card: Locator = page.getByTestId("card").filter({
+                has: page.getByRole("heading", { name: title, exact: true }),
+              });
+              await expect(card).toBeVisible();
+              const layout: CardLayout = await card.evaluate(
+                (element: HTMLElement): CardLayout => {
+                  // This ancestor belongs to shared Page, outside the page's wrapper.
+                  const content: Element | null =
+                    element.closest(".space-y-6.flex-1");
+                  if (!content) {
+                    throw new Error("Cannot find the Page content column");
+                  }
+                  const bounds: DOMRect = element.getBoundingClientRect();
+                  const contentBounds: DOMRect =
+                    content.getBoundingClientRect();
+                  return {
+                    left: bounds.left,
+                    right: bounds.right,
+                    width: bounds.width,
+                    contentLeft: contentBounds.left,
+                    contentRight: contentBounds.right,
+                    contentWidth: contentBounds.width,
+                  };
+                },
+              );
+              expect(
+                Math.abs(layout.left - layout.contentLeft),
+                `${title} aligns with the content column at ${viewport.width}px`,
+              ).toBeLessThanOrEqual(1);
+              expect(
+                Math.abs(layout.right - layout.contentRight),
+                `${title} fills the available right edge at ${viewport.width}px`,
+              ).toBeLessThanOrEqual(1);
+              expect(
+                Math.abs(layout.width - layout.contentWidth),
+              ).toBeLessThanOrEqual(1);
+              if (title === settings.title && viewport.width === 1440) {
+                desktopWidth = layout.width;
+              }
+              if (title === settings.title && viewport.width === 2560) {
+                expect(layout.width).toBeGreaterThan(desktopWidth + 800);
+              }
+            }
+
+            await expect(
+              page.getByText(
+                /Existing credentials appear on both security pages/,
+              ),
+            ).toHaveCount(0);
+            await expect(
+              page.getByText(/They continue to work as before/),
+            ).toHaveCount(0);
+            expect(
+              await page.evaluate((): boolean => {
+                return (
+                  document.documentElement.scrollWidth <=
+                  document.documentElement.clientWidth + 1
+                );
+              }),
+              `No page overflow at ${viewport.width}px`,
+            ).toBe(true);
+
+            await test.info().attach(`${settings.route}-${viewport.width}px`, {
+              body: await page.screenshot({ fullPage: true }),
+              contentType: "image/png",
+            });
+          }
+        } finally {
+          await page.unroute("**/user-webauthn/get-list*");
+          await page.unroute("**/user-totp-auth/get-list*");
+        }
+      });
+    }
+  }
+});

--- a/E2E/Tests/Dashboard/SecuritySettingsLayout.spec.ts
+++ b/E2E/Tests/Dashboard/SecuritySettingsLayout.spec.ts
@@ -293,4 +293,78 @@ test.describe("Security settings card layout", () => {
       });
     }
   }
+
+  test("persists self-service two-factor changes across reloads and leaves cancelled changes untouched", async () => {
+    const page: Page = shared.page;
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.goto(`${origin}/dashboard/user-profile/two-factor-auth`);
+
+    const status: Locator = page.getByTestId("two-factor-status");
+    const adminOnlyText: RegExp =
+      /An administrator can turn this off for your account|only an administrator can turn it off/i;
+    const setTwoFactorEnabled: (enabled: boolean) => Promise<void> = async (
+      enabled: boolean,
+    ): Promise<void> => {
+      const action: string = enabled
+        ? "Enable two-factor authentication"
+        : "Turn off two-factor authentication";
+      await page.getByRole("button", { name: action, exact: true }).click();
+      const dialog: Locator = page.getByRole("dialog", {
+        name: `${action}?`,
+        exact: true,
+      });
+      await expect(dialog).toBeVisible();
+      await expect(dialog).toContainText(
+        enabled
+          ? "finish setup at your next sign-in"
+          : "Your authenticator apps and security keys will stay saved",
+      );
+      await expect(page.getByText(adminOnlyText)).toHaveCount(0);
+      await dialog.getByRole("button", { name: action, exact: true }).click();
+      await expect(dialog).toBeHidden();
+      await expect(status).toHaveText(enabled ? "Enabled" : "Not enabled");
+    };
+
+    // These updates use the real User CRUD endpoint and the onboarded account.
+    await expect(status).toHaveText("Not enabled");
+    await setTwoFactorEnabled(true);
+    await expect(page.getByText(adminOnlyText)).toHaveCount(0);
+
+    await page
+      .getByRole("button", {
+        name: "Turn off two-factor authentication",
+        exact: true,
+      })
+      .click();
+    const cancelDialog: Locator = page.getByRole("dialog", {
+      name: "Turn off two-factor authentication?",
+      exact: true,
+    });
+    await expect(cancelDialog).toBeVisible();
+    await cancelDialog
+      .getByRole("button", { name: "Cancel", exact: true })
+      .click();
+    await expect(cancelDialog).toBeHidden();
+    await expect(status).toHaveText("Enabled");
+    await page.reload();
+    await expect(status).toHaveText("Enabled");
+
+    await setTwoFactorEnabled(false);
+    await page.reload();
+    await expect(status).toHaveText("Not enabled");
+    await expect(
+      page.getByRole("button", {
+        name: "Enable two-factor authentication",
+        exact: true,
+      }),
+    ).toBeEnabled();
+
+    await setTwoFactorEnabled(true);
+    await page.reload();
+    await expect(status).toHaveText("Enabled");
+    await expect(page.getByText(adminOnlyText)).toHaveCount(0);
+
+    // Leave the temporary account in its original state for shared cleanup.
+    await setTwoFactorEnabled(false);
+  });
 });


### PR DESCRIPTION
The Passkeys and two-factor authentication pages capped their cards at 72rem, leaving much of a wide screen unused. Both pages now fill the available content column, and the explanatory legacy-credential notice and “Existing credential” badge are removed from both lists. Credential names, readiness status, filtering, and management actions remain available. Successful security-key registration now refreshes the list without the extra success banner, while preserving newly issued backup codes.

Enabled two-factor authentication now has a **Turn off two-factor authentication** action. A confirmation explains the effect and preserves saved authenticator apps, security keys, and backup codes. The UI updates only after the server succeeds, prevents duplicate submissions, and supports retrying a failed save. The administrator-only explanatory text is removed from both enabled and enable-confirmation states.

The ordinary User API allows disabling only when the target is exactly the authenticated user's own row. It rejects malformed boolean values, broad/operator queries, and foreign targets before persistence; existing administrator endpoints and their session checks remain covered. The existing `enableTwoFactorAuth` flag is shared between user and administrator changes, so users can turn it off for their own account regardless of how it was enabled.

Validation:

- 56 focused UI tests passed: 17 two-factor status tests and 39 credential-management/registration tests. Coverage includes banner and badge removal while preserving a key whose user-chosen name is “Existing credential”. Jest ran with isolated transpilation locally; project compilation was checked separately.
- 168 focused server tests passed: 82 service, 50 administrator API, 17 email-change regression, and 19 new self-service API integration cases. Integration tests run real request deserialization, service hooks, permissions, and update logic with database I/O replaced at the boundary.
- 4 focused browser checks against actual pages with fixture data passed at 2560px and 390px: badges are absent, saved key names and controls remain, and neither page overflows horizontally. All four screenshots were visually reviewed. The layout and two-factor toggle flows also passed their earlier browser checks.
- A live E2E regression covers the real toggle lifecycle and persistence after reload, alongside the existing layout scenarios.
- Dashboard, Common, and E2E project compilation passed.
- Root `npm run fix` passed, scoped to the changed files.

Live development-server E2E remains blocked by an existing HTTP 502 response at onboarding. The new live toggle case was compiled but could not be executed against that server; the fixture browser checks and API integration tests passed independently.
