### PR TITLE
Make unresolved exceptions the default tab

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/AIChat/PageContext.ts
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/PageContext.ts
@@ -184,7 +184,7 @@ const areaPageRules: Array<AreaPageRule> = [
   {
     /*
      * The exceptions area has no plain base entry in RouteMap (EXCEPTIONS
-     * points at /exceptions/overview and EXCEPTIONS_ROOT is a `/*` wildcard
+     * points at /exceptions/unresolved and EXCEPTIONS_ROOT is a `/*` wildcard
      * that segment-matching cannot use), so build the base route here.
      */
     baseRoute: new Route(`/dashboard/${RouteParams.ProjectID}/exceptions`),

--- a/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionsNavTabs.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionsNavTabs.tsx
@@ -14,13 +14,7 @@ import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import IncludesNone from "Common/Types/BaseDatabase/IncludesNone";
 import { NON_ACTIONABLE_ERROR_CLASSES } from "Common/Types/Telemetry/ErrorClass";
-
-export type ExceptionsTabKey =
-  | "overview"
-  | "unresolved"
-  | "resolved"
-  | "archived"
-  | "setup";
+import { ExceptionsTabKey } from "../../Utils/ExceptionsNavigation";
 
 interface Props {
   active: ExceptionsTabKey;
@@ -83,7 +77,7 @@ const ExceptionsNavTabs: FunctionComponent<Props> = (
    * They used to be dropped on every tab click — filter to five services in
    * Unresolved, click Resolved, and the filter was gone.
    *
-   * Overview deliberately does not carry: it is a different, unscoped
+   * Insights deliberately does not carry: it is a different, unscoped
    * component, and handing it a filtered URL would put a scope in the
    * address bar that none of its numbers honour.
    *
@@ -92,14 +86,6 @@ const ExceptionsNavTabs: FunctionComponent<Props> = (
    * from.
    */
   const tabs: Array<TelemetryTab> = [
-    {
-      key: "overview",
-      label: "Overview",
-      icon: IconProp.Home,
-      to: RouteUtil.populateRouteParams(
-        RouteMap[PageMap.EXCEPTIONS_OVERVIEW] as Route,
-      ),
-    },
     {
       key: "unresolved",
       label: "Unresolved",
@@ -116,6 +102,14 @@ const ExceptionsNavTabs: FunctionComponent<Props> = (
           }
         : {}),
       carriesScope: true,
+    },
+    {
+      key: "overview",
+      label: "Insights",
+      icon: IconProp.ChartBar,
+      to: RouteUtil.populateRouteParams(
+        RouteMap[PageMap.EXCEPTIONS_OVERVIEW] as Route,
+      ),
     },
     {
       key: "resolved",

--- a/App/FeatureSet/Dashboard/src/Pages/Exceptions/Layout.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Exceptions/Layout.tsx
@@ -1,32 +1,13 @@
 import { getExceptionsBreadcrumbs } from "../../Utils/Breadcrumbs";
 import PageMap from "../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
+import { getActiveExceptionsTab } from "../../Utils/ExceptionsNavigation";
 import PageComponentProps from "../PageComponentProps";
-import ExceptionsNavTabs, {
-  ExceptionsTabKey,
-} from "../../Components/Exceptions/ExceptionsNavTabs";
+import ExceptionsNavTabs from "../../Components/Exceptions/ExceptionsNavTabs";
 import Page from "Common/UI/Components/Page/Page";
 import Navigation from "Common/UI/Utils/Navigation";
 import React, { FunctionComponent, ReactElement } from "react";
 import { Outlet } from "react-router-dom";
-
-const getActiveExceptionsTab: (path: string) => ExceptionsTabKey = (
-  path: string,
-): ExceptionsTabKey => {
-  if (path.includes("/exceptions/unresolved")) {
-    return "unresolved";
-  }
-  if (path.includes("/exceptions/resolved")) {
-    return "resolved";
-  }
-  if (path.includes("/exceptions/archived")) {
-    return "archived";
-  }
-  if (path.includes("/exceptions/documentation")) {
-    return "setup";
-  }
-  return "overview";
-};
 
 const ExceptionsLayout: FunctionComponent<
   PageComponentProps
@@ -35,7 +16,7 @@ const ExceptionsLayout: FunctionComponent<
 
   if (path.endsWith("exceptions") || path.endsWith("exceptions/*")) {
     Navigation.navigate(
-      RouteUtil.populateRouteParams(RouteMap[PageMap.EXCEPTIONS_OVERVIEW]!),
+      RouteUtil.populateRouteParams(RouteMap[PageMap.EXCEPTIONS]!),
     );
 
     return <></>;

--- a/App/FeatureSet/Dashboard/src/Pages/Exceptions/View/Layout.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Exceptions/View/Layout.tsx
@@ -14,7 +14,7 @@ const ExceptionViewLayout: FunctionComponent<
 
   if (path.endsWith("exceptions")) {
     Navigation.navigate(
-      RouteUtil.populateRouteParams(RouteMap[PageMap.EXCEPTIONS_OVERVIEW]!),
+      RouteUtil.populateRouteParams(RouteMap[PageMap.EXCEPTIONS]!),
     );
 
     return <></>;

--- a/App/FeatureSet/Dashboard/src/Routes/ExceptionsRoutes.tsx
+++ b/App/FeatureSet/Dashboard/src/Routes/ExceptionsRoutes.tsx
@@ -24,7 +24,7 @@ const ExceptionsRoutes: FunctionComponent<ComponentProps> = (
         <PageRoute
           index
           element={
-            <ExceptionsOverview
+            <ExceptionsUnresolved
               {...props}
               pageRoute={RouteMap[PageMap.EXCEPTIONS] as Route}
             />

--- a/App/FeatureSet/Dashboard/src/Utils/Breadcrumbs/ExceptionsBreadcrumbs.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Breadcrumbs/ExceptionsBreadcrumbs.ts
@@ -14,7 +14,7 @@ export function getExceptionsBreadcrumbs(
     ...BuildBreadcrumbLinksByTitles(PageMap.EXCEPTIONS_OVERVIEW, [
       "Project",
       "Exceptions",
-      "Overview",
+      "Insights",
     ]),
     ...BuildBreadcrumbLinksByTitles(PageMap.EXCEPTIONS_UNRESOLVED, [
       "Project",

--- a/App/FeatureSet/Dashboard/src/Utils/ExceptionsNavigation.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/ExceptionsNavigation.ts
@@ -1,0 +1,25 @@
+export type ExceptionsTabKey =
+  | "overview"
+  | "unresolved"
+  | "resolved"
+  | "archived"
+  | "setup";
+
+export function getActiveExceptionsTab(path: string): ExceptionsTabKey {
+  if (path.includes("/exceptions/unresolved")) {
+    return "unresolved";
+  }
+  if (path.includes("/exceptions/overview")) {
+    return "overview";
+  }
+  if (path.includes("/exceptions/resolved")) {
+    return "resolved";
+  }
+  if (path.includes("/exceptions/archived")) {
+    return "archived";
+  }
+  if (path.includes("/exceptions/documentation")) {
+    return "setup";
+  }
+  return "unresolved";
+}

--- a/App/FeatureSet/Dashboard/src/Utils/NavigationItems.tsx
+++ b/App/FeatureSet/Dashboard/src/Utils/NavigationItems.tsx
@@ -162,7 +162,7 @@ export function useDashboardNavigationItems(): DashboardNavigationItems {
       route: RouteUtil.populateRouteParams(
         RouteMap[PageMap.EXCEPTIONS] as Route,
       ),
-      activeRoute: RouteMap[PageMap.EXCEPTIONS],
+      activeRoute: RouteMap[PageMap.EXCEPTIONS_VIEW_ROOT],
       icon: IconProp.Bug,
       iconColor: "orange",
       category: observabilityCategory,

--- a/App/FeatureSet/Dashboard/src/Utils/RouteMap.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/RouteMap.ts
@@ -603,7 +603,7 @@ export const TopologyRoutePath: Dictionary<string> = {
 };
 
 export const ExceptionsRoutePath: Dictionary<string> = {
-  [PageMap.EXCEPTIONS]: "overview",
+  [PageMap.EXCEPTIONS]: "unresolved",
   [PageMap.EXCEPTIONS_OVERVIEW]: "overview",
   [PageMap.EXCEPTIONS_UNRESOLVED]: "unresolved",
   [PageMap.EXCEPTIONS_RESOLVED]: "resolved",

--- a/App/Tests/Dashboard/ExceptionsLandingNavigation.test.ts
+++ b/App/Tests/Dashboard/ExceptionsLandingNavigation.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import { getActiveExceptionsTab } from "../../FeatureSet/Dashboard/src/Utils/ExceptionsNavigation";
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function readSquashed(relativePath: string): string {
+  return fs
+    .readFileSync(path.join(DASHBOARD_SRC, relativePath), "utf8")
+    .replace(/\s+/g, " ");
+}
+
+function sectionBetween(
+  source: string,
+  startMarker: string,
+  endMarker: string,
+): string {
+  const start: number = source.indexOf(startMarker);
+
+  if (start < 0) {
+    throw new Error(`Start marker not found: ${startMarker}`);
+  }
+
+  const end: number = source.indexOf(endMarker, start + startMarker.length);
+
+  if (end < 0) {
+    throw new Error(`End marker not found: ${endMarker}`);
+  }
+
+  return source.slice(start, end);
+}
+
+interface TabDefinition {
+  key: string;
+  label: string;
+}
+
+function getTabDefinitions(source: string): Array<TabDefinition> {
+  return Array.from(source.matchAll(/key: "([^"]+)", label: "([^"]+)",/g)).map(
+    (match: RegExpMatchArray): TabDefinition => {
+      const key: string | undefined = match[1];
+      const label: string | undefined = match[2];
+
+      if (!key || !label) {
+        throw new Error("A tab is missing its key or label");
+      }
+
+      return { key, label };
+    },
+  );
+}
+
+describe("Exceptions landing navigation", () => {
+  test.each([
+    ["/dashboard/project-id/exceptions", "unresolved"],
+    ["/dashboard/project-id/exceptions/unresolved", "unresolved"],
+    ["/dashboard/project-id/exceptions/overview", "overview"],
+    ["/dashboard/project-id/exceptions/resolved", "resolved"],
+    ["/dashboard/project-id/exceptions/archived", "archived"],
+    ["/dashboard/project-id/exceptions/documentation", "setup"],
+  ])("selects the %s route's %s tab", (route: string, tab: string) => {
+    expect(getActiveExceptionsTab(route)).toBe(tab);
+  });
+
+  test("shows Unresolved first and the former Overview dashboard as Insights second", () => {
+    const source: string = readSquashed(
+      "Components/Exceptions/ExceptionsNavTabs.tsx",
+    );
+    const tabs: string = sectionBetween(
+      source,
+      "const tabs: Array<TelemetryTab> = [",
+      "];",
+    );
+
+    expect(getTabDefinitions(tabs).slice(0, 2)).toEqual([
+      { key: "unresolved", label: "Unresolved" },
+      { key: "overview", label: "Insights" },
+    ]);
+
+    const insightsTab: string = sectionBetween(
+      tabs,
+      'key: "overview",',
+      'key: "resolved",',
+    );
+
+    expect(insightsTab).toContain("IconProp.ChartBar");
+    expect(insightsTab).toContain("PageMap.EXCEPTIONS_OVERVIEW");
+  });
+
+  test("makes the primary Exceptions route unresolved while preserving the Overview URL", () => {
+    const source: string = readSquashed("Utils/RouteMap.ts");
+
+    expect(source).toContain('[PageMap.EXCEPTIONS]: "unresolved"');
+    expect(source).toContain('[PageMap.EXCEPTIONS_UNRESOLVED]: "unresolved"');
+    expect(source).toContain('[PageMap.EXCEPTIONS_OVERVIEW]: "overview"');
+  });
+
+  test("keeps the Exceptions product active across every child route", () => {
+    const source: string = readSquashed("Utils/NavigationItems.tsx");
+    const exceptionsItem: string = sectionBetween(
+      source,
+      'title: t("navbar.items.exceptionsTitle")',
+      'title: t("navbar.items.llmObservabilityTitle"',
+    );
+
+    expect(exceptionsItem).toContain("RouteMap[PageMap.EXCEPTIONS] as Route");
+    expect(exceptionsItem).toContain(
+      "activeRoute: RouteMap[PageMap.EXCEPTIONS_VIEW_ROOT]",
+    );
+  });
+
+  test("renders and redirects every bare Exceptions entry point to the primary route", () => {
+    const routes: string = readSquashed("Routes/ExceptionsRoutes.tsx");
+    const indexRoute: string = sectionBetween(
+      routes,
+      "<PageRoute index",
+      "<PageRoute path=",
+    );
+    const insightsRoute: string = sectionBetween(
+      routes,
+      "path={ExceptionsRoutePath[PageMap.EXCEPTIONS_OVERVIEW]",
+      "path={ExceptionsRoutePath[PageMap.EXCEPTIONS_UNRESOLVED]",
+    );
+
+    expect(indexRoute).toContain("<ExceptionsUnresolved");
+    expect(indexRoute).toContain("RouteMap[PageMap.EXCEPTIONS]");
+    expect(indexRoute).not.toContain("<ExceptionsOverview");
+    expect(insightsRoute).toContain("<ExceptionsOverview");
+    expect(insightsRoute).toContain(
+      "RouteMap[PageMap.EXCEPTIONS_OVERVIEW] as Route",
+    );
+    expect(insightsRoute).not.toContain("<ExceptionsUnresolved");
+
+    for (const layout of [
+      "Pages/Exceptions/Layout.tsx",
+      "Pages/Exceptions/View/Layout.tsx",
+    ]) {
+      const source: string = readSquashed(layout);
+
+      expect(source).toContain(
+        "Navigation.navigate( RouteUtil.populateRouteParams(RouteMap[PageMap.EXCEPTIONS]!), );",
+      );
+      expect(source).not.toContain("RouteMap[PageMap.EXCEPTIONS_OVERVIEW]!");
+    }
+  });
+
+  test("labels the preserved Overview route as Insights in its breadcrumb", () => {
+    const source: string = readSquashed(
+      "Utils/Breadcrumbs/ExceptionsBreadcrumbs.ts",
+    );
+    const insightsBreadcrumb: string = sectionBetween(
+      source,
+      "BuildBreadcrumbLinksByTitles(PageMap.EXCEPTIONS_OVERVIEW",
+      "BuildBreadcrumbLinksByTitles(PageMap.EXCEPTIONS_UNRESOLVED",
+    );
+
+    expect(insightsBreadcrumb).toContain('"Insights"');
+    expect(insightsBreadcrumb).not.toContain('"Overview"');
+  });
+});

--- a/App/Tests/Dashboard/TelemetryScopeHandoffWiring.test.ts
+++ b/App/Tests/Dashboard/TelemetryScopeHandoffWiring.test.ts
@@ -185,7 +185,7 @@ describe("the Logs explorer's first URL write is never narrower than the link", 
   });
 });
 
-describe("the Exceptions status tabs carry scope, and Overview does not", () => {
+describe("the Exceptions status tabs carry scope, and Insights does not", () => {
   const EXCEPTIONS_NAV_TABS: string =
     "Components/Exceptions/ExceptionsNavTabs.tsx";
 
@@ -223,14 +223,14 @@ describe("the Exceptions status tabs carry scope, and Overview does not", () => 
        * different status default, so a service filter, a search or a window
        * set on one describes the other two exactly. Those three carry.
        *
-       * Overview must not. It is a different, unscoped component: handing it
+       * Insights must not. It is a different, unscoped component: handing it
        * a filtered URL would put a scope in the address bar that none of its
        * numbers honour, which is worse than losing the filter — the user
        * reads project-wide totals under a five-service label and believes
        * them. Setup Guide is not a view of the data at all.
        *
        * Asserting per tab rather than by count is the point: moving the
-       * marker from Archived to Overview keeps the count at three and breaks
+       * marker from Archived to Insights keeps the count at three and breaks
        * exactly this test.
        */
       const entry: string = tabEntry(exceptionsTabsArray(), key);

--- a/Common/Tests/App/Dashboard/ExceptionsLandingRedirect.test.tsx
+++ b/Common/Tests/App/Dashboard/ExceptionsLandingRedirect.test.tsx
@@ -1,0 +1,63 @@
+import ExceptionsLayout from "../../../../App/FeatureSet/Dashboard/src/Pages/Exceptions/Layout";
+import PageComponentProps from "../../../../App/FeatureSet/Dashboard/src/Pages/PageComponentProps";
+import PageMap from "../../../../App/FeatureSet/Dashboard/src/Utils/PageMap";
+import RouteMap, {
+  RouteUtil,
+} from "../../../../App/FeatureSet/Dashboard/src/Utils/RouteMap";
+import Route from "../../../Types/API/Route";
+import Navigation from "../../../UI/Utils/Navigation";
+import "@testing-library/jest-dom";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { Location } from "react-router-dom";
+
+const PROJECT_ID: string = "10000000-0000-4000-8000-000000000001";
+
+interface NavigateSpy {
+  mock: {
+    calls: ReadonlyArray<ReadonlyArray<unknown>>;
+  };
+}
+
+function goTo(path: string): void {
+  window.history.pushState({}, "", path);
+  Navigation.setLocation({
+    pathname: path,
+    search: "",
+    hash: "",
+    state: null,
+    key: "test",
+  } as Location);
+}
+
+afterEach((): void => {
+  cleanup();
+  jest.restoreAllMocks();
+});
+
+describe("Exceptions landing redirect", () => {
+  test("a bare Exceptions URL opens the Unresolved list", () => {
+    const barePath: string = `/dashboard/${PROJECT_ID}/exceptions`;
+    goTo(barePath);
+
+    const navigate: NavigateSpy = jest
+      .spyOn(Navigation, "navigate")
+      .mockImplementation((): void => {});
+
+    render(<ExceptionsLayout {...({} as PageComponentProps)} />);
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+
+    const destination: Route = navigate.mock.calls[0]![0] as Route;
+
+    expect(destination.toString()).toBe(
+      `/dashboard/${PROJECT_ID}/exceptions/unresolved`,
+    );
+    expect(destination.toString()).toBe(
+      RouteUtil.populateRouteParams(
+        RouteMap[PageMap.EXCEPTIONS] as Route,
+      ).toString(),
+    );
+  });
+});

--- a/Common/Tests/UI/Components/NavBar.test.tsx
+++ b/Common/Tests/UI/Components/NavBar.test.tsx
@@ -1,15 +1,18 @@
 import Navbar, {
   ComponentProps,
+  MoreMenuItem,
   NavItem,
 } from "../../../UI/Components/Navbar/NavBar";
-import { describe, expect, it, beforeEach } from "@jest/globals";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import Route from "../../../Types/API/Route";
 import IconProp from "../../../Types/Icon/IconProp";
 import Navigation from "../../../UI/Utils/Navigation";
 import { Location } from "react-router-dom";
+
+const ORIGINAL_INNER_WIDTH: number = window.innerWidth;
 
 describe("Navbar", () => {
   // Mock Navigation location for Navigation utility
@@ -22,6 +25,15 @@ describe("Navbar", () => {
       key: "default",
     };
     Navigation.setLocation(mockLocation);
+  });
+
+  afterEach(() => {
+    cleanup();
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: ORIGINAL_INNER_WIDTH,
+    });
   });
   const defaultProps: ComponentProps = {
     children: <div>Test</div>,
@@ -62,5 +74,82 @@ describe("Navbar", () => {
     render(<Navbar {...customProps} />);
     expect(screen.getByText("Child 1")).toBeInTheDocument();
     expect(screen.getByText("Child 2")).toBeInTheDocument();
+  });
+
+  it("uses a product's section-wide active route in the mobile selector", () => {
+    const projectId: string = "10000000-0000-4000-8000-000000000001";
+    const path: string = `/dashboard/${projectId}/exceptions/overview`;
+
+    Navigation.setLocation({
+      pathname: path,
+      search: "",
+      hash: "",
+      state: null,
+      key: "test",
+    } as Location);
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 375,
+    });
+
+    const home: NavItem = {
+      id: "home-nav-bar-item",
+      title: "Home",
+      icon: IconProp.Home,
+      route: new Route(`/dashboard/${projectId}/home`),
+    };
+    const exceptions: MoreMenuItem = {
+      title: "Exceptions",
+      description: "Investigate application exceptions.",
+      icon: IconProp.Bug,
+      route: new Route(`/dashboard/${projectId}/exceptions/unresolved`),
+      activeRoute: new Route("/dashboard/:projectId/exceptions"),
+    };
+
+    render(<Navbar items={[home]} moreMenuItems={[exceptions]} />);
+
+    expect(screen.getByTestId("mobile-nav-toggle")).toBeInTheDocument();
+    expect(screen.getByText("Exceptions")).toBeInTheDocument();
+    expect(screen.queryByText("Home")).not.toBeInTheDocument();
+  });
+
+  it("uses a product's section-wide active route in the desktop selector", () => {
+    const projectId: string = "10000000-0000-4000-8000-000000000001";
+    const path: string = `/dashboard/${projectId}/exceptions/overview`;
+
+    Navigation.setLocation({
+      pathname: path,
+      search: "",
+      hash: "",
+      state: null,
+      key: "test",
+    } as Location);
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 1024,
+    });
+
+    const home: NavItem = {
+      id: "home-nav-bar-item",
+      title: "Home",
+      icon: IconProp.Home,
+      route: new Route(`/dashboard/${projectId}/home`),
+    };
+    const exceptions: MoreMenuItem = {
+      title: "Exceptions",
+      description: "Investigate application exceptions.",
+      icon: IconProp.Bug,
+      route: new Route(`/dashboard/${projectId}/exceptions/unresolved`),
+      activeRoute: new Route("/dashboard/:projectId/exceptions"),
+    };
+
+    render(<Navbar items={[home]} moreMenuItems={[exceptions]} />);
+
+    expect(screen.queryByTestId("mobile-nav-toggle")).not.toBeInTheDocument();
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.getByText("Exceptions")).toBeInTheDocument();
+    expect(screen.queryByText("Products")).not.toBeInTheDocument();
   });
 });

--- a/Common/Tests/UI/Utils/Breadcrumb/fixtures/RealBreadcrumbTrails.ts
+++ b/Common/Tests/UI/Utils/Breadcrumb/fixtures/RealBreadcrumbTrails.ts
@@ -680,7 +680,7 @@ const realBreadcrumbTrails: Array<BreadcrumbTrailFixture> = [
   {
     getter: "getExceptionsBreadcrumbs",
     pagePattern: "/dashboard/:projectId/exceptions/overview",
-    titles: ["Project", "Exceptions", "Overview"],
+    titles: ["Project", "Exceptions", "Insights"],
   },
   {
     getter: "getExceptionsBreadcrumbs",

--- a/Common/Tests/UI/Utils/Breadcrumb/fixtures/RealRoutePatterns.ts
+++ b/Common/Tests/UI/Utils/Breadcrumb/fixtures/RealRoutePatterns.ts
@@ -768,7 +768,7 @@ const realRoutePatterns: Array<string> = [
   "/dashboard/:projectId/ai/insights/:id",
   "/dashboard/:projectId/ai/insights/settings",
   "/dashboard/:projectId/exceptions/*",
-  "/dashboard/:projectId/exceptions/overview",
+  "/dashboard/:projectId/exceptions/unresolved",
   "/dashboard/:projectId/llm/*",
   "/dashboard/:projectId/ai/chat",
   "/dashboard/:projectId/llm/overview",

--- a/Common/UI/Components/Navbar/NavBar.tsx
+++ b/Common/UI/Components/Navbar/NavBar.tsx
@@ -292,6 +292,7 @@ const Navbar: FunctionComponent<ComponentProps> = (
           title: item.title,
           icon: item.icon,
           route: item.route,
+          activeRoute: item.activeRoute,
           description: item.description,
         };
       }),


### PR DESCRIPTION
### Title of this pull request?

Make unresolved exceptions the default tab

### Small Description?

- Opens the Exceptions page on the Unresolved list so exceptions are visible immediately.
- Moves Unresolved to the first tab and renames the former Overview tab to Insights while preserving its existing `/exceptions/overview` URL.
- Keeps the Exceptions product selected across child routes on desktop and mobile.
- Adds regression coverage for landing redirects, tab and route wiring, active navigation, and breadcrumbs.

Validation:

- `npm run fix`
- `npm run compile` in `Common`, `App`, and `App/FeatureSet/Dashboard`
- Exceptions navigation and telemetry wiring suites: 31 tests passed
- Navbar suite: 6 tests passed
- Exceptions landing redirect suite: 1 test passed
- Breadcrumb resolver suite: 574 tests passed

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

N/A

### Screenshots (if appropriate):

N/A — navigation and route behavior change.
