### PR TITLE
Add managed security event connectors

### DIFF
--- a/App/FeatureSet/BaseAPI/Index.ts
+++ b/App/FeatureSet/BaseAPI/Index.ts
@@ -548,6 +548,9 @@ import GoogleSecOpsConnectionAPI from "Common/Server/API/GoogleSecOpsConnectionA
 import GoogleSecOpsConnectionRunService, {
   Service as GoogleSecOpsConnectionRunServiceType,
 } from "Common/Server/Services/GoogleSecOpsConnectionRunService";
+import SecurityEventConnectionService, {
+  Service as SecurityEventConnectionServiceType,
+} from "Common/Server/Services/SecurityEventConnectionService";
 import ThreatIntelFeedService, {
   Service as ThreatIntelFeedServiceType,
 } from "Common/Server/Services/ThreatIntelFeedService";
@@ -1429,6 +1432,7 @@ import LogPipelineProcessor from "Common/Models/DatabaseModels/LogPipelineProces
 import LogDropFilter from "Common/Models/DatabaseModels/LogDropFilter";
 import DetectionRule from "Common/Models/DatabaseModels/DetectionRule";
 import GoogleSecOpsConnectionRun from "Common/Models/DatabaseModels/GoogleSecOpsConnectionRun";
+import SecurityEventConnection from "Common/Models/DatabaseModels/SecurityEventConnection";
 import ThreatIntelFeed from "Common/Models/DatabaseModels/ThreatIntelFeed";
 import LogScrubRule from "Common/Models/DatabaseModels/LogScrubRule";
 import MetricPipelineRule from "Common/Models/DatabaseModels/MetricPipelineRule";
@@ -3542,6 +3546,14 @@ const BaseAPIFeatureSet: FeatureSet = {
     app.use(
       `/${APP_NAME.toLocaleLowerCase()}`,
       new GoogleSecOpsConnectionAPI().getRouter(),
+    );
+
+    app.use(
+      `/${APP_NAME.toLocaleLowerCase()}`,
+      new BaseAPI<SecurityEventConnection, SecurityEventConnectionServiceType>(
+        SecurityEventConnection,
+        SecurityEventConnectionService,
+      ).getRouter(),
     );
 
     app.use(

--- a/App/FeatureSet/Dashboard/src/Components/SecurityEvents/ManagedSecurityEventConnections.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SecurityEvents/ManagedSecurityEventConnections.tsx
@@ -1,0 +1,350 @@
+import SecurityEventConnection from "Common/Models/DatabaseModels/SecurityEventConnection";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { Green, LightGray, Red, Yellow } from "Common/Types/BrandColors";
+import Color from "Common/Types/Color";
+import { VoidFunction } from "Common/Types/FunctionTypes";
+import IconProp from "Common/Types/Icon/IconProp";
+import { JSONObject } from "Common/Types/JSON";
+import SecurityEventConnectorType from "Common/Types/SecurityEvent/SecurityEventConnectorType";
+import { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import BasicFormModal from "Common/UI/Components/FormModal/BasicFormModal";
+import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import { ModalWidth } from "Common/UI/Components/Modal/Modal";
+import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
+import Pill from "Common/UI/Components/Pill/Pill";
+import FieldType from "Common/UI/Components/Types/FieldType";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "Common/UI/Utils/PermissionGate";
+import ProjectUtil from "Common/UI/Utils/Project";
+import React, { FunctionComponent, ReactElement, useState } from "react";
+
+const providerOptions: Array<{ label: string; value: string }> = [
+  {
+    label: "AWS Security Hub",
+    value: SecurityEventConnectorType.AwsSecurityHub,
+  },
+  {
+    label: "Microsoft Defender XDR and Sentinel",
+    value: SecurityEventConnectorType.MicrosoftDefender,
+  },
+  { label: "Cloudflare", value: SecurityEventConnectorType.Cloudflare },
+  {
+    label: "CrowdStrike Falcon",
+    value: SecurityEventConnectorType.CrowdStrikeFalcon,
+  },
+  {
+    label: "Google Security Command Center",
+    value: SecurityEventConnectorType.GoogleSecurityCommandCenter,
+  },
+  { label: "Okta", value: SecurityEventConnectorType.Okta },
+  {
+    label: "Splunk Enterprise Security",
+    value: SecurityEventConnectorType.SplunkEnterpriseSecurity,
+  },
+];
+
+const documentationMarkdown: string = `
+### Managed security event connections
+
+OneUptime polls each enabled connection, normalizes the provider's findings or alerts, deduplicates them, enriches observable values with threat intelligence, and stores them as security events. Credentials are encrypted at rest and are never returned by the API.
+
+Enter **Configuration** and **Credentials JSON** using the shape for the selected provider:
+
+| Provider | Configuration | Credentials |
+| --- | --- | --- |
+| AWS Security Hub | \`{ "region": "us-east-1" }\` | \`{ "accessKeyId": "...", "secretAccessKey": "...", "sessionToken": "..." }\` |
+| Microsoft Defender XDR and Sentinel | \`{ "tenantId": "..." }\` | \`{ "clientId": "...", "clientSecret": "..." }\` |
+| Cloudflare | \`{ "zoneId": "..." }\` | \`{ "apiToken": "..." }\` |
+| CrowdStrike Falcon | \`{ "cloud": "us-1" }\` | \`{ "clientId": "...", "clientSecret": "..." }\` |
+| Google Security Command Center | \`{ "parent": "organizations/123/sources/-" }\` | A service-account key containing \`client_email\`, \`private_key\`, and optionally \`token_uri\` |
+| Okta | \`{ "baseUrl": "https://example.okta.com" }\` | \`{ "apiToken": "..." }\` |
+| Splunk Enterprise Security | \`{ "baseUrl": "https://splunk.example.com:8089", "search": "search index=notable" }\` | \`{ "apiToken": "...", "tokenScheme": "Bearer" }\` or \`{ "username": "...", "password": "..." }\` |
+
+The first poll reads the preceding 15 minutes. Time-window providers later overlap the previous cursor by one minute and catch up in 24-hour windows; Okta resumes its ascending next link. Provider pagination is resumed across polls, and busy or repeatedly failing windows are narrowed automatically. GuardDuty findings must first be integrated into Security Hub, and Sentinel must be onboarded to the Defender portal. Invalid records create durable audit events and are shown as a partial import while later records continue to flow. **Last Error** and **Last Poll Result** show the latest provider and import outcome.
+
+Credential updates are rotations for the same source. Create a new connection when AWS or CrowdStrike credentials point to a different account with otherwise identical settings.
+`;
+
+function connectionHealth(item: SecurityEventConnection): {
+  color: Color;
+  text: string;
+} {
+  if (item.lastPollResult?.["error"]) {
+    return { color: Red, text: "Last poll failed" };
+  }
+  if (item.lastPollResult?.["complete"] === false) {
+    return { color: Yellow, text: "Partial import" };
+  }
+  if (item.lastError) {
+    return { color: Red, text: "Last poll failed" };
+  }
+  if (!item.lastPolledAt) {
+    return { color: LightGray, text: "Never polled" };
+  }
+  const interval: number = Math.max(1, item.pollIntervalInMinutes || 5);
+  if (
+    item.isEnabled &&
+    item.lastPolledAt.getTime() + interval * 2 * 60_000 < Date.now()
+  ) {
+    return { color: Yellow, text: "Poll overdue" };
+  }
+  return { color: Green, text: "Healthy" };
+}
+
+const ManagedSecurityEventConnections: FunctionComponent = (): ReactElement => {
+  const [credentialItem, setCredentialItem] =
+    useState<SecurityEventConnection | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [refreshCounter, setRefreshCounter] = useState<number>(0);
+  const updateGate: PermissionGateResult = PermissionGate.check(
+    new SecurityEventConnection(),
+    ModelAction.Update,
+  );
+
+  return (
+    <>
+      <ModelTable<SecurityEventConnection>
+        modelType={SecurityEventConnection}
+        refreshToggle={String(refreshCounter)}
+        selectMoreFields={{
+          projectId: true,
+          provider: true,
+          configuration: true,
+          isEnabled: true,
+          pollIntervalInMinutes: true,
+          lastPolledAt: true,
+          lastSuccessfulPollAt: true,
+          lastEventIngestedAt: true,
+          lastPollResult: true,
+          lastError: true,
+        }}
+        query={{ projectId: ProjectUtil.getCurrentProjectId()! }}
+        id="managed-security-event-connections-table"
+        name="Security Events > Managed Connections"
+        userPreferencesKey="managed-security-event-connections-table"
+        isDeleteable={true}
+        isEditable={true}
+        isCreateable={true}
+        isViewable={false}
+        createEditModalWidth={ModalWidth.Large}
+        sortBy="name"
+        sortOrder={SortOrder.Ascending}
+        cardProps={{
+          title: "Managed Security Event Connections",
+          description:
+            "Import findings and alerts from AWS, Microsoft, Cloudflare, CrowdStrike, Google Security Command Center, Okta, and Splunk.",
+        }}
+        helpContent={{
+          title: "Configure managed security event connections",
+          description:
+            "Provider settings, credential formats, polling, and connector health",
+          markdown: documentationMarkdown,
+        }}
+        noItemsMessage='No managed security event connections found. Click "Create" to add one.'
+        createInitialValues={{ isEnabled: true, pollIntervalInMinutes: 5 }}
+        formFields={[
+          {
+            field: { name: true },
+            title: "Name",
+            fieldType: FormFieldSchemaType.Text,
+            required: true,
+            placeholder: "e.g. Production Security Hub",
+            validation: { minLength: 2 },
+          },
+          {
+            field: { provider: true },
+            title: "Provider",
+            description:
+              "The security product this connection reads from. Create another connection to change providers.",
+            fieldType: FormFieldSchemaType.Dropdown,
+            dropdownOptions: providerOptions,
+            required: true,
+            doNotShowWhenEditing: true,
+            placeholder: "Select a provider",
+          },
+          {
+            field: { configuration: true },
+            title: "Configuration",
+            description:
+              "Non-secret provider settings. Open Help for the exact JSON shape for each provider.",
+            fieldType: FormFieldSchemaType.JSON,
+            required: true,
+            placeholder: '{ "region": "us-east-1" }',
+          },
+          {
+            field: { credentialJson: true },
+            title: "Credentials JSON",
+            description:
+              "Provider credentials. They are encrypted at rest and never returned; use Update Credentials to rotate them.",
+            fieldType: FormFieldSchemaType.JSON,
+            required: true,
+            doNotShowWhenEditing: true,
+            placeholder: '{ "apiToken": "..." }',
+          },
+          {
+            field: { isEnabled: true },
+            title: "Enabled",
+            description:
+              "Disabled connections are skipped by scheduled polling.",
+            fieldType: FormFieldSchemaType.Toggle,
+            required: false,
+          },
+          {
+            field: { pollIntervalInMinutes: true },
+            title: "Poll Interval (Minutes)",
+            description: "How often events are fetched. Default 5 minutes.",
+            fieldType: FormFieldSchemaType.Number,
+            required: true,
+            placeholder: "5",
+            validation: { minValue: 1, maxValue: 1440 },
+          },
+        ]}
+        searchableFields={["name", "provider"]}
+        showRefreshButton={true}
+        showViewIdButton={true}
+        actionButtons={[
+          {
+            title: "Update Credentials",
+            icon: IconProp.Key,
+            buttonStyleType: ButtonStyleType.OUTLINE,
+            disabled: !updateGate.isAllowed,
+            tooltip: updateGate.isAllowed
+              ? "Replace the encrypted credentials for this connection."
+              : updateGate.disabledReason,
+            onClick: (
+              item: SecurityEventConnection,
+              onCompleteAction: VoidFunction,
+            ): void => {
+              setCredentialItem(item);
+              onCompleteAction();
+            },
+          },
+        ]}
+        filters={[
+          {
+            field: { name: true },
+            type: FieldType.Text,
+            title: "Name",
+          },
+          {
+            field: { provider: true },
+            type: FieldType.Text,
+            title: "Provider",
+          },
+          {
+            field: { isEnabled: true },
+            type: FieldType.Boolean,
+            title: "Enabled",
+          },
+        ]}
+        columns={[
+          { field: { name: true }, title: "Name", type: FieldType.Text },
+          {
+            field: { provider: true },
+            title: "Provider",
+            type: FieldType.Text,
+          },
+          {
+            field: { isEnabled: true },
+            title: "Status",
+            type: FieldType.Boolean,
+            getElement: (item: SecurityEventConnection): ReactElement => {
+              return item.isEnabled ? (
+                <Pill color={Green} text="Enabled" />
+              ) : (
+                <Pill color={Red} text="Disabled" />
+              );
+            },
+          },
+          {
+            field: { lastPollResult: true },
+            title: "Health",
+            type: FieldType.JSON,
+            getElement: (item: SecurityEventConnection): ReactElement => {
+              const health: { color: Color; text: string } =
+                connectionHealth(item);
+              return <Pill color={health.color} text={health.text} />;
+            },
+          },
+          {
+            field: { pollIntervalInMinutes: true },
+            title: "Interval (Minutes)",
+            type: FieldType.Number,
+            noValueMessage: "-",
+          },
+          {
+            field: { lastPolledAt: true },
+            title: "Last Polled",
+            type: FieldType.DateTime,
+            noValueMessage: "Never",
+          },
+          {
+            field: { lastSuccessfulPollAt: true },
+            title: "Last Successful Poll",
+            type: FieldType.DateTime,
+            noValueMessage: "Never",
+          },
+          {
+            field: { lastEventIngestedAt: true },
+            title: "Last Event Imported",
+            type: FieldType.DateTime,
+            noValueMessage: "Never",
+          },
+          {
+            field: { lastError: true },
+            title: "Last Error",
+            type: FieldType.LongText,
+            noValueMessage: "-",
+          },
+        ]}
+      />
+
+      {credentialItem && (
+        <BasicFormModal<JSONObject>
+          title="Update Credentials"
+          name="Security Events > Update Managed Connection Credentials"
+          isLoading={isLoading}
+          onClose={(): void => {
+            setIsLoading(false);
+            setCredentialItem(null);
+          }}
+          onSubmit={async (data: JSONObject): Promise<void> => {
+            setIsLoading(true);
+            try {
+              await ModelAPI.updateById<SecurityEventConnection>({
+                modelType: SecurityEventConnection,
+                id: credentialItem.id!,
+                data: { credentialJson: data["credentialJson"] },
+              });
+              setCredentialItem(null);
+              setRefreshCounter((value: number): number => {
+                return value + 1;
+              });
+            } finally {
+              setIsLoading(false);
+            }
+          }}
+          formProps={{
+            initialValues: {},
+            fields: [
+              {
+                field: { credentialJson: true },
+                title: "Credentials JSON",
+                description:
+                  "The replacement credential object. It is encrypted at rest and cannot be retrieved after saving.",
+                fieldType: FormFieldSchemaType.JSON,
+                required: true,
+                placeholder: '{ "apiToken": "..." }',
+              },
+            ],
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export default ManagedSecurityEventConnections;

--- a/App/FeatureSet/Dashboard/src/Pages/SecurityEvents/GoogleSecOpsConnections.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/SecurityEvents/GoogleSecOpsConnections.tsx
@@ -26,6 +26,7 @@ import ProjectUtil from "Common/UI/Utils/Project";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import GoogleSecOpsDiagnostics from "../../Components/SecurityEvents/GoogleSecOpsDiagnostics";
 import { googleSecOpsHealth } from "../../Components/SecurityEvents/GoogleSecOpsDiagnosticsUtil";
+import ManagedSecurityEventConnections from "../../Components/SecurityEvents/ManagedSecurityEventConnections";
 import React, {
   Fragment,
   FunctionComponent,
@@ -121,6 +122,8 @@ const GoogleSecOpsConnectionsPage: FunctionComponent<PageComponentProps> = (
 
   return (
     <Fragment>
+      <ManagedSecurityEventConnections />
+
       <ModelTable<GoogleSecOpsConnection>
         modelType={GoogleSecOpsConnection}
         refreshToggle={String(refreshCounter)}

--- a/App/FeatureSet/Docs/Content/en/integrations/index.md
+++ b/App/FeatureSet/Docs/Content/en/integrations/index.md
@@ -47,6 +47,7 @@ OneUptime Incident → On Create  ──►  API component  ──►  Jira / Pa
 | [Prometheus Alertmanager](/docs/integrations/prometheus-alertmanager) | Inbound              | Convert Alertmanager notifications into incidents.                            |
 | [Grafana](/docs/integrations/grafana)                                 | Inbound              | Convert Grafana alerts into incidents.                                        |
 | [Datadog](/docs/integrations/datadog)                                 | Inbound              | Convert Datadog monitor alerts into incidents.                                |
+| [Security Event Connectors](/docs/integrations/security-event-connectors) | Inbound           | Pull security findings from AWS, Microsoft, Cloudflare, CrowdStrike, Google, Okta, and Splunk. |
 | [GitHub](/docs/integrations/github)                                   | Outbound             | Open a GitHub issue for an incident.                                          |
 | [GitLab](/docs/integrations/gitlab)                                   | Outbound             | Open a GitLab issue for an incident.                                          |
 | [Discord](/docs/integrations/discord)                                 | Outbound             | Post incident updates to a Discord channel.                                   |

--- a/App/FeatureSet/Docs/Content/en/integrations/security-event-connectors.md
+++ b/App/FeatureSet/Docs/Content/en/integrations/security-event-connectors.md
@@ -1,0 +1,210 @@
+# Managed Security Event Connectors
+
+OneUptime can pull security findings and alerts from AWS Security Hub, Microsoft Defender XDR and Sentinel, Cloudflare, CrowdStrike Falcon, Google Security Command Center, Okta, and Splunk Enterprise Security. The connectors normalize provider records to OneUptime's OCSF-based security event model, deduplicate overlapping results, enrich observables with configured threat-intelligence feeds, and store the events alongside logs, metrics, and traces.
+
+Google SecOps has its own managed connection and diagnostics workflow. See the [Google SecOps integration guide](/docs/integrations/google-secops).
+
+## Create a connection
+
+1. In OneUptime, open **Security Events → Connections**.
+2. On **Managed Security Event Connections**, select **Create**.
+3. Choose the provider and enter the provider's non-secret **Configuration** JSON and **Credentials JSON** from the sections below.
+4. Choose a poll interval from `1` to `1440` minutes and save the connection.
+
+Credentials are encrypted at rest and are write-only. OneUptime never returns a saved credential through its API. Use **Update Credentials** on the connection row when a token, key, or client secret is rotated.
+
+Credential updates are treated as rotations for the same provider source, so replayed events keep their existing identities. If new AWS or CrowdStrike credentials point to a different account while the visible configuration stays the same, create a new connection instead of rotating the credentials on the existing connection.
+
+Use a dedicated read-only identity for each connector. Grant only the permissions listed below and rotate long-lived secrets according to your organization's policy.
+
+## AWS Security Hub
+
+The connector calls Security Hub `GetFindings` in one AWS region and reads findings whose `UpdatedAt` falls within the poll window.
+
+Configuration:
+
+```json
+{
+  "region": "us-east-1"
+}
+```
+
+Credentials:
+
+```json
+{
+  "accessKeyId": "AKIA...",
+  "secretAccessKey": "...",
+  "sessionToken": "..."
+}
+```
+
+`sessionToken` is optional for a long-lived IAM access key and required for temporary credentials. The IAM principal needs `securityhub:GetFindings` in the selected region. Prefer temporary credentials and a narrowly scoped role where your deployment can rotate them.
+
+GuardDuty findings are included after GuardDuty is integrated with Security Hub in that region. This connector does not call the GuardDuty API directly, so enable the Security Hub integration for every GuardDuty region you want OneUptime to ingest.
+
+## Microsoft Defender XDR and Sentinel
+
+The connector obtains an application token from Microsoft Entra ID and reads Microsoft Graph security alerts and incidents. Defender and Sentinel records available through the unified Microsoft security incident experience are normalized under their reported product name.
+
+Configuration:
+
+```json
+{
+  "tenantId": "00000000-0000-0000-0000-000000000000"
+}
+```
+
+Credentials:
+
+```json
+{
+  "clientId": "00000000-0000-0000-0000-000000000000",
+  "clientSecret": "..."
+}
+```
+
+Create an app registration with Microsoft Graph application permissions `SecurityAlert.Read.All` and `SecurityIncident.Read.All`, then grant tenant-wide admin consent. The connector uses the OAuth client-credentials flow and does not need a user account.
+
+Sentinel incidents are available through this connector after the Sentinel workspace is onboarded to the Microsoft Defender portal and appears in the unified security incident experience.
+
+## Cloudflare
+
+The connector reads Security Events from the GraphQL Analytics API for one zone. It automatically divides busy time ranges into smaller windows when the API reaches its 1,000-event result ceiling.
+
+Configuration:
+
+```json
+{
+  "zoneId": "..."
+}
+```
+
+Credentials:
+
+```json
+{
+  "apiToken": "..."
+}
+```
+
+Create a scoped Cloudflare API token that can read firewall or security analytics for the selected account and zone. Availability and retention of `firewallEventsAdaptive` depend on the Cloudflare plan attached to that zone.
+Cloudflare can return sampled adaptive events at high traffic volumes, so use Enterprise Logpush when you require a complete raw event archive.
+
+## CrowdStrike Falcon
+
+The connector queries Falcon alerts by update time, then retrieves the full alert entities in bounded batches. It reads one stable ID page per time window; when more alerts are present, OneUptime narrows the time window instead of traversing mutable offset pages.
+
+Configuration:
+
+```json
+{
+  "cloud": "us-1"
+}
+```
+
+Supported cloud values are `us-1`, `us-2`, `eu-1`, and `us-gov-1`.
+
+Credentials:
+
+```json
+{
+  "clientId": "...",
+  "clientSecret": "..."
+}
+```
+
+Create a Falcon API client with read access to Alerts. The credentials are exchanged at the OAuth endpoint for the selected Falcon cloud.
+
+## Google Security Command Center
+
+The connector lists Security Command Center findings for an organization, folder, or project source. Use `-` as the source ID to include all sources visible to the service account.
+
+Configuration:
+
+```json
+{
+  "parent": "organizations/123456789/sources/-"
+}
+```
+
+For a regional source, append `/locations/{location}`, for example `organizations/123456789/sources/-/locations/eu`.
+
+Credentials are a Google service-account key:
+
+```json
+{
+  "client_email": "oneuptime-scc@example.iam.gserviceaccount.com",
+  "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+```
+
+Grant the service account a Security Command Center finding read role at the configured organization, folder, or project. OneUptime validates the private key and only exchanges it at Google's standard OAuth token endpoint.
+
+## Okta
+
+The connector reads the Okta System Log in ascending publication order. It omits an `until` boundary and persists Okta's next polling link, which keeps events eligible when Okta publishes them after their original event time.
+
+Configuration:
+
+```json
+{
+  "baseUrl": "https://example.okta.com"
+}
+```
+
+Credentials:
+
+```json
+{
+  "apiToken": "..."
+}
+```
+
+Create the token from a dedicated read-only Okta administrator account with permission to read the System Log. The connector follows Okta's `Link` pagination only when the next URL remains on the configured HTTPS origin.
+
+## Splunk Enterprise Security
+
+The connector runs a bounded export search through Splunk's management API. By default it reads notable and risk indexes. Set `search` to a narrower query when your deployment uses different indexes, macros, or data models.
+
+Configuration:
+
+```json
+{
+  "baseUrl": "https://splunk.example.com:8089",
+  "search": "search (index=notable OR index=risk)"
+}
+```
+
+Token credentials:
+
+```json
+{
+  "apiToken": "...",
+  "tokenScheme": "Bearer"
+}
+```
+
+`tokenScheme` defaults to `Bearer`. Set it to `Splunk` when `apiToken` is a Splunk session key.
+
+Basic credentials can be used instead:
+
+```json
+{
+  "username": "oneuptime-reader",
+  "password": "..."
+}
+```
+
+The Splunk identity needs permission to run the configured search and read every referenced index. The management API must be reachable from the OneUptime workers and present a certificate trusted by their operating system or container trust store; replace Splunk's default self-signed management certificate or install your internal CA in that trust store. A poll that reaches the 1,000-result ceiling is marked incomplete and retried over a narrower time range.
+
+## Polling and delivery guarantees
+
+The worker checks for due connections once a minute. A new connection initially reads the preceding 15 minutes. Time-window providers resume from the last complete cursor with a one-minute overlap, and a stale connection catches up in windows of at most 24 hours. Okta resumes its provider-issued ascending polling link instead.
+
+OneUptime derives an event ID from the connection, source settings, provider record, event class, and source revision. Exact repeats caused by overlap, provider retries, or interrupted runs are skipped, while later revisions of the same alert remain visible. Provider page tokens are saved between polls. Repeated provider or page-token failures clear the token and narrow the time range. If a provider still truncates a one-second window, OneUptime writes a durable gap audit event, reports possible data loss, and advances so the connection cannot remain permanently stuck.
+
+Malformed records and normalization failures create durable audit events, are counted, and are reported as a partial import so valid later records continue to flow. **Last Polled**, **Last Successful Poll**, **Last Event Imported**, **Last Poll Result**, and **Last Error** show the connection's current state.
+
+For self-hosted installations, workers need outbound HTTPS access to the selected providers. Okta custom domains and Splunk management endpoints may also require private network or internal DNS access from the worker deployment.

--- a/App/FeatureSet/Workers/Index.ts
+++ b/App/FeatureSet/Workers/Index.ts
@@ -202,6 +202,7 @@ import "./Jobs/Llm/EvaluateLlmCostBudgets";
 import "./Jobs/TelemetryMonitor/ScheduleTelemetryMonitorEvaluations";
 import "./Jobs/DetectionRules/EvaluateDetectionRules";
 import "./Jobs/SecurityEvents/PollGoogleSecOpsConnections";
+import "./Jobs/SecurityEvents/PollSecurityEventConnections";
 import "./Jobs/SecurityEvents/RunGoogleSecOpsConnection";
 import "./Jobs/ThreatIntel/PollThreatIntelFeeds";
 import "./Jobs/ThreatIntel/MatchThreatIntelIndicators";

--- a/App/FeatureSet/Workers/Jobs/SecurityEvents/PollSecurityEventConnections.ts
+++ b/App/FeatureSet/Workers/Jobs/SecurityEvents/PollSecurityEventConnections.ts
@@ -1,0 +1,20 @@
+import RunCron from "../../Utils/Cron";
+import { EVERY_MINUTE } from "Common/Utils/CronTime";
+import SecurityEventConnectionPoller from "Common/Server/Utils/SecurityEvent/Connectors/SecurityEventConnectionPoller";
+
+/*
+ * Poll all enabled managed security-event connections that are due. The
+ * poller owns provider pagination, overlap windows, deduplication, and cursor
+ * advancement, including persisted provider continuations and bounded retries.
+ */
+RunCron(
+  "SecurityEvents:PollSecurityEventConnections",
+  {
+    schedule: EVERY_MINUTE,
+    runOnStartup: false,
+    timeoutInMS: 12 * 60 * 1000,
+  },
+  async () => {
+    await SecurityEventConnectionPoller.pollAllDueConnections();
+  },
+);

--- a/App/Tests/Dashboard/ManagedSecurityEventConnections.test.ts
+++ b/App/Tests/Dashboard/ManagedSecurityEventConnections.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import nodePath from "path";
+
+const REPO_ROOT: string = nodePath.join(__dirname, "..", "..", "..");
+
+function source(relativePath: string): string {
+  return fs.readFileSync(nodePath.join(REPO_ROOT, relativePath), "utf8");
+}
+
+const componentSource: string = source(
+  "App/FeatureSet/Dashboard/src/Components/SecurityEvents/ManagedSecurityEventConnections.tsx",
+);
+const pageSource: string = source(
+  "App/FeatureSet/Dashboard/src/Pages/SecurityEvents/GoogleSecOpsConnections.tsx",
+);
+const workerIndexSource: string = source("App/FeatureSet/Workers/Index.ts");
+const workerSource: string = source(
+  "App/FeatureSet/Workers/Jobs/SecurityEvents/PollSecurityEventConnections.ts",
+);
+const baseApiSource: string = source("App/FeatureSet/BaseAPI/Index.ts");
+const docsSource: string = source(
+  "App/FeatureSet/Docs/Content/en/integrations/security-event-connectors.md",
+);
+
+const providers: Array<string> = [
+  "AwsSecurityHub",
+  "MicrosoftDefender",
+  "Cloudflare",
+  "CrowdStrikeFalcon",
+  "GoogleSecurityCommandCenter",
+  "Okta",
+  "SplunkEnterpriseSecurity",
+];
+
+describe("managed security event connection wiring", () => {
+  test("offers every supported provider in the creation form and documentation", () => {
+    for (const provider of providers) {
+      expect(componentSource).toContain(
+        `SecurityEventConnectorType.${provider}`,
+      );
+    }
+
+    for (const label of [
+      "AWS Security Hub",
+      "Microsoft Defender XDR and Sentinel",
+      "Cloudflare",
+      "CrowdStrike Falcon",
+      "Google Security Command Center",
+      "Okta",
+      "Splunk Enterprise Security",
+    ]) {
+      expect(docsSource).toContain(label);
+    }
+  });
+
+  test("keeps credentials write-only in edit flows and provides explicit rotation", () => {
+    const credentialField: number = componentSource.indexOf(
+      "field: { credentialJson: true }",
+    );
+    const enabledField: number = componentSource.indexOf(
+      "field: { isEnabled: true }",
+      credentialField,
+    );
+
+    expect(credentialField).toBeGreaterThan(-1);
+    expect(enabledField).toBeGreaterThan(credentialField);
+    expect(componentSource.slice(credentialField, enabledField)).toContain(
+      "doNotShowWhenEditing: true",
+    );
+    expect(componentSource).toContain('title: "Update Credentials"');
+    expect(componentSource).toContain(
+      'data: { credentialJson: data["credentialJson"] }',
+    );
+    expect(docsSource).toContain("encrypted at rest and are write-only");
+  });
+
+  test("shows poll health and imports the managed table on the existing Connections page", () => {
+    expect(componentSource).toContain('title: "Health"');
+    expect(componentSource).toContain('title: "Last Polled"');
+    expect(componentSource).toContain('title: "Last Successful Poll"');
+    expect(componentSource).toContain('title: "Last Event Imported"');
+    expect(componentSource).toContain('title: "Last Error"');
+    expect(pageSource).toContain(
+      'import ManagedSecurityEventConnections from "../../Components/SecurityEvents/ManagedSecurityEventConnections"',
+    );
+    expect(pageSource).toContain("<ManagedSecurityEventConnections />");
+  });
+
+  test("registers the API and minute worker", () => {
+    expect(baseApiSource).toContain(
+      "new BaseAPI<SecurityEventConnection, SecurityEventConnectionServiceType>",
+    );
+    expect(workerIndexSource).toContain(
+      'import "./Jobs/SecurityEvents/PollSecurityEventConnections"',
+    );
+    expect(workerSource).toContain("EVERY_MINUTE");
+    expect(workerSource).toContain(
+      "SecurityEventConnectionPoller.pollAllDueConnections()",
+    );
+  });
+});

--- a/Common/Models/DatabaseModels/Index.ts
+++ b/Common/Models/DatabaseModels/Index.ts
@@ -126,6 +126,7 @@ import LogDropFilter from "./LogDropFilter";
 import DetectionRule from "./DetectionRule";
 import GoogleSecOpsConnection from "./GoogleSecOpsConnection";
 import GoogleSecOpsConnectionRun from "./GoogleSecOpsConnectionRun";
+import SecurityEventConnection from "./SecurityEventConnection";
 import ThreatIntelFeed from "./ThreatIntelFeed";
 import LogScrubRule from "./LogScrubRule";
 import MetricPipelineRule from "./MetricPipelineRule";
@@ -501,6 +502,7 @@ const AllModelTypes: Array<{
   DetectionRule,
   GoogleSecOpsConnection,
   GoogleSecOpsConnectionRun,
+  SecurityEventConnection,
   ThreatIntelFeed,
   LogScrubRule,
   MetricPipelineRule,

--- a/Common/Models/DatabaseModels/SecurityEventConnection.ts
+++ b/Common/Models/DatabaseModels/SecurityEventConnection.ts
@@ -1,0 +1,376 @@
+import Project from "./Project";
+import User from "./User";
+import BaseModel from "./DatabaseBaseModel/DatabaseBaseModel";
+import Route from "../../Types/API/Route";
+import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
+import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
+import TableBillingAccessControl from "../../Types/Database/AccessControl/TableBillingAccessControl";
+import ColumnLength from "../../Types/Database/ColumnLength";
+import ColumnType from "../../Types/Database/ColumnType";
+import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
+import EnableDocumentation from "../../Types/Database/EnableDocumentation";
+import TableColumn from "../../Types/Database/TableColumn";
+import TableColumnType from "../../Types/Database/TableColumnType";
+import TableMetadata from "../../Types/Database/TableMetadata";
+import TenantColumn from "../../Types/Database/TenantColumn";
+import IconProp from "../../Types/Icon/IconProp";
+import ObjectID from "../../Types/ObjectID";
+import Permission from "../../Types/Permission";
+import { JSONObject } from "../../Types/JSON";
+import { PlanType } from "../../Types/Billing/SubscriptionPlan";
+import SecurityEventConnectorType from "../../Types/SecurityEvent/SecurityEventConnectorType";
+import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
+
+const adminPermissions: Array<Permission> = [
+  Permission.ProjectOwner,
+  Permission.ProjectAdmin,
+  Permission.SecurityAdmin,
+];
+
+const readPermissions: Array<Permission> = [
+  Permission.ProjectOwner,
+  Permission.ProjectAdmin,
+  Permission.SecurityAdmin,
+  Permission.SecurityMember,
+  Permission.SecurityViewer,
+];
+
+/**
+ * Managed pull connection for security products other than Google SecOps.
+ * Provider-specific settings are kept in configuration; credentialJson is
+ * encrypted and write-only. Keeping the lifecycle state common prevents each
+ * provider from growing its own scheduler and health contract.
+ */
+@EnableDocumentation()
+@TableBillingAccessControl({
+  create: PlanType.Free,
+  read: PlanType.Free,
+  update: PlanType.Free,
+  delete: PlanType.Free,
+})
+@TenantColumn("projectId")
+@CrudApiEndpoint(new Route("/security-event-connection"))
+@Entity({ name: "SecurityEventConnection" })
+@TableMetadata({
+  tableName: "SecurityEventConnection",
+  singularName: "Security Event Connection",
+  pluralName: "Security Event Connections",
+  icon: IconProp.ShieldCheck,
+  tableDescription:
+    "Managed connections to AWS, Microsoft, Cloudflare, CrowdStrike, Google Security Command Center, Okta, and Splunk security event sources.",
+})
+@TableAccessControl({
+  create: adminPermissions,
+  read: readPermissions,
+  update: adminPermissions,
+  delete: adminPermissions,
+})
+export default class SecurityEventConnection extends BaseModel {
+  @ColumnAccessControl({
+    create: adminPermissions,
+    read: readPermissions,
+    update: [],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "projectId",
+    type: TableColumnType.Entity,
+    modelType: Project,
+    title: "Project",
+    description: "Project that owns this connection.",
+  })
+  @ManyToOne(
+    () => {
+      return Project;
+    },
+    {
+      eager: false,
+      nullable: false,
+      onDelete: "CASCADE",
+      orphanedRowAction: "delete",
+    },
+  )
+  @JoinColumn({ name: "projectId" })
+  public project?: Project = undefined;
+
+  @ColumnAccessControl({
+    create: adminPermissions,
+    read: readPermissions,
+    update: [],
+  })
+  @Index()
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: true,
+    canReadOnRelationQuery: true,
+    title: "Project ID",
+    description: "ID of the project that owns this connection.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: false,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public projectId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: adminPermissions,
+    read: readPermissions,
+    update: adminPermissions,
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Name,
+    canReadOnRelationQuery: true,
+    title: "Name",
+    description: "Friendly name for this connection.",
+  })
+  @Column({
+    nullable: false,
+    type: ColumnType.Name,
+    length: ColumnLength.Name,
+  })
+  public name?: string = undefined;
+
+  @ColumnAccessControl({
+    create: adminPermissions,
+    read: readPermissions,
+    update: [],
+  })
+  @Index()
+  @TableColumn({
+    required: true,
+    type: TableColumnType.ShortText,
+    canReadOnRelationQuery: true,
+    title: "Provider",
+    description: "Security product this connection reads from.",
+  })
+  @Column({
+    nullable: false,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public provider?: SecurityEventConnectorType = undefined;
+
+  @ColumnAccessControl({
+    create: adminPermissions,
+    read: readPermissions,
+    update: adminPermissions,
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.JSON,
+    title: "Configuration",
+    description:
+      "Provider-specific non-secret settings such as region, tenant, zone, organization, or base URL.",
+  })
+  @Column({ type: ColumnType.JSON, nullable: false })
+  public configuration?: JSONObject = undefined;
+
+  @ColumnAccessControl({
+    create: adminPermissions,
+    read: [],
+    update: adminPermissions,
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.VeryLongText,
+    encrypted: true,
+    title: "Credentials JSON",
+    description:
+      "Provider credentials as JSON. Encrypted at rest and never returned by the API.",
+  })
+  @Column({ type: ColumnType.VeryLongText, nullable: false })
+  public credentialJson?: string = undefined;
+
+  @ColumnAccessControl({ create: adminPermissions, read: [], update: [] })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.ShortText,
+    title: "Source Fingerprint",
+    description:
+      "Internal fingerprint used to reset polling state atomically when source settings change.",
+  })
+  @Column({
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+    nullable: false,
+  })
+  public sourceFingerprint?: string = undefined;
+
+  @ColumnAccessControl({ create: [], read: [], update: [] })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Number,
+    title: "Source Generation",
+    description:
+      "Internal generation used to separate event identities after the provider or source settings change.",
+    defaultValue: 1,
+    isDefaultValueColumn: true,
+  })
+  @Column({ type: ColumnType.Number, nullable: false, default: 1 })
+  public sourceGeneration?: number = undefined;
+
+  @ColumnAccessControl({
+    create: adminPermissions,
+    read: readPermissions,
+    update: adminPermissions,
+  })
+  @Index()
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Boolean,
+    canReadOnRelationQuery: true,
+    title: "Enabled",
+    description: "Whether scheduled polling is enabled.",
+    defaultValue: true,
+    isDefaultValueColumn: true,
+  })
+  @Column({ type: ColumnType.Boolean, nullable: false, default: true })
+  public isEnabled?: boolean = undefined;
+
+  @ColumnAccessControl({
+    create: adminPermissions,
+    read: readPermissions,
+    update: adminPermissions,
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Number,
+    canReadOnRelationQuery: true,
+    title: "Poll Interval (Minutes)",
+    description: "How often the provider is polled.",
+    defaultValue: 5,
+    isDefaultValueColumn: true,
+  })
+  @Column({ type: ColumnType.Number, nullable: false, default: 5 })
+  public pollIntervalInMinutes?: number = undefined;
+
+  @ColumnAccessControl({ create: [], read: readPermissions, update: [] })
+  @TableColumn({
+    type: TableColumnType.Date,
+    required: false,
+    title: "Last Successful Poll",
+    description: "When a complete poll last finished successfully.",
+    canReadOnRelationQuery: true,
+  })
+  @Column({ type: ColumnType.Date, nullable: true })
+  public lastSuccessfulPollAt?: Date = undefined;
+
+  @ColumnAccessControl({ create: [], read: readPermissions, update: [] })
+  @TableColumn({
+    type: TableColumnType.Date,
+    required: false,
+    title: "Last Event Imported",
+    description: "When this connection most recently imported a new event.",
+    canReadOnRelationQuery: true,
+  })
+  @Column({ type: ColumnType.Date, nullable: true })
+  public lastEventIngestedAt?: Date = undefined;
+
+  @ColumnAccessControl({ create: [], read: readPermissions, update: [] })
+  @TableColumn({
+    type: TableColumnType.JSON,
+    required: false,
+    title: "Last Poll Result",
+    description: "Counts and warnings from the latest poll.",
+  })
+  @Column({ type: ColumnType.JSON, nullable: true })
+  public lastPollResult?: JSONObject = undefined;
+
+  @ColumnAccessControl({ create: [], read: readPermissions, update: [] })
+  @TableColumn({
+    type: TableColumnType.Date,
+    required: false,
+    title: "Last Polled At",
+    description: "When the latest polling attempt finished.",
+    canReadOnRelationQuery: true,
+  })
+  @Column({ type: ColumnType.Date, nullable: true })
+  public lastPolledAt?: Date = undefined;
+
+  @ColumnAccessControl({ create: [], read: [], update: [] })
+  @TableColumn({
+    type: TableColumnType.VeryLongText,
+    required: false,
+    encrypted: true,
+    title: "Cursor",
+    description:
+      "Encrypted internal checkpoint for time windows and provider pagination.",
+  })
+  @Column({
+    type: ColumnType.VeryLongText,
+    nullable: true,
+  })
+  public cursor?: string = undefined;
+
+  @ColumnAccessControl({ create: [], read: readPermissions, update: [] })
+  @TableColumn({
+    type: TableColumnType.VeryLongText,
+    required: false,
+    title: "Last Error",
+    description: "Complete credential-redacted error from the latest poll.",
+    canReadOnRelationQuery: true,
+  })
+  @Column({ type: ColumnType.VeryLongText, nullable: true })
+  public lastError?: string = undefined;
+
+  @ColumnAccessControl({ create: [], read: readPermissions, update: [] })
+  @TableColumn({
+    manyToOneRelationColumn: "createdByUserId",
+    type: TableColumnType.Entity,
+    modelType: User,
+    title: "Created By User",
+    description: "User that created this connection.",
+  })
+  @ManyToOne(
+    () => {
+      return User;
+    },
+    { eager: false, nullable: true, onDelete: "SET NULL" },
+  )
+  @JoinColumn({ name: "createdByUserId" })
+  public createdByUser?: User = undefined;
+
+  @ColumnAccessControl({ create: [], read: readPermissions, update: [] })
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    title: "Created By User ID",
+    description: "ID of the user that created this connection.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public createdByUserId?: ObjectID = undefined;
+
+  @ColumnAccessControl({ create: [], read: readPermissions, update: [] })
+  @TableColumn({
+    manyToOneRelationColumn: "deletedByUserId",
+    type: TableColumnType.Entity,
+    modelType: User,
+    title: "Deleted By User",
+    description: "User that deleted this connection.",
+  })
+  @ManyToOne(
+    () => {
+      return User;
+    },
+    { eager: false, nullable: true, onDelete: "SET NULL" },
+  )
+  @JoinColumn({ name: "deletedByUserId" })
+  public deletedByUser?: User = undefined;
+
+  @ColumnAccessControl({ create: [], read: readPermissions, update: [] })
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    title: "Deleted By User ID",
+    description: "ID of the user that deleted this connection.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public deletedByUserId?: ObjectID = undefined;
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1792400000000-AddSecurityEventConnection.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1792400000000-AddSecurityEventConnection.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSecurityEventConnection1792400000000
+  implements MigrationInterface
+{
+  public name: string = "AddSecurityEventConnection1792400000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "SecurityEventConnection" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "name" character varying(50) NOT NULL, "provider" character varying(100) NOT NULL, "configuration" jsonb NOT NULL, "credentialJson" text NOT NULL, "sourceFingerprint" character varying(100) NOT NULL, "sourceGeneration" integer NOT NULL DEFAULT '1', "isEnabled" boolean NOT NULL DEFAULT true, "pollIntervalInMinutes" integer NOT NULL DEFAULT '5', "lastSuccessfulPollAt" TIMESTAMP WITH TIME ZONE, "lastEventIngestedAt" TIMESTAMP WITH TIME ZONE, "lastPollResult" jsonb, "lastPolledAt" TIMESTAMP WITH TIME ZONE, "cursor" text, "lastError" text, "createdByUserId" uuid, "deletedByUserId" uuid, CONSTRAINT "PK_0f0e1fe86bb4ce002fb97c6761f" PRIMARY KEY ("_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_15f2e2db3f5815c70153c91f73" ON "SecurityEventConnection" ("projectId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6d59362e6f5d25392ebf5929fa" ON "SecurityEventConnection" ("provider") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_7a7edb50ab8639c78b7eafe75d" ON "SecurityEventConnection" ("isEnabled") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "SecurityEventConnection" ADD CONSTRAINT "FK_15f2e2db3f5815c70153c91f738" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "SecurityEventConnection" ADD CONSTRAINT "FK_a1c9e6213897547fbbfcc557180" FOREIGN KEY ("createdByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "SecurityEventConnection" ADD CONSTRAINT "FK_760637b50c4a45db4c77f50597b" FOREIGN KEY ("deletedByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "SecurityEventConnection" DROP CONSTRAINT "FK_760637b50c4a45db4c77f50597b"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "SecurityEventConnection" DROP CONSTRAINT "FK_a1c9e6213897547fbbfcc557180"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "SecurityEventConnection" DROP CONSTRAINT "FK_15f2e2db3f5815c70153c91f738"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_7a7edb50ab8639c78b7eafe75d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_6d59362e6f5d25392ebf5929fa"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_15f2e2db3f5815c70153c91f73"`,
+    );
+    await queryRunner.query(`DROP TABLE "SecurityEventConnection"`);
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -1,3 +1,4 @@
+import { AddSecurityEventConnection1792400000000 } from "./1792400000000-AddSecurityEventConnection";
 import { AddGoogleSecOpsDiagnostics1792300000000 } from "./1792300000000-AddGoogleSecOpsDiagnostics";
 import { AddUserWebAuthnPurpose1792200000000 } from "./1792200000000-AddUserWebAuthnPurpose";
 import InitialMigration from "./1717605043663-InitialMigration";
@@ -1172,4 +1173,5 @@ export default [
   AddGitHubCommandSettingsToCodeRepository1792100000000,
   AddUserWebAuthnPurpose1792200000000,
   AddGoogleSecOpsDiagnostics1792300000000,
+  AddSecurityEventConnection1792400000000,
 ];

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -533,6 +533,40 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
     return Promise.resolve({ updateBy, carryForward: null });
   }
 
+  /**
+   * Adds server-controlled columns to the same SQL statement as an update.
+   * This runs after caller permissions are checked, so subclasses can maintain
+   * derived state atomically without exposing those columns to API clients.
+   */
+  protected async getInternalUpdateData(
+    _onUpdate: OnUpdate<TBaseModel>,
+    _item: TBaseModel,
+  ): Promise<PartialEntity<TBaseModel>> {
+    return Promise.resolve({} as PartialEntity<TBaseModel>);
+  }
+
+  /**
+   * Validates every row admitted by the permission-scoped update query before
+   * the first write. Subclasses can use the decrypted snapshots here without
+   * reading caller-controlled rows as root in onBeforeUpdate.
+   */
+  protected async onBeforeUpdateItems(
+    _onUpdate: OnUpdate<TBaseModel>,
+    _items: Array<TBaseModel>,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  /**
+   * Loads columns needed to derive internal update data. These columns are
+   * fetched as root only after the caller's update query is permission-scoped.
+   */
+  protected getAdditionalUpdateSelect(
+    _onUpdate: OnUpdate<TBaseModel>,
+  ): Select<TBaseModel> {
+    return {} as Select<TBaseModel>;
+  }
+
   protected async onBeforeFind(
     findBy: FindBy<TBaseModel>,
   ): Promise<OnFind<TBaseModel>> {
@@ -2536,6 +2570,9 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
       const selectColumns: Select<TBaseModel> = {
         _id: true,
         ...Object.fromEntries(dataColumns),
+        ...(updateBy.props.ignoreHooks
+          ? {}
+          : this.getAdditionalUpdateSelect(onUpdate)),
       };
 
       if (this.getModel().getTenantColumn()) {
@@ -2572,6 +2609,10 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
             props: { isRoot: true, ignoreHooks: true },
           })
         : [];
+
+      if (!updateBy.props.ignoreHooks) {
+        await this.onBeforeUpdateItems(onUpdate, items);
+      }
 
       /*
        * save() has upsert semantics: if the located row is hard-deleted by a
@@ -2625,6 +2666,10 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
         logger.getLogLevel() === ConfigLogLevel.DEBUG;
 
       for (const item of items) {
+        const internalUpdateData: PartialEntity<TBaseModel> = updateBy.props
+          .ignoreHooks
+          ? ({} as PartialEntity<TBaseModel>)
+          : await this.getInternalUpdateData(onUpdate, item);
         /*
          * _id must be set AFTER the spread: update data can carry an
          * explicit `_id: undefined` (sanitizeUpdateData strips it from model
@@ -2635,6 +2680,7 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
          */
         const updatedItem: any = {
           ...data,
+          ...internalUpdateData,
           _id: item._id!,
         } as any;
 

--- a/Common/Server/Services/Index.ts
+++ b/Common/Server/Services/Index.ts
@@ -335,6 +335,7 @@ import AlertSeverityService from "./AlertSeverityService";
 import DetectionRuleService from "./DetectionRuleService";
 import GoogleSecOpsConnectionService from "./GoogleSecOpsConnectionService";
 import GoogleSecOpsConnectionRunService from "./GoogleSecOpsConnectionRunService";
+import SecurityEventConnectionService from "./SecurityEventConnectionService";
 import ThreatIntelFeedService from "./ThreatIntelFeedService";
 import ThreatIntelIndicatorService from "./ThreatIntelIndicatorService";
 import AlertNoteTemplateService from "./AlertNoteTemplateService";
@@ -765,6 +766,7 @@ const services: Array<BaseService> = [
   DetectionRuleService,
   GoogleSecOpsConnectionService,
   GoogleSecOpsConnectionRunService,
+  SecurityEventConnectionService,
   ThreatIntelFeedService,
   AlertNoteTemplateService,
   AlertFeedService,

--- a/Common/Server/Services/SecurityEventConnectionService.ts
+++ b/Common/Server/Services/SecurityEventConnectionService.ts
@@ -1,0 +1,537 @@
+import DatabaseService from "./DatabaseService";
+import Model from "../../Models/DatabaseModels/SecurityEventConnection";
+import CreateBy from "../Types/Database/CreateBy";
+import UpdateBy from "../Types/Database/UpdateBy";
+import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import BadDataException from "../../Types/Exception/BadDataException";
+import PartialEntity from "../../Types/Database/PartialEntity";
+import Select from "../Types/Database/Select";
+import { JSONObject, JSONValue } from "../../Types/JSON";
+import ObjectID from "../../Types/ObjectID";
+import SecurityEventConnectorType, {
+  SecurityEventConnectorTypes,
+} from "../../Types/SecurityEvent/SecurityEventConnectorType";
+import { createHash, createPrivateKey } from "crypto";
+import { UpdateQueryBuilder, UpdateResult } from "typeorm";
+import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
+
+const AWS_REGION_PATTERN: RegExp = /^[a-z]{2}(?:-gov)?-[a-z]+-\d$/;
+const MICROSOFT_TENANT_PATTERN: RegExp = /^[A-Za-z0-9.-]+$/;
+const GOOGLE_SCC_PARENT_PATTERN: RegExp =
+  /^(?:organizations|folders|projects)\/[^/\s?#%]+\/sources\/(?:-|[^/\s?#%]+)(?:\/locations\/[^/\s?#%]+)?$/;
+
+export interface SecurityEventPollingCheckpointUpdate {
+  lastPolledAt: Date;
+  lastPollResult: JSONObject;
+  lastError: string | null;
+  cursor?: string | null | undefined;
+  lastSuccessfulPollAt?: Date | undefined;
+  lastEventIngestedAt?: Date | undefined;
+}
+
+function requiredString(
+  value: JSONObject,
+  key: string,
+  provider: string,
+): string {
+  const candidate: JSONValue = value[key];
+  if (typeof candidate !== "string" || !candidate.trim()) {
+    throw new BadDataException(`${provider} requires ${key}.`);
+  }
+  return candidate.trim();
+}
+
+function optionalString(value: JSONObject, key: string): string {
+  const candidate: JSONValue = value[key];
+  if (candidate === undefined || candidate === null || candidate === "") {
+    return "";
+  }
+  if (typeof candidate !== "string") {
+    throw new BadDataException(`${key} must be a string.`);
+  }
+  return candidate.trim();
+}
+
+function validateHttpsOrigin(value: string, label: string): void {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new BadDataException(`${label} must be a valid HTTPS URL.`);
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  ) {
+    throw new BadDataException(
+      `${label} must be an HTTPS URL without credentials, query, or fragment.`,
+    );
+  }
+}
+
+function isSqlExpressionValue(value: unknown): boolean {
+  return typeof value === "function";
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value
+      .map((item: unknown): string => {
+        return stableJson(item);
+      })
+      .join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const record: Record<string, unknown> = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key: string): string => {
+        return `${JSON.stringify(key)}:${stableJson(record[key])}`;
+      })
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+interface SecurityEventConnectionUpdateCarryForward {
+  configurationSupplied: boolean;
+  credentialsSupplied: boolean;
+  configuration?: JSONObject | undefined;
+  credentialJson?: string | undefined;
+  pollIntervalInMinutes?: number | undefined;
+}
+
+function securityEventSourceFingerprint(
+  provider: SecurityEventConnectorType,
+  configuration: JSONObject,
+): string {
+  return createHash("sha256")
+    .update(stableJson({ provider, configuration }))
+    .digest("hex");
+}
+
+export function parseSecurityEventCredentialJson(value: string): JSONObject {
+  let parsed: JSONValue;
+  try {
+    parsed = JSON.parse(value || "") as JSONValue;
+  } catch {
+    throw new BadDataException("Credentials JSON is not valid JSON.");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new BadDataException("Credentials JSON must be a JSON object.");
+  }
+  return parsed as JSONObject;
+}
+
+export function parseSecurityEventConfiguration(
+  value: JSONObject | string,
+): JSONObject {
+  let parsed: unknown = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      throw new BadDataException("Configuration is not valid JSON.");
+    }
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new BadDataException("Configuration must be a JSON object.");
+  }
+  return parsed as JSONObject;
+}
+
+export function validateSecurityEventConnection(data: {
+  provider?: SecurityEventConnectorType | undefined;
+  configuration?: JSONObject | string | undefined;
+  credentialJson?: string | undefined;
+  pollIntervalInMinutes?: number | undefined;
+}): void {
+  if (data.pollIntervalInMinutes !== undefined) {
+    if (
+      !Number.isInteger(data.pollIntervalInMinutes) ||
+      data.pollIntervalInMinutes < 1 ||
+      data.pollIntervalInMinutes > 1440
+    ) {
+      throw new BadDataException(
+        "Poll interval must be a whole number of minutes between 1 and 1440.",
+      );
+    }
+  }
+
+  if (data.provider === undefined) {
+    return;
+  }
+  if (!SecurityEventConnectorTypes.includes(data.provider)) {
+    throw new BadDataException("Choose a supported security event provider.");
+  }
+  if (!data.configuration) {
+    throw new BadDataException("Configuration must be a JSON object.");
+  }
+  if (!data.credentialJson) {
+    throw new BadDataException("Credentials JSON is required.");
+  }
+
+  const configuration: JSONObject = parseSecurityEventConfiguration(
+    data.configuration,
+  );
+  const credentials: JSONObject = parseSecurityEventCredentialJson(
+    data.credentialJson,
+  );
+
+  switch (data.provider) {
+    case SecurityEventConnectorType.AwsSecurityHub: {
+      const region: string = requiredString(configuration, "region", "AWS");
+      if (!AWS_REGION_PATTERN.test(region)) {
+        throw new BadDataException("AWS region is not valid.");
+      }
+      requiredString(credentials, "accessKeyId", "AWS");
+      requiredString(credentials, "secretAccessKey", "AWS");
+      optionalString(credentials, "sessionToken");
+      break;
+    }
+    case SecurityEventConnectorType.MicrosoftDefender: {
+      const tenantId: string = requiredString(
+        configuration,
+        "tenantId",
+        "Microsoft",
+      );
+      if (!MICROSOFT_TENANT_PATTERN.test(tenantId)) {
+        throw new BadDataException("Microsoft tenantId is not valid.");
+      }
+      requiredString(credentials, "clientId", "Microsoft");
+      requiredString(credentials, "clientSecret", "Microsoft");
+      break;
+    }
+    case SecurityEventConnectorType.Cloudflare:
+      requiredString(configuration, "zoneId", "Cloudflare");
+      requiredString(credentials, "apiToken", "Cloudflare");
+      break;
+    case SecurityEventConnectorType.CrowdStrikeFalcon: {
+      const cloud: string = optionalString(configuration, "cloud") || "us-1";
+      if (!["us-1", "us-2", "eu-1", "us-gov-1"].includes(cloud)) {
+        throw new BadDataException(
+          "CrowdStrike cloud must be us-1, us-2, eu-1, or us-gov-1.",
+        );
+      }
+      requiredString(credentials, "clientId", "CrowdStrike");
+      requiredString(credentials, "clientSecret", "CrowdStrike");
+      break;
+    }
+    case SecurityEventConnectorType.GoogleSecurityCommandCenter: {
+      const parent: string = requiredString(
+        configuration,
+        "parent",
+        "Google Security Command Center",
+      );
+      if (!GOOGLE_SCC_PARENT_PATTERN.test(parent)) {
+        throw new BadDataException(
+          "Google Security Command Center parent must look like organizations/{id}/sources/- or organizations/{id}/sources/-/locations/{location}.",
+        );
+      }
+      requiredString(credentials, "client_email", "Google service account");
+      const privateKey: string = requiredString(
+        credentials,
+        "private_key",
+        "Google service account",
+      );
+      try {
+        createPrivateKey(privateKey);
+      } catch {
+        throw new BadDataException(
+          "Google service account private_key is not a valid private key.",
+        );
+      }
+      const tokenUri: string =
+        optionalString(credentials, "token_uri") ||
+        "https://oauth2.googleapis.com/token";
+      validateHttpsOrigin(tokenUri, "Google token_uri");
+      const parsedTokenUri: URL = new URL(tokenUri);
+      if (
+        parsedTokenUri.hostname !== "oauth2.googleapis.com" ||
+        parsedTokenUri.port ||
+        parsedTokenUri.pathname !== "/token"
+      ) {
+        throw new BadDataException(
+          "Google token_uri must be https://oauth2.googleapis.com/token.",
+        );
+      }
+      break;
+    }
+    case SecurityEventConnectorType.Okta: {
+      const baseUrl: string = requiredString(configuration, "baseUrl", "Okta");
+      validateHttpsOrigin(baseUrl, "Okta baseUrl");
+      requiredString(credentials, "apiToken", "Okta");
+      break;
+    }
+    case SecurityEventConnectorType.SplunkEnterpriseSecurity: {
+      const baseUrl: string = requiredString(
+        configuration,
+        "baseUrl",
+        "Splunk",
+      );
+      validateHttpsOrigin(baseUrl, "Splunk baseUrl");
+      const token: string = optionalString(credentials, "apiToken");
+      const username: string = optionalString(credentials, "username");
+      const password: string = optionalString(credentials, "password");
+      if (!token && !(username && password)) {
+        throw new BadDataException(
+          "Splunk requires apiToken or username and password.",
+        );
+      }
+      const tokenScheme: string =
+        optionalString(credentials, "tokenScheme") || "Bearer";
+      if (token && !["Bearer", "Splunk"].includes(tokenScheme)) {
+        throw new BadDataException(
+          "Splunk tokenScheme must be Bearer or Splunk.",
+        );
+      }
+      optionalString(configuration, "search");
+      break;
+    }
+  }
+}
+
+export class Service extends DatabaseService<Model> {
+  public constructor() {
+    super(Model);
+  }
+
+  /**
+   * Stores poll progress only while the connection is still the exact version
+   * that was loaded by the poller. Keeping the row-version predicate in the
+   * UPDATE statement prevents an in-flight poll from restoring an old cursor
+   * after credentials or source settings have changed and reset the state.
+   */
+  public async updatePollingCheckpointIfUnchanged(data: {
+    id: ObjectID;
+    expectedVersion: number;
+    checkpoint: SecurityEventPollingCheckpointUpdate;
+  }): Promise<number> {
+    const encryptedCheckpoint: Model = (await this.encrypt({
+      ...data.checkpoint,
+    } as unknown as Model)) as Model;
+    const queryBuilder: UpdateQueryBuilder<Model> = this.getRepository()
+      .createQueryBuilder()
+      .update(Model)
+      .set(encryptedCheckpoint as unknown as QueryDeepPartialEntity<Model>)
+      .where('"_id" = :id', { id: data.id.toString() })
+      .andWhere('"version" = :expectedVersion', {
+        expectedVersion: data.expectedVersion,
+      })
+      .andWhere('"deletedAt" IS NULL');
+
+    const result: UpdateResult = await queryBuilder.execute();
+    return result.affected || 0;
+  }
+
+  protected override async onBeforeCreate(
+    createBy: CreateBy<Model>,
+  ): Promise<OnCreate<Model>> {
+    const rawConfiguration: unknown = createBy.data.configuration;
+    if (typeof rawConfiguration === "string") {
+      createBy.data.configuration =
+        parseSecurityEventConfiguration(rawConfiguration);
+    }
+    validateSecurityEventConnection({
+      provider: createBy.data.provider,
+      configuration: createBy.data.configuration,
+      credentialJson: createBy.data.credentialJson,
+      pollIntervalInMinutes: createBy.data.pollIntervalInMinutes,
+    });
+    if (createBy.data.provider && createBy.data.configuration) {
+      createBy.data.sourceFingerprint = securityEventSourceFingerprint(
+        createBy.data.provider,
+        createBy.data.configuration,
+      );
+    }
+    return { createBy, carryForward: null };
+  }
+
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    delete (updateBy.data as unknown as Record<string, unknown>)[
+      "sourceFingerprint"
+    ];
+    const incomingProvider: unknown = updateBy.data.provider;
+    let incomingConfiguration: unknown = updateBy.data.configuration;
+    const incomingCredentialJson: unknown = updateBy.data.credentialJson;
+    const incomingPollInterval: unknown = updateBy.data.pollIntervalInMinutes;
+
+    if (incomingProvider !== undefined) {
+      throw new BadDataException(
+        "The provider cannot be changed. Create a new connection for another provider.",
+      );
+    }
+
+    const containsSqlExpression: boolean =
+      isSqlExpressionValue(incomingConfiguration) ||
+      isSqlExpressionValue(incomingCredentialJson) ||
+      isSqlExpressionValue(incomingPollInterval);
+
+    if (containsSqlExpression) {
+      throw new BadDataException(
+        "SQL expressions are not supported for security event connection settings.",
+      );
+    }
+
+    if (incomingConfiguration !== undefined) {
+      incomingConfiguration = parseSecurityEventConfiguration(
+        incomingConfiguration as JSONObject | string,
+      );
+      (
+        updateBy.data as unknown as {
+          configuration?: JSONObject | undefined;
+        }
+      ).configuration = incomingConfiguration as JSONObject;
+    }
+
+    if (incomingPollInterval !== undefined) {
+      validateSecurityEventConnection({
+        pollIntervalInMinutes: incomingPollInterval as number,
+      });
+    }
+
+    if (incomingCredentialJson !== undefined) {
+      parseSecurityEventCredentialJson(incomingCredentialJson as string);
+    }
+
+    if (
+      incomingConfiguration === undefined &&
+      incomingCredentialJson === undefined
+    ) {
+      return { updateBy, carryForward: null };
+    }
+
+    return {
+      updateBy,
+      carryForward: {
+        configurationSupplied: incomingConfiguration !== undefined,
+        credentialsSupplied: incomingCredentialJson !== undefined,
+        ...(incomingConfiguration !== undefined
+          ? { configuration: incomingConfiguration as JSONObject }
+          : {}),
+        ...(incomingCredentialJson !== undefined
+          ? { credentialJson: incomingCredentialJson as string }
+          : {}),
+        ...(incomingPollInterval !== undefined
+          ? { pollIntervalInMinutes: incomingPollInterval as number }
+          : {}),
+      } as SecurityEventConnectionUpdateCarryForward,
+    };
+  }
+
+  protected override getAdditionalUpdateSelect(
+    onUpdate: OnUpdate<Model>,
+  ): Select<Model> {
+    const carryForward: SecurityEventConnectionUpdateCarryForward | null =
+      onUpdate.carryForward as SecurityEventConnectionUpdateCarryForward | null;
+    if (
+      !carryForward?.configurationSupplied &&
+      !carryForward?.credentialsSupplied
+    ) {
+      return {} as Select<Model>;
+    }
+    return {
+      provider: true,
+      configuration: true,
+      credentialJson: true,
+      pollIntervalInMinutes: true,
+    } as Select<Model>;
+  }
+
+  protected override async onBeforeUpdateItems(
+    onUpdate: OnUpdate<Model>,
+    items: Array<Model>,
+  ): Promise<void> {
+    const carryForward: SecurityEventConnectionUpdateCarryForward | null =
+      onUpdate.carryForward as SecurityEventConnectionUpdateCarryForward | null;
+    if (!carryForward) {
+      return;
+    }
+
+    for (const item of items) {
+      validateSecurityEventConnection({
+        provider: item.provider,
+        configuration: carryForward.configurationSupplied
+          ? carryForward.configuration
+          : item.configuration,
+        credentialJson: carryForward.credentialsSupplied
+          ? carryForward.credentialJson
+          : item.credentialJson,
+        pollIntervalInMinutes:
+          carryForward.pollIntervalInMinutes ?? item.pollIntervalInMinutes,
+      });
+    }
+  }
+
+  protected override async getInternalUpdateData(
+    onUpdate: OnUpdate<Model>,
+    item: Model,
+  ): Promise<PartialEntity<Model>> {
+    const carryForward: SecurityEventConnectionUpdateCarryForward | null =
+      onUpdate.carryForward as SecurityEventConnectionUpdateCarryForward | null;
+    if (!carryForward) {
+      return {} as PartialEntity<Model>;
+    }
+
+    const sourceSettingsSupplied: boolean = carryForward.configurationSupplied;
+    const internalData: Record<string, unknown> = {};
+    let sourceChangedCondition: string = "";
+    if (sourceSettingsSupplied) {
+      const provider: SecurityEventConnectorType | undefined = item.provider;
+      const configuration: JSONObject | undefined = carryForward.configuration;
+      if (!provider || !configuration) {
+        throw new BadDataException(
+          "Provider and configuration are required to update source settings.",
+        );
+      }
+      const fingerprint: string = securityEventSourceFingerprint(
+        provider,
+        configuration,
+      );
+      sourceChangedCondition = `"sourceFingerprint" IS DISTINCT FROM '${fingerprint}'`;
+      internalData["sourceFingerprint"] = fingerprint;
+      internalData["sourceGeneration"] = (): string => {
+        return `CASE WHEN ${sourceChangedCondition} THEN "sourceGeneration" + 1 ELSE "sourceGeneration" END`;
+      };
+    }
+
+    const pollingStateColumns: Array<string> = [
+      "cursor",
+      "lastPolledAt",
+      "lastSuccessfulPollAt",
+      "lastEventIngestedAt",
+      "lastPollResult",
+      "lastError",
+    ];
+    if (carryForward.credentialsSupplied) {
+      for (const column of pollingStateColumns) {
+        internalData[column] = null;
+      }
+    } else if (sourceChangedCondition) {
+      for (const column of pollingStateColumns) {
+        internalData[column] = (): string => {
+          return `CASE WHEN ${sourceChangedCondition} THEN NULL ELSE "${column}" END`;
+        };
+      }
+    }
+    return internalData as unknown as PartialEntity<Model>;
+  }
+
+  protected override async onCreateSuccess(
+    _onCreate: OnCreate<Model>,
+    createdItem: Model,
+  ): Promise<Model> {
+    delete createdItem.credentialJson;
+    delete createdItem.cursor;
+    delete createdItem.sourceFingerprint;
+    delete createdItem.sourceGeneration;
+    return createdItem;
+  }
+}
+
+export default new Service();

--- a/Common/Server/Utils/DataSource/HttpFetch.ts
+++ b/Common/Server/Utils/DataSource/HttpFetch.ts
@@ -43,6 +43,7 @@ export interface DataSourceHttpRequest {
   body?: string | Dictionary<string> | undefined;
   formUrlEncoded?: boolean | undefined;
   timeoutInMs?: number | undefined;
+  signal?: AbortSignal | undefined;
   // Test seam — forwarded to the egress guard.
   egressOptions?: EgressGuardOptions | undefined;
 }
@@ -130,6 +131,7 @@ export default class DataSourceHttpFetch {
       headers: headers,
       data: data,
       timeout: request.timeoutInMs || DATA_SOURCE_QUERY_TIMEOUT_IN_MS,
+      ...(request.signal ? { signal: request.signal } : {}),
       maxRedirects: 0,
       maxContentLength: DATA_SOURCE_MAX_RESPONSE_SIZE_IN_BYTES,
       maxBodyLength: DATA_SOURCE_MAX_RESPONSE_SIZE_IN_BYTES,

--- a/Common/Server/Utils/SecurityEvent/Connectors/AwsSecurityHubClient.ts
+++ b/Common/Server/Utils/SecurityEvent/Connectors/AwsSecurityHubClient.ts
@@ -1,0 +1,182 @@
+import { createHash, createHmac } from "crypto";
+import SecurityEventConnection from "../../../../Models/DatabaseModels/SecurityEventConnection";
+import { JSONObject } from "../../../../Types/JSON";
+import {
+  defaultConnectorRequest,
+  jsonObjects,
+  MAX_CONNECTOR_PAGES,
+  parseCredentialJson,
+  requestJson,
+  requiredSetting,
+  stringValue,
+} from "./ConnectorHttp";
+import {
+  SecurityEventConnectorClient,
+  SecurityEventConnectorFetchResult,
+  SecurityEventConnectorHttpRequest,
+} from "./Types";
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function hmac(key: Buffer | string, value: string): Buffer {
+  return createHmac("sha256", key).update(value, "utf8").digest();
+}
+
+function awsDate(date: Date): { dateStamp: string; amzDate: string } {
+  const compact: string = date.toISOString().replace(/[:-]|\.\d{3}/g, "");
+  return { dateStamp: compact.slice(0, 8), amzDate: compact };
+}
+
+function awsDnsSuffix(region: string): string {
+  return region.startsWith("cn-") ? "amazonaws.com.cn" : "amazonaws.com";
+}
+
+export default class AwsSecurityHubClient
+  implements SecurityEventConnectorClient
+{
+  private readonly region: string;
+  private readonly accessKeyId: string;
+  private readonly secretAccessKey: string;
+  private readonly sessionToken: string;
+  private readonly request: SecurityEventConnectorHttpRequest;
+
+  public constructor(
+    connection: SecurityEventConnection,
+    request: SecurityEventConnectorHttpRequest = defaultConnectorRequest,
+  ) {
+    const configuration: JSONObject = connection.configuration || {};
+    const credentials: JSONObject = parseCredentialJson(
+      connection.credentialJson || "",
+    );
+    this.region = requiredSetting(configuration, "region", "AWS");
+    this.accessKeyId = requiredSetting(credentials, "accessKeyId", "AWS");
+    this.secretAccessKey = requiredSetting(
+      credentials,
+      "secretAccessKey",
+      "AWS",
+    );
+    this.sessionToken = stringValue(credentials["sessionToken"]);
+    this.request = request;
+  }
+
+  public async fetchEvents(data: {
+    startTime: Date;
+    endTime: Date;
+    continuation?: JSONObject | undefined;
+    signal?: AbortSignal | undefined;
+  }): Promise<SecurityEventConnectorFetchResult> {
+    const events: Array<JSONObject> = [];
+    let nextToken: string = stringValue(data.continuation?.["nextToken"]);
+    let requestCount: number = 0;
+
+    do {
+      const body: JSONObject = {
+        Filters: {
+          UpdatedAt: [
+            {
+              Start: data.startTime.toISOString(),
+              End: data.endTime.toISOString(),
+            },
+          ],
+        },
+        MaxResults: 100,
+        ...(nextToken ? { NextToken: nextToken } : {}),
+      };
+      const bodyText: string = JSON.stringify(body);
+      const hostname: string = `securityhub.${this.region}.${awsDnsSuffix(
+        this.region,
+      )}`;
+      const url: string = `https://${hostname}/findings`;
+      const now: Date = new Date();
+      const { dateStamp, amzDate } = awsDate(now);
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        Host: hostname,
+        "X-Amz-Date": amzDate,
+      };
+      if (this.sessionToken) {
+        headers["X-Amz-Security-Token"] = this.sessionToken;
+      }
+
+      const canonicalHeaders: string = Object.keys(headers)
+        .map((key: string): [string, string] => {
+          return [key.toLowerCase(), headers[key]!.trim().replace(/\s+/g, " ")];
+        })
+        .sort(([left]: [string, string], [right]: [string, string]): number => {
+          return left.localeCompare(right);
+        })
+        .map(([key, value]: [string, string]): string => {
+          return `${key}:${value}\n`;
+        })
+        .join("");
+      const signedHeaders: string = Object.keys(headers)
+        .map((key: string): string => {
+          return key.toLowerCase();
+        })
+        .sort()
+        .join(";");
+      const canonicalRequest: string = [
+        "POST",
+        "/findings",
+        "",
+        canonicalHeaders,
+        signedHeaders,
+        sha256(bodyText),
+      ].join("\n");
+      const scope: string = `${dateStamp}/${this.region}/securityhub/aws4_request`;
+      const stringToSign: string = [
+        "AWS4-HMAC-SHA256",
+        amzDate,
+        scope,
+        sha256(canonicalRequest),
+      ].join("\n");
+      const signingKey: Buffer = hmac(
+        hmac(
+          hmac(hmac(`AWS4${this.secretAccessKey}`, dateStamp), this.region),
+          "securityhub",
+        ),
+        "aws4_request",
+      );
+      const signature: string = createHmac("sha256", signingKey)
+        .update(stringToSign, "utf8")
+        .digest("hex");
+      headers["Authorization"] =
+        `AWS4-HMAC-SHA256 Credential=${this.accessKeyId}/${scope}, ` +
+        `SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+      const result: { body: JSONObject } = await requestJson({
+        request: this.request,
+        method: "POST",
+        url,
+        headers,
+        body: bodyText,
+        label: "AWS Security Hub",
+        signal: data.signal,
+      });
+      events.push(
+        ...jsonObjects(
+          result.body["Findings"],
+          "AWS Security Hub findings",
+          true,
+        ),
+      );
+      nextToken = stringValue(result.body["NextToken"]);
+      requestCount++;
+    } while (nextToken && requestCount < MAX_CONNECTOR_PAGES);
+
+    const complete: boolean = !nextToken;
+    return {
+      events,
+      complete,
+      requestCount,
+      ...(nextToken ? { continuation: { nextToken } } : {}),
+      warnings: complete
+        ? []
+        : [
+            "AWS Security Hub returned more pages than one poll can safely read; the cursor was held for retry.",
+          ],
+    };
+  }
+}

--- a/Common/Server/Utils/SecurityEvent/Connectors/CloudflareSecurityEventClient.ts
+++ b/Common/Server/Utils/SecurityEvent/Connectors/CloudflareSecurityEventClient.ts
@@ -1,0 +1,210 @@
+import SecurityEventConnection from "../../../../Models/DatabaseModels/SecurityEventConnection";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject, JSONValue } from "../../../../Types/JSON";
+import {
+  defaultConnectorRequest,
+  jsonObject,
+  jsonObjects,
+  MAX_CONNECTOR_PAGES,
+  parseCredentialJson,
+  requestJson,
+  requiredSetting,
+} from "./ConnectorHttp";
+import {
+  SecurityEventConnectorClient,
+  SecurityEventConnectorFetchResult,
+  SecurityEventConnectorHttpRequest,
+} from "./Types";
+
+const QUERY: string = `query OneUptimeFirewallEvents($zoneTag: string, $filter: FirewallEventsAdaptiveFilter_InputObject!) {
+  viewer {
+    zones(filter: { zoneTag: $zoneTag }) {
+      firewallEventsAdaptive(filter: $filter, limit: 1000, orderBy: [datetime_ASC]) {
+        action clientASNDescription clientCountryName clientIP clientRequestHTTPHost
+        clientRequestHTTPMethodName clientRequestHTTPProtocol clientRequestPath
+        clientRequestQuery datetime description originResponseStatus rayName
+        ref ruleId source userAgent
+      }
+    }
+  }
+}`;
+
+interface TimeWindow {
+  startTime: Date;
+  endTime: Date;
+}
+
+export default class CloudflareSecurityEventClient
+  implements SecurityEventConnectorClient
+{
+  private readonly zoneId: string;
+  private readonly apiToken: string;
+  private readonly request: SecurityEventConnectorHttpRequest;
+
+  public constructor(
+    connection: SecurityEventConnection,
+    request: SecurityEventConnectorHttpRequest = defaultConnectorRequest,
+  ) {
+    const configuration: JSONObject = connection.configuration || {};
+    const credentials: JSONObject = parseCredentialJson(
+      connection.credentialJson || "",
+    );
+    this.zoneId = requiredSetting(configuration, "zoneId", "Cloudflare");
+    this.apiToken = requiredSetting(credentials, "apiToken", "Cloudflare");
+    this.request = request;
+  }
+
+  private static readEvents(body: JSONObject): Array<JSONObject> {
+    const viewer: JSONObject = jsonObject(body["data"], "Cloudflare GraphQL");
+    const viewerObject: JSONObject = jsonObject(
+      viewer["viewer"],
+      "Cloudflare GraphQL",
+    );
+    const zones: Array<JSONObject> = jsonObjects(
+      viewerObject["zones"],
+      "Cloudflare GraphQL zones",
+      true,
+    );
+    if (!zones[0]) {
+      throw new BadDataException(
+        "Cloudflare returned no matching zone. Check the zone ID and API token access.",
+      );
+    }
+    return jsonObjects(
+      zones[0]["firewallEventsAdaptive"],
+      "Cloudflare firewall events",
+      true,
+    );
+  }
+
+  private static pendingWindows(data: {
+    startTime: Date;
+    endTime: Date;
+    continuation?: JSONObject | undefined;
+  }): Array<TimeWindow> {
+    const stored: JSONValue | undefined = data.continuation?.["pendingWindows"];
+    if (stored === undefined) {
+      return [{ startTime: data.startTime, endTime: data.endTime }];
+    }
+    if (!Array.isArray(stored)) {
+      throw new BadDataException("Cloudflare pagination state is not valid.");
+    }
+    const windows: Array<TimeWindow> = [];
+    for (const value of stored) {
+      const object: JSONObject = jsonObject(
+        value,
+        "Cloudflare pagination state",
+      );
+      const startTime: Date = new Date(String(object["startTime"] || ""));
+      const endTime: Date = new Date(String(object["endTime"] || ""));
+      if (
+        !Number.isFinite(startTime.getTime()) ||
+        !Number.isFinite(endTime.getTime()) ||
+        startTime >= endTime ||
+        startTime < data.startTime ||
+        endTime > data.endTime
+      ) {
+        throw new BadDataException(
+          "Cloudflare pagination window is not valid.",
+        );
+      }
+      windows.push({ startTime, endTime });
+    }
+    return windows;
+  }
+
+  public async fetchEvents(data: {
+    startTime: Date;
+    endTime: Date;
+    continuation?: JSONObject | undefined;
+    signal?: AbortSignal | undefined;
+  }): Promise<SecurityEventConnectorFetchResult> {
+    const pending: Array<TimeWindow> =
+      CloudflareSecurityEventClient.pendingWindows(data);
+    const events: Array<JSONObject> = [];
+    const warnings: Array<string> = [];
+    let complete: boolean = true;
+    let requestCount: number = 0;
+
+    while (pending.length > 0 && requestCount < MAX_CONNECTOR_PAGES) {
+      const window: TimeWindow = pending.shift()!;
+      const result: { body: JSONObject } = await requestJson({
+        request: this.request,
+        method: "POST",
+        url: "https://api.cloudflare.com/client/v4/graphql",
+        headers: {
+          Authorization: `Bearer ${this.apiToken}`,
+          Accept: "application/json",
+        },
+        body: {
+          query: QUERY,
+          variables: {
+            zoneTag: this.zoneId,
+            filter: {
+              datetime_geq: window.startTime.toISOString(),
+              datetime_lt: window.endTime.toISOString(),
+            },
+          },
+        },
+        label: "Cloudflare",
+        signal: data.signal,
+      });
+      requestCount++;
+      const errors: JSONValue = result.body["errors"];
+      if (Array.isArray(errors) && errors.length > 0) {
+        throw new BadDataException(
+          `Cloudflare GraphQL rejected the firewall-events query: ${JSON.stringify(errors).slice(0, 500)}`,
+        );
+      }
+      const batch: Array<JSONObject> = CloudflareSecurityEventClient.readEvents(
+        result.body,
+      );
+      if (batch.length < 1000) {
+        events.push(...batch);
+        continue;
+      }
+      const duration: number =
+        window.endTime.getTime() - window.startTime.getTime();
+      if (duration <= 1000) {
+        events.push(...batch);
+        complete = false;
+        warnings.push(
+          "Cloudflare returned 1,000 events in a one-second window; that window may be truncated.",
+        );
+        continue;
+      }
+      const midpoint: Date = new Date(
+        Math.floor((window.startTime.getTime() + window.endTime.getTime()) / 2),
+      );
+      pending.unshift(
+        { startTime: window.startTime, endTime: midpoint },
+        { startTime: midpoint, endTime: window.endTime },
+      );
+    }
+
+    if (pending.length > 0) {
+      complete = false;
+      warnings.push(
+        "Cloudflare required more split windows than one poll can safely request; the cursor was held for retry.",
+      );
+    }
+    return {
+      events,
+      complete,
+      requestCount,
+      warnings,
+      ...(pending.length
+        ? {
+            continuation: {
+              pendingWindows: pending.map((window: TimeWindow): JSONObject => {
+                return {
+                  startTime: window.startTime.toISOString(),
+                  endTime: window.endTime.toISOString(),
+                };
+              }),
+            },
+          }
+        : {}),
+    };
+  }
+}

--- a/Common/Server/Utils/SecurityEvent/Connectors/ConnectorHttp.ts
+++ b/Common/Server/Utils/SecurityEvent/Connectors/ConnectorHttp.ts
@@ -1,0 +1,136 @@
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject, JSONValue } from "../../../../Types/JSON";
+import DataSourceHttpFetch, {
+  DataSourceHttpRequest,
+  DataSourceHttpResponse,
+} from "../../DataSource/HttpFetch";
+import { SecurityEventConnectorHttpRequest } from "./Types";
+
+export const MAX_CONNECTOR_PAGES: number = 10;
+export const CONNECTOR_TIMEOUT_MS: number = 30_000;
+
+export function defaultConnectorRequest(
+  request: DataSourceHttpRequest,
+): Promise<DataSourceHttpResponse> {
+  return DataSourceHttpFetch.fetch(request);
+}
+
+export function jsonObject(value: unknown, label: string): JSONObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new BadDataException(`${label} returned an invalid JSON object.`);
+  }
+  return value as JSONObject;
+}
+
+export function jsonObjects(
+  value: unknown,
+  label: string = "Connector response",
+  required: boolean = false,
+): Array<JSONObject> {
+  if (value === undefined || value === null) {
+    if (required) {
+      throw new BadDataException(`${label} returned no result array.`);
+    }
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new BadDataException(`${label} returned an invalid result array.`);
+  }
+  const objects: Array<JSONObject> = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new BadDataException(
+        `${label} returned a non-object result array member.`,
+      );
+    }
+    objects.push(entry as JSONObject);
+  }
+  return objects;
+}
+
+export function stringValues(
+  value: unknown,
+  label: string,
+  required: boolean = false,
+): Array<string> {
+  if (value === undefined || value === null) {
+    if (required) {
+      throw new BadDataException(`${label} returned no result array.`);
+    }
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new BadDataException(`${label} returned an invalid result array.`);
+  }
+  const strings: Array<string> = [];
+  for (const entry of value) {
+    if (typeof entry !== "string" || !entry) {
+      throw new BadDataException(
+        `${label} returned a non-string result array member.`,
+      );
+    }
+    strings.push(entry);
+  }
+  return strings;
+}
+
+export function stringValue(value: JSONValue | undefined): string {
+  return typeof value === "string" ? value : "";
+}
+
+export async function requestJson(data: {
+  request: SecurityEventConnectorHttpRequest;
+  method: "GET" | "POST";
+  url: string;
+  headers?: Record<string, string> | undefined;
+  body?: JSONObject | string | undefined;
+  formUrlEncoded?: boolean | undefined;
+  signal?: AbortSignal | undefined;
+  label: string;
+}): Promise<{ response: DataSourceHttpResponse; body: JSONObject }> {
+  const response: DataSourceHttpResponse = await data.request({
+    method: data.method,
+    url: data.url,
+    headers: data.headers,
+    body:
+      typeof data.body === "string"
+        ? data.body
+        : data.body
+          ? JSON.stringify(data.body)
+          : undefined,
+    formUrlEncoded: data.formUrlEncoded,
+    signal: data.signal,
+    timeoutInMs: CONNECTOR_TIMEOUT_MS,
+    egressOptions: {
+      targetLabel: `${data.label} endpoint`,
+      privateNetworkHint:
+        "Private addresses are available on self-hosted OneUptime deployments.",
+    },
+  });
+  return {
+    response,
+    body: jsonObject(response.bodyJson, data.label),
+  };
+}
+
+export function parseCredentialJson(value: string): JSONObject {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value || "");
+  } catch {
+    throw new BadDataException("Credentials JSON is not valid JSON.");
+  }
+  return jsonObject(parsed, "Credentials JSON");
+}
+
+export function requiredSetting(
+  object: JSONObject,
+  key: string,
+  provider: string,
+): string {
+  const value: JSONValue = object[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new BadDataException(`${provider} requires ${key}.`);
+  }
+  return value.trim();
+}

--- a/Common/Server/Utils/SecurityEvent/Connectors/CrowdStrikeFalconClient.ts
+++ b/Common/Server/Utils/SecurityEvent/Connectors/CrowdStrikeFalconClient.ts
@@ -1,0 +1,216 @@
+import SecurityEventConnection from "../../../../Models/DatabaseModels/SecurityEventConnection";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../../Types/JSON";
+import { DataSourceHttpResponse } from "../../DataSource/HttpFetch";
+import {
+  CONNECTOR_TIMEOUT_MS,
+  defaultConnectorRequest,
+  jsonObject,
+  jsonObjects,
+  parseCredentialJson,
+  requestJson,
+  requiredSetting,
+  stringValues,
+  stringValue,
+} from "./ConnectorHttp";
+import {
+  SecurityEventConnectorClient,
+  SecurityEventConnectorFetchResult,
+  SecurityEventConnectorHttpRequest,
+} from "./Types";
+
+const CLOUD_HOSTS: Record<string, string> = {
+  "us-1": "api.crowdstrike.com",
+  "us-2": "api.us-2.crowdstrike.com",
+  "eu-1": "api.eu-1.crowdstrike.com",
+  "us-gov-1": "api.laggar.gcw.crowdstrike.com",
+};
+
+export default class CrowdStrikeFalconClient
+  implements SecurityEventConnectorClient
+{
+  private readonly baseUrl: string;
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly request: SecurityEventConnectorHttpRequest;
+
+  public constructor(
+    connection: SecurityEventConnection,
+    request: SecurityEventConnectorHttpRequest = defaultConnectorRequest,
+  ) {
+    const configuration: JSONObject = connection.configuration || {};
+    const credentials: JSONObject = parseCredentialJson(
+      connection.credentialJson || "",
+    );
+    const cloud: string = stringValue(configuration["cloud"]) || "us-1";
+    const host: string = CLOUD_HOSTS[cloud] || "";
+    if (!host) {
+      throw new BadDataException("CrowdStrike cloud is not supported.");
+    }
+    this.baseUrl = `https://${host}`;
+    this.clientId = requiredSetting(credentials, "clientId", "CrowdStrike");
+    this.clientSecret = requiredSetting(
+      credentials,
+      "clientSecret",
+      "CrowdStrike",
+    );
+    this.request = request;
+  }
+
+  private async accessToken(signal?: AbortSignal): Promise<string> {
+    const response: DataSourceHttpResponse = await this.request({
+      method: "POST",
+      url: `${this.baseUrl}/oauth2/token`,
+      headers: { Accept: "application/json" },
+      body: {
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+      },
+      formUrlEncoded: true,
+      timeoutInMs: CONNECTOR_TIMEOUT_MS,
+      egressOptions: { targetLabel: "CrowdStrike identity endpoint" },
+      signal,
+    });
+    const body: JSONObject = jsonObject(response.bodyJson, "CrowdStrike OAuth");
+    const token: string = stringValue(body["access_token"]);
+    if (!token) {
+      throw new BadDataException("CrowdStrike OAuth returned no access_token.");
+    }
+    return token;
+  }
+
+  private static errorMessages(body: JSONObject): Array<string> {
+    return jsonObjects(body["errors"], "CrowdStrike errors").map(
+      (error: JSONObject): string => {
+        const code: string = stringValue(error["code"]);
+        const message: string =
+          stringValue(error["message"]) || stringValue(error["detail"]);
+        return [code, message].filter(Boolean).join(": ") || "unknown error";
+      },
+    );
+  }
+
+  public async fetchEvents(data: {
+    startTime: Date;
+    endTime: Date;
+    continuation?: JSONObject | undefined;
+    signal?: AbortSignal | undefined;
+  }): Promise<SecurityEventConnectorFetchResult> {
+    if (data.continuation) {
+      throw new BadDataException(
+        "CrowdStrike does not support resuming mutable alert offsets; retry the saved time window without a provider continuation.",
+      );
+    }
+    const token: string = await this.accessToken(data.signal);
+    const url: URL = new URL(`${this.baseUrl}/alerts/queries/alerts/v2`);
+    url.searchParams.set(
+      "filter",
+      `updated_timestamp:>='${data.startTime.toISOString()}'+updated_timestamp:<'${data.endTime.toISOString()}'`,
+    );
+    url.searchParams.set("limit", "500");
+    url.searchParams.set("offset", "0");
+    const response: DataSourceHttpResponse = await this.request({
+      method: "GET",
+      url: url.toString(),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+      timeoutInMs: CONNECTOR_TIMEOUT_MS,
+      egressOptions: { targetLabel: "CrowdStrike alerts endpoint" },
+      signal: data.signal,
+    });
+    const body: JSONObject = jsonObject(
+      response.bodyJson,
+      "CrowdStrike alerts query",
+    );
+    const queryErrors: Array<string> =
+      CrowdStrikeFalconClient.errorMessages(body);
+    if (queryErrors.length) {
+      throw new BadDataException(
+        `CrowdStrike alert query failed: ${queryErrors.join("; ").slice(0, 500)}`,
+      );
+    }
+    const ids: Array<string> = stringValues(
+      body["resources"],
+      "CrowdStrike alert query",
+      true,
+    );
+    const meta: JSONObject = jsonObject(
+      body["meta"] || {},
+      "CrowdStrike alerts metadata",
+    );
+    const pagination: JSONObject = jsonObject(
+      meta["pagination"] || {},
+      "CrowdStrike alerts pagination",
+    );
+    const total: number = Number(pagination["total"] || ids.length);
+
+    const events: Array<JSONObject> = [];
+    const warnings: Array<string> = [];
+    let entityIncomplete: boolean = false;
+    let entityRequests: number = 0;
+    for (let index: number = 0; index < ids.length; index += 200) {
+      const requestedIds: Array<string> = ids.slice(index, index + 200);
+      const result: { body: JSONObject } = await requestJson({
+        request: this.request,
+        method: "POST",
+        url: `${this.baseUrl}/alerts/entities/alerts/v2`,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+        },
+        body: { composite_ids: requestedIds },
+        label: "CrowdStrike alert entities",
+        signal: data.signal,
+      });
+      const entityErrors: Array<string> = CrowdStrikeFalconClient.errorMessages(
+        result.body,
+      );
+      const resources: Array<JSONObject> = jsonObjects(
+        result.body["resources"],
+        "CrowdStrike alert entities",
+        true,
+      );
+      events.push(...resources);
+      const returnedIds: Array<string> = resources
+        .map((resource: JSONObject): string => {
+          return (
+            stringValue(resource["composite_id"]) || stringValue(resource["id"])
+          );
+        })
+        .filter(Boolean);
+      const returnedIdSet: Set<string> = new Set(returnedIds);
+      const missingIds: Array<string> =
+        returnedIds.length === resources.length
+          ? requestedIds.filter((requestedId: string): boolean => {
+              return !returnedIdSet.has(requestedId);
+            })
+          : requestedIds.slice(resources.length);
+      if (entityErrors.length || missingIds.length > 0) {
+        entityIncomplete = true;
+        warnings.push(
+          entityErrors.length
+            ? `CrowdStrike did not return every requested alert entity: ${entityErrors.join("; ").slice(0, 500)}`
+            : `CrowdStrike omitted ${missingIds.length} of ${requestedIds.length} requested alert entities.`,
+        );
+      }
+      entityRequests++;
+    }
+    const queryComplete: boolean = ids.length >= total;
+    const complete: boolean = queryComplete && !entityIncomplete;
+    return {
+      events,
+      complete,
+      requestCount: 2 + entityRequests,
+      warnings: [
+        ...warnings,
+        ...(!queryComplete
+          ? [
+              "CrowdStrike returned more alerts than one stable ID page; the time window will be narrowed and retried without mutable offset pagination.",
+            ]
+          : []),
+      ],
+    };
+  }
+}

--- a/Common/Server/Utils/SecurityEvent/Connectors/GoogleSecurityCommandCenterClient.ts
+++ b/Common/Server/Utils/SecurityEvent/Connectors/GoogleSecurityCommandCenterClient.ts
@@ -1,0 +1,173 @@
+import jwt from "jsonwebtoken";
+import SecurityEventConnection from "../../../../Models/DatabaseModels/SecurityEventConnection";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../../Types/JSON";
+import { DataSourceHttpResponse } from "../../DataSource/HttpFetch";
+import {
+  CONNECTOR_TIMEOUT_MS,
+  defaultConnectorRequest,
+  jsonObject,
+  jsonObjects,
+  MAX_CONNECTOR_PAGES,
+  parseCredentialJson,
+  requiredSetting,
+  stringValue,
+} from "./ConnectorHttp";
+import {
+  SecurityEventConnectorClient,
+  SecurityEventConnectorFetchResult,
+  SecurityEventConnectorHttpRequest,
+} from "./Types";
+
+const GOOGLE_SCOPE: string = "https://www.googleapis.com/auth/cloud-platform";
+
+export default class GoogleSecurityCommandCenterClient
+  implements SecurityEventConnectorClient
+{
+  private readonly parent: string;
+  private readonly clientEmail: string;
+  private readonly privateKey: string;
+  private readonly tokenUri: string;
+  private readonly request: SecurityEventConnectorHttpRequest;
+
+  public constructor(
+    connection: SecurityEventConnection,
+    request: SecurityEventConnectorHttpRequest = defaultConnectorRequest,
+  ) {
+    const configuration: JSONObject = connection.configuration || {};
+    const credentials: JSONObject = parseCredentialJson(
+      connection.credentialJson || "",
+    );
+    this.parent = requiredSetting(
+      configuration,
+      "parent",
+      "Google Security Command Center",
+    );
+    this.clientEmail = requiredSetting(
+      credentials,
+      "client_email",
+      "Google service account",
+    );
+    this.privateKey = requiredSetting(
+      credentials,
+      "private_key",
+      "Google service account",
+    );
+    this.tokenUri =
+      stringValue(credentials["token_uri"]) ||
+      "https://oauth2.googleapis.com/token";
+    this.request = request;
+  }
+
+  private async accessToken(signal?: AbortSignal): Promise<string> {
+    const issuedAt: number = Math.floor(Date.now() / 1000) - 30;
+    const assertion: string = jwt.sign(
+      {
+        iss: this.clientEmail,
+        scope: GOOGLE_SCOPE,
+        aud: this.tokenUri,
+        iat: issuedAt,
+        exp: issuedAt + 3600,
+      },
+      this.privateKey,
+      { algorithm: "RS256" },
+    );
+    const response: DataSourceHttpResponse = await this.request({
+      method: "POST",
+      url: this.tokenUri,
+      headers: { Accept: "application/json" },
+      body: {
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion,
+      },
+      formUrlEncoded: true,
+      timeoutInMs: CONNECTOR_TIMEOUT_MS,
+      egressOptions: { targetLabel: "Google identity endpoint" },
+      signal,
+    });
+    const body: JSONObject = jsonObject(response.bodyJson, "Google identity");
+    const token: string = stringValue(body["access_token"]);
+    if (!token) {
+      throw new BadDataException("Google identity returned no access_token.");
+    }
+    return token;
+  }
+
+  public async fetchEvents(data: {
+    startTime: Date;
+    endTime: Date;
+    continuation?: JSONObject | undefined;
+    signal?: AbortSignal | undefined;
+  }): Promise<SecurityEventConnectorFetchResult> {
+    const token: string = await this.accessToken(data.signal);
+    const events: Array<JSONObject> = [];
+    let pageToken: string = stringValue(data.continuation?.["pageToken"]);
+    let pageCount: number = 0;
+
+    do {
+      const url: URL = new URL(
+        `https://securitycenter.googleapis.com/v2/${this.parent
+          .split("/")
+          .map(encodeURIComponent)
+          .join("/")}/findings`,
+      );
+      url.searchParams.set(
+        "filter",
+        `eventTime >= "${data.startTime.toISOString()}" AND eventTime < "${data.endTime.toISOString()}"`,
+      );
+      url.searchParams.set("pageSize", "200");
+      url.searchParams.set("orderBy", "eventTime asc");
+      if (pageToken) {
+        url.searchParams.set("pageToken", pageToken);
+      }
+      const response: DataSourceHttpResponse = await this.request({
+        method: "GET",
+        url: url.toString(),
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+        },
+        timeoutInMs: CONNECTOR_TIMEOUT_MS,
+        egressOptions: {
+          targetLabel: "Google Security Command Center endpoint",
+        },
+        signal: data.signal,
+      });
+      const body: JSONObject = jsonObject(
+        response.bodyJson,
+        "Google Security Command Center",
+      );
+      for (const entry of jsonObjects(
+        body["listFindingsResults"],
+        "Google Security Command Center findings",
+      )) {
+        const finding: JSONObject = jsonObject(
+          entry["finding"],
+          "Google Security Command Center finding",
+        );
+        events.push({
+          finding,
+          ...(entry["resource"] ? { resource: entry["resource"] } : {}),
+          ...(entry["stateChange"]
+            ? { stateChange: entry["stateChange"] }
+            : {}),
+        });
+      }
+      pageToken = stringValue(body["nextPageToken"]);
+      pageCount++;
+    } while (pageToken && pageCount < MAX_CONNECTOR_PAGES);
+
+    const complete: boolean = !pageToken;
+    return {
+      events,
+      complete,
+      requestCount: 1 + pageCount,
+      ...(pageToken ? { continuation: { pageToken } } : {}),
+      warnings: complete
+        ? []
+        : [
+            "Google Security Command Center returned more pages than one poll can safely read; the cursor was held for retry.",
+          ],
+    };
+  }
+}

--- a/Common/Server/Utils/SecurityEvent/Connectors/MicrosoftGraphSecurityClient.ts
+++ b/Common/Server/Utils/SecurityEvent/Connectors/MicrosoftGraphSecurityClient.ts
@@ -1,0 +1,220 @@
+import SecurityEventConnection from "../../../../Models/DatabaseModels/SecurityEventConnection";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../../Types/JSON";
+import { DataSourceHttpResponse } from "../../DataSource/HttpFetch";
+import {
+  CONNECTOR_TIMEOUT_MS,
+  defaultConnectorRequest,
+  jsonObject,
+  jsonObjects,
+  MAX_CONNECTOR_PAGES,
+  parseCredentialJson,
+  requiredSetting,
+  stringValue,
+} from "./ConnectorHttp";
+import {
+  SecurityEventConnectorClient,
+  SecurityEventConnectorFetchResult,
+  SecurityEventConnectorHttpRequest,
+} from "./Types";
+
+interface MicrosoftGraphCollectionResult {
+  events: Array<JSONObject>;
+  complete: boolean;
+  requestCount: number;
+  nextUrl: string;
+}
+
+export default class MicrosoftGraphSecurityClient
+  implements SecurityEventConnectorClient
+{
+  private readonly tenantId: string;
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly request: SecurityEventConnectorHttpRequest;
+
+  public constructor(
+    connection: SecurityEventConnection,
+    request: SecurityEventConnectorHttpRequest = defaultConnectorRequest,
+  ) {
+    const configuration: JSONObject = connection.configuration || {};
+    const credentials: JSONObject = parseCredentialJson(
+      connection.credentialJson || "",
+    );
+    this.tenantId = requiredSetting(configuration, "tenantId", "Microsoft");
+    this.clientId = requiredSetting(credentials, "clientId", "Microsoft");
+    this.clientSecret = requiredSetting(
+      credentials,
+      "clientSecret",
+      "Microsoft",
+    );
+    this.request = request;
+  }
+
+  private async accessToken(signal?: AbortSignal): Promise<string> {
+    const response: DataSourceHttpResponse = await this.request({
+      method: "POST",
+      url: `https://login.microsoftonline.com/${encodeURIComponent(this.tenantId)}/oauth2/v2.0/token`,
+      headers: { Accept: "application/json" },
+      body: {
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        grant_type: "client_credentials",
+        scope: "https://graph.microsoft.com/.default",
+      },
+      formUrlEncoded: true,
+      timeoutInMs: CONNECTOR_TIMEOUT_MS,
+      egressOptions: { targetLabel: "Microsoft identity endpoint" },
+      signal,
+    });
+    const body: JSONObject = jsonObject(
+      response.bodyJson,
+      "Microsoft identity",
+    );
+    const token: string = stringValue(body["access_token"]);
+    if (!token) {
+      throw new BadDataException(
+        "Microsoft identity returned no access_token.",
+      );
+    }
+    return token;
+  }
+
+  private async fetchCollection(data: {
+    url: string;
+    token: string;
+    resourceType: "alert" | "incident";
+    signal?: AbortSignal | undefined;
+  }): Promise<MicrosoftGraphCollectionResult> {
+    const events: Array<JSONObject> = [];
+    let nextUrl: string = data.url;
+    let requestCount: number = 0;
+
+    while (nextUrl && requestCount < MAX_CONNECTOR_PAGES) {
+      const parsed: URL = new URL(nextUrl);
+      if (
+        parsed.protocol !== "https:" ||
+        parsed.hostname !== "graph.microsoft.com" ||
+        !parsed.pathname.startsWith("/v1.0/security/")
+      ) {
+        throw new BadDataException(
+          "Microsoft Graph returned an unsafe pagination URL.",
+        );
+      }
+      const response: DataSourceHttpResponse = await this.request({
+        method: "GET",
+        url: parsed.toString(),
+        headers: {
+          Authorization: `Bearer ${data.token}`,
+          Accept: "application/json",
+        },
+        timeoutInMs: CONNECTOR_TIMEOUT_MS,
+        egressOptions: { targetLabel: "Microsoft Graph endpoint" },
+        signal: data.signal,
+      });
+      const body: JSONObject = jsonObject(
+        response.bodyJson,
+        "Microsoft Graph Security",
+      );
+      for (const event of jsonObjects(
+        body["value"],
+        "Microsoft Graph Security results",
+        true,
+      )) {
+        if (!event["@odata.type"]) {
+          event["@odata.type"] =
+            data.resourceType === "incident"
+              ? "#microsoft.graph.security.incident"
+              : "#microsoft.graph.security.alert";
+        }
+        events.push(event);
+      }
+      nextUrl = stringValue(body["@odata.nextLink"]);
+      requestCount++;
+    }
+    return { events, complete: !nextUrl, requestCount, nextUrl };
+  }
+
+  public async fetchEvents(data: {
+    startTime: Date;
+    endTime: Date;
+    continuation?: JSONObject | undefined;
+    signal?: AbortSignal | undefined;
+  }): Promise<SecurityEventConnectorFetchResult> {
+    const token: string = await this.accessToken(data.signal);
+    const filter: string =
+      `lastUpdateDateTime ge ${data.startTime.toISOString()} and ` +
+      `lastUpdateDateTime lt ${data.endTime.toISOString()}`;
+    const alertUrl: URL = new URL(
+      "https://graph.microsoft.com/v1.0/security/alerts_v2",
+    );
+    alertUrl.searchParams.set("$filter", filter);
+    alertUrl.searchParams.set("$top", "50");
+    const incidentUrl: URL = new URL(
+      "https://graph.microsoft.com/v1.0/security/incidents",
+    );
+    incidentUrl.searchParams.set("$filter", filter);
+    incidentUrl.searchParams.set("$top", "50");
+    incidentUrl.searchParams.set("$expand", "alerts");
+
+    const phase: string = stringValue(data.continuation?.["phase"]);
+    const continuationUrl: string = stringValue(data.continuation?.["nextUrl"]);
+    if (phase && !["alerts", "incidents"].includes(phase)) {
+      throw new BadDataException(
+        "Microsoft Graph pagination state is not valid.",
+      );
+    }
+    if (phase && !continuationUrl) {
+      throw new BadDataException(
+        "Microsoft Graph pagination state has no next URL.",
+      );
+    }
+
+    const alerts: MicrosoftGraphCollectionResult =
+      phase === "incidents"
+        ? { events: [], complete: true, requestCount: 0, nextUrl: "" }
+        : await this.fetchCollection({
+            url: phase === "alerts" ? continuationUrl : alertUrl.toString(),
+            token,
+            resourceType: "alert",
+            signal: data.signal,
+          });
+    if (!alerts.complete) {
+      return {
+        events: alerts.events,
+        complete: false,
+        requestCount: 1 + alerts.requestCount,
+        continuation: { phase: "alerts", nextUrl: alerts.nextUrl },
+        warnings: [
+          "Microsoft Graph alert pagination will continue in the next poll.",
+        ],
+      };
+    }
+    const incidents: MicrosoftGraphCollectionResult =
+      await this.fetchCollection({
+        url: phase === "incidents" ? continuationUrl : incidentUrl.toString(),
+        token,
+        resourceType: "incident",
+        signal: data.signal,
+      });
+    const complete: boolean = alerts.complete && incidents.complete;
+    return {
+      events: [...alerts.events, ...incidents.events],
+      complete,
+      requestCount: 1 + alerts.requestCount + incidents.requestCount,
+      ...(!incidents.complete
+        ? {
+            continuation: {
+              phase: "incidents",
+              nextUrl: incidents.nextUrl,
+            },
+          }
+        : {}),
+      warnings: complete
+        ? []
+        : [
+            "Microsoft Graph returned more pages than one poll can safely read; the cursor was held for retry.",
+          ],
+    };
+  }
+}

--- a/Common/Server/Utils/SecurityEvent/Connectors/OktaSystemLogClient.ts
+++ b/Common/Server/Utils/SecurityEvent/Connectors/OktaSystemLogClient.ts
@@ -1,0 +1,124 @@
+import SecurityEventConnection from "../../../../Models/DatabaseModels/SecurityEventConnection";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../../Types/JSON";
+import { DataSourceHttpResponse } from "../../DataSource/HttpFetch";
+import {
+  CONNECTOR_TIMEOUT_MS,
+  defaultConnectorRequest,
+  jsonObjects,
+  MAX_CONNECTOR_PAGES,
+  parseCredentialJson,
+  requiredSetting,
+  stringValue,
+} from "./ConnectorHttp";
+import {
+  SecurityEventConnectorClient,
+  SecurityEventConnectorFetchResult,
+  SecurityEventConnectorHttpRequest,
+} from "./Types";
+
+function nextLink(value: string): string {
+  for (const part of value.split(",")) {
+    const match: RegExpMatchArray | null = part.match(
+      /<([^>]+)>\s*;\s*rel=["']?next["']?/i,
+    );
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return "";
+}
+
+function safeLogUrl(value: string, baseUrl: URL): string {
+  const parsed: URL = new URL(value);
+  if (parsed.origin !== baseUrl.origin || parsed.pathname !== "/api/v1/logs") {
+    throw new BadDataException("Okta returned an unsafe pagination URL.");
+  }
+  return parsed.toString();
+}
+
+export default class OktaSystemLogClient
+  implements SecurityEventConnectorClient
+{
+  private readonly baseUrl: URL;
+  private readonly apiToken: string;
+  private readonly request: SecurityEventConnectorHttpRequest;
+
+  public constructor(
+    connection: SecurityEventConnection,
+    request: SecurityEventConnectorHttpRequest = defaultConnectorRequest,
+  ) {
+    const configuration: JSONObject = connection.configuration || {};
+    const credentials: JSONObject = parseCredentialJson(
+      connection.credentialJson || "",
+    );
+    this.baseUrl = new URL(requiredSetting(configuration, "baseUrl", "Okta"));
+    this.apiToken = requiredSetting(credentials, "apiToken", "Okta");
+    this.request = request;
+  }
+
+  public async fetchEvents(data: {
+    startTime: Date;
+    endTime: Date;
+    continuation?: JSONObject | undefined;
+    signal?: AbortSignal | undefined;
+  }): Promise<SecurityEventConnectorFetchResult> {
+    const first: URL = new URL("/api/v1/logs", this.baseUrl);
+    first.searchParams.set("since", data.startTime.toISOString());
+    first.searchParams.set("limit", "200");
+    first.searchParams.set("sortOrder", "ASCENDING");
+    const events: Array<JSONObject> = [];
+    let url: string =
+      stringValue(data.continuation?.["nextUrl"]) || first.toString();
+    let pageCount: number = 0;
+
+    while (url && pageCount < MAX_CONNECTOR_PAGES) {
+      url = safeLogUrl(url, this.baseUrl);
+      const response: DataSourceHttpResponse = await this.request({
+        method: "GET",
+        url,
+        headers: {
+          Authorization: `SSWS ${this.apiToken}`,
+          Accept: "application/json",
+        },
+        timeoutInMs: CONNECTOR_TIMEOUT_MS,
+        egressOptions: {
+          targetLabel: "Okta System Log endpoint",
+          privateNetworkHint:
+            "Private Okta-compatible endpoints are available on self-hosted OneUptime deployments.",
+        },
+        signal: data.signal,
+      });
+      const pageEvents: Array<JSONObject> = jsonObjects(
+        response.bodyJson,
+        "Okta System Log",
+        true,
+      );
+      events.push(...pageEvents);
+      url = nextLink(response.headers?.["link"] || "");
+      pageCount++;
+      if (!url) {
+        throw new BadDataException(
+          "Okta System Log did not return its required next polling link.",
+        );
+      }
+      url = safeLogUrl(url, this.baseUrl);
+      if (pageEvents.length === 0) {
+        break;
+      }
+    }
+
+    return {
+      events,
+      complete: true,
+      requestCount: pageCount,
+      continuation: { nextUrl: url },
+      warnings:
+        pageCount === MAX_CONNECTOR_PAGES
+          ? [
+              "Okta returned a full bounded page batch; the next polling link was saved for the following poll.",
+            ]
+          : [],
+    };
+  }
+}

--- a/Common/Server/Utils/SecurityEvent/Connectors/SecurityEventConnectionPoller.ts
+++ b/Common/Server/Utils/SecurityEvent/Connectors/SecurityEventConnectionPoller.ts
@@ -1,0 +1,1215 @@
+import { ResponseJSON, ResultSet } from "@clickhouse/client";
+import { createHash } from "crypto";
+import SecurityEventConnection from "../../../../Models/DatabaseModels/SecurityEventConnection";
+import TableColumnType from "../../../../Types/AnalyticsDatabase/TableColumnType";
+import LIMIT_MAX from "../../../../Types/Database/LimitMax";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import NormalizedSecurityEvent from "../../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity, {
+  OcsfSeverityId,
+} from "../../../../Types/SecurityEvent/OcsfSeverity";
+import SecurityEventConnectorResult from "../../../../Types/SecurityEvent/SecurityEventConnectorResult";
+import GenericNormalizer from "../../../../Utils/SecurityEvent/GenericNormalizer";
+import VendorSecurityEventNormalizer from "../../../../Utils/SecurityEvent/VendorSecurityEventNormalizer";
+import {
+  getClickhouseClusterName,
+  getClickhouseDatabaseName,
+  getStorageTableName,
+} from "../../AnalyticsDatabase/ClusterConfig";
+import { getQuerySettings } from "../../AnalyticsDatabase/QuerySettingsHelper";
+import { SQL, Statement } from "../../AnalyticsDatabase/Statement";
+import Semaphore, {
+  SemaphoreLockTimeoutError,
+  SemaphoreMutex,
+} from "../../../Infrastructure/Semaphore";
+import OTelIngestService, {
+  TelemetryServiceMetadata,
+} from "../../../Services/OpenTelemetryIngestService";
+import SecurityEventConnectionService, {
+  SecurityEventPollingCheckpointUpdate,
+  validateSecurityEventConnection,
+} from "../../../Services/SecurityEventConnectionService";
+import SecurityEventService from "../../../Services/SecurityEventService";
+import { resolveTelemetryRetentionInDays } from "../../../../Types/Telemetry/TelemetryRetentionConfig";
+import logger from "../../Logger";
+import { redactLogString } from "../../LogRedaction";
+import ConnectorErrorMessage from "../ConnectorErrorMessage";
+import { buildSecurityEventDbRow } from "../SecurityEventRow";
+import ThreatIntelEnricher from "../ThreatIntel/ThreatIntelEnricher";
+import SecurityEventConnectorClientFactory from "./SecurityEventConnectorClientFactory";
+import {
+  SecurityEventConnectorClient,
+  SecurityEventConnectorFetchResult,
+} from "./Types";
+
+const DEFAULT_LOOKBACK_MS: number = 15 * 60 * 1000;
+const MAX_WINDOW_MS: number = 24 * 60 * 60 * 1000;
+const OVERLAP_MS: number = 60 * 1000;
+const UID_BATCH_SIZE: number = 1000;
+const MIN_RETRY_WINDOW_MS: number = 1000;
+const MAX_SPLIT_ATTEMPTS: number = 20;
+const MAX_SAME_CONTINUATION_ATTEMPTS: number = 3;
+const MAX_CONTINUATION_BATCHES: number = 20;
+const MAX_OPERATION_FAILURE_ATTEMPTS: number = 3;
+const CONNECTION_LOCK_TIMEOUT_MS: number = 15 * 60 * 1000;
+export const SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY: number = 4;
+export const SECURITY_EVENT_CONNECTION_POLL_DEADLINE_MS: number = 8 * 60 * 1000;
+export const SECURITY_EVENT_CONNECTION_SWEEP_START_BUDGET_MS: number =
+  2 * 60 * 1000;
+export const SECURITY_EVENT_CONNECTION_LOCK_NAMESPACE: string =
+  "SecurityEventConnectionSource";
+export const SECURITY_EVENT_CONNECTION_SWEEP_LOCK_NAMESPACE: string =
+  "SecurityEventConnectionSweep";
+
+interface PollWindow {
+  startTime: Date;
+  endTime: Date;
+  hasCursor: boolean;
+  isPinned: boolean;
+  attempt: number;
+  continuationCount: number;
+  continuation?: JSONObject | undefined;
+}
+
+interface StoredCursor {
+  version: 1;
+  nextStart: string;
+  endTime?: string | undefined;
+  attempt?: number | undefined;
+  continuationCount?: number | undefined;
+  continuation?: JSONObject | undefined;
+}
+
+class InvalidSecurityEventConnectionCursorError extends Error {}
+class SecurityEventConnectionStartBudgetExceededError extends Error {
+  public constructor() {
+    super("Security event connection sweep start budget was exceeded.");
+  }
+}
+class SecurityEventConnectionDeadlineError extends Error {
+  public constructor() {
+    super("Security event connection exceeded its 8-minute polling deadline.");
+  }
+}
+
+export default class SecurityEventConnectionPoller {
+  private static isDue(
+    connection: SecurityEventConnection,
+    now: number,
+  ): boolean {
+    const interval: number = Math.max(1, connection.pollIntervalInMinutes || 5);
+    return !(
+      connection.lastPolledAt &&
+      connection.lastPolledAt.getTime() + interval * 60_000 > now
+    );
+  }
+
+  public static async pollAllDueConnections(): Promise<void> {
+    let sweepMutex: SemaphoreMutex;
+    try {
+      sweepMutex = await Semaphore.lock({
+        namespace: SECURITY_EVENT_CONNECTION_SWEEP_LOCK_NAMESPACE,
+        key: "all",
+        lockTimeout: CONNECTION_LOCK_TIMEOUT_MS,
+        acquireTimeout: 100,
+        retryInterval: 100,
+      });
+    } catch (error) {
+      if (error instanceof SemaphoreLockTimeoutError) {
+        return;
+      }
+      throw error;
+    }
+    try {
+      const stopStartingAt: number =
+        Date.now() + SECURITY_EVENT_CONNECTION_SWEEP_START_BUDGET_MS;
+      const connections: Array<SecurityEventConnection> = [];
+      let skip: number = 0;
+      let page: Array<SecurityEventConnection>;
+      do {
+        page = await SecurityEventConnectionService.findBy({
+          query: { isEnabled: true },
+          select: {
+            _id: true,
+            pollIntervalInMinutes: true,
+            lastPolledAt: true,
+            createdAt: true,
+          },
+          skip,
+          limit: LIMIT_MAX,
+          props: { isRoot: true },
+        });
+        connections.push(...page);
+        skip += page.length;
+      } while (page.length === LIMIT_MAX);
+      const now: number = Date.now();
+      const dueConnections: Array<SecurityEventConnection> = connections.filter(
+        (connection: SecurityEventConnection): boolean => {
+          return this.isDue(connection, now);
+        },
+      );
+      dueConnections.sort(
+        (
+          left: SecurityEventConnection,
+          right: SecurityEventConnection,
+        ): number => {
+          const leftTime: number = left.lastPolledAt
+            ? left.lastPolledAt.getTime() +
+              Math.max(1, left.pollIntervalInMinutes || 5) * 60_000
+            : left.createdAt?.getTime() || Number.MIN_SAFE_INTEGER;
+          const rightTime: number = right.lastPolledAt
+            ? right.lastPolledAt.getTime() +
+              Math.max(1, right.pollIntervalInMinutes || 5) * 60_000
+            : right.createdAt?.getTime() || Number.MIN_SAFE_INTEGER;
+          return (
+            leftTime - rightTime ||
+            (left.id?.toString() || "").localeCompare(
+              right.id?.toString() || "",
+            )
+          );
+        },
+      );
+
+      let nextIndex: number = 0;
+      await Promise.all(
+        Array.from(
+          {
+            length: Math.min(
+              SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY,
+              dueConnections.length,
+            ),
+          },
+          async (): Promise<void> => {
+            while (nextIndex < dueConnections.length) {
+              if (Date.now() >= stopStartingAt) {
+                return;
+              }
+
+              const scheduledConnection: SecurityEventConnection =
+                dueConnections[nextIndex++]!;
+              const connectionId: ObjectID | null = scheduledConnection.id;
+              if (!connectionId) {
+                continue;
+              }
+
+              try {
+                const connection: SecurityEventConnection | null =
+                  await SecurityEventConnectionService.findOneBy({
+                    query: {
+                      _id: connectionId.toString(),
+                      isEnabled: true,
+                    },
+                    select: {
+                      _id: true,
+                      projectId: true,
+                      provider: true,
+                      configuration: true,
+                      credentialJson: true,
+                      sourceGeneration: true,
+                      pollIntervalInMinutes: true,
+                      lastPolledAt: true,
+                      cursor: true,
+                      createdAt: true,
+                      version: true,
+                      isEnabled: true,
+                    },
+                    props: { isRoot: true },
+                  });
+
+                if (
+                  !connection ||
+                  !connection.isEnabled ||
+                  !this.isDue(connection, Date.now())
+                ) {
+                  continue;
+                }
+                if (Date.now() >= stopStartingAt) {
+                  return;
+                }
+
+                await this.pollConnection(
+                  connection,
+                  undefined,
+                  stopStartingAt,
+                );
+              } catch (error) {
+                if (
+                  error instanceof
+                  SecurityEventConnectionStartBudgetExceededError
+                ) {
+                  return;
+                }
+                logger.error(
+                  `SecurityEventConnectionPoller: ${connectionId.toString()}: ${redactLogString(
+                    ConnectorErrorMessage.toMessage(error, { truncate: false }),
+                  )}`,
+                );
+              }
+            }
+          },
+        ),
+      );
+    } finally {
+      await Semaphore.release(sweepMutex);
+    }
+  }
+
+  private static parseStoredCursor(value: string): StoredCursor | null {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return null;
+      }
+      const cursor: Record<string, unknown> = parsed as Record<string, unknown>;
+      if (cursor["version"] !== 1 || typeof cursor["nextStart"] !== "string") {
+        return null;
+      }
+      const continuation: unknown = cursor["continuation"];
+      if (
+        continuation !== undefined &&
+        (!continuation ||
+          typeof continuation !== "object" ||
+          Array.isArray(continuation))
+      ) {
+        return null;
+      }
+      for (const key of ["attempt", "continuationCount"]) {
+        if (
+          cursor[key] !== undefined &&
+          (!Number.isInteger(cursor[key]) || Number(cursor[key]) < 0)
+        ) {
+          return null;
+        }
+      }
+      return {
+        version: 1,
+        nextStart: cursor["nextStart"],
+        ...(typeof cursor["endTime"] === "string"
+          ? { endTime: cursor["endTime"] }
+          : {}),
+        ...(Number.isInteger(cursor["attempt"])
+          ? { attempt: cursor["attempt"] as number }
+          : {}),
+        ...(Number.isInteger(cursor["continuationCount"])
+          ? { continuationCount: cursor["continuationCount"] as number }
+          : {}),
+        ...(continuation ? { continuation: continuation as JSONObject } : {}),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private static encodeStoredCursor(data: {
+    nextStart: Date;
+    endTime?: Date | undefined;
+    attempt?: number | undefined;
+    continuationCount?: number | undefined;
+    continuation?: JSONObject | undefined;
+  }): string {
+    const cursor: StoredCursor = {
+      version: 1,
+      nextStart: data.nextStart.toISOString(),
+      ...(data.endTime ? { endTime: data.endTime.toISOString() } : {}),
+      ...(data.attempt ? { attempt: data.attempt } : {}),
+      ...(data.continuationCount
+        ? { continuationCount: data.continuationCount }
+        : {}),
+      ...(data.continuation ? { continuation: data.continuation } : {}),
+    };
+    return JSON.stringify(cursor);
+  }
+
+  private static getWindow(connection: SecurityEventConnection): PollWindow {
+    const now: Date = new Date();
+    if (connection.cursor) {
+      const stored: StoredCursor | null = this.parseStoredCursor(
+        connection.cursor,
+      );
+      if (stored) {
+        const startTime: Date = new Date(stored.nextStart);
+        const storedEndTime: Date | null = stored.endTime
+          ? new Date(stored.endTime)
+          : null;
+        if (
+          Number.isFinite(startTime.getTime()) &&
+          startTime.getTime() <= now.getTime() &&
+          (!storedEndTime ||
+            (Number.isFinite(storedEndTime.getTime()) &&
+              storedEndTime > startTime))
+        ) {
+          const endTime: Date = storedEndTime
+            ? new Date(Math.min(storedEndTime.getTime(), now.getTime()))
+            : new Date(
+                Math.min(now.getTime(), startTime.getTime() + MAX_WINDOW_MS),
+              );
+          return {
+            startTime,
+            endTime,
+            hasCursor: true,
+            isPinned: Boolean(storedEndTime),
+            attempt: Math.max(0, stored.attempt || 0),
+            continuationCount: Math.max(0, stored.continuationCount || 0),
+            ...(stored.continuation
+              ? { continuation: stored.continuation }
+              : {}),
+          };
+        }
+      }
+
+      const cursor: Date = new Date(connection.cursor);
+      if (
+        Number.isFinite(cursor.getTime()) &&
+        cursor.getTime() <= now.getTime()
+      ) {
+        const startTime: Date = new Date(
+          Math.max(0, cursor.getTime() - OVERLAP_MS),
+        );
+        return {
+          startTime,
+          endTime: new Date(
+            Math.min(now.getTime(), startTime.getTime() + MAX_WINDOW_MS),
+          ),
+          hasCursor: true,
+          isPinned: false,
+          attempt: 0,
+          continuationCount: 0,
+        };
+      }
+
+      throw new InvalidSecurityEventConnectionCursorError(
+        "Security event connection has an invalid or future polling cursor. Update its source settings to reset the checkpoint.",
+      );
+    }
+
+    const startTime: Date = new Date(now.getTime() - DEFAULT_LOOKBACK_MS);
+    return {
+      startTime,
+      endTime: now,
+      hasCursor: false,
+      isPinned: false,
+      attempt: 0,
+      continuationCount: 0,
+    };
+  }
+
+  private static readStringPath(value: JSONObject, path: string): string {
+    let current: unknown = value;
+    for (const part of path.split(".")) {
+      if (!current || typeof current !== "object" || Array.isArray(current)) {
+        return "";
+      }
+      current = (current as Record<string, unknown>)[part];
+    }
+    return typeof current === "string" ? current : "";
+  }
+
+  private static stableJson(value: unknown): string {
+    if (Array.isArray(value)) {
+      return `[${value
+        .map((item: unknown): string => {
+          return this.stableJson(item);
+        })
+        .join(",")}]`;
+    }
+    if (value && typeof value === "object") {
+      const object: Record<string, unknown> = value as Record<string, unknown>;
+      return `{${Object.keys(object)
+        .sort()
+        .map((key: string): string => {
+          return `${JSON.stringify(key)}:${this.stableJson(object[key])}`;
+        })
+        .join(",")}}`;
+    }
+    return JSON.stringify(value) ?? "null";
+  }
+
+  private static digest(value: unknown): string {
+    return createHash("sha256").update(this.stableJson(value)).digest("hex");
+  }
+
+  private static sourceFingerprint(
+    connection: SecurityEventConnection,
+  ): string {
+    return this.digest({
+      provider: connection.provider,
+      configuration: connection.configuration,
+      sourceGeneration: connection.sourceGeneration || 1,
+    });
+  }
+
+  private static sourceRevision(
+    provider: string,
+    rawEvent: JSONObject,
+  ): string {
+    const providerPaths: Record<string, Array<string>> = {
+      "AWS Security Hub": ["UpdatedAt", "LastObservedAt"],
+      "Microsoft Defender XDR and Sentinel": [
+        "lastUpdateDateTime",
+        "lastActivityDateTime",
+      ],
+      Cloudflare: ["datetime"],
+      "CrowdStrike Falcon": [
+        "updated_timestamp",
+        "updatedTimestamp",
+        "last_updated_timestamp",
+      ],
+      "Google Security Command Center": [
+        "finding.eventTime",
+        "finding.event_time",
+        "finding.createTime",
+      ],
+      Okta: ["published"],
+      "Splunk Enterprise Security": ["mod_time", "updated", "_time"],
+    };
+    for (const path of providerPaths[provider] || []) {
+      const revision: string = this.readStringPath(rawEvent, path);
+      if (revision) {
+        return `${revision}\u0000content:${this.digest(rawEvent)}`;
+      }
+    }
+    return `content:${this.digest(rawEvent)}`;
+  }
+
+  private static namespaceEventUid(data: {
+    connection: SecurityEventConnection;
+    rawEvent: JSONObject;
+    normalized: NormalizedSecurityEvent;
+  }): void {
+    const sourceUid: string = data.normalized.eventUid;
+    const revision: string = this.sourceRevision(
+      data.connection.provider!,
+      data.rawEvent,
+    );
+    data.normalized.attributes["oneuptime.security_event.source_uid"] =
+      sourceUid;
+    data.normalized.attributes["oneuptime.security_event.source_revision"] =
+      revision;
+    const sourceFingerprint: string = this.sourceFingerprint(data.connection);
+    data.normalized.attributes["oneuptime.security_event.source_fingerprint"] =
+      sourceFingerprint;
+    data.normalized.eventUid = createHash("sha256")
+      .update(
+        [
+          data.connection.id!.toString(),
+          sourceFingerprint,
+          data.normalized.classUid.toString(),
+          sourceUid,
+          revision,
+        ].join("\u0000"),
+      )
+      .digest("hex");
+  }
+
+  private static auditMarker(data: {
+    connection: SecurityEventConnection;
+    rawEvent: JSONObject;
+    time: Date;
+    markerType: "rejected_record" | "normalization_failure" | "irreducible_gap";
+    message: string;
+  }): NormalizedSecurityEvent {
+    const marker: NormalizedSecurityEvent = GenericNormalizer.normalize(
+      data.rawEvent,
+    );
+    marker.time = data.time;
+    marker.eventUid = `connector-audit:${data.markerType}:${this.digest(
+      data.rawEvent,
+    )}`;
+    marker.categoryUid = 0;
+    marker.categoryName = "Uncategorized";
+    marker.classUid = 0;
+    marker.className = "Base Event";
+    marker.activityName = "Connector Audit";
+    marker.severityName = OcsfSeverity.Unknown;
+    marker.severityId = OcsfSeverityId[OcsfSeverity.Unknown];
+    marker.statusName = "Failure";
+    marker.message = data.message;
+    marker.vendorName = data.connection.provider!;
+    marker.productName = data.connection.provider!;
+    marker.attributes["oneuptime.security_event.audit_marker"] = true;
+    marker.attributes["oneuptime.security_event.audit_marker_type"] =
+      data.markerType;
+    this.namespaceEventUid({
+      connection: data.connection,
+      rawEvent: data.rawEvent,
+      normalized: marker,
+    });
+    return marker;
+  }
+
+  private static sameContinuation(
+    left: JSONObject | undefined,
+    right: JSONObject | undefined,
+  ): boolean {
+    return Boolean(
+      left && right && JSON.stringify(left) === JSON.stringify(right),
+    );
+  }
+
+  private static willAdvanceIncompleteWindow(data: {
+    window: PollWindow;
+    nextContinuation?: JSONObject | undefined;
+  }): boolean {
+    const sameContinuation: boolean = this.sameContinuation(
+      data.window.continuation,
+      data.nextContinuation,
+    );
+    const continuationAttempt: number = sameContinuation
+      ? data.window.attempt + 1
+      : 0;
+    const continuationCount: number = data.window.continuationCount + 1;
+    if (
+      data.nextContinuation &&
+      continuationAttempt < MAX_SAME_CONTINUATION_ATTEMPTS &&
+      continuationCount < MAX_CONTINUATION_BATCHES
+    ) {
+      return false;
+    }
+    return (
+      data.window.endTime.getTime() - data.window.startTime.getTime() <=
+        MIN_RETRY_WINDOW_MS || data.window.attempt >= MAX_SPLIT_ATTEMPTS
+    );
+  }
+
+  private static throwIfAborted(signal: AbortSignal): void {
+    if (signal.aborted) {
+      throw new Error("Security event connection poll exceeded its deadline.");
+    }
+  }
+
+  private static isResponseSizeLimitError(error: unknown): boolean {
+    const message: string = ConnectorErrorMessage.toMessage(error, {
+      truncate: false,
+    }).toLowerCase();
+    return (
+      message.includes("maxcontentlength") ||
+      message.includes("maxbodylength") ||
+      message.includes("response size") ||
+      (message.includes("response body") && message.includes("too large"))
+    );
+  }
+
+  private static async persistDeadlineFailure(
+    connection: SecurityEventConnection,
+    error: SecurityEventConnectionDeadlineError,
+  ): Promise<void> {
+    if (!connection.id) {
+      return;
+    }
+    const completedAt: Date = new Date();
+    const message: string = error.message;
+    const result: SecurityEventConnectorResult = {
+      startedAt: completedAt.toISOString(),
+      completedAt: completedAt.toISOString(),
+      windowStart: completedAt.toISOString(),
+      windowEnd: completedAt.toISOString(),
+      fetchedCount: 0,
+      ingestedCount: 0,
+      duplicateCount: 0,
+      rejectedCount: 0,
+      failedCount: 0,
+      markerCount: 0,
+      requestCount: 0,
+      complete: false,
+      retryScheduled: true,
+      warnings: [],
+      error: message,
+    };
+    const checkpoint: SecurityEventPollingCheckpointUpdate = {
+      lastPolledAt: completedAt,
+      lastPollResult: result as unknown as JSONObject,
+      lastError: message,
+    };
+    if (connection.version !== undefined) {
+      await SecurityEventConnectionService.updatePollingCheckpointIfUnchanged({
+        id: connection.id,
+        expectedVersion: connection.version,
+        checkpoint,
+      });
+      return;
+    }
+    await SecurityEventConnectionService.updateOneById({
+      id: connection.id,
+      data: checkpoint as never,
+      props: { isRoot: true },
+    });
+  }
+
+  public static async pollConnection(
+    connection: SecurityEventConnection,
+    clientOverride?: SecurityEventConnectorClient | undefined,
+    startBefore?: number | undefined,
+  ): Promise<SecurityEventConnectorResult> {
+    if (!connection.id) {
+      throw new Error("Security event connection is missing its id.");
+    }
+    const mutex: SemaphoreMutex = await Semaphore.lock({
+      namespace: SECURITY_EVENT_CONNECTION_LOCK_NAMESPACE,
+      key: connection.id.toString(),
+      lockTimeout: CONNECTION_LOCK_TIMEOUT_MS,
+      acquireTimeout: 10_000,
+      retryInterval: 100,
+    });
+    if (startBefore !== undefined && Date.now() >= startBefore) {
+      await Semaphore.release(mutex);
+      throw new SecurityEventConnectionStartBudgetExceededError();
+    }
+    const abortController: AbortController = new AbortController();
+    let deadline: ReturnType<typeof setTimeout> | undefined;
+    const deadlinePromise: Promise<never> = new Promise(
+      (_resolve: (value: never) => void, reject: (error: Error) => void) => {
+        deadline = setTimeout((): void => {
+          abortController.abort();
+          reject(new SecurityEventConnectionDeadlineError());
+        }, SECURITY_EVENT_CONNECTION_POLL_DEADLINE_MS);
+      },
+    );
+    let releaseWhenPollingSettles: boolean = false;
+    let pollingPromise: Promise<SecurityEventConnectorResult> | undefined;
+    try {
+      pollingPromise = (async () => {
+        try {
+          return await this.pollUnlocked(
+            connection,
+            abortController.signal,
+            clientOverride,
+          );
+        } catch (error) {
+          if (!(error instanceof InvalidSecurityEventConnectionCursorError)) {
+            throw error;
+          }
+          const completedAt: Date = new Date();
+          const message: string = redactLogString(
+            ConnectorErrorMessage.toMessage(error, { truncate: false }),
+          );
+          const result: SecurityEventConnectorResult = {
+            startedAt: completedAt.toISOString(),
+            completedAt: completedAt.toISOString(),
+            windowStart: completedAt.toISOString(),
+            windowEnd: completedAt.toISOString(),
+            fetchedCount: 0,
+            ingestedCount: 0,
+            duplicateCount: 0,
+            rejectedCount: 0,
+            failedCount: 0,
+            markerCount: 0,
+            requestCount: 0,
+            complete: false,
+            warnings: [],
+            error: message,
+          };
+          const checkpoint: SecurityEventPollingCheckpointUpdate = {
+            lastPolledAt: completedAt,
+            lastPollResult: result as unknown as JSONObject,
+            lastError: message,
+          };
+          if (connection.version !== undefined) {
+            await SecurityEventConnectionService.updatePollingCheckpointIfUnchanged(
+              {
+                id: connection.id!,
+                expectedVersion: connection.version,
+                checkpoint,
+              },
+            );
+          } else {
+            await SecurityEventConnectionService.updateOneById({
+              id: connection.id!,
+              data: checkpoint as never,
+              props: { isRoot: true },
+            });
+          }
+          throw error;
+        }
+      })();
+      return await Promise.race([pollingPromise, deadlinePromise]);
+    } catch (error) {
+      if (error instanceof SecurityEventConnectionDeadlineError) {
+        releaseWhenPollingSettles = true;
+        void pollingPromise
+          ?.then(
+            async (): Promise<void> => {
+              await Semaphore.release(mutex);
+            },
+            async (): Promise<void> => {
+              await Semaphore.release(mutex);
+            },
+          )
+          .catch((releaseError: unknown): void => {
+            logger.error(
+              `SecurityEventConnectionPoller: could not release the timed-out connection lock: ${redactLogString(
+                ConnectorErrorMessage.toMessage(releaseError, {
+                  truncate: false,
+                }),
+              )}`,
+            );
+          });
+        await this.persistDeadlineFailure(connection, error);
+      }
+      throw error;
+    } finally {
+      if (deadline) {
+        clearTimeout(deadline);
+      }
+      if (!releaseWhenPollingSettles) {
+        await Semaphore.release(mutex);
+      }
+    }
+  }
+
+  private static async pollUnlocked(
+    connection: SecurityEventConnection,
+    signal: AbortSignal,
+    clientOverride?: SecurityEventConnectorClient | undefined,
+  ): Promise<SecurityEventConnectorResult> {
+    const window: PollWindow = this.getWindow(connection);
+    const startedAt: Date = new Date();
+    const result: SecurityEventConnectorResult = {
+      startedAt: startedAt.toISOString(),
+      completedAt: startedAt.toISOString(),
+      windowStart: window.startTime.toISOString(),
+      windowEnd: window.endTime.toISOString(),
+      fetchedCount: 0,
+      ingestedCount: 0,
+      duplicateCount: 0,
+      rejectedCount: 0,
+      failedCount: 0,
+      markerCount: 0,
+      requestCount: 0,
+      complete: true,
+      warnings: [],
+    };
+    let providerComplete: boolean = true;
+    let nextContinuation: JSONObject | undefined = undefined;
+    let operationFailed: boolean = false;
+    try {
+      if (
+        !connection.projectId ||
+        !connection.provider ||
+        !connection.configuration ||
+        !connection.credentialJson
+      ) {
+        throw new Error(
+          "Security event connection is missing projectId, provider, configuration, or credentials.",
+        );
+      }
+      validateSecurityEventConnection({
+        provider: connection.provider,
+        configuration: connection.configuration,
+        credentialJson: connection.credentialJson,
+        pollIntervalInMinutes: connection.pollIntervalInMinutes,
+      });
+      this.throwIfAborted(signal);
+      const client: SecurityEventConnectorClient =
+        clientOverride ||
+        SecurityEventConnectorClientFactory.create(connection);
+      const fetched: SecurityEventConnectorFetchResult =
+        await client.fetchEvents({
+          startTime: window.startTime,
+          endTime: window.endTime,
+          ...(window.continuation ? { continuation: window.continuation } : {}),
+          signal,
+        });
+      this.throwIfAborted(signal);
+      result.fetchedCount = fetched.events.length;
+      result.requestCount = fetched.requestCount;
+      providerComplete = fetched.complete;
+      nextContinuation = fetched.continuation;
+      result.complete = providerComplete;
+      result.warnings.push(...fetched.warnings);
+
+      const normalized: Array<NormalizedSecurityEvent> = [];
+      for (const rawEvent of fetched.events) {
+        try {
+          if (
+            !VendorSecurityEventNormalizer.isEvent(
+              connection.provider!,
+              rawEvent,
+            )
+          ) {
+            result.rejectedCount++;
+            normalized.push(
+              this.auditMarker({
+                connection,
+                rawEvent,
+                time: window.endTime,
+                markerType: "rejected_record",
+                message:
+                  "Managed connector received a record that did not match the selected provider schema.",
+              }),
+            );
+            continue;
+          }
+          const normalizedEvent: NormalizedSecurityEvent =
+            VendorSecurityEventNormalizer.normalize(
+              connection.provider!,
+              rawEvent,
+            );
+          this.namespaceEventUid({
+            connection,
+            rawEvent,
+            normalized: normalizedEvent,
+          });
+          normalized.push(normalizedEvent);
+        } catch {
+          result.failedCount++;
+          normalized.push(
+            this.auditMarker({
+              connection,
+              rawEvent,
+              time: window.endTime,
+              markerType: "normalization_failure",
+              message:
+                "Managed connector could not normalize a provider record.",
+            }),
+          );
+        }
+      }
+      if (result.rejectedCount) {
+        result.warnings.push(
+          `${result.rejectedCount} returned records did not match the selected provider.`,
+        );
+      }
+      if (result.failedCount) {
+        result.warnings.push(
+          `${result.failedCount} returned records could not be normalized.`,
+        );
+      }
+      result.complete =
+        result.complete &&
+        result.rejectedCount === 0 &&
+        result.failedCount === 0;
+      this.throwIfAborted(signal);
+      await this.ingest(connection, normalized, result, signal);
+    } catch (error) {
+      result.complete = false;
+      if (this.isResponseSizeLimitError(error)) {
+        providerComplete = false;
+        result.warnings.push(
+          "The provider response exceeded the safe transport size; the time window will be narrowed and retried.",
+        );
+      } else {
+        operationFailed = true;
+        result.error = redactLogString(
+          ConnectorErrorMessage.toMessage(error, { truncate: false }),
+        );
+      }
+    }
+
+    if (
+      !operationFailed &&
+      !providerComplete &&
+      this.willAdvanceIncompleteWindow({
+        window,
+        ...(nextContinuation ? { nextContinuation } : {}),
+      })
+    ) {
+      try {
+        await this.ingest(
+          connection,
+          [
+            this.auditMarker({
+              connection,
+              rawEvent: {
+                provider: connection.provider!,
+                windowStart: window.startTime.toISOString(),
+                windowEnd: window.endTime.toISOString(),
+                dataLossPossible: true,
+                warnings: result.warnings.join(" "),
+              },
+              time: window.endTime,
+              markerType: "irreducible_gap",
+              message:
+                "Managed connector advanced after a minimum-size window remained truncated; some provider records may be missing.",
+            }),
+          ],
+          result,
+          signal,
+        );
+      } catch (error) {
+        operationFailed = true;
+        result.error = redactLogString(
+          ConnectorErrorMessage.toMessage(error, { truncate: false }),
+        );
+      }
+    }
+
+    const completedAt: Date = new Date();
+    result.completedAt = completedAt.toISOString();
+    let cursor: string;
+    if (operationFailed) {
+      const failureAttempt: number = window.attempt + 1;
+      const duration: number =
+        window.endTime.getTime() - window.startTime.getTime();
+      if (failureAttempt < MAX_OPERATION_FAILURE_ATTEMPTS) {
+        cursor = this.encodeStoredCursor({
+          nextStart: window.startTime,
+          endTime: window.endTime,
+          attempt: failureAttempt,
+          ...(window.continuation ? { continuation: window.continuation } : {}),
+          ...(window.continuationCount
+            ? { continuationCount: window.continuationCount }
+            : {}),
+        });
+      } else if (duration > MIN_RETRY_WINDOW_MS) {
+        const midpoint: Date = new Date(
+          Math.floor(
+            (window.startTime.getTime() + window.endTime.getTime()) / 2,
+          ),
+        );
+        cursor = this.encodeStoredCursor({
+          nextStart: window.startTime,
+          endTime: midpoint,
+          attempt: 0,
+        });
+        result.warnings.push(
+          "Repeated provider failures cleared the saved page token and narrowed the time window for a safe retry.",
+        );
+      } else {
+        cursor = this.encodeStoredCursor({
+          nextStart: window.startTime,
+          endTime: window.endTime,
+          attempt: 0,
+        });
+        result.warnings.push(
+          "The provider still failed for the minimum retry window; the cursor remains held until the source recovers.",
+        );
+      }
+      result.retryScheduled = true;
+    } else if (!providerComplete) {
+      const sameContinuation: boolean = this.sameContinuation(
+        window.continuation,
+        nextContinuation,
+      );
+      const continuationAttempt: number = sameContinuation
+        ? window.attempt + 1
+        : 0;
+      const continuationCount: number = window.continuationCount + 1;
+      if (
+        nextContinuation &&
+        continuationAttempt < MAX_SAME_CONTINUATION_ATTEMPTS &&
+        continuationCount < MAX_CONTINUATION_BATCHES
+      ) {
+        cursor = this.encodeStoredCursor({
+          nextStart: window.startTime,
+          endTime: window.endTime,
+          attempt: continuationAttempt,
+          continuationCount,
+          continuation: nextContinuation,
+        });
+        result.retryScheduled = true;
+      } else {
+        if (nextContinuation) {
+          result.warnings.push(
+            continuationCount >= MAX_CONTINUATION_BATCHES
+              ? "The provider exceeded the bounded pagination budget; the time window will be narrowed instead."
+              : "The provider pagination cursor stopped advancing; the time window will be narrowed instead.",
+          );
+        }
+        const duration: number =
+          window.endTime.getTime() - window.startTime.getTime();
+        if (
+          duration > MIN_RETRY_WINDOW_MS &&
+          window.attempt < MAX_SPLIT_ATTEMPTS
+        ) {
+          const midpoint: Date = new Date(
+            Math.floor(
+              (window.startTime.getTime() + window.endTime.getTime()) / 2,
+            ),
+          );
+          cursor = this.encodeStoredCursor({
+            nextStart: window.startTime,
+            endTime: midpoint,
+            attempt: window.attempt + 1,
+          });
+          result.retryScheduled = true;
+          result.warnings.push(
+            `The incomplete window will retry as ${window.startTime.toISOString()} to ${midpoint.toISOString()}.`,
+          );
+        } else {
+          cursor = this.encodeStoredCursor({ nextStart: window.endTime });
+          result.cursorAdvanced = true;
+          result.dataLossPossible = true;
+          result.warnings.push(
+            "The provider still truncated a minimum-size retry window. The cursor advanced without overlap to prevent a permanent stall; some events in this window may be missing.",
+          );
+        }
+      }
+    } else if (nextContinuation) {
+      cursor = this.encodeStoredCursor({
+        nextStart: window.startTime,
+        endTime: window.endTime,
+        attempt: 0,
+        continuation: nextContinuation,
+      });
+      result.cursorAdvanced = true;
+    } else {
+      cursor = window.endTime.toISOString();
+      result.cursorAdvanced = true;
+    }
+    this.throwIfAborted(signal);
+    const checkpoint: SecurityEventPollingCheckpointUpdate = {
+      lastPolledAt: completedAt,
+      lastPollResult: result as unknown as JSONObject,
+      lastError: result.complete
+        ? null
+        : result.error ||
+          result.warnings.join(" ") ||
+          "Poll was incomplete; the same window will be retried.",
+      cursor,
+      ...(result.complete ? { lastSuccessfulPollAt: completedAt } : {}),
+      ...(result.ingestedCount ? { lastEventIngestedAt: completedAt } : {}),
+    };
+    if (connection.version !== undefined) {
+      const updatedRows: number =
+        await SecurityEventConnectionService.updatePollingCheckpointIfUnchanged(
+          {
+            id: connection.id!,
+            expectedVersion: connection.version,
+            checkpoint,
+          },
+        );
+      if (updatedRows === 0) {
+        result.complete = false;
+        result.cursorAdvanced = false;
+        result.warnings.push(
+          "Connection settings changed during this poll; its checkpoint was discarded so the new source starts safely.",
+        );
+        return result;
+      }
+    } else {
+      await SecurityEventConnectionService.updateOneById({
+        id: connection.id!,
+        data: checkpoint as never,
+        props: { isRoot: true },
+      });
+    }
+    if (result.error) {
+      throw new Error(result.error);
+    }
+    return result;
+  }
+
+  public static async findExistingEventUids(
+    projectId: ObjectID,
+    ids: Array<string>,
+  ): Promise<Set<string>> {
+    const existing: Set<string> = new Set<string>();
+    for (
+      let offset: number = 0;
+      offset < ids.length;
+      offset += UID_BATCH_SIZE
+    ) {
+      const statement: Statement = SQL`SELECT DISTINCT eventUid FROM clusterAllReplicas(
+        ${{ type: TableColumnType.Text, value: getClickhouseClusterName() }},
+        ${{ type: TableColumnType.Text, value: getClickhouseDatabaseName() }},
+        ${{ type: TableColumnType.Text, value: getStorageTableName(SecurityEventService.model.tableName) }}
+      ) WHERE projectId = ${{ type: TableColumnType.ObjectID, value: projectId }}
+        AND eventUid IN ${{ type: TableColumnType.ArrayText, value: ids.slice(offset, offset + UID_BATCH_SIZE) }}`;
+      statement.append(
+        getQuerySettings({
+          maxExecutionTimeInSeconds: 30,
+          timeoutOverflowMode: "throw",
+          boundScanMemory: true,
+          additionalSettings: { skip_unavailable_shards: 0 },
+        }),
+      );
+      const response: ResultSet<"JSON"> =
+        await SecurityEventService.executeQuery(statement);
+      const data: ResponseJSON<JSONObject> = await response.json<JSONObject>();
+      for (const row of data.data) {
+        if (typeof row["eventUid"] === "string") {
+          existing.add(row["eventUid"]);
+        }
+      }
+    }
+    return existing;
+  }
+
+  private static async ingest(
+    connection: SecurityEventConnection,
+    events: Array<NormalizedSecurityEvent>,
+    result: SecurityEventConnectorResult,
+    signal: AbortSignal,
+  ): Promise<void> {
+    this.throwIfAborted(signal);
+    if (!events.length) {
+      return;
+    }
+    const seen: Set<string> = new Set<string>();
+    const unique: Array<NormalizedSecurityEvent> = events.filter(
+      (event: NormalizedSecurityEvent): boolean => {
+        if (seen.has(event.eventUid)) {
+          result.duplicateCount++;
+          return false;
+        }
+        seen.add(event.eventUid);
+        return true;
+      },
+    );
+    const existing: Set<string> = await this.findExistingEventUids(
+      connection.projectId!,
+      unique.map((event: NormalizedSecurityEvent): string => {
+        return event.eventUid;
+      }),
+    );
+    this.throwIfAborted(signal);
+    const fresh: Array<NormalizedSecurityEvent> = unique.filter(
+      (event: NormalizedSecurityEvent): boolean => {
+        if (existing.has(event.eventUid)) {
+          result.duplicateCount++;
+          return false;
+        }
+        return true;
+      },
+    );
+    if (!fresh.length) {
+      return;
+    }
+    const serviceMetadata: TelemetryServiceMetadata =
+      await OTelIngestService.telemetryServiceFromName({
+        serviceName: connection.provider!,
+        projectId: connection.projectId!,
+      });
+    this.throwIfAborted(signal);
+    const retentionDays: number = resolveTelemetryRetentionInDays({
+      pillar: "securityEvents",
+      serviceConfig: serviceMetadata.serviceRetentionConfig,
+      serviceRetentionInDays: serviceMetadata.serviceRetentionInDays,
+      projectConfig: serviceMetadata.projectRetentionConfig,
+      projectRetentionInDays: serviceMetadata.projectRetentionInDays,
+    });
+    await ThreatIntelEnricher.enrichNormalizedEvents({
+      projectId: connection.projectId!,
+      events: fresh,
+    });
+    this.throwIfAborted(signal);
+    const rows: Array<JSONObject> = fresh.map(
+      (event: NormalizedSecurityEvent): JSONObject => {
+        event.attributes["oneuptime.security_event_connection.id"] =
+          connection.id!.toString();
+        event.attributes["oneuptime.security_event_connection.provider"] =
+          connection.provider!;
+        return buildSecurityEventDbRow({
+          normalized: event,
+          projectId: connection.projectId!,
+          serviceMetadata,
+          retentionDays,
+        });
+      },
+    );
+    const markerCount: number = fresh.filter(
+      (event: NormalizedSecurityEvent): boolean => {
+        return (
+          event.attributes["oneuptime.security_event.audit_marker"] === true
+        );
+      },
+    ).length;
+    await SecurityEventService.insertJsonRows(rows, {
+      clickhouseSettings: { async_insert: 0, insert_distributed_sync: 1 },
+    });
+    this.throwIfAborted(signal);
+    result.ingestedCount += rows.length;
+    result.markerCount += markerCount;
+  }
+}

--- a/Common/Server/Utils/SecurityEvent/Connectors/SecurityEventConnectorClientFactory.ts
+++ b/Common/Server/Utils/SecurityEvent/Connectors/SecurityEventConnectorClientFactory.ts
@@ -1,0 +1,42 @@
+import SecurityEventConnection from "../../../../Models/DatabaseModels/SecurityEventConnection";
+import SecurityEventConnectorType from "../../../../Types/SecurityEvent/SecurityEventConnectorType";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import AwsSecurityHubClient from "./AwsSecurityHubClient";
+import CloudflareSecurityEventClient from "./CloudflareSecurityEventClient";
+import CrowdStrikeFalconClient from "./CrowdStrikeFalconClient";
+import GoogleSecurityCommandCenterClient from "./GoogleSecurityCommandCenterClient";
+import MicrosoftGraphSecurityClient from "./MicrosoftGraphSecurityClient";
+import OktaSystemLogClient from "./OktaSystemLogClient";
+import SplunkEnterpriseSecurityClient from "./SplunkEnterpriseSecurityClient";
+import {
+  SecurityEventConnectorClient,
+  SecurityEventConnectorHttpRequest,
+} from "./Types";
+
+export default class SecurityEventConnectorClientFactory {
+  public static create(
+    connection: SecurityEventConnection,
+    request?: SecurityEventConnectorHttpRequest | undefined,
+  ): SecurityEventConnectorClient {
+    switch (connection.provider) {
+      case SecurityEventConnectorType.AwsSecurityHub:
+        return new AwsSecurityHubClient(connection, request);
+      case SecurityEventConnectorType.MicrosoftDefender:
+        return new MicrosoftGraphSecurityClient(connection, request);
+      case SecurityEventConnectorType.Cloudflare:
+        return new CloudflareSecurityEventClient(connection, request);
+      case SecurityEventConnectorType.CrowdStrikeFalcon:
+        return new CrowdStrikeFalconClient(connection, request);
+      case SecurityEventConnectorType.GoogleSecurityCommandCenter:
+        return new GoogleSecurityCommandCenterClient(connection, request);
+      case SecurityEventConnectorType.Okta:
+        return new OktaSystemLogClient(connection, request);
+      case SecurityEventConnectorType.SplunkEnterpriseSecurity:
+        return new SplunkEnterpriseSecurityClient(connection, request);
+      default:
+        throw new BadDataException(
+          "The security event connection provider is not supported.",
+        );
+    }
+  }
+}

--- a/Common/Server/Utils/SecurityEvent/Connectors/SplunkEnterpriseSecurityClient.ts
+++ b/Common/Server/Utils/SecurityEvent/Connectors/SplunkEnterpriseSecurityClient.ts
@@ -1,0 +1,161 @@
+import SecurityEventConnection from "../../../../Models/DatabaseModels/SecurityEventConnection";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject, JSONValue } from "../../../../Types/JSON";
+import { DataSourceHttpResponse } from "../../DataSource/HttpFetch";
+import {
+  CONNECTOR_TIMEOUT_MS,
+  defaultConnectorRequest,
+  jsonObjects,
+  parseCredentialJson,
+  requiredSetting,
+  stringValue,
+} from "./ConnectorHttp";
+import {
+  SecurityEventConnectorClient,
+  SecurityEventConnectorFetchResult,
+  SecurityEventConnectorHttpRequest,
+} from "./Types";
+
+const MAX_RESULTS: number = 1_000;
+const DEFAULT_SEARCH: string = "search (index=notable OR index=risk)";
+
+export default class SplunkEnterpriseSecurityClient
+  implements SecurityEventConnectorClient
+{
+  private readonly baseUrl: URL;
+  private readonly search: string;
+  private readonly credentials: JSONObject;
+  private readonly request: SecurityEventConnectorHttpRequest;
+
+  public constructor(
+    connection: SecurityEventConnection,
+    request: SecurityEventConnectorHttpRequest = defaultConnectorRequest,
+  ) {
+    const configuration: JSONObject = connection.configuration || {};
+    this.baseUrl = new URL(requiredSetting(configuration, "baseUrl", "Splunk"));
+    this.search = stringValue(configuration["search"]) || DEFAULT_SEARCH;
+    this.credentials = parseCredentialJson(connection.credentialJson || "");
+    this.request = request;
+  }
+
+  private authHeader(): string {
+    const apiToken: string = stringValue(this.credentials["apiToken"]);
+    if (apiToken) {
+      const scheme: string = stringValue(this.credentials["tokenScheme"]);
+      return `${scheme || "Bearer"} ${apiToken}`;
+    }
+    const username: string = requiredSetting(
+      this.credentials,
+      "username",
+      "Splunk",
+    );
+    const password: string = requiredSetting(
+      this.credentials,
+      "password",
+      "Splunk",
+    );
+    return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+  }
+
+  private static parseExport(bodyText: string): {
+    events: Array<JSONObject>;
+    warnings: Array<string>;
+  } {
+    const events: Array<JSONObject> = [];
+    const warnings: Array<string> = [];
+    for (const line of bodyText.split(/\r?\n/)) {
+      if (!line.trim()) {
+        continue;
+      }
+      let parsed: JSONValue;
+      try {
+        parsed = JSON.parse(line) as JSONValue;
+      } catch {
+        throw new BadDataException(
+          "Splunk search export returned a non-JSON result line.",
+        );
+      }
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new BadDataException(
+          "Splunk search export returned an invalid result object.",
+        );
+      }
+      const envelope: JSONObject = parsed as JSONObject;
+      for (const message of jsonObjects(
+        envelope["messages"],
+        "Splunk search messages",
+      )) {
+        const type: string = stringValue(message["type"]).toUpperCase();
+        const text: string =
+          stringValue(message["text"]) || "Splunk returned a search message.";
+        if (type === "ERROR" || type === "FATAL") {
+          throw new BadDataException(
+            `Splunk search failed: ${text.slice(0, 500)}`,
+          );
+        }
+        if (type === "WARN" || type === "WARNING") {
+          warnings.push(`Splunk search warning: ${text.slice(0, 500)}`);
+        }
+      }
+      const result: JSONValue = envelope["result"];
+      if (result && typeof result === "object" && !Array.isArray(result)) {
+        events.push(result as JSONObject);
+      } else {
+        events.push(
+          ...jsonObjects(envelope["results"], "Splunk search results"),
+        );
+      }
+    }
+    return { events, warnings: [...new Set(warnings)] };
+  }
+
+  public async fetchEvents(data: {
+    startTime: Date;
+    endTime: Date;
+    continuation?: JSONObject | undefined;
+    signal?: AbortSignal | undefined;
+  }): Promise<SecurityEventConnectorFetchResult> {
+    const url: URL = new URL("/services/search/v2/jobs/export", this.baseUrl);
+    const response: DataSourceHttpResponse = await this.request({
+      method: "POST",
+      url: url.toString(),
+      headers: {
+        Authorization: this.authHeader(),
+        Accept: "application/json",
+      },
+      body: {
+        search: this.search,
+        earliest_time: data.startTime.toISOString(),
+        latest_time: data.endTime.toISOString(),
+        output_mode: "json",
+        preview: "false",
+        max_count: String(MAX_RESULTS),
+      },
+      formUrlEncoded: true,
+      timeoutInMs: CONNECTOR_TIMEOUT_MS,
+      egressOptions: {
+        targetLabel: "Splunk management endpoint",
+        privateNetworkHint:
+          "Private Splunk servers are available on self-hosted OneUptime deployments.",
+      },
+      signal: data.signal,
+    });
+    const parsed: { events: Array<JSONObject>; warnings: Array<string> } =
+      SplunkEnterpriseSecurityClient.parseExport(response.bodyText);
+    const events: Array<JSONObject> = parsed.events;
+    const complete: boolean = events.length < MAX_RESULTS;
+    return {
+      events,
+      complete,
+      requestCount: 1,
+      warnings: [
+        ...parsed.warnings,
+        ...(!complete
+          ? [
+              "Splunk returned the configured 1,000-result ceiling; the time window will be narrowed and retried.",
+            ]
+          : []),
+      ],
+    };
+  }
+}

--- a/Common/Server/Utils/SecurityEvent/Connectors/Types.ts
+++ b/Common/Server/Utils/SecurityEvent/Connectors/Types.ts
@@ -1,0 +1,32 @@
+import { JSONObject } from "../../../../Types/JSON";
+import SecurityEventConnection from "../../../../Models/DatabaseModels/SecurityEventConnection";
+import {
+  DataSourceHttpRequest,
+  DataSourceHttpResponse,
+} from "../../DataSource/HttpFetch";
+
+export interface SecurityEventConnectorFetchResult {
+  events: Array<JSONObject>;
+  complete: boolean;
+  requestCount: number;
+  warnings: Array<string>;
+  continuation?: JSONObject | undefined;
+}
+
+export type SecurityEventConnectorHttpRequest = (
+  request: DataSourceHttpRequest,
+) => Promise<DataSourceHttpResponse>;
+
+export interface SecurityEventConnectorClient {
+  fetchEvents(data: {
+    startTime: Date;
+    endTime: Date;
+    continuation?: JSONObject | undefined;
+    signal?: AbortSignal | undefined;
+  }): Promise<SecurityEventConnectorFetchResult>;
+}
+
+export type SecurityEventConnectorClientFactory = (
+  connection: SecurityEventConnection,
+  request?: SecurityEventConnectorHttpRequest,
+) => SecurityEventConnectorClient;

--- a/Common/Tests/App/Dashboard/ManagedSecurityEventConnections.test.tsx
+++ b/Common/Tests/App/Dashboard/ManagedSecurityEventConnections.test.tsx
@@ -1,0 +1,223 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { cleanup, render } from "@testing-library/react";
+import React, { act, ReactElement } from "react";
+import ManagedSecurityEventConnections from "../../../../App/FeatureSet/Dashboard/src/Components/SecurityEvents/ManagedSecurityEventConnections";
+import SecurityEventConnection from "../../../Models/DatabaseModels/SecurityEventConnection";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import SecurityEventConnectorType from "../../../Types/SecurityEvent/SecurityEventConnectorType";
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
+import PermissionGate from "../../../UI/Utils/PermissionGate";
+import ProjectUtil from "../../../UI/Utils/Project";
+
+type CapturedField = {
+  field: Record<string, boolean>;
+  dropdownOptions?: Array<{ label: string; value: string }> | undefined;
+  doNotShowWhenEditing?: boolean | undefined;
+};
+
+type CapturedColumn = {
+  title: string;
+  getElement?: ((item: SecurityEventConnection) => ReactElement) | undefined;
+};
+
+type CapturedAction = {
+  title: string;
+  disabled?: boolean | undefined;
+  onClick: (
+    item: SecurityEventConnection,
+    onCompleteAction: () => void,
+  ) => void;
+};
+
+type CapturedTableProps = {
+  query?: Record<string, unknown> | undefined;
+  refreshToggle?: string | undefined;
+  selectMoreFields?: Record<string, boolean> | undefined;
+  formFields?: Array<CapturedField> | undefined;
+  columns?: Array<CapturedColumn> | undefined;
+  actionButtons?: Array<CapturedAction> | undefined;
+};
+
+type CapturedModalProps = {
+  title?: string | undefined;
+  formProps?: { fields?: Array<CapturedField> | undefined } | undefined;
+  onSubmit?: ((data: Record<string, unknown>) => Promise<void>) | undefined;
+};
+
+let tableProps: CapturedTableProps | null = null;
+let modalProps: CapturedModalProps | null = null;
+
+jest.mock("../../../UI/Components/ModelTable/ModelTable", () => {
+  return {
+    __esModule: true,
+    default: (props: CapturedTableProps): null => {
+      tableProps = props;
+      return null;
+    },
+  };
+});
+
+jest.mock("../../../UI/Components/FormModal/BasicFormModal", () => {
+  return {
+    __esModule: true,
+    default: (props: CapturedModalProps): null => {
+      modalProps = props;
+      return null;
+    },
+  };
+});
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const CONNECTION_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+function renderedTable(): CapturedTableProps {
+  if (!tableProps) {
+    throw new Error("Managed connections table was not rendered.");
+  }
+  return tableProps;
+}
+
+function fieldName(field: CapturedField): string {
+  return Object.keys(field.field)[0] || "";
+}
+
+function healthElement(item: SecurityEventConnection): ReactElement<{
+  color: unknown;
+  text: string;
+}> {
+  const column: CapturedColumn | undefined = renderedTable().columns?.find(
+    (candidate: CapturedColumn): boolean => {
+      return candidate.title === "Health";
+    },
+  );
+  if (!column?.getElement) {
+    throw new Error("Health column was not configured.");
+  }
+  return column.getElement(item) as ReactElement<{
+    color: unknown;
+    text: string;
+  }>;
+}
+
+describe("ManagedSecurityEventConnections", () => {
+  beforeEach(() => {
+    tableProps = null;
+    modalProps = null;
+    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(PROJECT_ID);
+    jest.spyOn(PermissionGate, "check").mockReturnValue({ isAllowed: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  test("scopes the list, keeps secrets out of reads, and offers every provider", () => {
+    render(<ManagedSecurityEventConnections />);
+
+    const props: CapturedTableProps = renderedTable();
+    expect(props.query).toEqual({ projectId: PROJECT_ID });
+    expect(props.selectMoreFields).not.toHaveProperty("credentialJson");
+    expect(props.selectMoreFields).not.toHaveProperty("cursor");
+    expect(props.selectMoreFields).not.toHaveProperty("sourceGeneration");
+
+    const credentialField: CapturedField | undefined = props.formFields?.find(
+      (field: CapturedField): boolean => {
+        return fieldName(field) === "credentialJson";
+      },
+    );
+    expect(credentialField?.doNotShowWhenEditing).toBe(true);
+
+    const providerField: CapturedField | undefined = props.formFields?.find(
+      (field: CapturedField): boolean => {
+        return fieldName(field) === "provider";
+      },
+    );
+    expect(providerField?.doNotShowWhenEditing).toBe(true);
+    expect(
+      providerField?.dropdownOptions?.map(
+        (option: { label: string; value: string }): string => {
+          return option.value;
+        },
+      ),
+    ).toEqual([
+      SecurityEventConnectorType.AwsSecurityHub,
+      SecurityEventConnectorType.MicrosoftDefender,
+      SecurityEventConnectorType.Cloudflare,
+      SecurityEventConnectorType.CrowdStrikeFalcon,
+      SecurityEventConnectorType.GoogleSecurityCommandCenter,
+      SecurityEventConnectorType.Okta,
+      SecurityEventConnectorType.SplunkEnterpriseSecurity,
+    ]);
+  });
+
+  test("shows failures ahead of partial imports and reports partial imports", () => {
+    render(<ManagedSecurityEventConnections />);
+
+    const failed: SecurityEventConnection = new SecurityEventConnection();
+    failed.lastPollResult = { complete: false, error: "denied" };
+    expect(healthElement(failed).props.text).toBe("Last poll failed");
+
+    const partial: SecurityEventConnection = new SecurityEventConnection();
+    partial.lastPollResult = { complete: false };
+    expect(healthElement(partial).props.text).toBe("Partial import");
+  });
+
+  test("rotates only the credential field and refreshes the table", async () => {
+    const updateById: jest.Mock = jest
+      .spyOn(ModelAPI, "updateById")
+      .mockResolvedValue(
+        new HTTPResponse<JSONObject>(200, {}, {}),
+      ) as unknown as jest.Mock;
+    render(<ManagedSecurityEventConnections />);
+
+    const updateAction: CapturedAction | undefined =
+      renderedTable().actionButtons?.find((action: CapturedAction): boolean => {
+        return action.title === "Update Credentials";
+      });
+    if (!updateAction) {
+      throw new Error("Update Credentials action was not configured.");
+    }
+
+    const connection: SecurityEventConnection = new SecurityEventConnection();
+    connection.id = CONNECTION_ID;
+    const completeAction: jest.Mock = jest.fn();
+    await act(async () => {
+      updateAction.onClick(connection, completeAction);
+    });
+
+    expect(completeAction).toHaveBeenCalledTimes(1);
+    expect(modalProps?.title).toBe("Update Credentials");
+    expect(modalProps?.formProps?.fields?.map(fieldName)).toEqual([
+      "credentialJson",
+    ]);
+    if (!modalProps?.onSubmit) {
+      throw new Error("Credential update form was not rendered.");
+    }
+
+    await act(async () => {
+      await modalProps?.onSubmit?.({ credentialJson: '{"apiToken":"new"}' });
+    });
+
+    expect(updateById).toHaveBeenCalledWith({
+      modelType: SecurityEventConnection,
+      id: CONNECTION_ID,
+      data: { credentialJson: '{"apiToken":"new"}' },
+    });
+    expect(renderedTable().refreshToggle).toBe("1");
+  });
+});

--- a/Common/Tests/Server/Services/DatabaseServiceUpdateWriteRouting.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServiceUpdateWriteRouting.test.ts
@@ -155,6 +155,81 @@ describe("DatabaseService._updateBy — save() vs update() write routing", () =>
     expect((versionValue as () => string)()).toBe('"version" + 1');
   });
 
+  test("writes internal and caller fields together while internal values take precedence", async () => {
+    const internalUpdate: jest.Mock = jest
+      .spyOn(NetworkDeviceDiscoveryScanService as any, "getInternalUpdateData")
+      .mockResolvedValue({
+        status: "Completed",
+      } as never) as unknown as jest.Mock;
+
+    await NetworkDeviceDiscoveryScanService.updateOneById({
+      id: scanId,
+      data: { status: "In Progress" } as ScanUpdateData,
+      props: { isRoot: true },
+    });
+
+    expect(internalUpdate).toHaveBeenCalledTimes(1);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(updateMock.mock.calls[0]![1]).toEqual(
+      expect.objectContaining({ status: "Completed" }),
+    );
+  });
+
+  test("does not derive internal update data when hooks are ignored", async () => {
+    const internalUpdate: jest.Mock = jest.spyOn(
+      NetworkDeviceDiscoveryScanService as any,
+      "getInternalUpdateData",
+    ) as unknown as jest.Mock;
+
+    await NetworkDeviceDiscoveryScanService.updateOneById({
+      id: scanId,
+      data: { status: "In Progress" } as ScanUpdateData,
+      props: { isRoot: true, ignoreHooks: true },
+    });
+
+    expect(internalUpdate).not.toHaveBeenCalled();
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(updateMock.mock.calls[0]![1]).toEqual(
+      expect.objectContaining({ status: "In Progress" }),
+    );
+  });
+
+  test("validates every permission-scoped row before the first write", async () => {
+    const secondItem: NetworkDeviceDiscoveryScan =
+      new NetworkDeviceDiscoveryScan();
+    secondItem._id = ObjectID.generate().toString();
+    jest
+      .spyOn(NetworkDeviceDiscoveryScanService as any, "_findBy")
+      .mockResolvedValue([
+        new NetworkDeviceDiscoveryScan(scanId),
+        secondItem,
+      ] as never);
+    const validationError: Error = new Error("invalid second row");
+    const validateItems: jest.Mock = jest
+      .spyOn(NetworkDeviceDiscoveryScanService as any, "onBeforeUpdateItems")
+      .mockRejectedValue(validationError) as unknown as jest.Mock;
+
+    await expect(
+      NetworkDeviceDiscoveryScanService.updateBy({
+        query: {},
+        data: { status: "In Progress" } as ScanUpdateData,
+        skip: 0,
+        limit: 2,
+        props: { isRoot: true },
+      }),
+    ).rejects.toBe(validationError);
+
+    expect(validateItems).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.arrayContaining([
+        expect.objectContaining({ _id: scanId.toString() }),
+        expect.objectContaining({ _id: secondItem._id }),
+      ]),
+    );
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
   test("an Entity (many-to-one) column takes update(), not save() — it is just an FK on this row", async () => {
     const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
     scan.status = "Completed";

--- a/Common/Tests/Server/Services/SecurityEventConnectionPostgres.test.ts
+++ b/Common/Tests/Server/Services/SecurityEventConnectionPostgres.test.ts
@@ -1,0 +1,250 @@
+import SecurityEventConnection from "../../../Models/DatabaseModels/SecurityEventConnection";
+import Entities from "../../../Models/DatabaseModels/Index";
+import PostgresAppInstance from "../../../Server/Infrastructure/PostgresDatabase";
+import { AddSecurityEventConnection1792400000000 } from "../../../Server/Infrastructure/Postgres/SchemaMigrations/1792400000000-AddSecurityEventConnection";
+import SecurityEventConnectionService from "../../../Server/Services/SecurityEventConnectionService";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import PartialEntity from "../../../Types/Database/PartialEntity";
+import SecurityEventConnectorType from "../../../Types/SecurityEvent/SecurityEventConnectorType";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { DataSource, QueryRunner } from "typeorm";
+
+/*
+ * Opt in against local development Postgres. The suite creates a unique schema
+ * and applies the feature migration there, so it exercises TypeORM, encryption,
+ * optimistic checkpoint writes, and update hooks without touching project data.
+ */
+const describePostgres: typeof describe.skip =
+  process.env["RUN_POSTGRES_SECURITY_EVENT_CONNECTION_TESTS"] === "true"
+    ? describe
+    : describe.skip;
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const INITIAL_CREDENTIALS: string = JSON.stringify({
+  accessKeyId: "AKIAINTEGRATION",
+  secretAccessKey: "first-secret",
+});
+const ROTATED_CREDENTIALS: string = JSON.stringify({
+  accessKeyId: "AKIAINTEGRATION",
+  secretAccessKey: "rotated-secret",
+});
+const CHECKPOINT: string = JSON.stringify({
+  version: 1,
+  nextStart: "2026-09-11T12:00:00.000Z",
+});
+
+interface StoredConnection {
+  credentialJson: string;
+  cursor: string | null;
+  isEnabled: boolean;
+  pollIntervalInMinutes: number;
+  sourceFingerprint: string;
+  sourceGeneration: number;
+}
+
+jest.setTimeout(180_000);
+
+describePostgres("SecurityEventConnection persistence against Postgres", () => {
+  const schema: string = `security_event_connection_${ObjectID.generate()
+    .toString()
+    .replace(/-/g, "")}`;
+  let database: DataSource;
+
+  beforeAll(async (): Promise<void> => {
+    database = new DataSource({
+      type: "postgres",
+      host: process.env["SECURITY_EVENT_TEST_DATABASE_HOST"] || "localhost",
+      port: Number(process.env["SECURITY_EVENT_TEST_DATABASE_PORT"] || "5400"),
+      username: process.env["DATABASE_USERNAME"] || "postgres",
+      password: process.env["DATABASE_PASSWORD"] || "password",
+      database: process.env["DATABASE_NAME"] || "oneuptimedb",
+      entities: Entities,
+      schema,
+      synchronize: false,
+      extra: { options: `-c search_path=${schema},public` },
+    });
+    await database.initialize();
+    await database.query(`CREATE SCHEMA "${schema}"`);
+    await database.query(
+      `CREATE TABLE "${schema}"."Project" ("_id" uuid PRIMARY KEY)`,
+    );
+    await database.query(
+      `CREATE TABLE "${schema}"."User" ("_id" uuid PRIMARY KEY)`,
+    );
+    const queryRunner: QueryRunner = database.createQueryRunner();
+    try {
+      await new AddSecurityEventConnection1792400000000().up(queryRunner);
+    } finally {
+      await queryRunner.release();
+    }
+    await database.query(
+      `INSERT INTO "${schema}"."Project" ("_id") VALUES ($1)`,
+      [PROJECT_ID.toString()],
+    );
+    jest.spyOn(PostgresAppInstance, "isConnected").mockReturnValue(true);
+    jest.spyOn(PostgresAppInstance, "getDataSource").mockReturnValue(database);
+  });
+
+  afterAll(async (): Promise<void> => {
+    jest.restoreAllMocks();
+    if (database?.isInitialized) {
+      await database.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+      await database.destroy();
+    }
+  });
+
+  async function stored(id: ObjectID): Promise<StoredConnection> {
+    const rows: Array<StoredConnection> = await database.query(
+      `SELECT "credentialJson", "cursor", "isEnabled", "pollIntervalInMinutes", "sourceFingerprint", "sourceGeneration"
+       FROM "${schema}"."SecurityEventConnection" WHERE "_id" = $1`,
+      [id.toString()],
+    );
+    return rows[0]!;
+  }
+
+  async function loaded(id: ObjectID): Promise<SecurityEventConnection> {
+    const item: SecurityEventConnection | null =
+      await SecurityEventConnectionService.findOneById({
+        id,
+        select: {
+          _id: true,
+          projectId: true,
+          provider: true,
+          configuration: true,
+          credentialJson: true,
+          sourceGeneration: true,
+          cursor: true,
+          version: true,
+        },
+        props: { isRoot: true },
+      });
+    if (!item) {
+      throw new Error("Persisted security event connection was not found.");
+    }
+    return item;
+  }
+
+  test("encrypts secrets and checkpoints while preserving identity on rotation", async () => {
+    const connection: SecurityEventConnection = new SecurityEventConnection();
+    connection.name = "Postgres integration Security Hub";
+    connection.projectId = PROJECT_ID;
+    connection.provider = SecurityEventConnectorType.AwsSecurityHub;
+    connection.configuration = { region: "us-east-1" };
+    connection.credentialJson = INITIAL_CREDENTIALS;
+    const created: SecurityEventConnection =
+      await SecurityEventConnectionService.create({
+        data: connection,
+        props: { isRoot: true, tenantId: PROJECT_ID },
+      });
+    const connectionId: ObjectID = created.id!;
+    expect(created.credentialJson).toBeUndefined();
+    expect(created.cursor).toBeUndefined();
+    expect(created.sourceFingerprint).toBeUndefined();
+    expect(created.sourceGeneration).toBeUndefined();
+    const createdRow: StoredConnection = await stored(connectionId);
+    expect(createdRow.credentialJson).not.toBe(INITIAL_CREDENTIALS);
+    expect(createdRow.credentialJson).not.toContain("first-secret");
+    expect(createdRow.sourceFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(createdRow.sourceGeneration).toBe(1);
+    expect(createdRow.isEnabled).toBe(true);
+    expect(createdRow.pollIntervalInMinutes).toBe(5);
+    expect((await loaded(connectionId)).credentialJson).toBe(
+      INITIAL_CREDENTIALS,
+    );
+
+    const current: SecurityEventConnection = await loaded(connectionId);
+    await expect(
+      SecurityEventConnectionService.updatePollingCheckpointIfUnchanged({
+        id: connectionId,
+        expectedVersion: current.version!,
+        checkpoint: {
+          cursor: CHECKPOINT,
+          lastPolledAt: new Date("2026-09-11T12:00:00.000Z"),
+          lastPollResult: { complete: true } as JSONObject,
+          lastError: null,
+        },
+      }),
+    ).resolves.toBe(1);
+    const checkpointRow: StoredConnection = await stored(connectionId);
+    expect(checkpointRow.cursor).not.toBe(CHECKPOINT);
+    expect(checkpointRow.cursor).not.toContain("nextStart");
+    expect((await loaded(connectionId)).cursor).toBe(CHECKPOINT);
+
+    await SecurityEventConnectionService.updateOneById({
+      id: connectionId,
+      data: { credentialJson: ROTATED_CREDENTIALS },
+      props: { isRoot: true },
+    });
+    const rotatedRow: StoredConnection = await stored(connectionId);
+    expect(rotatedRow.credentialJson).not.toBe(ROTATED_CREDENTIALS);
+    expect(rotatedRow.cursor).toBeNull();
+    expect(rotatedRow.sourceGeneration).toBe(1);
+    expect((await loaded(connectionId)).credentialJson).toBe(
+      ROTATED_CREDENTIALS,
+    );
+
+    const afterRotation: SecurityEventConnection = await loaded(connectionId);
+    await expect(
+      SecurityEventConnectionService.updatePollingCheckpointIfUnchanged({
+        id: connectionId,
+        expectedVersion: afterRotation.version!,
+        checkpoint: {
+          cursor: CHECKPOINT,
+          lastPolledAt: new Date("2026-09-11T12:05:00.000Z"),
+          lastPollResult: { complete: true } as JSONObject,
+          lastError: null,
+        },
+      }),
+    ).resolves.toBe(1);
+    const beforeUnchangedEdit: StoredConnection = await stored(connectionId);
+    const unchangedConfigurationUpdate: PartialEntity<SecurityEventConnection> =
+      {
+        configuration: { region: "us-east-1" },
+      } as unknown as PartialEntity<SecurityEventConnection>;
+    await SecurityEventConnectionService.updateOneById({
+      id: connectionId,
+      data: unchangedConfigurationUpdate,
+      props: { isRoot: true },
+    });
+    expect(await stored(connectionId)).toMatchObject({
+      cursor: beforeUnchangedEdit.cursor,
+      sourceFingerprint: beforeUnchangedEdit.sourceFingerprint,
+      sourceGeneration: 1,
+    });
+
+    const versionBeforeRepoint: number = (await loaded(connectionId)).version!;
+    const configurationUpdate: PartialEntity<SecurityEventConnection> = {
+      configuration: { region: "eu-west-2" },
+    } as unknown as PartialEntity<SecurityEventConnection>;
+    await SecurityEventConnectionService.updateOneById({
+      id: connectionId,
+      data: configurationUpdate,
+      props: { isRoot: true },
+    });
+    expect(await stored(connectionId)).toMatchObject({
+      cursor: null,
+      sourceGeneration: 2,
+    });
+    await expect(
+      SecurityEventConnectionService.updatePollingCheckpointIfUnchanged({
+        id: connectionId,
+        expectedVersion: versionBeforeRepoint,
+        checkpoint: {
+          cursor: CHECKPOINT,
+          lastPolledAt: new Date("2026-09-11T12:10:00.000Z"),
+          lastPollResult: { complete: true } as JSONObject,
+          lastError: null,
+        },
+      }),
+    ).resolves.toBe(0);
+    expect((await stored(connectionId)).cursor).toBeNull();
+  });
+});

--- a/Common/Tests/Server/Services/SecurityEventConnectionService.test.ts
+++ b/Common/Tests/Server/Services/SecurityEventConnectionService.test.ts
@@ -1,0 +1,752 @@
+import SecurityEventConnection from "../../../Models/DatabaseModels/SecurityEventConnection";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import SecurityEventConnectionService, {
+  parseSecurityEventConfiguration,
+  parseSecurityEventCredentialJson,
+  SecurityEventPollingCheckpointUpdate,
+  validateSecurityEventConnection,
+} from "../../../Server/Services/SecurityEventConnectionService";
+import Encryption from "../../../Server/Utils/Encryption";
+import { ColumnAccessControl } from "../../../Types/BaseDatabase/AccessControl";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import Permission from "../../../Types/Permission";
+import SecurityEventConnectorType from "../../../Types/SecurityEvent/SecurityEventConnectorType";
+import { generateKeyPairSync } from "crypto";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+interface ConnectionHooks {
+  onBeforeCreate: (data: unknown) => Promise<unknown>;
+  onBeforeUpdate: (data: unknown) => Promise<unknown>;
+  onBeforeUpdateItems: (
+    data: unknown,
+    items: Array<SecurityEventConnection>,
+  ) => Promise<void>;
+  onCreateSuccess: (
+    data: unknown,
+    item: SecurityEventConnection,
+  ) => Promise<SecurityEventConnection>;
+  getInternalUpdateData: (
+    data: unknown,
+    item: SecurityEventConnection,
+  ) => Promise<Record<string, unknown>>;
+  getAdditionalUpdateSelect: (data: unknown) => Record<string, unknown>;
+  findBy: (data: unknown) => Promise<Array<SecurityEventConnection>>;
+}
+
+const hooks: ConnectionHooks =
+  SecurityEventConnectionService as unknown as ConnectionHooks;
+
+const { privateKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+const ADMIN_PERMISSIONS: Array<Permission> = [
+  Permission.ProjectOwner,
+  Permission.ProjectAdmin,
+  Permission.SecurityAdmin,
+];
+
+const READ_PERMISSIONS: Array<Permission> = [
+  ...ADMIN_PERMISSIONS,
+  Permission.SecurityMember,
+  Permission.SecurityViewer,
+];
+
+function credentials(value: Record<string, string>): string {
+  return JSON.stringify(value);
+}
+
+function awsConnection(): SecurityEventConnection {
+  const connection: SecurityEventConnection = new SecurityEventConnection();
+  connection._id = "22222222-2222-4222-8222-222222222222";
+  connection.provider = SecurityEventConnectorType.AwsSecurityHub;
+  connection.configuration = { region: "us-east-1" };
+  connection.credentialJson = credentials({
+    accessKeyId: "access-key",
+    secretAccessKey: "secret-key",
+  });
+  connection.pollIntervalInMinutes = 5;
+  return connection;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("SecurityEventConnection provider validation", () => {
+  test.each([
+    [
+      "AWS Security Hub",
+      SecurityEventConnectorType.AwsSecurityHub,
+      { region: "us-gov-west-1" },
+      { accessKeyId: "access-key", secretAccessKey: "secret-key" },
+    ],
+    [
+      "Microsoft Defender",
+      SecurityEventConnectorType.MicrosoftDefender,
+      { tenantId: "a03f104f-91f1-4e90-9ba3-3b2d3f7b1aa7" },
+      { clientId: "client-id", clientSecret: "client-secret" },
+    ],
+    [
+      "Cloudflare",
+      SecurityEventConnectorType.Cloudflare,
+      { zoneId: "zone-id" },
+      { apiToken: "api-token" },
+    ],
+    [
+      "CrowdStrike Falcon",
+      SecurityEventConnectorType.CrowdStrikeFalcon,
+      { cloud: "eu-1" },
+      { clientId: "client-id", clientSecret: "client-secret" },
+    ],
+    [
+      "Google Security Command Center",
+      SecurityEventConnectorType.GoogleSecurityCommandCenter,
+      { parent: "organizations/123456/sources/-" },
+      {
+        client_email: "service@example.iam.gserviceaccount.com",
+        private_key: privateKey,
+      },
+    ],
+    [
+      "Okta",
+      SecurityEventConnectorType.Okta,
+      { baseUrl: "https://example.okta.com/api/v1" },
+      { apiToken: "api-token" },
+    ],
+    [
+      "Splunk Enterprise Security with token credentials",
+      SecurityEventConnectorType.SplunkEnterpriseSecurity,
+      { baseUrl: "https://splunk.example.com", search: "search index=main" },
+      { apiToken: "api-token", tokenScheme: "Splunk" },
+    ],
+    [
+      "Splunk Enterprise Security with username and password",
+      SecurityEventConnectorType.SplunkEnterpriseSecurity,
+      { baseUrl: "https://splunk.example.com" },
+      { username: "reader", password: "password" },
+    ],
+  ])(
+    "accepts complete %s configuration and credentials",
+    (
+      _name: string,
+      provider: SecurityEventConnectorType,
+      configuration: Record<string, string>,
+      credentialValues: Record<string, string>,
+    ) => {
+      expect(() => {
+        validateSecurityEventConnection({
+          provider,
+          configuration,
+          credentialJson: credentials(credentialValues),
+          pollIntervalInMinutes: 5,
+        });
+      }).not.toThrow();
+    },
+  );
+
+  test("accepts CrowdStrike's default cloud and Google's default token URI", () => {
+    expect(() => {
+      validateSecurityEventConnection({
+        provider: SecurityEventConnectorType.CrowdStrikeFalcon,
+        configuration: {},
+        credentialJson: credentials({
+          clientId: "client-id",
+          clientSecret: "secret",
+        }),
+      });
+      validateSecurityEventConnection({
+        provider: SecurityEventConnectorType.GoogleSecurityCommandCenter,
+        configuration: { parent: "projects/project-id/sources/source-id" },
+        credentialJson: credentials({
+          client_email: "service@example.iam.gserviceaccount.com",
+          private_key: privateKey,
+        }),
+      });
+    }).not.toThrow();
+  });
+
+  test.each([
+    [
+      SecurityEventConnectorType.AwsSecurityHub,
+      { region: "invalid-region" },
+      { accessKeyId: "id", secretAccessKey: "secret" },
+      "AWS region",
+    ],
+    [
+      SecurityEventConnectorType.MicrosoftDefender,
+      { tenantId: "tenant/id" },
+      { clientId: "id", clientSecret: "secret" },
+      "tenantId",
+    ],
+    [
+      SecurityEventConnectorType.Cloudflare,
+      { accountId: "account" },
+      { apiToken: "token" },
+      "zoneId",
+    ],
+    [
+      SecurityEventConnectorType.CrowdStrikeFalcon,
+      { cloud: "moon-1" },
+      { clientId: "id", clientSecret: "secret" },
+      "cloud",
+    ],
+    [
+      SecurityEventConnectorType.GoogleSecurityCommandCenter,
+      { parent: "organizations/id" },
+      { client_email: "service@example.com", private_key: privateKey },
+      "parent",
+    ],
+    [
+      SecurityEventConnectorType.Okta,
+      { baseUrl: "http://example.okta.com" },
+      { apiToken: "token" },
+      "HTTPS",
+    ],
+    [
+      SecurityEventConnectorType.SplunkEnterpriseSecurity,
+      { baseUrl: "https://splunk.example.com" },
+      { username: "reader" },
+      "apiToken or username and password",
+    ],
+  ])(
+    "rejects invalid %s connection settings",
+    (
+      provider: SecurityEventConnectorType,
+      configuration: Record<string, string>,
+      credentialValues: Record<string, string>,
+      error: string,
+    ) => {
+      expect(() => {
+        validateSecurityEventConnection({
+          provider,
+          configuration,
+          credentialJson: credentials(credentialValues),
+        });
+      }).toThrow(error);
+    },
+  );
+
+  test.each([
+    "http://example.okta.com",
+    "https://token@example.okta.com",
+    "https://example.okta.com?destination=https://169.254.169.254",
+    "https://example.okta.com#https://169.254.169.254",
+  ])("rejects SSRF-relevant Okta URL %s", (baseUrl: string) => {
+    expect(() => {
+      validateSecurityEventConnection({
+        provider: SecurityEventConnectorType.Okta,
+        configuration: { baseUrl },
+        credentialJson: credentials({ apiToken: "api-token" }),
+      });
+    }).toThrow("HTTPS");
+  });
+
+  test.each([
+    "http://splunk.example.com",
+    "https://token@splunk.example.com",
+    "https://splunk.example.com?redirect=https://127.0.0.1",
+    "https://splunk.example.com#https://127.0.0.1",
+  ])("rejects SSRF-relevant Splunk URL %s", (baseUrl: string) => {
+    expect(() => {
+      validateSecurityEventConnection({
+        provider: SecurityEventConnectorType.SplunkEnterpriseSecurity,
+        configuration: { baseUrl },
+        credentialJson: credentials({ apiToken: "api-token" }),
+      });
+    }).toThrow("HTTPS");
+  });
+
+  test("rejects an unsupported Splunk token authorization scheme", () => {
+    expect(() => {
+      validateSecurityEventConnection({
+        provider: SecurityEventConnectorType.SplunkEnterpriseSecurity,
+        configuration: { baseUrl: "https://splunk.example.com" },
+        credentialJson: credentials({
+          apiToken: "api-token",
+          tokenScheme: "Basic",
+        }),
+      });
+    }).toThrow("Bearer or Splunk");
+  });
+
+  test.each([
+    "https://oauth2.googleapis.com/other",
+    "https://oauth2.googleapis.com:8443/token",
+    "https://oauth2.googleapis.com@169.254.169.254/token",
+    "https://metadata.google.internal/token",
+  ])(
+    "rejects Google token URI outside the exact OAuth endpoint: %s",
+    (tokenUri: string) => {
+      expect(() => {
+        validateSecurityEventConnection({
+          provider: SecurityEventConnectorType.GoogleSecurityCommandCenter,
+          configuration: { parent: "folders/123/sources/-" },
+          credentialJson: credentials({
+            client_email: "service@example.iam.gserviceaccount.com",
+            private_key: privateKey,
+            token_uri: tokenUri,
+          }),
+        });
+      }).toThrow();
+    },
+  );
+
+  test("rejects malformed Google private keys before a connection is stored", () => {
+    expect(() => {
+      validateSecurityEventConnection({
+        provider: SecurityEventConnectorType.GoogleSecurityCommandCenter,
+        configuration: { parent: "organizations/123/sources/-" },
+        credentialJson: credentials({
+          client_email: "service@example.iam.gserviceaccount.com",
+          private_key: "definitely not a PEM key",
+        }),
+      });
+    }).toThrow("private_key");
+  });
+});
+
+describe("SecurityEventConnection common validation", () => {
+  test.each([1, 5, 1440])(
+    "accepts poll interval %i minutes",
+    (pollIntervalInMinutes: number) => {
+      expect(() => {
+        validateSecurityEventConnection({ pollIntervalInMinutes });
+      }).not.toThrow();
+    },
+  );
+
+  test.each([0, -1, 1.5, 1441, Number.NaN])(
+    "rejects invalid poll interval %p",
+    (pollIntervalInMinutes: number) => {
+      expect(() => {
+        validateSecurityEventConnection({ pollIntervalInMinutes });
+      }).toThrow("whole number of minutes between 1 and 1440");
+    },
+  );
+
+  test.each(["", "not json", "[]", "null"])(
+    "rejects credential JSON %p",
+    (credentialJson: string) => {
+      expect(() => {
+        return parseSecurityEventCredentialJson(credentialJson);
+      }).toThrow();
+    },
+  );
+
+  test("parses object-shaped configuration JSON from form submissions", () => {
+    expect(parseSecurityEventConfiguration('{"region":"us-east-1"}')).toEqual({
+      region: "us-east-1",
+    });
+    expect(() => {
+      return parseSecurityEventConfiguration("[]");
+    }).toThrow("Configuration must be a JSON object");
+    expect(() => {
+      return parseSecurityEventConfiguration("not json");
+    }).toThrow("Configuration is not valid JSON");
+  });
+
+  test("normalizes configuration JSON before creating a connection", async () => {
+    const connection: SecurityEventConnection = awsConnection();
+    connection.configuration = JSON.stringify({
+      region: "us-west-2",
+    }) as unknown as JSONObject;
+
+    const beforeCreate: unknown = await hooks.onBeforeCreate({
+      data: connection,
+    });
+
+    expect(beforeCreate).toMatchObject({
+      createBy: {
+        data: {
+          configuration: { region: "us-west-2" },
+          sourceFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+        },
+      },
+    });
+  });
+
+  test("rejects unsupported providers and missing credentials", () => {
+    expect(() => {
+      validateSecurityEventConnection({
+        provider: "unknown" as SecurityEventConnectorType,
+        configuration: {},
+        credentialJson: "{}",
+      });
+    }).toThrow("supported security event provider");
+    expect(() => {
+      validateSecurityEventConnection({
+        provider: SecurityEventConnectorType.Cloudflare,
+        configuration: { accountId: "account", zoneId: "zone" },
+      });
+    }).toThrow("Credentials JSON is required");
+  });
+});
+
+describe("SecurityEventConnection update validation", () => {
+  test("writes a polling checkpoint with the row version in the same SQL statement", async () => {
+    const builder: Record<string, ReturnType<typeof jest.fn>> = {};
+    for (const method of ["update", "set", "where", "andWhere"]) {
+      builder[method] = jest.fn(() => {
+        return builder;
+      });
+    }
+    builder["execute"] = jest.fn(async () => {
+      return { affected: 1 };
+    });
+    jest
+      .spyOn(SecurityEventConnectionService, "getRepository")
+      .mockReturnValue({
+        createQueryBuilder: jest.fn(() => {
+          return builder;
+        }),
+      } as never);
+    const id: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+    const checkpoint: SecurityEventPollingCheckpointUpdate = {
+      lastPolledAt: new Date("2026-09-11T12:00:00.000Z"),
+      lastPollResult: { complete: true },
+      lastError: null,
+      cursor: "2026-09-11T12:00:00.000Z",
+    };
+
+    await expect(
+      SecurityEventConnectionService.updatePollingCheckpointIfUnchanged({
+        id,
+        expectedVersion: 7,
+        checkpoint,
+      }),
+    ).resolves.toBe(1);
+
+    const storedCheckpoint: typeof checkpoint = builder["set"]!.mock
+      .calls[0]![0] as typeof checkpoint;
+    expect(storedCheckpoint).toMatchObject({
+      lastPolledAt: checkpoint.lastPolledAt,
+      lastPollResult: checkpoint.lastPollResult,
+      lastError: null,
+    });
+    const storedCursor: string | null | undefined = storedCheckpoint.cursor;
+    if (typeof storedCursor !== "string") {
+      throw new Error("The encrypted checkpoint cursor was not stored.");
+    }
+    expect(storedCursor).not.toBe(checkpoint.cursor);
+    expect(await Encryption.decrypt(storedCursor)).toBe(checkpoint.cursor);
+    expect(checkpoint.cursor).toBe("2026-09-11T12:00:00.000Z");
+    expect(builder["where"]).toHaveBeenCalledWith('"_id" = :id', {
+      id: id.toString(),
+    });
+    expect(builder["andWhere"]).toHaveBeenCalledWith(
+      '"version" = :expectedVersion',
+      { expectedVersion: 7 },
+    );
+    expect(builder["andWhere"]).toHaveBeenCalledWith('"deletedAt" IS NULL');
+  });
+
+  test("reports a lost checkpoint race when the row version changed", async () => {
+    const builder: Record<string, ReturnType<typeof jest.fn>> = {};
+    for (const method of ["update", "set", "where", "andWhere"]) {
+      builder[method] = jest.fn(() => {
+        return builder;
+      });
+    }
+    builder["execute"] = jest.fn(async () => {
+      return { affected: 0 };
+    });
+    jest
+      .spyOn(SecurityEventConnectionService, "getRepository")
+      .mockReturnValue({
+        createQueryBuilder: jest.fn(() => {
+          return builder;
+        }),
+      } as never);
+
+    await expect(
+      SecurityEventConnectionService.updatePollingCheckpointIfUnchanged({
+        id: ObjectID.generate(),
+        expectedVersion: 7,
+        checkpoint: {
+          lastPolledAt: new Date(),
+          lastPollResult: { complete: true },
+          lastError: null,
+          cursor: null,
+        },
+      }),
+    ).resolves.toBe(0);
+  });
+
+  test("defers provider validation until after permission-scoped rows are loaded", async () => {
+    const connection: SecurityEventConnection = awsConnection();
+    const findBy: jest.Mock = jest.spyOn(
+      hooks,
+      "findBy",
+    ) as unknown as jest.Mock;
+
+    const onUpdate: unknown = await hooks.onBeforeUpdate({
+      data: { configuration: { region: "us-west-2" } },
+      query: { _id: "connection-id" },
+      skip: 0,
+      limit: 1,
+    });
+
+    expect(onUpdate).toMatchObject({
+      carryForward: {
+        configurationSupplied: true,
+        credentialsSupplied: false,
+        configuration: { region: "us-west-2" },
+      },
+    });
+    expect(findBy).not.toHaveBeenCalled();
+    expect(hooks.getAdditionalUpdateSelect(onUpdate)).toEqual({
+      provider: true,
+      configuration: true,
+      credentialJson: true,
+      pollIntervalInMinutes: true,
+    });
+    await expect(
+      hooks.onBeforeUpdateItems(onUpdate, [connection]),
+    ).resolves.toBeUndefined();
+  });
+
+  test("does not reveal provider-specific validation for rows denied by the scoped query", async () => {
+    const findBy: jest.Mock = jest.spyOn(
+      hooks,
+      "findBy",
+    ) as unknown as jest.Mock;
+    const onUpdate: unknown = await hooks.onBeforeUpdate({
+      data: { credentialJson: "{}" },
+      query: { _id: "cross-tenant-connection-id" },
+      skip: 0,
+      limit: 1,
+    });
+
+    expect(findBy).not.toHaveBeenCalled();
+    await expect(
+      hooks.onBeforeUpdateItems(onUpdate, []),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      hooks.onBeforeUpdateItems(onUpdate, [awsConnection()]),
+    ).rejects.toThrow("AWS requires accessKeyId");
+  });
+
+  test("validates every authorized row before writes begin", async () => {
+    const invalid: SecurityEventConnection = awsConnection();
+    invalid.configuration = { region: "invalid-region" };
+    const onUpdate: unknown = await hooks.onBeforeUpdate({
+      data: {
+        credentialJson: credentials({
+          accessKeyId: "rotated-access-key",
+          secretAccessKey: "rotated-secret-key",
+        }),
+      },
+      query: {},
+      skip: 0,
+      limit: 2,
+    });
+
+    await expect(
+      hooks.onBeforeUpdateItems(onUpdate, [awsConnection(), invalid]),
+    ).rejects.toThrow("AWS region is not valid");
+  });
+
+  test("normalizes source settings before carrying them to scoped validation", async () => {
+    await expect(
+      hooks.onBeforeUpdate({
+        data: { configuration: '{"region":"us-west-2"}' },
+        query: { _id: "connection-id" },
+        skip: 0,
+        limit: 1,
+      }),
+    ).resolves.toMatchObject({
+      carryForward: {
+        configurationSupplied: true,
+        credentialsSupplied: false,
+        configuration: { region: "us-west-2" },
+      },
+    });
+  });
+
+  test("rejects provider changes so source fingerprint updates cannot race", async () => {
+    await expect(
+      hooks.onBeforeUpdate({
+        data: { provider: SecurityEventConnectorType.Cloudflare },
+        query: { _id: "connection-id" },
+        skip: 0,
+        limit: 1,
+      }),
+    ).rejects.toThrow("provider cannot be changed");
+  });
+
+  test("validates the poll interval when updating connection settings", async () => {
+    await expect(
+      hooks.onBeforeUpdate({
+        data: { isEnabled: false, pollIntervalInMinutes: 0 },
+        query: { _id: "connection-id" },
+        skip: 0,
+        limit: 1,
+      }),
+    ).rejects.toThrow("whole number of minutes between 1 and 1440");
+  });
+
+  test("resets polling state without changing identity after credential rotation", async () => {
+    const connection: SecurityEventConnection = awsConnection();
+    const onUpdate: unknown = await hooks.onBeforeUpdate({
+      data: {
+        credentialJson: credentials({
+          accessKeyId: "rotated-access-key",
+          secretAccessKey: "rotated-secret-key",
+        }),
+      },
+      query: { _id: connection._id },
+      skip: 0,
+      limit: 1,
+    });
+
+    await hooks.onBeforeUpdateItems(onUpdate, [connection]);
+
+    expect(await hooks.getInternalUpdateData(onUpdate, connection)).toEqual({
+      cursor: null,
+      lastPolledAt: null,
+      lastSuccessfulPollAt: null,
+      lastEventIngestedAt: null,
+      lastPollResult: null,
+      lastError: null,
+    });
+  });
+
+  test("increments source identity and resets polling state after repointing", async () => {
+    const connection: SecurityEventConnection = awsConnection();
+    const onUpdate: unknown = await hooks.onBeforeUpdate({
+      data: { configuration: { region: "eu-west-2" } },
+      query: { _id: connection._id },
+      skip: 0,
+      limit: 1,
+    });
+
+    await hooks.onBeforeUpdateItems(onUpdate, [connection]);
+
+    const internalData: Record<string, unknown> =
+      await hooks.getInternalUpdateData(onUpdate, connection);
+    expect(internalData).toEqual({
+      sourceFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+      sourceGeneration: expect.any(Function),
+      cursor: expect.any(Function),
+      lastPolledAt: expect.any(Function),
+      lastSuccessfulPollAt: expect.any(Function),
+      lastEventIngestedAt: expect.any(Function),
+      lastPollResult: expect.any(Function),
+      lastError: expect.any(Function),
+    });
+    expect((internalData["sourceGeneration"] as () => string)()).toContain(
+      '"sourceFingerprint" IS DISTINCT FROM',
+    );
+    expect((internalData["cursor"] as () => string)()).toContain(
+      'THEN NULL ELSE "cursor" END',
+    );
+    expect(hooks.getAdditionalUpdateSelect(onUpdate)).toEqual({
+      provider: true,
+      configuration: true,
+      credentialJson: true,
+      pollIntervalInMinutes: true,
+    });
+  });
+
+  test("keeps polling state when only the interval changes", async () => {
+    const beforeUpdate: unknown = await hooks.onBeforeUpdate({
+      data: { pollIntervalInMinutes: 10 },
+      query: { _id: "connection-id" },
+    });
+    expect(
+      await hooks.getInternalUpdateData(beforeUpdate, awsConnection()),
+    ).toEqual({});
+  });
+
+  test("keeps polling identity when an edit resubmits unchanged configuration", async () => {
+    const connection: SecurityEventConnection = awsConnection();
+    const onUpdate: unknown = await hooks.onBeforeUpdate({
+      data: {
+        name: "Renamed connection",
+        configuration: { region: "us-east-1" },
+      },
+      query: { _id: connection._id },
+      skip: 0,
+      limit: 1,
+    });
+
+    await hooks.onBeforeUpdateItems(onUpdate, [connection]);
+
+    const internalData: Record<string, unknown> =
+      await hooks.getInternalUpdateData(onUpdate, connection);
+    expect(internalData["sourceFingerprint"]).toMatch(/^[a-f0-9]{64}$/);
+    expect(typeof internalData["sourceGeneration"]).toBe("function");
+    expect(typeof internalData["cursor"]).toBe("function");
+  });
+});
+
+describe("SecurityEventConnection credential and permissions contract", () => {
+  const model: SecurityEventConnection = new SecurityEventConnection();
+  const accessControl: Record<string, ColumnAccessControl> =
+    model.getColumnAccessControlForAllColumns();
+
+  test("encrypts credentials and makes them write-only through CRUD", () => {
+    expect(model.getEncryptedColumns().columns).toEqual(
+      expect.arrayContaining(["credentialJson", "cursor"]),
+    );
+    expect(model.getTableColumnMetadata("credentialJson").encrypted).toBe(true);
+    expect(accessControl["credentialJson"]?.read).toEqual([]);
+    expect(accessControl["credentialJson"]?.create).toEqual(ADMIN_PERMISSIONS);
+    expect(accessControl["credentialJson"]?.update).toEqual(ADMIN_PERMISSIONS);
+    expect(accessControl["cursor"]?.read).toEqual([]);
+    expect(accessControl["sourceFingerprint"]?.read).toEqual([]);
+    expect(accessControl["sourceFingerprint"]?.update).toEqual([]);
+    expect(accessControl["sourceGeneration"]?.read).toEqual([]);
+  });
+
+  test("uses database defaults for internal generation and scheduling fields", () => {
+    expect(model.isDefaultValueColumn("sourceGeneration")).toBe(true);
+    expect(model.isDefaultValueColumn("isEnabled")).toBe(true);
+    expect(model.isDefaultValueColumn("pollIntervalInMinutes")).toBe(true);
+  });
+
+  test("removes write-only state before a created connection is serialized", async () => {
+    const created: SecurityEventConnection = awsConnection();
+    created.sourceFingerprint = "source-fingerprint";
+    created.sourceGeneration = 4;
+    created.cursor = "encrypted-cursor";
+
+    const returned: SecurityEventConnection = await hooks.onCreateSuccess(
+      {},
+      created,
+    );
+    const response: JSONObject = BaseModel.toJSONObject(
+      returned,
+      SecurityEventConnection,
+    );
+
+    expect(response).toEqual(
+      expect.objectContaining({
+        _id: created._id,
+        provider: SecurityEventConnectorType.AwsSecurityHub,
+      }),
+    );
+    expect(response).not.toHaveProperty("credentialJson");
+    expect(response).not.toHaveProperty("cursor");
+    expect(response).not.toHaveProperty("sourceFingerprint");
+    expect(response).not.toHaveProperty("sourceGeneration");
+  });
+
+  test("limits connection changes to connector administrators while allowing security readers to view non-secret details", () => {
+    expect(model.getCreatePermissions()).toEqual(ADMIN_PERMISSIONS);
+    expect(model.getUpdatePermissions()).toEqual(ADMIN_PERMISSIONS);
+    expect(model.getDeletePermissions()).toEqual(ADMIN_PERMISSIONS);
+    expect(model.getReadPermissions()).toEqual(READ_PERMISSIONS);
+    expect(accessControl["configuration"]?.read).toEqual(READ_PERMISSIONS);
+    expect(accessControl["pollIntervalInMinutes"]?.read).toEqual(
+      READ_PERMISSIONS,
+    );
+    expect(accessControl["lastError"]?.create).toEqual([]);
+    expect(accessControl["lastError"]?.update).toEqual([]);
+  });
+});

--- a/Common/Tests/Server/Utils/DataSource/HttpFetch.test.ts
+++ b/Common/Tests/Server/Utils/DataSource/HttpFetch.test.ts
@@ -190,6 +190,20 @@ describe("DataSourceHttpFetch.fetch - hardened axios config", () => {
     expect(getAxiosConfig().timeout).toBe(1234);
   });
 
+  test("forwards the caller cancellation signal to axios", async () => {
+    const controller: AbortController = new AbortController();
+
+    await DataSourceHttpFetch.fetch(makeRequest({ signal: controller.signal }));
+
+    expect(getAxiosConfig().signal).toBe(controller.signal);
+  });
+
+  test("omits the axios signal when the caller does not provide one", async () => {
+    await DataSourceHttpFetch.fetch(makeRequest());
+
+    expect(getAxiosConfig()).not.toHaveProperty("signal");
+  });
+
   test("passes the guard-validated URL and method through to axios", async () => {
     await DataSourceHttpFetch.fetch(makeRequest());
     const config: AxiosRequestConfig = getAxiosConfig();

--- a/Common/Tests/Server/Utils/SecurityEvent/Connectors/SecurityEventConnectionPoller.test.ts
+++ b/Common/Tests/Server/Utils/SecurityEvent/Connectors/SecurityEventConnectionPoller.test.ts
@@ -1,0 +1,1239 @@
+import SecurityEventConnection from "../../../../../Models/DatabaseModels/SecurityEventConnection";
+import Semaphore, {
+  SemaphoreLockTimeoutError,
+} from "../../../../../Server/Infrastructure/Semaphore";
+import OTelIngestService, {
+  TelemetryServiceMetadata,
+} from "../../../../../Server/Services/OpenTelemetryIngestService";
+import SecurityEventConnectionService from "../../../../../Server/Services/SecurityEventConnectionService";
+import SecurityEventService from "../../../../../Server/Services/SecurityEventService";
+import SecurityEventConnectionPoller, {
+  SECURITY_EVENT_CONNECTION_LOCK_NAMESPACE,
+  SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY,
+  SECURITY_EVENT_CONNECTION_POLL_DEADLINE_MS,
+  SECURITY_EVENT_CONNECTION_SWEEP_LOCK_NAMESPACE,
+  SECURITY_EVENT_CONNECTION_SWEEP_START_BUDGET_MS,
+} from "../../../../../Server/Utils/SecurityEvent/Connectors/SecurityEventConnectionPoller";
+import LIMIT_MAX from "../../../../../Types/Database/LimitMax";
+import {
+  SecurityEventConnectorClient,
+  SecurityEventConnectorFetchResult,
+} from "../../../../../Server/Utils/SecurityEvent/Connectors/Types";
+import ThreatIntelEnricher from "../../../../../Server/Utils/SecurityEvent/ThreatIntel/ThreatIntelEnricher";
+import { JSONObject } from "../../../../../Types/JSON";
+import ObjectID from "../../../../../Types/ObjectID";
+import SecurityEventConnectorResult from "../../../../../Types/SecurityEvent/SecurityEventConnectorResult";
+import SecurityEventConnectorType from "../../../../../Types/SecurityEvent/SecurityEventConnectorType";
+import ServiceType from "../../../../../Types/Telemetry/ServiceType";
+import { getJestSpyOn } from "../../../../Spy";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const CONNECTION_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const NOW: Date = new Date("2026-09-11T12:00:00.000Z");
+
+type FetchInput = Parameters<SecurityEventConnectorClient["fetchEvents"]>[0];
+
+interface ClientResult {
+  client: SecurityEventConnectorClient;
+  calls: Array<FetchInput>;
+}
+
+function connection(
+  id: string = CONNECTION_ID.toString(),
+): SecurityEventConnection {
+  const item: SecurityEventConnection = new SecurityEventConnection();
+  item._id = id;
+  item.projectId = PROJECT_ID;
+  item.name = "Production Security Hub";
+  item.provider = SecurityEventConnectorType.AwsSecurityHub;
+  item.configuration = { region: "us-east-1" };
+  item.credentialJson = JSON.stringify({
+    accessKeyId: "AKIATEST",
+    secretAccessKey: "test-secret",
+  });
+  item.sourceGeneration = 1;
+  item.pollIntervalInMinutes = 5;
+  item.isEnabled = true;
+  item.version = 7;
+  return item;
+}
+
+function mockConnectionDetails(
+  connections: Array<SecurityEventConnection>,
+): void {
+  const connectionsById: Map<string, SecurityEventConnection> = new Map(
+    connections.map(
+      (item: SecurityEventConnection): [string, SecurityEventConnection] => {
+        return [item.id!.toString(), item];
+      },
+    ),
+  );
+  getJestSpyOn(SecurityEventConnectionService, "findOneBy").mockImplementation(
+    async (data: {
+      query: { _id?: unknown };
+    }): Promise<SecurityEventConnection | null> => {
+      return connectionsById.get(String(data.query._id)) || null;
+    },
+  );
+}
+
+async function waitForCallCount(
+  mock: { mock: { calls: Array<Array<unknown>> } },
+  expected: number,
+  remainingAttempts: number = 25,
+): Promise<void> {
+  if (mock.mock.calls.length >= expected) {
+    return;
+  }
+  if (remainingAttempts === 0) {
+    throw new Error(
+      `Expected ${expected} calls but observed ${mock.mock.calls.length}.`,
+    );
+  }
+  await Promise.resolve();
+  await waitForCallCount(mock, expected, remainingAttempts - 1);
+}
+
+function finding(
+  id: string = "finding-1",
+  updatedAt: string = "2026-09-11T11:59:00Z",
+): JSONObject {
+  return {
+    SchemaVersion: "2018-10-08",
+    Id: id,
+    ProductArn: "arn:aws:securityhub:us-east-1::product/aws/guardduty",
+    GeneratorId: "guardduty-test",
+    Title: "Suspicious network activity",
+    UpdatedAt: updatedAt,
+    Severity: { Label: "HIGH" },
+  };
+}
+
+function metadata(): TelemetryServiceMetadata {
+  return {
+    serviceName: "AWS Security Hub",
+    primaryEntityId: new ObjectID("33333333-3333-4333-8333-333333333333"),
+    primaryEntityType: ServiceType.OpenTelemetry,
+    dataRententionInDays: 15,
+    serviceRetentionConfig: null,
+    serviceRetentionInDays: null,
+    projectRetentionConfig: null,
+    projectRetentionInDays: 15,
+  };
+}
+
+function clientResult(
+  overrides: Partial<SecurityEventConnectorFetchResult> = {},
+): ClientResult {
+  const calls: Array<FetchInput> = [];
+  const client: SecurityEventConnectorClient = {
+    fetchEvents: (
+      window: FetchInput,
+    ): Promise<SecurityEventConnectorFetchResult> => {
+      calls.push(window);
+      return Promise.resolve({
+        events: [],
+        complete: true,
+        requestCount: 1,
+        warnings: [],
+        ...overrides,
+      });
+    },
+  };
+  return { client, calls };
+}
+
+function updateData(index: number = 0): JSONObject {
+  const updateMock: jest.Mock =
+    SecurityEventConnectionService.updatePollingCheckpointIfUnchanged as unknown as jest.Mock;
+  return (updateMock.mock.calls[index]![0] as { checkpoint: JSONObject })
+    .checkpoint;
+}
+
+function storedCursor(index: number = 0): Record<string, unknown> {
+  return JSON.parse(String(updateData(index)["cursor"])) as Record<
+    string,
+    unknown
+  >;
+}
+
+function insertedUid(index: number): string {
+  const insertMock: jest.Mock =
+    SecurityEventService.insertJsonRows as unknown as jest.Mock;
+  const rows: Array<JSONObject> = insertMock.mock.calls[
+    index
+  ]![0] as Array<JSONObject>;
+  return String(rows[0]?.["eventUid"] || "");
+}
+
+describe("SecurityEventConnectionPoller", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    getJestSpyOn(Semaphore, "lock").mockResolvedValue({});
+    getJestSpyOn(Semaphore, "release").mockResolvedValue(undefined);
+    getJestSpyOn(
+      SecurityEventConnectionService,
+      "updatePollingCheckpointIfUnchanged",
+    ).mockResolvedValue(1 as never);
+    getJestSpyOn(
+      SecurityEventConnectionPoller,
+      "findExistingEventUids",
+    ).mockResolvedValue(new Set());
+    getJestSpyOn(
+      OTelIngestService,
+      "telemetryServiceFromName",
+    ).mockResolvedValue(metadata() as never);
+    getJestSpyOn(
+      ThreatIntelEnricher,
+      "enrichNormalizedEvents",
+    ).mockResolvedValue(undefined);
+    getJestSpyOn(SecurityEventService, "insertJsonRows").mockResolvedValue(
+      undefined,
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test("uses a 15-minute first window and advances the cursor after a complete poll", async () => {
+    const { client, calls }: ClientResult = clientResult();
+
+    const result: SecurityEventConnectorResult =
+      await SecurityEventConnectionPoller.pollConnection(connection(), client);
+
+    expect(calls).toEqual([
+      expect.objectContaining({
+        startTime: new Date("2026-09-11T11:45:00.000Z"),
+        endTime: NOW,
+      }),
+    ]);
+    expect(result.complete).toBe(true);
+    expect(updateData()).toMatchObject({
+      cursor: NOW.toISOString(),
+      lastError: null,
+      lastPolledAt: NOW,
+      lastSuccessfulPollAt: NOW,
+    });
+  });
+
+  test("overlaps a saved cursor by one minute and caps catch-up at 24 hours", async () => {
+    const item: SecurityEventConnection = connection();
+    item.cursor = "2026-09-01T00:00:00.000Z";
+    const { client, calls }: ClientResult = clientResult();
+
+    await SecurityEventConnectionPoller.pollConnection(item, client);
+
+    expect(calls[0]).toEqual(
+      expect.objectContaining({
+        startTime: new Date("2026-08-31T23:59:00.000Z"),
+        endTime: new Date("2026-09-01T23:59:00.000Z"),
+      }),
+    );
+  });
+
+  test("holds the poll window when a provider reports truncation", async () => {
+    const { client }: ClientResult = clientResult({
+      complete: false,
+      warnings: ["provider page limit reached"],
+    });
+
+    const result: SecurityEventConnectorResult =
+      await SecurityEventConnectionPoller.pollConnection(connection(), client);
+
+    expect(result.complete).toBe(false);
+    expect(storedCursor()).toMatchObject({
+      nextStart: "2026-09-11T11:45:00.000Z",
+      endTime: "2026-09-11T11:52:30.000Z",
+      attempt: 1,
+    });
+    expect(String(updateData()["lastError"])).toContain(
+      "provider page limit reached",
+    );
+    expect(updateData()["lastSuccessfulPollAt"]).toBeUndefined();
+  });
+
+  test("persists and resumes a provider continuation, then restores overlap", async () => {
+    const first: ClientResult = clientResult({
+      complete: false,
+      continuation: { nextToken: "page-eleven" },
+      warnings: ["more pages"],
+    });
+    await SecurityEventConnectionPoller.pollConnection(
+      connection(),
+      first.client,
+    );
+    expect(storedCursor()).toMatchObject({
+      nextStart: "2026-09-11T11:45:00.000Z",
+      endTime: NOW.toISOString(),
+      continuation: { nextToken: "page-eleven" },
+    });
+
+    const resumed: SecurityEventConnection = connection();
+    resumed.cursor = String(updateData()["cursor"]);
+    const second: ClientResult = clientResult();
+    await SecurityEventConnectionPoller.pollConnection(resumed, second.client);
+    expect(second.calls[0]).toEqual(
+      expect.objectContaining({
+        startTime: new Date("2026-09-11T11:45:00.000Z"),
+        endTime: NOW,
+        continuation: { nextToken: "page-eleven" },
+      }),
+    );
+    expect(updateData(1)["cursor"]).toBe(NOW.toISOString());
+
+    const next: SecurityEventConnection = connection();
+    next.cursor = String(updateData(1)["cursor"]);
+    const third: ClientResult = clientResult();
+    await SecurityEventConnectionPoller.pollConnection(next, third.client);
+    expect(third.calls[0]?.startTime).toEqual(
+      new Date("2026-09-11T11:59:00.000Z"),
+    );
+  });
+
+  test("narrows a window when a continuation repeatedly stops advancing", async () => {
+    const item: SecurityEventConnection = connection();
+    item.cursor = JSON.stringify({
+      version: 1,
+      nextStart: "2026-09-11T11:45:00.000Z",
+      endTime: NOW.toISOString(),
+      attempt: 2,
+      continuation: { nextToken: "stuck" },
+    });
+    const { client }: ClientResult = clientResult({
+      complete: false,
+      continuation: { nextToken: "stuck" },
+    });
+
+    const result: SecurityEventConnectorResult =
+      await SecurityEventConnectionPoller.pollConnection(item, client);
+
+    expect(result.warnings.join(" ")).toContain("stopped advancing");
+    expect(storedCursor()).toEqual({
+      version: 1,
+      nextStart: "2026-09-11T11:45:00.000Z",
+      endTime: "2026-09-11T11:52:30.000Z",
+      attempt: 3,
+    });
+  });
+
+  test("narrows a window after the total continuation budget even when tokens keep changing", async () => {
+    const item: SecurityEventConnection = connection();
+    item.cursor = JSON.stringify({
+      version: 1,
+      nextStart: "2026-09-11T11:45:00.000Z",
+      endTime: NOW.toISOString(),
+      continuationCount: 19,
+      continuation: { nextToken: "token-a" },
+    });
+    const { client }: ClientResult = clientResult({
+      complete: false,
+      continuation: { nextToken: "token-b" },
+    });
+
+    const result: SecurityEventConnectorResult =
+      await SecurityEventConnectionPoller.pollConnection(item, client);
+
+    expect(result.warnings.join(" ")).toContain("bounded pagination budget");
+    expect(storedCursor()).toEqual({
+      version: 1,
+      nextStart: "2026-09-11T11:45:00.000Z",
+      endTime: "2026-09-11T11:52:30.000Z",
+      attempt: 1,
+    });
+  });
+
+  test("writes a gap marker and advances after an irreducible capped window", async () => {
+    const item: SecurityEventConnection = connection();
+    item.cursor = JSON.stringify({
+      version: 1,
+      nextStart: "2026-09-11T11:59:59.000Z",
+      endTime: NOW.toISOString(),
+      attempt: 20,
+    });
+    const { client }: ClientResult = clientResult({
+      complete: false,
+      warnings: ["still capped"],
+    });
+
+    const result: SecurityEventConnectorResult =
+      await SecurityEventConnectionPoller.pollConnection(item, client);
+
+    expect(result).toMatchObject({
+      markerCount: 1,
+      ingestedCount: 1,
+      dataLossPossible: true,
+      cursorAdvanced: true,
+    });
+    expect(storedCursor()).toEqual({
+      version: 1,
+      nextStart: NOW.toISOString(),
+    });
+  });
+
+  test("narrows oversized provider responses instead of retrying forever", async () => {
+    const client: SecurityEventConnectorClient = {
+      fetchEvents: (): Promise<SecurityEventConnectorFetchResult> => {
+        return Promise.reject(
+          new Error("maxContentLength size of 20971520 exceeded"),
+        );
+      },
+    };
+
+    const result: SecurityEventConnectorResult =
+      await SecurityEventConnectionPoller.pollConnection(connection(), client);
+
+    expect(result).toMatchObject({ complete: false, retryScheduled: true });
+    expect(result.error).toBeUndefined();
+    expect(result.warnings.join(" ")).toContain("transport size");
+    expect(storedCursor()["endTime"]).toBe("2026-09-11T11:52:30.000Z");
+  });
+
+  test("clears a failed page token and narrows the window after bounded retries", async () => {
+    const item: SecurityEventConnection = connection();
+    item.cursor = JSON.stringify({
+      version: 1,
+      nextStart: "2026-09-11T11:45:00.000Z",
+      endTime: NOW.toISOString(),
+      attempt: 2,
+      continuation: { nextToken: "expired" },
+    });
+    const client: SecurityEventConnectorClient = {
+      fetchEvents: (): Promise<SecurityEventConnectorFetchResult> => {
+        return Promise.reject(new Error("saved page token expired"));
+      },
+    };
+
+    await expect(
+      SecurityEventConnectionPoller.pollConnection(item, client),
+    ).rejects.toThrow("saved page token expired");
+
+    expect(storedCursor()).toEqual({
+      version: 1,
+      nextStart: "2026-09-11T11:45:00.000Z",
+      endTime: "2026-09-11T11:52:30.000Z",
+    });
+    expect(String(updateData()["lastError"])).toContain(
+      "saved page token expired",
+    );
+  });
+
+  test("writes a durable audit marker for a mismatched payload and advances", async () => {
+    const { client }: ClientResult = clientResult({
+      events: [{ unrelated: true }],
+    });
+
+    const result: SecurityEventConnectorResult =
+      await SecurityEventConnectionPoller.pollConnection(connection(), client);
+
+    expect(result).toMatchObject({
+      fetchedCount: 1,
+      rejectedCount: 1,
+      markerCount: 1,
+      ingestedCount: 1,
+      complete: false,
+      cursorAdvanced: true,
+    });
+    expect(SecurityEventService.insertJsonRows).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ classUid: 0 })]),
+      expect.anything(),
+    );
+    expect(updateData()["cursor"]).toBe(NOW.toISOString());
+    expect(String(updateData()["lastError"])).toContain("did not match");
+  });
+
+  test("does not count an audit marker when its durable insert fails", async () => {
+    getJestSpyOn(SecurityEventService, "insertJsonRows").mockRejectedValueOnce(
+      new Error("ClickHouse unavailable"),
+    );
+
+    await expect(
+      SecurityEventConnectionPoller.pollConnection(
+        connection(),
+        clientResult({ events: [{ unrelated: true }] }).client,
+      ),
+    ).rejects.toThrow("ClickHouse unavailable");
+
+    expect(updateData()["lastPollResult"]).toMatchObject({
+      markerCount: 0,
+      ingestedCount: 0,
+      complete: false,
+    });
+  });
+
+  test("normalizes, enriches, deduplicates, and synchronously inserts fresh events", async () => {
+    const findMock: jest.Mock =
+      SecurityEventConnectionPoller.findExistingEventUids as unknown as jest.Mock;
+    findMock.mockImplementation(
+      (_projectId: ObjectID, ids: Array<string>): Promise<Set<string>> => {
+        return Promise.resolve(new Set(ids[1] ? [ids[1]] : []));
+      },
+    );
+    const { client }: ClientResult = clientResult({
+      events: [finding(), finding(), finding("already-stored")],
+    });
+
+    const result: SecurityEventConnectorResult =
+      await SecurityEventConnectionPoller.pollConnection(connection(), client);
+
+    expect(result).toMatchObject({
+      fetchedCount: 3,
+      duplicateCount: 2,
+      ingestedCount: 1,
+      complete: true,
+    });
+    expect(ThreatIntelEnricher.enrichNormalizedEvents).toHaveBeenCalledTimes(1);
+    expect(SecurityEventService.insertJsonRows).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventUid: expect.stringMatching(/^[a-f0-9]{64}$/),
+          classUid: 2004,
+        }),
+      ]),
+      { clickhouseSettings: { async_insert: 0, insert_distributed_sync: 1 } },
+    );
+    expect(updateData()).toMatchObject({ lastEventIngestedAt: NOW });
+  });
+
+  test("namespaces IDs by connection, source generation, and revision", async () => {
+    await SecurityEventConnectionPoller.pollConnection(
+      connection(),
+      clientResult({ events: [finding()] }).client,
+    );
+    await SecurityEventConnectionPoller.pollConnection(
+      connection("44444444-4444-4444-8444-444444444444"),
+      clientResult({ events: [finding()] }).client,
+    );
+    await SecurityEventConnectionPoller.pollConnection(
+      connection(),
+      clientResult({
+        events: [finding("finding-1", "2026-09-11T12:00:00Z")],
+      }).client,
+    );
+    const repointed: SecurityEventConnection = connection();
+    repointed.sourceGeneration = 2;
+    await SecurityEventConnectionPoller.pollConnection(
+      repointed,
+      clientResult({ events: [finding()] }).client,
+    );
+
+    expect(insertedUid(0)).toMatch(/^[a-f0-9]{64}$/);
+    expect(insertedUid(1)).not.toBe(insertedUid(0));
+    expect(insertedUid(2)).not.toBe(insertedUid(0));
+    expect(insertedUid(3)).not.toBe(insertedUid(0));
+  });
+
+  test("uses payload content as the revision when a source timestamp is absent", async () => {
+    const payload: JSONObject = finding();
+    delete payload["UpdatedAt"];
+    await SecurityEventConnectionPoller.pollConnection(
+      connection(),
+      clientResult({ events: [payload] }).client,
+    );
+    jest.setSystemTime(new Date(NOW.getTime() + 60_000));
+    await SecurityEventConnectionPoller.pollConnection(
+      connection(),
+      clientResult({ events: [payload] }).client,
+    );
+    await SecurityEventConnectionPoller.pollConnection(
+      connection(),
+      clientResult({
+        events: [{ ...payload, Title: "Changed finding" }],
+      }).client,
+    );
+
+    expect(insertedUid(1)).toBe(insertedUid(0));
+    expect(insertedUid(2)).not.toBe(insertedUid(0));
+  });
+
+  test("uses payload content when a source timestamp does not change", async () => {
+    const payload: JSONObject = finding();
+    await SecurityEventConnectionPoller.pollConnection(
+      connection(),
+      clientResult({ events: [payload] }).client,
+    );
+    await SecurityEventConnectionPoller.pollConnection(
+      connection(),
+      clientResult({
+        events: [
+          { ...payload, Title: "Changed at the same provider revision" },
+        ],
+      }).client,
+    );
+
+    expect(insertedUid(1)).not.toBe(insertedUid(0));
+  });
+
+  test("persists a redacted failure and always releases the connection lock", async () => {
+    const client: SecurityEventConnectorClient = {
+      fetchEvents: (): Promise<SecurityEventConnectorFetchResult> => {
+        return Promise.reject(new Error("Bearer secret-token was rejected"));
+      },
+    };
+
+    await expect(
+      SecurityEventConnectionPoller.pollConnection(connection(), client),
+    ).rejects.toThrow();
+
+    expect(updateData()).toMatchObject({
+      lastPolledAt: NOW,
+    });
+    expect(updateData()["lastError"]).toBeTruthy();
+    expect(String(updateData()["lastError"])).not.toContain("secret-token");
+    expect(Semaphore.lock).toHaveBeenCalledWith({
+      namespace: SECURITY_EVENT_CONNECTION_LOCK_NAMESPACE,
+      key: CONNECTION_ID.toString(),
+      lockTimeout: 15 * 60 * 1000,
+      acquireTimeout: 10_000,
+      retryInterval: 100,
+    });
+    expect(Semaphore.release).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves the continuation budget across provider failures", async () => {
+    const item: SecurityEventConnection = connection();
+    item.cursor = JSON.stringify({
+      version: 1,
+      nextStart: "2026-09-11T11:45:00.000Z",
+      endTime: NOW.toISOString(),
+      attempt: 0,
+      continuationCount: 19,
+      continuation: { nextToken: "page-nineteen" },
+    });
+    const client: SecurityEventConnectorClient = {
+      fetchEvents: (): Promise<SecurityEventConnectorFetchResult> => {
+        return Promise.reject(new Error("provider temporarily unavailable"));
+      },
+    };
+
+    await expect(
+      SecurityEventConnectionPoller.pollConnection(item, client),
+    ).rejects.toThrow("provider temporarily unavailable");
+
+    expect(storedCursor()).toEqual({
+      version: 1,
+      nextStart: "2026-09-11T11:45:00.000Z",
+      endTime: NOW.toISOString(),
+      attempt: 1,
+      continuationCount: 19,
+      continuation: { nextToken: "page-nineteen" },
+    });
+  });
+
+  test("aborts a provider request at the per-connection deadline", async () => {
+    let observedSignal: AbortSignal | undefined;
+    let rejectFetch: ((error: Error) => void) | undefined;
+    let releaseFence: (() => void) | undefined;
+    const released: Promise<void> = new Promise((resolve: () => void): void => {
+      releaseFence = resolve;
+    });
+    getJestSpyOn(Semaphore, "release").mockImplementation(
+      async (): Promise<void> => {
+        releaseFence?.();
+      },
+    );
+    const client: SecurityEventConnectorClient = {
+      fetchEvents: ({
+        signal,
+      }: FetchInput): Promise<SecurityEventConnectorFetchResult> => {
+        observedSignal = signal;
+        return new Promise(
+          (
+            _resolve: (value: SecurityEventConnectorFetchResult) => void,
+            reject: (error: Error) => void,
+          ): void => {
+            rejectFetch = reject;
+          },
+        );
+      },
+    };
+
+    const pending: Promise<SecurityEventConnectorResult> =
+      SecurityEventConnectionPoller.pollConnection(connection(), client);
+    const assertion: Promise<void> = expect(pending).rejects.toThrow(
+      "8-minute polling deadline",
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    jest.advanceTimersByTime(SECURITY_EVENT_CONNECTION_POLL_DEADLINE_MS);
+    await Promise.resolve();
+    await assertion;
+
+    expect(observedSignal?.aborted).toBe(true);
+    expect(String(updateData()["lastError"])).toContain(
+      "8-minute polling deadline",
+    );
+    expect(Semaphore.release).not.toHaveBeenCalled();
+
+    rejectFetch?.(new Error("provider stopped after the abort"));
+    await released;
+    expect(Semaphore.release).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    JSON.stringify({ version: 2, nextStart: "2026-09-01T00:00:00.000Z" }),
+    "2026-09-12T00:00:00.000Z",
+    "not-a-cursor",
+  ])("holds and reports an invalid cursor: %s", async (cursor: string) => {
+    const item: SecurityEventConnection = connection();
+    item.cursor = cursor;
+    const { client, calls }: ClientResult = clientResult();
+
+    await expect(
+      SecurityEventConnectionPoller.pollConnection(item, client),
+    ).rejects.toThrow("invalid or future polling cursor");
+
+    expect(calls).toHaveLength(0);
+    expect(updateData()["cursor"]).toBeUndefined();
+    expect(String(updateData()["lastError"])).toContain(
+      "invalid or future polling cursor",
+    );
+  });
+
+  test("persists invalid provider settings so a bad row does not monopolize due batches", async () => {
+    const item: SecurityEventConnection = connection();
+    item.configuration = { region: "invalid-region" };
+    const { client, calls }: ClientResult = clientResult();
+
+    await expect(
+      SecurityEventConnectionPoller.pollConnection(item, client),
+    ).rejects.toThrow("AWS region is not valid");
+
+    expect(calls).toHaveLength(0);
+    expect(updateData()).toMatchObject({ lastPolledAt: NOW });
+    expect(String(updateData()["lastError"])).toContain(
+      "AWS region is not valid",
+    );
+  });
+
+  test("does not overwrite a reset when connection settings change mid-poll", async () => {
+    const updateMock: jest.Mock =
+      SecurityEventConnectionService.updatePollingCheckpointIfUnchanged as unknown as jest.Mock;
+    updateMock.mockResolvedValueOnce(0);
+
+    const result: SecurityEventConnectorResult =
+      await SecurityEventConnectionPoller.pollConnection(
+        connection(),
+        clientResult({ events: [finding()] }).client,
+      );
+
+    expect(result).toMatchObject({ complete: false, cursorAdvanced: false });
+    expect(result.warnings.join(" ")).toContain("settings changed");
+    expect(updateMock).toHaveBeenCalledWith({
+      id: CONNECTION_ID,
+      expectedVersion: 7,
+      checkpoint: expect.any(Object),
+    });
+  });
+
+  test("deduplicates an inserted event when checkpoint storage is replayed", async () => {
+    let stored: boolean = false;
+    const findMock: jest.Mock =
+      SecurityEventConnectionPoller.findExistingEventUids as unknown as jest.Mock;
+    findMock.mockImplementation(
+      (_projectId: ObjectID, ids: Array<string>): Promise<Set<string>> => {
+        return Promise.resolve(stored ? new Set(ids) : new Set());
+      },
+    );
+    const updateMock: jest.Mock =
+      SecurityEventConnectionService.updatePollingCheckpointIfUnchanged as unknown as jest.Mock;
+    updateMock.mockRejectedValueOnce(new Error("checkpoint unavailable"));
+    const client: SecurityEventConnectorClient = clientResult({
+      events: [finding()],
+    }).client;
+
+    await expect(
+      SecurityEventConnectionPoller.pollConnection(connection(), client),
+    ).rejects.toThrow("checkpoint unavailable");
+    stored = true;
+    const replay: SecurityEventConnectorResult =
+      await SecurityEventConnectionPoller.pollConnection(connection(), client);
+
+    expect(replay).toMatchObject({ duplicateCount: 1, ingestedCount: 0 });
+    expect(SecurityEventService.insertJsonRows).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses a secret-free scheduling query and polls only due connections", async () => {
+    const due: SecurityEventConnection = connection();
+    const notDue: SecurityEventConnection = connection();
+    notDue._id = "44444444-4444-4444-8444-444444444444";
+    notDue.lastPolledAt = new Date("2026-09-11T11:58:00.000Z");
+    const findBy: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionService,
+      "findBy",
+    ).mockResolvedValue([due, notDue] as never);
+    const findOneBy: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionService,
+      "findOneBy",
+    ).mockResolvedValue(due as never);
+    const pollSpy: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionPoller,
+      "pollConnection",
+    ).mockResolvedValue({} as never);
+
+    await SecurityEventConnectionPoller.pollAllDueConnections();
+
+    expect(findBy).toHaveBeenCalledWith({
+      query: { isEnabled: true },
+      select: {
+        _id: true,
+        pollIntervalInMinutes: true,
+        lastPolledAt: true,
+        createdAt: true,
+      },
+      skip: 0,
+      limit: LIMIT_MAX,
+      props: { isRoot: true },
+    });
+    expect(findBy.mock.calls[0]![0].select).not.toHaveProperty(
+      "credentialJson",
+    );
+    expect(findBy.mock.calls[0]![0].select).not.toHaveProperty("cursor");
+    expect(findBy.mock.calls[0]![0].select).not.toHaveProperty("configuration");
+    expect(findOneBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: { _id: due.id!.toString(), isEnabled: true },
+        select: expect.objectContaining({
+          credentialJson: true,
+          cursor: true,
+          configuration: true,
+        }),
+      }),
+    );
+    expect(pollSpy).toHaveBeenCalledTimes(1);
+    expect(pollSpy).toHaveBeenCalledWith(
+      due,
+      undefined,
+      NOW.getTime() + SECURITY_EVENT_CONNECTION_SWEEP_START_BUDGET_MS,
+    );
+  });
+
+  test("isolates detail-load failures so another due connection still polls", async () => {
+    const broken: SecurityEventConnection = connection(
+      "00000000-0000-4000-8000-000000000000",
+    );
+    const healthy: SecurityEventConnection = connection(
+      "00000000-0000-4000-8000-000000000001",
+    );
+    getJestSpyOn(SecurityEventConnectionService, "findBy").mockResolvedValue([
+      broken,
+      healthy,
+    ] as never);
+    getJestSpyOn(
+      SecurityEventConnectionService,
+      "findOneBy",
+    ).mockImplementation(
+      async (data: {
+        query: { _id?: unknown };
+      }): Promise<SecurityEventConnection | null> => {
+        if (String(data.query._id) === broken.id!.toString()) {
+          throw new Error("credential decrypt failed");
+        }
+        return healthy;
+      },
+    );
+    const pollSpy: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionPoller,
+      "pollConnection",
+    ).mockResolvedValue({} as never);
+
+    await expect(
+      SecurityEventConnectionPoller.pollAllDueConnections(),
+    ).resolves.toBeUndefined();
+
+    expect(pollSpy).toHaveBeenCalledTimes(1);
+    expect(pollSpy).toHaveBeenCalledWith(
+      healthy,
+      undefined,
+      NOW.getTime() + SECURITY_EVENT_CONNECTION_SWEEP_START_BUDGET_MS,
+    );
+  });
+
+  test("skips connections disabled or no longer due after detail reload", async () => {
+    const disabledSummary: SecurityEventConnection = connection(
+      "00000000-0000-4000-8000-000000000000",
+    );
+    const recentlyPolledSummary: SecurityEventConnection = connection(
+      "00000000-0000-4000-8000-000000000001",
+    );
+    const disabled: SecurityEventConnection = connection(
+      disabledSummary.id!.toString(),
+    );
+    disabled.isEnabled = false;
+    const recentlyPolled: SecurityEventConnection = connection(
+      recentlyPolledSummary.id!.toString(),
+    );
+    recentlyPolled.lastPolledAt = NOW;
+    getJestSpyOn(SecurityEventConnectionService, "findBy").mockResolvedValue([
+      disabledSummary,
+      recentlyPolledSummary,
+    ] as never);
+    mockConnectionDetails([disabled, recentlyPolled]);
+    const pollSpy: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionPoller,
+      "pollConnection",
+    ).mockResolvedValue({} as never);
+
+    await SecurityEventConnectionPoller.pollAllDueConnections();
+
+    expect(SecurityEventConnectionService.findOneBy).toHaveBeenCalledTimes(2);
+    (
+      SecurityEventConnectionService.findOneBy as unknown as jest.Mock
+    ).mock.calls.forEach(
+      (call: Array<{ query: { isEnabled: boolean } }>): void => {
+        expect(call[0]!.query.isEnabled).toBe(true);
+      },
+    );
+    expect(pollSpy).not.toHaveBeenCalled();
+  });
+
+  test("drains more than one batch while bounding active polls", async () => {
+    const due: Array<SecurityEventConnection> = Array.from(
+      { length: SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY + 3 },
+      (_value: unknown, index: number): SecurityEventConnection => {
+        return connection(
+          `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+        );
+      },
+    );
+    getJestSpyOn(SecurityEventConnectionService, "findBy").mockResolvedValue(
+      due as never,
+    );
+    mockConnectionDetails(due);
+    let release: (() => void) | undefined;
+    const gate: Promise<void> = new Promise((resolve: () => void): void => {
+      release = resolve;
+    });
+    let active: number = 0;
+    let maximumActive: number = 0;
+    const pollSpy: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionPoller,
+      "pollConnection",
+    ).mockImplementation(async (): Promise<SecurityEventConnectorResult> => {
+      active++;
+      maximumActive = Math.max(maximumActive, active);
+      await gate;
+      active--;
+      return {} as SecurityEventConnectorResult;
+    });
+
+    const sweep: Promise<void> =
+      SecurityEventConnectionPoller.pollAllDueConnections();
+    try {
+      await waitForCallCount(
+        pollSpy,
+        SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY,
+      );
+      expect(active).toBe(SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY);
+    } finally {
+      release?.();
+      await sweep;
+    }
+    expect(maximumActive).toBe(SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY);
+    expect(pollSpy).toHaveBeenCalledTimes(due.length);
+  });
+
+  test("does not start another connection after the sweep start budget", async () => {
+    const due: Array<SecurityEventConnection> = Array.from(
+      { length: SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY + 1 },
+      (_value: unknown, index: number): SecurityEventConnection => {
+        return connection(
+          `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+        );
+      },
+    );
+    getJestSpyOn(SecurityEventConnectionService, "findBy").mockResolvedValue(
+      due as never,
+    );
+    const findOneBy: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionService,
+      "findOneBy",
+    ).mockImplementation(
+      async (data: {
+        query: { _id?: unknown };
+      }): Promise<SecurityEventConnection | null> => {
+        return (
+          due.find((item: SecurityEventConnection): boolean => {
+            return item.id!.toString() === String(data.query._id);
+          }) || null
+        );
+      },
+    );
+    let release: (() => void) | undefined;
+    const gate: Promise<void> = new Promise((resolve: () => void): void => {
+      release = resolve;
+    });
+    const pollSpy: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionPoller,
+      "pollConnection",
+    ).mockImplementation(async (): Promise<SecurityEventConnectorResult> => {
+      await gate;
+      return {} as SecurityEventConnectorResult;
+    });
+
+    const sweep: Promise<void> =
+      SecurityEventConnectionPoller.pollAllDueConnections();
+    try {
+      await waitForCallCount(
+        pollSpy,
+        SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY,
+      );
+      jest.setSystemTime(
+        new Date(
+          NOW.getTime() + SECURITY_EVENT_CONNECTION_SWEEP_START_BUDGET_MS,
+        ),
+      );
+    } finally {
+      release?.();
+      await sweep;
+    }
+
+    expect(pollSpy).toHaveBeenCalledTimes(
+      SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY,
+    );
+    expect(findOneBy).toHaveBeenCalledTimes(
+      SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY,
+    );
+  });
+
+  test("rechecks the start budget after acquiring the connection lock", async () => {
+    const startBefore: number =
+      NOW.getTime() + SECURITY_EVENT_CONNECTION_SWEEP_START_BUDGET_MS;
+    const { client, calls }: ClientResult = clientResult();
+    const lockMock: jest.Mock = Semaphore.lock as unknown as jest.Mock;
+    lockMock.mockImplementation(
+      async (data: { namespace: string }): Promise<JSONObject> => {
+        expect(data.namespace).toBe(SECURITY_EVENT_CONNECTION_LOCK_NAMESPACE);
+        jest.setSystemTime(new Date(startBefore));
+        return {};
+      },
+    );
+
+    await expect(
+      SecurityEventConnectionPoller.pollConnection(
+        connection(),
+        client,
+        startBefore,
+      ),
+    ).rejects.toThrow("sweep start budget was exceeded");
+
+    expect(calls).toHaveLength(0);
+    expect(Semaphore.release).toHaveBeenCalledTimes(1);
+  });
+
+  test("skips an overlapping scheduler sweep instead of selecting the same busy rows", async () => {
+    const due: Array<SecurityEventConnection> = Array.from(
+      { length: SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY + 2 },
+      (_value: unknown, index: number): SecurityEventConnection => {
+        return connection(
+          `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+        );
+      },
+    );
+    getJestSpyOn(SecurityEventConnectionService, "findBy").mockResolvedValue(
+      due as never,
+    );
+    mockConnectionDetails(due);
+    let releasePolls: (() => void) | undefined;
+    const pollGate: Promise<void> = new Promise((resolve: () => void): void => {
+      releasePolls = resolve;
+    });
+    const pollSpy: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionPoller,
+      "pollConnection",
+    ).mockImplementation(async (): Promise<SecurityEventConnectorResult> => {
+      await pollGate;
+      return {} as SecurityEventConnectorResult;
+    });
+    const lockMock: jest.Mock = Semaphore.lock as unknown as jest.Mock;
+    let sweepClaims: number = 0;
+    lockMock.mockImplementation(
+      (data: { namespace: string }): Promise<JSONObject> => {
+        if (data.namespace === SECURITY_EVENT_CONNECTION_SWEEP_LOCK_NAMESPACE) {
+          sweepClaims++;
+          if (sweepClaims > 1) {
+            return Promise.reject(
+              new SemaphoreLockTimeoutError("sweep already running"),
+            );
+          }
+        }
+        return Promise.resolve({});
+      },
+    );
+
+    const firstSweep: Promise<void> =
+      SecurityEventConnectionPoller.pollAllDueConnections();
+    try {
+      await waitForCallCount(
+        pollSpy,
+        SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY,
+      );
+      await SecurityEventConnectionPoller.pollAllDueConnections();
+      expect(pollSpy).toHaveBeenCalledTimes(
+        SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY,
+      );
+    } finally {
+      releasePolls?.();
+      await firstSweep;
+    }
+    expect(pollSpy).toHaveBeenCalledTimes(due.length);
+  });
+
+  test("reports sweep lock backend failures", async () => {
+    const lockError: Error = new Error("Redis connection closed");
+    const findBy: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionService,
+      "findBy",
+    ).mockResolvedValue([] as never);
+    getJestSpyOn(Semaphore, "lock").mockRejectedValueOnce(lockError);
+
+    await expect(
+      SecurityEventConnectionPoller.pollAllDueConnections(),
+    ).rejects.toBe(lockError);
+    expect(findBy).not.toHaveBeenCalled();
+  });
+
+  test("pages past the service limit so tail connections remain eligible", async () => {
+    const notDue: SecurityEventConnection = connection();
+    notDue.lastPolledAt = NOW;
+    const due: SecurityEventConnection = connection(
+      "99999999-9999-4999-8999-999999999999",
+    );
+    const findMock: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionService,
+      "findBy",
+    );
+    findMock
+      .mockResolvedValueOnce(Array(LIMIT_MAX).fill(notDue) as never)
+      .mockResolvedValueOnce([due] as never);
+    mockConnectionDetails([due]);
+    const pollSpy: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionPoller,
+      "pollConnection",
+    ).mockResolvedValue({} as never);
+
+    await SecurityEventConnectionPoller.pollAllDueConnections();
+
+    expect(findMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ skip: LIMIT_MAX }),
+    );
+    expect(pollSpy).toHaveBeenCalledWith(
+      due,
+      undefined,
+      NOW.getTime() + SECURITY_EVENT_CONNECTION_SWEEP_START_BUDGET_MS,
+    );
+  });
+
+  test("prioritizes the earliest due time over newly created rows", async () => {
+    const overdue: Array<SecurityEventConnection> = Array.from(
+      { length: SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY },
+      (_value: unknown, index: number): SecurityEventConnection => {
+        const item: SecurityEventConnection = connection(
+          `99999999-9999-4999-8999-${String(index).padStart(12, "0")}`,
+        );
+        item.lastPolledAt = new Date("2026-09-11T11:00:00.000Z");
+        return item;
+      },
+    );
+    const newRows: Array<SecurityEventConnection> = Array.from(
+      { length: SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY },
+      (_value: unknown, index: number): SecurityEventConnection => {
+        const item: SecurityEventConnection = connection(
+          `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+        );
+        item.createdAt = new Date("2026-09-11T11:59:00.000Z");
+        return item;
+      },
+    );
+    getJestSpyOn(SecurityEventConnectionService, "findBy").mockResolvedValue([
+      ...newRows,
+      ...overdue,
+    ] as never);
+    mockConnectionDetails([...newRows, ...overdue]);
+    let releasePolls: (() => void) | undefined;
+    const pollGate: Promise<void> = new Promise((resolve: () => void): void => {
+      releasePolls = resolve;
+    });
+    const pollSpy: jest.SpyInstance = getJestSpyOn(
+      SecurityEventConnectionPoller,
+      "pollConnection",
+    ).mockImplementation(async (): Promise<SecurityEventConnectorResult> => {
+      await pollGate;
+      return {} as SecurityEventConnectorResult;
+    });
+
+    const sweep: Promise<void> =
+      SecurityEventConnectionPoller.pollAllDueConnections();
+    try {
+      await waitForCallCount(
+        pollSpy,
+        SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY,
+      );
+      expect(
+        pollSpy.mock.calls.map(
+          (call: Array<SecurityEventConnection>): SecurityEventConnection => {
+            return call[0]!;
+          },
+        ),
+      ).toEqual(overdue);
+    } finally {
+      releasePolls?.();
+      await sweep;
+    }
+    expect(pollSpy).toHaveBeenCalledTimes(overdue.length + newRows.length);
+  });
+
+  test("drains every never-polled row in one sweep", async () => {
+    const due: Array<SecurityEventConnection> = Array.from(
+      { length: SECURITY_EVENT_CONNECTION_POLL_CONCURRENCY + 3 },
+      (_value: unknown, index: number): SecurityEventConnection => {
+        return connection(
+          `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+        );
+      },
+    );
+    getJestSpyOn(SecurityEventConnectionService, "findBy").mockResolvedValue(
+      due as never,
+    );
+    mockConnectionDetails(due);
+    const polled: Array<string> = [];
+    getJestSpyOn(
+      SecurityEventConnectionPoller,
+      "pollConnection",
+    ).mockImplementation(
+      async (
+        item: SecurityEventConnection,
+      ): Promise<SecurityEventConnectorResult> => {
+        polled.push(item.id!.toString());
+        item.lastPolledAt = NOW;
+        return {} as SecurityEventConnectorResult;
+      },
+    );
+
+    await SecurityEventConnectionPoller.pollAllDueConnections();
+
+    expect(new Set(polled)).toEqual(
+      new Set(
+        due.map((item: SecurityEventConnection): string => {
+          return item.id!.toString();
+        }),
+      ),
+    );
+    expect(polled).toHaveLength(due.length);
+  });
+});

--- a/Common/Tests/Server/Utils/SecurityEvent/Connectors/SecurityEventConnectorClients.test.ts
+++ b/Common/Tests/Server/Utils/SecurityEvent/Connectors/SecurityEventConnectorClients.test.ts
@@ -1,0 +1,994 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { generateKeyPairSync, KeyObject } from "crypto";
+import SecurityEventConnection from "../../../../../Models/DatabaseModels/SecurityEventConnection";
+import {
+  DataSourceHttpRequest,
+  DataSourceHttpResponse,
+} from "../../../../../Server/Utils/DataSource/HttpFetch";
+import AwsSecurityHubClient from "../../../../../Server/Utils/SecurityEvent/Connectors/AwsSecurityHubClient";
+import CloudflareSecurityEventClient from "../../../../../Server/Utils/SecurityEvent/Connectors/CloudflareSecurityEventClient";
+import CrowdStrikeFalconClient from "../../../../../Server/Utils/SecurityEvent/Connectors/CrowdStrikeFalconClient";
+import GoogleSecurityCommandCenterClient from "../../../../../Server/Utils/SecurityEvent/Connectors/GoogleSecurityCommandCenterClient";
+import MicrosoftGraphSecurityClient from "../../../../../Server/Utils/SecurityEvent/Connectors/MicrosoftGraphSecurityClient";
+import OktaSystemLogClient from "../../../../../Server/Utils/SecurityEvent/Connectors/OktaSystemLogClient";
+import SplunkEnterpriseSecurityClient from "../../../../../Server/Utils/SecurityEvent/Connectors/SplunkEnterpriseSecurityClient";
+import {
+  SecurityEventConnectorFetchResult,
+  SecurityEventConnectorHttpRequest,
+} from "../../../../../Server/Utils/SecurityEvent/Connectors/Types";
+import { JSONObject } from "../../../../../Types/JSON";
+
+const startTime: Date = new Date("2026-01-01T00:00:00.000Z");
+const endTime: Date = new Date("2026-01-01T00:01:00.000Z");
+
+interface QueuedRequest {
+  calls: Array<DataSourceHttpRequest>;
+  request: SecurityEventConnectorHttpRequest;
+}
+
+interface GeneratedKeyPair {
+  publicKey: KeyObject;
+  privateKey: KeyObject;
+}
+
+function connection(
+  configuration: JSONObject,
+  credentials: JSONObject,
+): SecurityEventConnection {
+  return {
+    configuration,
+    credentialJson: JSON.stringify(credentials),
+  } as SecurityEventConnection;
+}
+
+function response(
+  bodyJson: unknown,
+  headers?: Record<string, string>,
+  bodyText?: string,
+): DataSourceHttpResponse {
+  return {
+    statusCode: 200,
+    bodyJson,
+    bodyText: bodyText === undefined ? JSON.stringify(bodyJson) : bodyText,
+    headers,
+  };
+}
+
+function queuedRequest(
+  responses: Array<DataSourceHttpResponse>,
+): QueuedRequest {
+  const calls: Array<DataSourceHttpRequest> = [];
+  return {
+    calls,
+    request: async (
+      request: DataSourceHttpRequest,
+    ): Promise<DataSourceHttpResponse> => {
+      calls.push(request);
+      const next: DataSourceHttpResponse | undefined = responses.shift();
+      if (!next) {
+        throw new Error("Unexpected connector request.");
+      }
+      return next;
+    },
+  };
+}
+
+describe("security event connector HTTP clients", () => {
+  test("AWS signs paginated findings requests and returns every page", async () => {
+    const http: QueuedRequest = queuedRequest([
+      response({ Findings: [{ Id: "first" }], NextToken: "page-two" }),
+      response({ Findings: [{ Id: "second" }] }),
+    ]);
+    const client: AwsSecurityHubClient = new AwsSecurityHubClient(
+      connection(
+        { region: "eu-west-2" },
+        {
+          accessKeyId: "test-access-key",
+          secretAccessKey: "test-secret-key",
+          sessionToken: "test-session-token",
+        },
+      ),
+      http.request,
+    );
+
+    const result: SecurityEventConnectorFetchResult = await client.fetchEvents({
+      startTime,
+      endTime,
+    });
+
+    expect(result).toMatchObject({
+      events: [{ Id: "first" }, { Id: "second" }],
+      complete: true,
+      requestCount: 2,
+      warnings: [],
+    });
+    expect(http.calls[0]).toMatchObject({
+      method: "POST",
+      url: "https://securityhub.eu-west-2.amazonaws.com/findings",
+      timeoutInMs: 30_000,
+      headers: {
+        Host: "securityhub.eu-west-2.amazonaws.com",
+        "X-Amz-Security-Token": "test-session-token",
+      },
+    });
+    expect(http.calls[0]?.headers?.["Authorization"]).toContain(
+      "Credential=test-access-key/",
+    );
+    expect(http.calls[0]?.headers?.["Authorization"]).not.toContain(
+      "test-secret-key",
+    );
+    expect(JSON.parse(http.calls[1]?.body as string)).toMatchObject({
+      NextToken: "page-two",
+    });
+  });
+
+  test.each([
+    [
+      "commercial",
+      "eu-west-2",
+      "securityhub.eu-west-2.amazonaws.com",
+      "5effdab30cf77931a3d23ae06848d5e747a9511cfe445b78560861e1b85237ea",
+    ],
+    [
+      "GovCloud",
+      "us-gov-west-1",
+      "securityhub.us-gov-west-1.amazonaws.com",
+      "22f3cb6daf50f76586bad453e7486b3e083734678e8115452315e95c20982afd",
+    ],
+    [
+      "China",
+      "cn-north-1",
+      "securityhub.cn-north-1.amazonaws.com.cn",
+      "8bda7af50a1479ecadd38a8d033fd223757c8768519f6d545f74ee48cbd083b0",
+    ],
+  ])(
+    "AWS uses the %s partition endpoint and signs its exact host",
+    async (
+      _partition: string,
+      region: string,
+      hostname: string,
+      signature: string,
+    ) => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2026-01-02T03:04:05.000Z"));
+      try {
+        const http: QueuedRequest = queuedRequest([response({ Findings: [] })]);
+        const client: AwsSecurityHubClient = new AwsSecurityHubClient(
+          connection(
+            { region },
+            {
+              accessKeyId: "partition-access-key",
+              secretAccessKey: "partition-secret",
+            },
+          ),
+          http.request,
+        );
+
+        await client.fetchEvents({ startTime, endTime });
+
+        expect(http.calls[0]).toMatchObject({
+          method: "POST",
+          url: `https://${hostname}/findings`,
+          headers: {
+            Host: hostname,
+            "X-Amz-Date": "20260102T030405Z",
+            Authorization:
+              `AWS4-HMAC-SHA256 Credential=partition-access-key/20260102/${region}/securityhub/aws4_request, ` +
+              `SignedHeaders=content-type;host;x-amz-date, Signature=${signature}`,
+          },
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    },
+  );
+
+  test("AWS reports incomplete after its bounded page limit", async () => {
+    const http: QueuedRequest = queuedRequest(
+      Array.from(
+        { length: 10 },
+        (_: unknown, index: number): DataSourceHttpResponse => {
+          return response({
+            Findings: [{ Id: String(index) }],
+            NextToken: "more",
+          });
+        },
+      ),
+    );
+    const client: AwsSecurityHubClient = new AwsSecurityHubClient(
+      connection(
+        { region: "us-east-1" },
+        { accessKeyId: "id", secretAccessKey: "key" },
+      ),
+      http.request,
+    );
+
+    const result: SecurityEventConnectorFetchResult = await client.fetchEvents({
+      startTime,
+      endTime,
+    });
+
+    expect(result.complete).toBe(false);
+    expect(result.events).toHaveLength(10);
+    expect(result.continuation).toEqual({ nextToken: "more" });
+    expect(result.warnings[0]).toContain("more pages");
+  });
+
+  test("Cloudflare sends its GraphQL time range, splits full windows, and keeps results", async () => {
+    const fullBatch: Array<JSONObject> = Array.from(
+      { length: 1000 },
+      (_: unknown, index: number): JSONObject => {
+        return { rayName: String(index) };
+      },
+    );
+    const http: QueuedRequest = queuedRequest([
+      response({
+        data: { viewer: { zones: [{ firewallEventsAdaptive: fullBatch }] } },
+      }),
+      response({
+        data: {
+          viewer: {
+            zones: [{ firewallEventsAdaptive: [{ rayName: "left" }] }],
+          },
+        },
+      }),
+      response({
+        data: {
+          viewer: {
+            zones: [{ firewallEventsAdaptive: [{ rayName: "right" }] }],
+          },
+        },
+      }),
+    ]);
+    const client: CloudflareSecurityEventClient =
+      new CloudflareSecurityEventClient(
+        connection(
+          { accountId: "account", zoneId: "zone" },
+          { apiToken: "cf-token" },
+        ),
+        http.request,
+      );
+
+    const result: SecurityEventConnectorFetchResult = await client.fetchEvents({
+      startTime,
+      endTime,
+    });
+    const firstBody: JSONObject = JSON.parse(
+      http.calls[0]?.body as string,
+    ) as JSONObject;
+
+    expect(result).toMatchObject({
+      complete: true,
+      requestCount: 3,
+      warnings: [],
+    });
+    expect(result.events).toEqual([{ rayName: "left" }, { rayName: "right" }]);
+    expect(http.calls[0]).toMatchObject({
+      method: "POST",
+      url: "https://api.cloudflare.com/client/v4/graphql",
+      headers: { Authorization: "Bearer cf-token" },
+    });
+    expect(firstBody).toMatchObject({
+      variables: {
+        zoneTag: "zone",
+        filter: {
+          datetime_geq: startTime.toISOString(),
+          datetime_lt: endTime.toISOString(),
+        },
+      },
+    });
+  });
+
+  test("Cloudflare makes a one-second full result window explicitly incomplete", async () => {
+    const http: QueuedRequest = queuedRequest([
+      response({
+        data: {
+          viewer: {
+            zones: [
+              {
+                firewallEventsAdaptive: Array.from({ length: 1000 }, () => {
+                  return {};
+                }),
+              },
+            ],
+          },
+        },
+      }),
+    ]);
+    const client: CloudflareSecurityEventClient =
+      new CloudflareSecurityEventClient(
+        connection(
+          { accountId: "account", zoneId: "zone" },
+          { apiToken: "token" },
+        ),
+        http.request,
+      );
+
+    const result: SecurityEventConnectorFetchResult = await client.fetchEvents({
+      startTime,
+      endTime: new Date(startTime.getTime() + 1000),
+    });
+
+    expect(result).toMatchObject({ complete: false, requestCount: 1 });
+    expect(result.warnings[0]).toContain("may be truncated");
+  });
+
+  test("Cloudflare surfaces GraphQL error bodies", async () => {
+    const http: QueuedRequest = queuedRequest([
+      response({ errors: [{ message: "denied" }] }),
+    ]);
+    const client: CloudflareSecurityEventClient =
+      new CloudflareSecurityEventClient(
+        connection(
+          { accountId: "account", zoneId: "zone" },
+          { apiToken: "token" },
+        ),
+        http.request,
+      );
+
+    await expect(client.fetchEvents({ startTime, endTime })).rejects.toThrow(
+      "denied",
+    );
+  });
+
+  test("CrowdStrike exchanges credentials once and fetches a stable ID page", async () => {
+    const http: QueuedRequest = queuedRequest([
+      response({ access_token: "falcon-access-token" }),
+      response({
+        resources: ["a", "b", "c"],
+        meta: { pagination: { total: 3 } },
+      }),
+      response({
+        resources: [
+          { composite_id: "a" },
+          { composite_id: "b" },
+          { composite_id: "c" },
+        ],
+      }),
+    ]);
+    const client: CrowdStrikeFalconClient = new CrowdStrikeFalconClient(
+      connection({}, { clientId: "client-id", clientSecret: "client-secret" }),
+      http.request,
+    );
+
+    const result: SecurityEventConnectorFetchResult = await client.fetchEvents({
+      startTime,
+      endTime,
+    });
+
+    expect(result).toMatchObject({
+      complete: true,
+      requestCount: 3,
+      warnings: [],
+    });
+    expect(result.events).toHaveLength(3);
+    expect(http.calls[0]).toMatchObject({
+      method: "POST",
+      url: "https://api.crowdstrike.com/oauth2/token",
+      formUrlEncoded: true,
+      body: { client_id: "client-id", client_secret: "client-secret" },
+    });
+    expect(http.calls[1]?.headers?.["Authorization"]).toBe(
+      "Bearer falcon-access-token",
+    );
+    expect(http.calls[1]?.url).toContain("offset=0");
+    expect(new URL(http.calls[1]!.url).searchParams.get("sort")).toBeNull();
+    expect(
+      http.calls
+        .slice(1)
+        .map((call: DataSourceHttpRequest): string => {
+          return JSON.stringify(call);
+        })
+        .join("\n"),
+    ).not.toContain("client-secret");
+  });
+
+  test("CrowdStrike treats a bounded alert-ID query as incomplete", async () => {
+    const http: QueuedRequest = queuedRequest([
+      response({ access_token: "token" }),
+      response({
+        resources: ["id-0"],
+        meta: { pagination: { total: 21 } },
+      }),
+      response({
+        resources: [{ composite_id: "id-0" }],
+      }),
+    ]);
+    const client: CrowdStrikeFalconClient = new CrowdStrikeFalconClient(
+      connection({}, { clientId: "id", clientSecret: "secret" }),
+      http.request,
+    );
+
+    const result: SecurityEventConnectorFetchResult = await client.fetchEvents({
+      startTime,
+      endTime,
+    });
+
+    expect(result).toMatchObject({ complete: false, requestCount: 3 });
+    expect(result.continuation).toBeUndefined();
+    expect(result.warnings.join(" ")).toContain("without mutable offset");
+  });
+
+  test("Google SCC exchanges a signed assertion and follows page tokens", async () => {
+    const keys: GeneratedKeyPair = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+    });
+    const privateKey: string = keys.privateKey
+      .export({ type: "pkcs1", format: "pem" })
+      .toString();
+    const http: QueuedRequest = queuedRequest([
+      response({ access_token: "google-token" }),
+      response({
+        listFindingsResults: [
+          { finding: { name: "first" }, resource: { name: "resource" } },
+        ],
+        nextPageToken: "next-page",
+      }),
+      response({ listFindingsResults: [{ finding: { name: "second" } }] }),
+    ]);
+    const client: GoogleSecurityCommandCenterClient =
+      new GoogleSecurityCommandCenterClient(
+        connection(
+          { parent: "organizations/123/sources/-" },
+          { client_email: "service@example.test", private_key: privateKey },
+        ),
+        http.request,
+      );
+
+    const result: SecurityEventConnectorFetchResult = await client.fetchEvents({
+      startTime,
+      endTime,
+    });
+
+    expect(result).toMatchObject({
+      complete: true,
+      requestCount: 3,
+      warnings: [],
+    });
+    expect(result.events).toEqual([
+      { finding: { name: "first" }, resource: { name: "resource" } },
+      { finding: { name: "second" } },
+    ]);
+    expect(http.calls[0]).toMatchObject({
+      method: "POST",
+      url: "https://oauth2.googleapis.com/token",
+      formUrlEncoded: true,
+      body: { grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer" },
+    });
+    expect(http.calls[1]?.headers?.["Authorization"]).toBe(
+      "Bearer google-token",
+    );
+    expect(new URL(http.calls[1]!.url).searchParams.get("filter")).toBe(
+      `eventTime >= "${startTime.toISOString()}" AND eventTime < "${endTime.toISOString()}"`,
+    );
+    expect(new URL(http.calls[1]!.url).searchParams.get("orderBy")).toBe(
+      "eventTime asc",
+    );
+    expect(http.calls[2]?.url).toContain("pageToken=next-page");
+  });
+
+  test("Microsoft includes paged alerts and incidents", async () => {
+    const http: QueuedRequest = queuedRequest([
+      response({ access_token: "graph-token" }),
+      response({
+        value: [{ id: "alert-one" }],
+        "@odata.nextLink":
+          "https://graph.microsoft.com/v1.0/security/alerts_v2?$skiptoken=two",
+      }),
+      response({ value: [{ id: "alert-two", "@odata.type": "provided" }] }),
+      response({ value: [{ id: "incident-one" }] }),
+    ]);
+    const client: MicrosoftGraphSecurityClient =
+      new MicrosoftGraphSecurityClient(
+        connection(
+          { tenantId: "tenant/with slash" },
+          { clientId: "client", clientSecret: "secret" },
+        ),
+        http.request,
+      );
+
+    const result: SecurityEventConnectorFetchResult = await client.fetchEvents({
+      startTime,
+      endTime,
+    });
+
+    expect(result).toMatchObject({
+      complete: true,
+      requestCount: 4,
+      warnings: [],
+    });
+    expect(result.events).toEqual([
+      { id: "alert-one", "@odata.type": "#microsoft.graph.security.alert" },
+      { id: "alert-two", "@odata.type": "provided" },
+      {
+        id: "incident-one",
+        "@odata.type": "#microsoft.graph.security.incident",
+      },
+    ]);
+    expect(http.calls[0]?.url).toContain("tenant%2Fwith%20slash");
+    expect(http.calls[1]?.url).toContain("%24filter=");
+    expect(http.calls[2]?.url).toContain("$skiptoken=two");
+    expect(
+      http.calls
+        .slice(1)
+        .map((call: DataSourceHttpRequest): string => {
+          return JSON.stringify(call);
+        })
+        .join("\n"),
+    ).not.toContain("secret");
+  });
+
+  test("Microsoft stops before calling an unsafe pagination URL", async () => {
+    const http: QueuedRequest = queuedRequest([
+      response({ access_token: "token" }),
+      response({
+        value: [],
+        "@odata.nextLink": "https://attacker.example/v1.0/security/alerts_v2",
+      }),
+    ]);
+    const client: MicrosoftGraphSecurityClient =
+      new MicrosoftGraphSecurityClient(
+        connection(
+          { tenantId: "tenant" },
+          { clientId: "client", clientSecret: "secret" },
+        ),
+        http.request,
+      );
+
+    await expect(client.fetchEvents({ startTime, endTime })).rejects.toThrow(
+      "unsafe pagination URL",
+    );
+    expect(http.calls).toHaveLength(2);
+  });
+
+  test("Okta saves its ascending polling link without a bounded until filter", async () => {
+    const pages: Array<DataSourceHttpResponse> = Array.from(
+      { length: 10 },
+      (_: unknown, index: number): DataSourceHttpResponse => {
+        return response([{ uuid: String(index) }], {
+          link: '<https://okta.example/api/v1/logs?after=more>; rel="next"',
+        });
+      },
+    );
+    const http: QueuedRequest = queuedRequest(pages);
+    const client: OktaSystemLogClient = new OktaSystemLogClient(
+      connection(
+        { baseUrl: "https://okta.example/tenant" },
+        { apiToken: "okta-token" },
+      ),
+      http.request,
+    );
+
+    const result: SecurityEventConnectorFetchResult = await client.fetchEvents({
+      startTime,
+      endTime,
+    });
+
+    expect(result).toMatchObject({
+      complete: true,
+      requestCount: 10,
+      continuation: {
+        nextUrl: "https://okta.example/api/v1/logs?after=more",
+      },
+    });
+    expect(result.events).toHaveLength(10);
+    expect(result.warnings[0]).toContain("next polling link was saved");
+    expect(http.calls[0]).toMatchObject({
+      headers: { Authorization: "SSWS okta-token" },
+    });
+    expect(http.calls[0]?.url).toContain("sortOrder=ASCENDING");
+    expect(http.calls[0]?.url).toContain(
+      `since=${encodeURIComponent(startTime.toISOString())}`,
+    );
+    expect(http.calls[0]?.url).not.toContain("until=");
+  });
+
+  test("Okta resumes the exact provider polling link so delayed events remain eligible", async () => {
+    const savedNextUrl: string =
+      "https://okta.example/api/v1/logs?after=saved-provider-cursor";
+    const nextUrl: string =
+      "https://okta.example/api/v1/logs?after=next-provider-cursor";
+    const http: QueuedRequest = queuedRequest([
+      response([], { link: `<${nextUrl}>; rel="next"` }),
+    ]);
+    const client: OktaSystemLogClient = new OktaSystemLogClient(
+      connection({ baseUrl: "https://okta.example" }, { apiToken: "token" }),
+      http.request,
+    );
+
+    const result: SecurityEventConnectorFetchResult = await client.fetchEvents({
+      startTime,
+      endTime,
+      continuation: { nextUrl: savedNextUrl },
+    });
+
+    expect(http.calls[0]?.url).toBe(savedNextUrl);
+    expect(result).toMatchObject({
+      complete: true,
+      continuation: { nextUrl },
+    });
+  });
+
+  test("Okta stops before calling a pagination link from another origin", async () => {
+    const http: QueuedRequest = queuedRequest([
+      response([], {
+        link: '<https://attacker.example/api/v1/logs?after=bad>; rel="next"',
+      }),
+    ]);
+    const client: OktaSystemLogClient = new OktaSystemLogClient(
+      connection({ baseUrl: "https://okta.example" }, { apiToken: "token" }),
+      http.request,
+    );
+
+    await expect(client.fetchEvents({ startTime, endTime })).rejects.toThrow(
+      "unsafe pagination URL",
+    );
+    expect(http.calls).toHaveLength(1);
+  });
+
+  test("Splunk parses streaming export records and makes its 1,000-result ceiling visible", async () => {
+    const fullExport: string = `${'{"result":{"id":"one"}}\n'}${'{"results":[{"id":"two"},{"id":"three"}]}\n'}`;
+    const http: QueuedRequest = queuedRequest([
+      response(undefined, undefined, fullExport),
+    ]);
+    const client: SplunkEnterpriseSecurityClient =
+      new SplunkEnterpriseSecurityClient(
+        connection(
+          {
+            baseUrl: "https://splunk.example:8089",
+            search: "search index=main",
+          },
+          { apiToken: "splunk-token" },
+        ),
+        http.request,
+      );
+
+    const result: SecurityEventConnectorFetchResult = await client.fetchEvents({
+      startTime,
+      endTime,
+    });
+
+    expect(result).toMatchObject({
+      events: [{ id: "one" }, { id: "two" }, { id: "three" }],
+      complete: true,
+      requestCount: 1,
+    });
+    expect(http.calls[0]).toMatchObject({
+      method: "POST",
+      url: "https://splunk.example:8089/services/search/v2/jobs/export",
+      formUrlEncoded: true,
+      headers: { Authorization: "Bearer splunk-token" },
+      body: {
+        search: "search index=main",
+        earliest_time: startTime.toISOString(),
+        latest_time: endTime.toISOString(),
+        max_count: "1000",
+      },
+    });
+
+    const cappedHttp: QueuedRequest = queuedRequest([
+      response(undefined, undefined, '{"result":{"id":"x"}}\n'.repeat(1_000)),
+    ]);
+    const cappedClient: SplunkEnterpriseSecurityClient =
+      new SplunkEnterpriseSecurityClient(
+        connection(
+          { baseUrl: "https://splunk.example" },
+          { apiToken: "token" },
+        ),
+        cappedHttp.request,
+      );
+    const cappedResult: SecurityEventConnectorFetchResult =
+      await cappedClient.fetchEvents({ startTime, endTime });
+    expect(cappedResult).toMatchObject({ complete: false, requestCount: 1 });
+    expect(cappedResult.warnings[0]).toContain("1,000-result ceiling");
+  });
+
+  test("Splunk supports session-key and basic authentication", async () => {
+    const sessionHttp: QueuedRequest = queuedRequest([
+      response(undefined, undefined, '{"result":{"id":"one"}}\n'),
+    ]);
+    const sessionClient: SplunkEnterpriseSecurityClient =
+      new SplunkEnterpriseSecurityClient(
+        connection(
+          { baseUrl: "https://splunk.example" },
+          { apiToken: "session-key", tokenScheme: "Splunk" },
+        ),
+        sessionHttp.request,
+      );
+    await sessionClient.fetchEvents({ startTime, endTime });
+    expect(sessionHttp.calls[0]?.headers).toMatchObject({
+      Authorization: "Splunk session-key",
+    });
+
+    const basicHttp: QueuedRequest = queuedRequest([
+      response(undefined, undefined, '{"result":{"id":"two"}}\n'),
+    ]);
+    const basicClient: SplunkEnterpriseSecurityClient =
+      new SplunkEnterpriseSecurityClient(
+        connection(
+          { baseUrl: "https://splunk.example" },
+          { username: "reader", password: "secret" },
+        ),
+        basicHttp.request,
+      );
+    await basicClient.fetchEvents({ startTime, endTime });
+    expect(basicHttp.calls[0]?.headers).toMatchObject({
+      Authorization: `Basic ${Buffer.from("reader:secret").toString("base64")}`,
+    });
+  });
+
+  test("Splunk reports malformed export error bodies", async () => {
+    const http: QueuedRequest = queuedRequest([
+      response(undefined, undefined, "not json\n"),
+    ]);
+    const client: SplunkEnterpriseSecurityClient =
+      new SplunkEnterpriseSecurityClient(
+        connection(
+          { baseUrl: "https://splunk.example" },
+          { apiToken: "token" },
+        ),
+        http.request,
+      );
+
+    await expect(client.fetchEvents({ startTime, endTime })).rejects.toThrow(
+      "non-JSON result line",
+    );
+  });
+
+  test("AWS resumes a saved page token and rejects mixed findings arrays", async () => {
+    const resumeHttp: QueuedRequest = queuedRequest([
+      response({ Findings: [] }),
+    ]);
+    const resumeClient: AwsSecurityHubClient = new AwsSecurityHubClient(
+      connection(
+        { region: "us-east-1" },
+        { accessKeyId: "id", secretAccessKey: "secret" },
+      ),
+      resumeHttp.request,
+    );
+    await resumeClient.fetchEvents({
+      startTime,
+      endTime,
+      continuation: { nextToken: "saved-token" },
+    });
+    expect(JSON.parse(String(resumeHttp.calls[0]?.body))).toMatchObject({
+      NextToken: "saved-token",
+    });
+
+    const malformedHttp: QueuedRequest = queuedRequest([
+      response({ Findings: [{ Id: "one" }, "bad-member"] }),
+    ]);
+    const malformedClient: AwsSecurityHubClient = new AwsSecurityHubClient(
+      connection(
+        { region: "us-east-1" },
+        { accessKeyId: "id", secretAccessKey: "secret" },
+      ),
+      malformedHttp.request,
+    );
+    await expect(
+      malformedClient.fetchEvents({ startTime, endTime }),
+    ).rejects.toThrow("non-object result array member");
+  });
+
+  test("Cloudflare rejects invisible zones and malformed event members", async () => {
+    const missingZoneHttp: QueuedRequest = queuedRequest([
+      response({ data: { viewer: { zones: [] } } }),
+    ]);
+    const missingZoneClient: CloudflareSecurityEventClient =
+      new CloudflareSecurityEventClient(
+        connection(
+          { accountId: "account", zoneId: "missing" },
+          { apiToken: "token" },
+        ),
+        missingZoneHttp.request,
+      );
+    await expect(
+      missingZoneClient.fetchEvents({ startTime, endTime }),
+    ).rejects.toThrow("no matching zone");
+
+    const malformedHttp: QueuedRequest = queuedRequest([
+      response({
+        data: {
+          viewer: {
+            zones: [{ firewallEventsAdaptive: [{ rayName: "one" }, 7] }],
+          },
+        },
+      }),
+    ]);
+    const malformedClient: CloudflareSecurityEventClient =
+      new CloudflareSecurityEventClient(
+        connection(
+          { accountId: "account", zoneId: "zone" },
+          { apiToken: "token" },
+        ),
+        malformedHttp.request,
+      );
+    await expect(
+      malformedClient.fetchEvents({ startTime, endTime }),
+    ).rejects.toThrow("non-object result array member");
+  });
+
+  test("CrowdStrike surfaces API errors and detects exact missing entities", async () => {
+    const errorHttp: QueuedRequest = queuedRequest([
+      response({ access_token: "token" }),
+      response({
+        resources: [],
+        errors: [{ code: "403", message: "denied" }],
+      }),
+    ]);
+    const errorClient: CrowdStrikeFalconClient = new CrowdStrikeFalconClient(
+      connection({}, { clientId: "id", clientSecret: "secret" }),
+      errorHttp.request,
+    );
+    await expect(
+      errorClient.fetchEvents({ startTime, endTime }),
+    ).rejects.toThrow("403: denied");
+
+    const partialHttp: QueuedRequest = queuedRequest([
+      response({ access_token: "token" }),
+      response({
+        resources: ["a", "b"],
+        meta: { pagination: { total: 2 } },
+      }),
+      response({
+        resources: [{ composite_id: "a" }, { composite_id: "other" }],
+      }),
+    ]);
+    const partialClient: CrowdStrikeFalconClient = new CrowdStrikeFalconClient(
+      connection({}, { clientId: "id", clientSecret: "secret" }),
+      partialHttp.request,
+    );
+    const partialResult: SecurityEventConnectorFetchResult =
+      await partialClient.fetchEvents({
+        startTime,
+        endTime,
+      });
+    expect(partialResult.complete).toBe(false);
+    expect(partialResult.continuation).toBeUndefined();
+    expect(partialResult.warnings.join(" ")).toContain("omitted 1");
+  });
+
+  test("Microsoft, Google, and Okta reject malformed result containers", async () => {
+    const microsoftHttp: QueuedRequest = queuedRequest([
+      response({ access_token: "token" }),
+      response({ value: { id: "not-an-array" } }),
+    ]);
+    const microsoftClient: MicrosoftGraphSecurityClient =
+      new MicrosoftGraphSecurityClient(
+        connection(
+          { tenantId: "tenant" },
+          { clientId: "id", clientSecret: "secret" },
+        ),
+        microsoftHttp.request,
+      );
+    await expect(
+      microsoftClient.fetchEvents({ startTime, endTime }),
+    ).rejects.toThrow("invalid result array");
+
+    const keys: GeneratedKeyPair = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+    });
+    const privateKey: string = keys.privateKey
+      .export({ type: "pkcs1", format: "pem" })
+      .toString();
+    const googleHttp: QueuedRequest = queuedRequest([
+      response({ access_token: "token" }),
+      response({ listFindingsResults: [{ finding: {} }, false] }),
+    ]);
+    const googleClient: GoogleSecurityCommandCenterClient =
+      new GoogleSecurityCommandCenterClient(
+        connection(
+          { parent: "organizations/123/sources/-" },
+          { client_email: "service@example.test", private_key: privateKey },
+        ),
+        googleHttp.request,
+      );
+    await expect(
+      googleClient.fetchEvents({ startTime, endTime }),
+    ).rejects.toThrow("non-object result array member");
+
+    const oktaHttp: QueuedRequest = queuedRequest([
+      response({ uuid: "not-an-array" }),
+    ]);
+    const oktaClient: OktaSystemLogClient = new OktaSystemLogClient(
+      connection({ baseUrl: "https://okta.example" }, { apiToken: "token" }),
+      oktaHttp.request,
+    );
+    await expect(
+      oktaClient.fetchEvents({ startTime, endTime }),
+    ).rejects.toThrow("invalid result array");
+  });
+
+  test("Splunk surfaces search messages and rejects mixed result arrays", async () => {
+    const errorHttp: QueuedRequest = queuedRequest([
+      response(
+        undefined,
+        undefined,
+        '{"messages":[{"type":"ERROR","text":"search denied"}]}\n',
+      ),
+    ]);
+    const errorClient: SplunkEnterpriseSecurityClient =
+      new SplunkEnterpriseSecurityClient(
+        connection(
+          { baseUrl: "https://splunk.example" },
+          { apiToken: "token" },
+        ),
+        errorHttp.request,
+      );
+    await expect(
+      errorClient.fetchEvents({ startTime, endTime }),
+    ).rejects.toThrow("search denied");
+
+    const warningHttp: QueuedRequest = queuedRequest([
+      response(
+        undefined,
+        undefined,
+        '{"messages":[{"type":"WARN","text":"partial index"}],"result":{"id":"one"}}\n',
+      ),
+    ]);
+    const warningClient: SplunkEnterpriseSecurityClient =
+      new SplunkEnterpriseSecurityClient(
+        connection(
+          { baseUrl: "https://splunk.example" },
+          { apiToken: "token" },
+        ),
+        warningHttp.request,
+      );
+    const warningResult: SecurityEventConnectorFetchResult =
+      await warningClient.fetchEvents({
+        startTime,
+        endTime,
+      });
+    expect(warningResult.warnings).toContain(
+      "Splunk search warning: partial index",
+    );
+
+    const malformedHttp: QueuedRequest = queuedRequest([
+      response(undefined, undefined, '{"results":[{"id":"one"},3]}\n'),
+    ]);
+    const malformedClient: SplunkEnterpriseSecurityClient =
+      new SplunkEnterpriseSecurityClient(
+        connection(
+          { baseUrl: "https://splunk.example" },
+          { apiToken: "token" },
+        ),
+        malformedHttp.request,
+      );
+    await expect(
+      malformedClient.fetchEvents({ startTime, endTime }),
+    ).rejects.toThrow("non-object result array member");
+  });
+
+  test("forwards cancellation signals through provider and identity requests", async () => {
+    const controller: AbortController = new AbortController();
+    const awsHttp: QueuedRequest = queuedRequest([response({ Findings: [] })]);
+    await new AwsSecurityHubClient(
+      connection(
+        { region: "us-east-1" },
+        { accessKeyId: "id", secretAccessKey: "secret" },
+      ),
+      awsHttp.request,
+    ).fetchEvents({ startTime, endTime, signal: controller.signal });
+
+    const microsoftHttp: QueuedRequest = queuedRequest([
+      response({ access_token: "token" }),
+      response({ value: [] }),
+      response({ value: [] }),
+    ]);
+    await new MicrosoftGraphSecurityClient(
+      connection(
+        { tenantId: "tenant" },
+        { clientId: "id", clientSecret: "secret" },
+      ),
+      microsoftHttp.request,
+    ).fetchEvents({ startTime, endTime, signal: controller.signal });
+
+    expect(
+      [...awsHttp.calls, ...microsoftHttp.calls].every(
+        (call: DataSourceHttpRequest): boolean => {
+          return call.signal === controller.signal;
+        },
+      ),
+    ).toBe(true);
+  });
+});

--- a/Common/Tests/Utils/SecurityEvent/Vendor/AwsSecurityHubNormalizer.test.ts
+++ b/Common/Tests/Utils/SecurityEvent/Vendor/AwsSecurityHubNormalizer.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, test } from "@jest/globals";
+import { JSONObject } from "../../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity from "../../../../Types/SecurityEvent/OcsfSeverity";
+import AwsSecurityHubNormalizer from "../../../../Utils/SecurityEvent/Vendor/AwsSecurityHubNormalizer";
+
+describe("AwsSecurityHubNormalizer", () => {
+  function finding(): JSONObject {
+    return {
+      SchemaVersion: "2018-10-08",
+      Id: "arn:aws:securityhub:eu-west-1:123:finding/f-1",
+      ProductArn: "arn:aws:securityhub:eu-west-1::product/aws/guardduty",
+      AwsAccountId: "123456789012",
+      GeneratorId: "guardduty-detector-1",
+      CompanyName: "Amazon",
+      ProductName: "GuardDuty",
+      Title: "Unusual API calls from an EC2 instance",
+      Description: "An instance called an unusual API.",
+      Types: ["TTPs/Command and Control"],
+      CreatedAt: "2026-01-01T10:00:00Z",
+      UpdatedAt: "2026-01-01T11:00:00Z",
+      LastObservedAt: "2026-01-01T12:00:00Z",
+      Severity: { Label: "HIGH", Normalized: 80 },
+      Workflow: { Status: "NEW" },
+      Resources: [
+        {
+          Type: "AwsEc2Instance",
+          Id: "arn:aws:ec2:eu-west-1:123:instance/i-target",
+          ResourceRole: "Target",
+        },
+        {
+          Type: "AwsIamRole",
+          Id: "arn:aws:iam::123:role/suspicious-actor",
+          ResourceRole: "Actor",
+        },
+      ],
+      Network: {
+        SourceIpV4: "198.51.100.4",
+        SourceDomain: "scanner.example",
+        DestinationIpV4: "10.0.0.8",
+        DestinationDomain: "api.internal.example",
+        DestinationPort: 443,
+      },
+      Process: { Name: "curl" },
+      ThreatIntelIndicators: [{ Type: "IPV4_ADDRESS", Value: "203.0.113.9" }],
+      Threats: [
+        {
+          Name: "Example.Backdoor",
+          FilePaths: [
+            {
+              FileName: "backdoor",
+              Hash: "sha256:abc123",
+              ResourceId: "volume-1",
+            },
+          ],
+        },
+      ],
+      ProductFields: {
+        mitreTactic: "TA0011",
+        mitreTechnique: "T1071.001",
+      },
+    };
+  }
+
+  test("detects direct ASFF findings and common delivery envelopes", () => {
+    expect(AwsSecurityHubNormalizer.isAwsSecurityHubFinding(finding())).toBe(
+      true,
+    );
+    expect(
+      AwsSecurityHubNormalizer.isAwsSecurityHubFinding({
+        "detail-type": "Security Hub Findings - Imported",
+        detail: { findings: [finding()] },
+      }),
+    ).toBe(true);
+    expect(
+      AwsSecurityHubNormalizer.isAwsSecurityHubFinding({
+        Findings: [finding()],
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects unrelated AWS-shaped payloads", () => {
+    expect(
+      AwsSecurityHubNormalizer.isAwsSecurityHubFinding({
+        AwsAccountId: "123",
+        message: "ordinary event",
+      }),
+    ).toBe(false);
+  });
+
+  test("maps the ASFF finding identity, classification, and provenance", () => {
+    const result: NormalizedSecurityEvent =
+      AwsSecurityHubNormalizer.normalize(finding());
+
+    expect(result).toMatchObject({
+      eventUid:
+        "arn:aws:securityhub:eu-west-1::product/aws/guardduty|arn:aws:securityhub:eu-west-1:123:finding/f-1",
+      categoryUid: 2,
+      categoryName: "Findings",
+      classUid: 2004,
+      className: "Detection Finding",
+      activityName: "Create",
+      severityId: 4,
+      severityName: OcsfSeverity.High,
+      statusName: "NEW",
+      message: "Unusual API calls from an EC2 instance",
+      vendorName: "Amazon",
+      productName: "GuardDuty",
+      ruleId: "guardduty-detector-1",
+      ruleName: "Unusual API calls from an EC2 instance",
+    });
+    expect(result.time.toISOString()).toBe("2026-01-01T12:00:00.000Z");
+  });
+
+  test("scopes finding identity by product ARN", () => {
+    const first: JSONObject = finding();
+    const second: JSONObject = {
+      ...finding(),
+      ProductArn:
+        "arn:aws:securityhub:eu-west-1::product/partner/different-product",
+    };
+
+    expect(AwsSecurityHubNormalizer.normalize(first).eventUid).not.toBe(
+      AwsSecurityHubNormalizer.normalize(second).eventUid,
+    );
+  });
+
+  test("extracts network, process, resource, threat, and MITRE context", () => {
+    const result: NormalizedSecurityEvent =
+      AwsSecurityHubNormalizer.normalize(finding());
+
+    expect(result.principalUser).toBe("arn:aws:iam::123:role/suspicious-actor");
+    expect(result.principalHost).toBe("scanner.example");
+    expect(result.principalIp).toBe("198.51.100.4");
+    expect(result.principalProcess).toBe("curl");
+    expect(result.targetHost).toBe("api.internal.example");
+    expect(result.targetIp).toBe("10.0.0.8");
+    expect(result.targetPort).toBe(443);
+    expect(result.targetResource).toBe(
+      "arn:aws:ec2:eu-west-1:123:instance/i-target",
+    );
+    expect(result.mitreTactics).toEqual(["TA0011"]);
+    expect(result.mitreTechniques).toEqual(["T1071.001"]);
+    expect(result.observables).toEqual(
+      expect.arrayContaining([
+        "198.51.100.4",
+        "api.internal.example",
+        "203.0.113.9",
+        "Example.Backdoor",
+        "sha256:abc123",
+        "backdoor",
+        "volume-1",
+      ]),
+    );
+  });
+
+  test("retains the complete EventBridge envelope in attributes", () => {
+    const result: NormalizedSecurityEvent = AwsSecurityHubNormalizer.normalize({
+      id: "eventbridge-id",
+      "detail-type": "Security Hub Findings - Imported",
+      detail: { findings: [finding()] },
+    });
+
+    expect(result.eventUid).toContain("finding/f-1");
+    expect(result.attributes["id"]).toBe("eventbridge-id");
+    expect(result.attributes["detail.findings.0.Title"]).toBe(
+      "Unusual API calls from an EC2 instance",
+    );
+  });
+
+  test.each<[number, OcsfSeverity]>([
+    [0, OcsfSeverity.Informational],
+    [1, OcsfSeverity.Low],
+    [39, OcsfSeverity.Low],
+    [40, OcsfSeverity.Medium],
+    [69, OcsfSeverity.Medium],
+    [70, OcsfSeverity.High],
+    [89, OcsfSeverity.High],
+    [90, OcsfSeverity.Critical],
+    [100, OcsfSeverity.Critical],
+  ])(
+    "maps ASFF normalized severity %i",
+    (score: number, expected: OcsfSeverity) => {
+      const payload: JSONObject = finding();
+      payload["Severity"] = { Normalized: score };
+
+      expect(AwsSecurityHubNormalizer.normalize(payload).severityName).toBe(
+        expected,
+      );
+    },
+  );
+
+  test("uses provider severity when the mutable top-level severity is absent", () => {
+    const payload: JSONObject = finding();
+    payload["Severity"] = undefined;
+    payload["FindingProviderFields"] = { Severity: { Label: "CRITICAL" } };
+
+    expect(AwsSecurityHubNormalizer.normalize(payload).severityName).toBe(
+      OcsfSeverity.Critical,
+    );
+  });
+
+  test("classifies compliance and vulnerability findings separately", () => {
+    expect(
+      AwsSecurityHubNormalizer.normalize({
+        ...finding(),
+        Compliance: { Status: "FAILED" },
+      }).classUid,
+    ).toBe(2003);
+    expect(
+      AwsSecurityHubNormalizer.normalize({
+        ...finding(),
+        Vulnerabilities: [{ Id: "CVE-2026-1234" }],
+      }).classUid,
+    ).toBe(2002);
+  });
+
+  test("uses action network details when retired Network fields are absent", () => {
+    const result: NormalizedSecurityEvent = AwsSecurityHubNormalizer.normalize({
+      ...finding(),
+      Network: undefined,
+      Action: {
+        NetworkConnectionAction: {
+          RemoteIpDetails: { IpAddressV4: "192.0.2.4" },
+          LocalIpDetails: { IpAddressV4: "10.1.2.3" },
+          LocalPortDetails: { Port: 22 },
+        },
+      },
+    });
+
+    expect(result.principalIp).toBe("192.0.2.4");
+    expect(result.targetIp).toBe("10.1.2.3");
+    expect(result.targetPort).toBe(22);
+  });
+
+  test("falls back safely when optional fields are missing", () => {
+    const payload: JSONObject = {
+      SchemaVersion: "2018-10-08",
+      ProductArn: "arn:aws:securityhub:eu-west-1::product/aws/guardduty",
+      AwsAccountId: "123",
+      GeneratorId: "generator",
+    };
+    const result: NormalizedSecurityEvent =
+      AwsSecurityHubNormalizer.normalize(payload);
+
+    expect(result.eventUid).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(result.message).toBe("AWS Security Hub finding");
+    expect(result.vendorName).toBe("Amazon Web Services");
+    expect(result.productName).toBe("Amazon GuardDuty");
+    expect(result.severityName).toBe(OcsfSeverity.Unknown);
+  });
+});

--- a/Common/Tests/Utils/SecurityEvent/Vendor/CloudflareSecurityEventNormalizer.test.ts
+++ b/Common/Tests/Utils/SecurityEvent/Vendor/CloudflareSecurityEventNormalizer.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "@jest/globals";
+import { JSONObject } from "../../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity from "../../../../Types/SecurityEvent/OcsfSeverity";
+import CloudflareSecurityEventNormalizer from "../../../../Utils/SecurityEvent/Vendor/CloudflareSecurityEventNormalizer";
+
+describe("CloudflareSecurityEventNormalizer", () => {
+  function wafEvent(): JSONObject {
+    return {
+      RayID: "ray-123",
+      Source: "waf",
+      Action: "block",
+      RuleID: "rule-42",
+      Description: "Block SQL injection",
+      ClientIP: "198.51.100.12",
+      ClientRequestHost: "shop.example.com",
+      ClientRequestURI: "/checkout?item=1",
+      ClientRequestScheme: "https",
+      OriginIP: "10.0.0.15",
+      OriginPort: 443,
+      Datetime: "2026-01-02T03:04:05Z",
+      Severity: "high",
+      metadata: {
+        tactic: "TA0001",
+        technique: "T1190",
+      },
+    };
+  }
+
+  test("detects direct Logpush events, result envelopes, and GraphQL dimensions", () => {
+    expect(
+      CloudflareSecurityEventNormalizer.isCloudflareSecurityEvent(wafEvent()),
+    ).toBe(true);
+    expect(
+      CloudflareSecurityEventNormalizer.isCloudflareSecurityEvent({
+        result: [wafEvent()],
+      }),
+    ).toBe(true);
+    expect(
+      CloudflareSecurityEventNormalizer.isCloudflareSecurityEvent({
+        data: {
+          viewer: {
+            zones: { firewallEventsAdaptive: [{ dimensions: wafEvent() }] },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects unrelated request-shaped payloads", () => {
+    expect(
+      CloudflareSecurityEventNormalizer.isCloudflareSecurityEvent({
+        action: "block",
+        client_ip: "198.51.100.12",
+      }),
+    ).toBe(false);
+  });
+
+  test("maps WAF identity, status, severity, target, and MITRE context", () => {
+    const result: NormalizedSecurityEvent =
+      CloudflareSecurityEventNormalizer.normalize(wafEvent());
+
+    expect(result).toMatchObject({
+      eventUid: "ray-123:rule-42:waf:block",
+      categoryUid: 2,
+      classUid: 2004,
+      className: "Detection Finding",
+      activityName: "Block",
+      severityName: OcsfSeverity.High,
+      statusName: "Blocked",
+      message: "Block SQL injection",
+      vendorName: "Cloudflare",
+      productName: "Cloudflare WAF",
+      ruleId: "rule-42",
+      principalIp: "198.51.100.12",
+      targetHost: "shop.example.com",
+      targetIp: "10.0.0.15",
+      targetPort: 443,
+      targetResource: "https://shop.example.com/checkout?item=1",
+      mitreTactics: ["TA0001"],
+      mitreTechniques: ["T1190"],
+    });
+    expect(result.time.toISOString()).toBe("2026-01-02T03:04:05.000Z");
+    expect(result.observables).toEqual(
+      expect.arrayContaining([
+        "198.51.100.12",
+        "shop.example.com",
+        "10.0.0.15",
+        "https://shop.example.com/checkout?item=1",
+      ]),
+    );
+  });
+
+  test("uses an explicit event id and recognizes non-WAF security actions", () => {
+    const result: NormalizedSecurityEvent =
+      CloudflareSecurityEventNormalizer.normalize({
+        id: "event-1",
+        source: "ratelimit",
+        action: "managedChallenge",
+        clientIP: "203.0.113.7",
+        clientRequestHost: "api.example.com",
+        clientRequestPath: "v1/orders",
+        timestamp: 1767225600,
+      });
+
+    expect(result.eventUid).toBe("event-1");
+    expect(result.productName).toBe("Cloudflare Rate Limiting");
+    expect(result.activityName).toBe("Managed Challenge");
+    expect(result.statusName).toBe("Challenge");
+    expect(result.targetResource).toBe("https://api.example.com/v1/orders");
+    expect(result.time.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  test("uses safe defaults and a stable hash when optional identity fields are absent", () => {
+    const payload: JSONObject = { Source: "dlp" };
+    const first: NormalizedSecurityEvent =
+      CloudflareSecurityEventNormalizer.normalize(payload);
+    const second: NormalizedSecurityEvent =
+      CloudflareSecurityEventNormalizer.normalize(payload);
+
+    expect(first.eventUid).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(first.eventUid).toBe(second.eventUid);
+    expect(first.message).toBe("Cloudflare security event");
+    expect(first.productName).toBe("Cloudflare Data Loss Prevention");
+    expect(first.severityName).toBe(OcsfSeverity.Unknown);
+  });
+});

--- a/Common/Tests/Utils/SecurityEvent/Vendor/CrowdStrikeFalconNormalizer.test.ts
+++ b/Common/Tests/Utils/SecurityEvent/Vendor/CrowdStrikeFalconNormalizer.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "@jest/globals";
+import { JSONObject } from "../../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity from "../../../../Types/SecurityEvent/OcsfSeverity";
+import CrowdStrikeFalconNormalizer from "../../../../Utils/SecurityEvent/Vendor/CrowdStrikeFalconNormalizer";
+
+describe("CrowdStrikeFalconNormalizer", () => {
+  function alert(): JSONObject {
+    return {
+      composite_id: "composite-1",
+      display_name: "Suspicious PowerShell",
+      aggregation_rule_id: "rule-1",
+      aggregation_rule_name: "PowerShell detection",
+      severity: 85,
+      status: "new",
+      timestamp: "2026-02-03T04:05:06Z",
+      user_name: "analyst@example.com",
+      device: {
+        hostname: "workstation-01",
+        local_ip: "10.1.2.3",
+        device_id: "device-123",
+      },
+      command_line: "powershell.exe -enc payload",
+      tactic_id: "TA0002",
+      technique_id: "T1059.001",
+      behaviors: [
+        {
+          description: "Encoded command execution",
+          domain_name: "evil.example",
+          remote_ip: "203.0.113.8",
+          sha256: "abc123",
+          tactic_id: "TA0005",
+          technique_id: "T1027",
+        },
+      ],
+    };
+  }
+
+  test("detects Falcon payload signatures and rejects unrelated events", () => {
+    expect(CrowdStrikeFalconNormalizer.isCrowdStrikeFalconEvent(alert())).toBe(
+      true,
+    );
+    expect(
+      CrowdStrikeFalconNormalizer.isCrowdStrikeFalconAlert({
+        vendor_name: "CrowdStrike",
+      }),
+    ).toBe(true);
+    expect(
+      CrowdStrikeFalconNormalizer.isCrowdStrikeFalconEvent({
+        vendor: "another vendor",
+        message: "ordinary event",
+      }),
+    ).toBe(false);
+  });
+
+  test("maps alert metadata, entities, observables, and MITRE references", () => {
+    const result: NormalizedSecurityEvent =
+      CrowdStrikeFalconNormalizer.normalize(alert());
+
+    expect(result).toMatchObject({
+      eventUid: "composite-1",
+      categoryUid: 2,
+      classUid: 2004,
+      severityName: OcsfSeverity.Critical,
+      statusName: "new",
+      message: "Suspicious PowerShell",
+      vendorName: "CrowdStrike",
+      productName: "Falcon",
+      ruleId: "rule-1",
+      ruleName: "PowerShell detection",
+      principalUser: "analyst@example.com",
+      principalProcess: "powershell.exe -enc payload",
+      targetHost: "workstation-01",
+      targetIp: "10.1.2.3",
+      targetResource: "device-123",
+      mitreTactics: ["TA0002", "TA0005"],
+      mitreTechniques: ["T1059.001", "T1027"],
+    });
+    expect(result.time.toISOString()).toBe("2026-02-03T04:05:06.000Z");
+    expect(result.observables).toEqual(
+      expect.arrayContaining([
+        "analyst@example.com",
+        "workstation-01",
+        "10.1.2.3",
+        "evil.example",
+        "203.0.113.8",
+        "abc123",
+      ]),
+    );
+  });
+
+  test.each<[number, OcsfSeverity]>([
+    [1, OcsfSeverity.Informational],
+    [20, OcsfSeverity.Low],
+    [40, OcsfSeverity.Medium],
+    [60, OcsfSeverity.High],
+    [80, OcsfSeverity.Critical],
+  ])(
+    "maps numeric severity score %i",
+    (score: number, expected: OcsfSeverity) => {
+      expect(
+        CrowdStrikeFalconNormalizer.normalize({
+          ...alert(),
+          severity: score,
+          severity_name: undefined,
+        }).severityName,
+      ).toBe(expected);
+    },
+  );
+
+  test("prefers named severity and behavior details when top-level fields are absent", () => {
+    const result: NormalizedSecurityEvent =
+      CrowdStrikeFalconNormalizer.normalize({
+        detection_id: "detection-1",
+        severity_display_name: "medium",
+        behaviors: [
+          {
+            description: "Behavior-only alert",
+            username: "behavior-user",
+            hostname: "behavior-host",
+            local_ip: "192.0.2.9",
+            cmdline: "cmd.exe /c whoami",
+          },
+        ],
+      });
+
+    expect(result.eventUid).toBe("detection-1");
+    expect(result.severityName).toBe(OcsfSeverity.Medium);
+    expect(result.message).toBe("Behavior-only alert");
+    expect(result.principalUser).toBe("behavior-user");
+    expect(result.targetHost).toBe("behavior-host");
+    expect(result.principalProcess).toBe("cmd.exe /c whoami");
+  });
+
+  test("uses a stable hash and unknown severity for a minimally identified alert", () => {
+    const payload: JSONObject = { product: "Falcon" };
+    const result: NormalizedSecurityEvent =
+      CrowdStrikeFalconNormalizer.normalize(payload);
+
+    expect(result.eventUid).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(result.message).toBe("CrowdStrike Falcon alert");
+    expect(result.severityName).toBe(OcsfSeverity.Unknown);
+  });
+});

--- a/Common/Tests/Utils/SecurityEvent/Vendor/GoogleSecurityCommandCenterNormalizer.test.ts
+++ b/Common/Tests/Utils/SecurityEvent/Vendor/GoogleSecurityCommandCenterNormalizer.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "@jest/globals";
+import { JSONObject } from "../../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity from "../../../../Types/SecurityEvent/OcsfSeverity";
+import GoogleSecurityCommandCenterNormalizer from "../../../../Utils/SecurityEvent/Vendor/GoogleSecurityCommandCenterNormalizer";
+
+describe("GoogleSecurityCommandCenterNormalizer", () => {
+  function finding(): JSONObject {
+    return {
+      canonicalName:
+        "organizations/1/sources/2/locations/global/findings/finding-1",
+      findingClass: "THREAT",
+      category: "MALWARE_DETECTED",
+      state: "ACTIVE",
+      severity: "HIGH",
+      eventTime: "2026-03-04T05:06:07Z",
+      description: "Malware was detected",
+      resourceName:
+        "//compute.googleapis.com/projects/project-1/instances/vm-1",
+      access: {
+        principalEmail: "operator@example.com",
+        callerIp: "198.51.100.5",
+      },
+      indicator: {
+        ipAddresses: ["203.0.113.10"],
+        domains: ["malware.example"],
+      },
+      connections: [{ destinationIp: "10.2.3.4" }],
+      mitreAttack: {
+        tactic: "INITIAL ACCESS",
+        technique: "T1190",
+      },
+      sourceProperties: {
+        ruleId: "detector-1",
+        mitre_tactic_id: "TA0005",
+      },
+    };
+  }
+
+  test("detects direct findings and SCC Pub/Sub envelopes", () => {
+    expect(
+      GoogleSecurityCommandCenterNormalizer.isGoogleSecurityCommandCenterEvent(
+        finding(),
+      ),
+    ).toBe(true);
+    expect(
+      GoogleSecurityCommandCenterNormalizer.isGoogleSecurityCommandCenterFinding(
+        {
+          finding: finding(),
+          stateChange: "ADDED",
+        },
+      ),
+    ).toBe(true);
+    expect(
+      GoogleSecurityCommandCenterNormalizer.isGoogleSecurityCommandCenterEvent({
+        category: "ordinary",
+        state: "ACTIVE",
+      }),
+    ).toBe(false);
+  });
+
+  test("maps detection findings, resource context, and MITRE names and ids", () => {
+    const result: NormalizedSecurityEvent =
+      GoogleSecurityCommandCenterNormalizer.normalize({
+        finding: finding(),
+        stateChange: "ADDED",
+        resource: {
+          displayName: "production-vm",
+        },
+      });
+
+    expect(result).toMatchObject({
+      eventUid: "organizations/1/sources/2/locations/global/findings/finding-1",
+      categoryUid: 2,
+      classUid: 2004,
+      className: "Detection Finding",
+      activityName: "Create",
+      severityName: OcsfSeverity.High,
+      statusName: "ACTIVE",
+      message: "Malware was detected",
+      vendorName: "Google",
+      productName: "Security Command Center",
+      ruleId: "detector-1",
+      ruleName: "Malware Detected",
+      principalUser: "operator@example.com",
+      principalIp: "198.51.100.5",
+      targetHost: "production-vm",
+      targetIp: "10.2.3.4",
+      targetResource:
+        "//compute.googleapis.com/projects/project-1/instances/vm-1",
+      mitreTactics: ["TA0005", "TA0001"],
+      mitreTechniques: ["T1190"],
+    });
+    expect(result.time.toISOString()).toBe("2026-03-04T05:06:07.000Z");
+    expect(result.observables).toEqual(
+      expect.arrayContaining([
+        "operator@example.com",
+        "198.51.100.5",
+        "production-vm",
+        "203.0.113.10",
+        "malware.example",
+      ]),
+    );
+  });
+
+  test.each<[string, number, string, string]>([
+    ["VULNERABILITY", 2002, "Vulnerability Finding", "Update"],
+    ["MISCONFIGURATION", 2003, "Compliance Finding", "Close"],
+    ["POSTURE_VIOLATION", 2003, "Compliance Finding", "Create"],
+  ])(
+    "maps %s findings to their OCSF class and activity",
+    (
+      findingClass: string,
+      classUid: number,
+      className: string,
+      activityName: string,
+    ) => {
+      const payload: JSONObject = {
+        ...finding(),
+        findingClass,
+        state: activityName === "Close" ? "INACTIVE" : "ACTIVE",
+      };
+      const stateChange: string = activityName === "Update" ? "CHANGED" : "";
+
+      const result: NormalizedSecurityEvent =
+        GoogleSecurityCommandCenterNormalizer.normalize({
+          finding: payload,
+          stateChange,
+        });
+
+      expect(result.classUid).toBe(classUid);
+      expect(result.className).toBe(className);
+      expect(result.activityName).toBe(activityName);
+    },
+  );
+
+  test("uses category and resource fallbacks when optional SCC fields are missing", () => {
+    const payload: JSONObject = {
+      resourceName: "projects/project-1/resources/resource-1",
+      category: "OPEN_BUCKET",
+      state: "ACTIVE",
+      severity: "SEVERITY_UNSPECIFIED",
+    };
+    const result: NormalizedSecurityEvent =
+      GoogleSecurityCommandCenterNormalizer.normalize({
+        finding: payload,
+        resource: { name: "resource-fallback" },
+      });
+
+    expect(result.eventUid).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(result.ruleId).toBe("OPEN_BUCKET");
+    expect(result.ruleName).toBe("Open Bucket");
+    expect(result.message).toBe("Open Bucket");
+    expect(result.targetResource).toBe(
+      "projects/project-1/resources/resource-1",
+    );
+    expect(result.severityName).toBe(OcsfSeverity.Unknown);
+  });
+});

--- a/Common/Tests/Utils/SecurityEvent/Vendor/MicrosoftGraphSecurityNormalizer.test.ts
+++ b/Common/Tests/Utils/SecurityEvent/Vendor/MicrosoftGraphSecurityNormalizer.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "@jest/globals";
+import { JSONObject } from "../../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity from "../../../../Types/SecurityEvent/OcsfSeverity";
+import MicrosoftGraphSecurityNormalizer from "../../../../Utils/SecurityEvent/Vendor/MicrosoftGraphSecurityNormalizer";
+
+describe("MicrosoftGraphSecurityNormalizer", () => {
+  function alert(): JSONObject {
+    return {
+      "@odata.type": "#microsoft.graph.security.alert",
+      id: "alert-1",
+      displayName: "Suspicious sign-in",
+      severity: "high",
+      status: "new",
+      serviceSource: "microsoftDefenderForEndpoint",
+      productName: "Microsoft Defender for Endpoint",
+      createdDateTime: "2026-04-05T06:07:08Z",
+      alertPolicyId: "policy-1",
+      threatDisplayName: "Password spray",
+      categories: ["CredentialAccess"],
+      mitreTechniques: ["T1110"],
+      evidence: [
+        {
+          "@odata.type": "#microsoft.graph.security.userEvidence",
+          roles: ["attacker"],
+          userAccount: { userPrincipalName: "attacker@example.com" },
+        },
+        {
+          "@odata.type": "#microsoft.graph.security.deviceEvidence",
+          roles: ["impacted"],
+          deviceDnsName: "target.example.com",
+          ipInterfaces: ["10.0.0.8"],
+        },
+        {
+          "@odata.type": "#microsoft.graph.security.ipEvidence",
+          roles: ["source"],
+          ipAddress: "198.51.100.10",
+        },
+        {
+          "@odata.type": "#microsoft.graph.security.processEvidence",
+          processCommandLine: "powershell.exe -enc payload",
+          fileDetails: { sha256: "hash-1", fileName: "payload.ps1" },
+        },
+      ],
+    };
+  }
+
+  test("detects direct alerts, collection responses, and change notifications", () => {
+    expect(
+      MicrosoftGraphSecurityNormalizer.isMicrosoftGraphSecurityEvent(alert()),
+    ).toBe(true);
+    expect(
+      MicrosoftGraphSecurityNormalizer.isMicrosoftGraphSecurityEvent({
+        "@odata.context":
+          "https://graph.microsoft.com/v1.0/$metadata#security/alerts",
+        value: [alert()],
+      }),
+    ).toBe(true);
+    expect(
+      MicrosoftGraphSecurityNormalizer.isMicrosoftGraphSecurityEvent({
+        value: [{ resourceData: alert() }],
+      }),
+    ).toBe(true);
+    expect(
+      MicrosoftGraphSecurityNormalizer.isMicrosoftGraphSecurityEvent({
+        id: "ordinary-event",
+      }),
+    ).toBe(false);
+  });
+
+  test("maps an alert's identity, evidence, and attack metadata", () => {
+    const result: NormalizedSecurityEvent =
+      MicrosoftGraphSecurityNormalizer.normalize(alert());
+
+    expect(result).toMatchObject({
+      eventUid: "alert-1",
+      categoryUid: 2,
+      classUid: 2004,
+      className: "Detection Finding",
+      severityName: OcsfSeverity.High,
+      statusName: "new",
+      message: "Suspicious sign-in",
+      vendorName: "Microsoft",
+      productName: "Microsoft Defender for Endpoint",
+      ruleId: "policy-1",
+      ruleName: "Password spray",
+      mitreTactics: ["CredentialAccess"],
+      mitreTechniques: ["T1110"],
+      principalUser: "attacker@example.com",
+      principalIp: "198.51.100.10",
+      principalProcess: "powershell.exe -enc payload",
+      targetHost: "target.example.com",
+      targetResource: "payload.ps1",
+    });
+    expect(result.time.toISOString()).toBe("2026-04-05T06:07:08.000Z");
+    expect(result.observables).toEqual(
+      expect.arrayContaining([
+        "attacker@example.com",
+        "198.51.100.10",
+        "target.example.com",
+        "hash-1",
+        "payload.ps1",
+      ]),
+    );
+  });
+
+  test("expands incident alerts and derives the Sentinel product and priority severity", () => {
+    const result: NormalizedSecurityEvent =
+      MicrosoftGraphSecurityNormalizer.normalize({
+        "@odata.type": "#microsoft.graph.security.incident",
+        id: "incident-1",
+        displayName: "Coordinated attack",
+        priorityScore: 20,
+        status: "active",
+        serviceSource: "microsoftSentinel",
+        lastActivityDateTime: "2026-04-06T00:00:00Z",
+        alerts: [
+          {
+            id: "alert-child",
+            detectorId: "detector-1",
+            category: "Malware",
+            mitreTechniques: ["T1059"],
+            evidence: [
+              {
+                "@odata.type": "#microsoft.graph.security.ipEvidence",
+                roles: ["attacker"],
+                ipAddress: "203.0.113.11",
+              },
+            ],
+          },
+        ],
+      });
+
+    expect(result.classUid).toBe(2005);
+    expect(result.className).toBe("Incident Finding");
+    expect(result.productName).toBe("Microsoft Sentinel");
+    expect(result.severityName).toBe(OcsfSeverity.Medium);
+    expect(result.ruleId).toBe("detector-1");
+    expect(result.ruleName).toBe("Malware");
+    expect(result.principalIp).toBe("203.0.113.11");
+    expect(result.mitreTechniques).toEqual(["T1059"]);
+  });
+
+  test.each<[number, OcsfSeverity]>([
+    [0, OcsfSeverity.Low],
+    [15, OcsfSeverity.Medium],
+    [86, OcsfSeverity.High],
+  ])("maps priority score %i", (score: number, expected: OcsfSeverity) => {
+    expect(
+      MicrosoftGraphSecurityNormalizer.normalize({
+        providerAlertId: "provider-alert",
+        serviceSource: "defender",
+        priorityScore: score,
+      }).severityName,
+    ).toBe(expected);
+  });
+});

--- a/Common/Tests/Utils/SecurityEvent/Vendor/OktaSystemLogNormalizer.test.ts
+++ b/Common/Tests/Utils/SecurityEvent/Vendor/OktaSystemLogNormalizer.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "@jest/globals";
+import { JSONObject } from "../../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity from "../../../../Types/SecurityEvent/OcsfSeverity";
+import OktaSystemLogNormalizer from "../../../../Utils/SecurityEvent/Vendor/OktaSystemLogNormalizer";
+
+describe("OktaSystemLogNormalizer", () => {
+  function authenticationEvent(): JSONObject {
+    return {
+      uuid: "okta-1",
+      eventType: "user.session.start",
+      published: "2026-05-06T07:08:09Z",
+      displayMessage: "User login to Okta",
+      severity: "INFO",
+      outcome: { result: "SUCCESS" },
+      actor: {
+        alternateId: "user@example.com",
+        displayName: "Example User",
+      },
+      client: {
+        device: "MacBook Pro",
+        ipAddress: "198.51.100.20",
+      },
+      target: [
+        { type: "User", alternateId: "target@example.com" },
+        { type: "Device", displayName: "target-laptop" },
+      ],
+      request: {
+        ipChain: [{ ip: "198.51.100.20" }, { ip: "203.0.113.20" }],
+      },
+      debugContext: {
+        debugData: { requestUri: "/api/v1/authn" },
+      },
+    };
+  }
+
+  test("detects System Log records and rejects arbitrary typed events", () => {
+    expect(
+      OktaSystemLogNormalizer.isOktaSystemLogEvent(authenticationEvent()),
+    ).toBe(true);
+    expect(
+      OktaSystemLogNormalizer.isOktaSystemLogEvent({
+        event_type: "user.lifecycle.activate",
+        outcome: { result: "SUCCESS" },
+      }),
+    ).toBe(true);
+    expect(
+      OktaSystemLogNormalizer.isOktaSystemLogEvent({
+        eventType: "user.session.start",
+      }),
+    ).toBe(false);
+  });
+
+  test("maps authentication actor, targets, outcome, and request data", () => {
+    const result: NormalizedSecurityEvent = OktaSystemLogNormalizer.normalize(
+      authenticationEvent(),
+    );
+
+    expect(result).toMatchObject({
+      eventUid: "okta-1",
+      categoryUid: 3,
+      classUid: 3002,
+      className: "Authentication",
+      activityName: "Logon",
+      severityName: OcsfSeverity.Informational,
+      statusName: "Success",
+      message: "User login to Okta",
+      vendorName: "Okta",
+      productName: "System Log",
+      ruleId: "user.session.start",
+      ruleName: "User Session Start",
+      principalUser: "user@example.com",
+      principalHost: "MacBook Pro",
+      principalIp: "198.51.100.20",
+      targetUser: "target@example.com",
+      targetHost: "target-laptop",
+      targetResource: "/api/v1/authn",
+    });
+    expect(result.time.toISOString()).toBe("2026-05-06T07:08:09.000Z");
+    expect(result.observables).toEqual(
+      expect.arrayContaining([
+        "user@example.com",
+        "MacBook Pro",
+        "198.51.100.20",
+        "target@example.com",
+        "target-laptop",
+        "203.0.113.20",
+      ]),
+    );
+  });
+
+  test.each<[string, number, string]>([
+    ["user.lifecycle.activate", 3001, "Activate"],
+    ["group.user_membership.add", 3006, "Add"],
+    ["application.lifecycle.create", 3004, "Create"],
+    ["policy.evaluate_sign_on", 3003, "Authorize"],
+    ["system.api_token.create", 6003, "System Api Token Create"],
+  ])(
+    "maps %s to the appropriate OCSF class",
+    (eventType: string, classUid: number, activityName: string) => {
+      const result: NormalizedSecurityEvent = OktaSystemLogNormalizer.normalize(
+        {
+          uuid: `okta-${eventType}`,
+          eventType,
+          outcome: { result: "FAILURE" },
+        },
+      );
+
+      expect(result.classUid).toBe(classUid);
+      expect(result.activityName).toBe(activityName);
+      expect(result.statusName).toBe("Failure");
+    },
+  );
+
+  test("maps session end events to logoff and falls back to target resource", () => {
+    const result: NormalizedSecurityEvent = OktaSystemLogNormalizer.normalize({
+      eventId: "okta-end",
+      event_type: "user.session.end",
+      actor: { id: "actor-id" },
+      target: [{ type: "ApplicationInstance", alternateId: "app-id" }],
+    });
+
+    expect(result.eventUid).toBe("okta-end");
+    expect(result.activityName).toBe("Logoff");
+    expect(result.targetResource).toBe("app-id");
+    expect(result.message).toBe("User Session End");
+    expect(result.severityName).toBe(OcsfSeverity.Unknown);
+  });
+
+  test("uses a stable hash when an otherwise valid record has no event id", () => {
+    const payload: JSONObject = {
+      eventType: "user.lifecycle.deactivate",
+      displayMessage: "Deactivate user",
+    };
+    const result: NormalizedSecurityEvent =
+      OktaSystemLogNormalizer.normalize(payload);
+
+    expect(result.eventUid).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(result.classUid).toBe(3001);
+  });
+});

--- a/Common/Tests/Utils/SecurityEvent/Vendor/SplunkEnterpriseSecurityNormalizer.test.ts
+++ b/Common/Tests/Utils/SecurityEvent/Vendor/SplunkEnterpriseSecurityNormalizer.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "@jest/globals";
+import { JSONObject } from "../../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity from "../../../../Types/SecurityEvent/OcsfSeverity";
+import SplunkEnterpriseSecurityNormalizer from "../../../../Utils/SecurityEvent/Vendor/SplunkEnterpriseSecurityNormalizer";
+
+describe("SplunkEnterpriseSecurityNormalizer", () => {
+  function notableEvent(): JSONObject {
+    return {
+      event_id: "notable-1",
+      _time: "2026-06-07T08:09:10Z",
+      rule_id: "rule-1",
+      rule_name: "Brute force detected",
+      description: "Repeated failed authentication attempts",
+      urgency: "high",
+      status_label: "2",
+      src_user: "attacker",
+      src_ip: "198.51.100.30",
+      dest_user: "target-user",
+      dest: "target-host",
+      dest_ip: "10.3.4.5",
+      dest_port: "22",
+      process_name: "sshd",
+      annotations: '{"tactic":"TA0006","technique":"T1110"}',
+      sha256: "file-hash",
+      domain: "bad.example",
+    };
+  }
+
+  test("detects notable and risk events while rejecting ordinary Splunk records", () => {
+    expect(
+      SplunkEnterpriseSecurityNormalizer.isSplunkEnterpriseSecurityEvent(
+        notableEvent(),
+      ),
+    ).toBe(true);
+    expect(
+      SplunkEnterpriseSecurityNormalizer.isSplunkNotableOrRiskEvent({
+        risk_object: "target-user",
+        risk_score: 85,
+      }),
+    ).toBe(true);
+    expect(
+      SplunkEnterpriseSecurityNormalizer.isSplunkEnterpriseSecurityEvent({
+        host: "indexer-1",
+        message: "ordinary log",
+      }),
+    ).toBe(false);
+  });
+
+  test("maps notable event identity, status, network fields, and annotations", () => {
+    const result: NormalizedSecurityEvent =
+      SplunkEnterpriseSecurityNormalizer.normalize(notableEvent());
+
+    expect(result).toMatchObject({
+      eventUid: "notable-1",
+      categoryUid: 2,
+      classUid: 2004,
+      activityName: "Create",
+      severityName: OcsfSeverity.High,
+      statusName: "In Progress",
+      message: "Repeated failed authentication attempts",
+      vendorName: "Splunk",
+      productName: "Enterprise Security",
+      ruleId: "rule-1",
+      ruleName: "Brute force detected",
+      principalUser: "attacker",
+      principalIp: "198.51.100.30",
+      principalProcess: "sshd",
+      targetUser: "target-user",
+      targetHost: "target-host",
+      targetIp: "10.3.4.5",
+      targetPort: 22,
+      mitreTactics: ["TA0006"],
+      mitreTechniques: ["T1110"],
+    });
+    expect(result.time.toISOString()).toBe("2026-06-07T08:09:10.000Z");
+    expect(result.observables).toEqual(
+      expect.arrayContaining([
+        "attacker",
+        "198.51.100.30",
+        "target-user",
+        "target-host",
+        "10.3.4.5",
+        "file-hash",
+        "bad.example",
+      ]),
+    );
+  });
+
+  test.each<[number, OcsfSeverity]>([
+    [1, OcsfSeverity.Informational],
+    [40, OcsfSeverity.Low],
+    [60, OcsfSeverity.Medium],
+    [80, OcsfSeverity.High],
+    [100, OcsfSeverity.Critical],
+  ])("maps risk score %i", (riskScore: number, expected: OcsfSeverity) => {
+    expect(
+      SplunkEnterpriseSecurityNormalizer.normalize({
+        risk_object: "account@example.com",
+        risk_object_type: "user",
+        risk_score: riskScore,
+      }).severityName,
+    ).toBe(expected);
+  });
+
+  test("maps risk modifiers separately and extracts MITRE data from scalar fields", () => {
+    const result: NormalizedSecurityEvent =
+      SplunkEnterpriseSecurityNormalizer.normalize({
+        risk_object: "server-1",
+        risk_object_type: "system",
+        risk_score: 90,
+        mitre_tactic: "TA0008",
+        mitre_technique_id: "T1021.001",
+      });
+
+    expect(result.activityName).toBe("Update");
+    expect(result.statusName).toBe("");
+    expect(result.message).toBe("Risk modifier for server-1");
+    expect(result.targetHost).toBe("server-1");
+    expect(result.targetResource).toBe("server-1");
+    expect(result.mitreTactics).toEqual(["TA0008"]);
+    expect(result.mitreTechniques).toEqual(["T1021.001"]);
+  });
+
+  test("uses a stable hash and safe defaults when optional notable fields are absent", () => {
+    const payload: JSONObject = { rule_name: "minimal", owner: "analyst" };
+    const first: NormalizedSecurityEvent =
+      SplunkEnterpriseSecurityNormalizer.normalize(payload);
+    const second: NormalizedSecurityEvent =
+      SplunkEnterpriseSecurityNormalizer.normalize(payload);
+
+    expect(first.eventUid).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(first.eventUid).toBe(second.eventUid);
+    expect(first.message).toBe("minimal");
+    expect(first.severityName).toBe(OcsfSeverity.Unknown);
+  });
+
+  test("scopes raw data addresses by bucket", () => {
+    const first: NormalizedSecurityEvent =
+      SplunkEnterpriseSecurityNormalizer.normalize({
+        _bkt: "main~1~bucket-a",
+        _cd: "12:34",
+        rule_name: "first",
+      });
+    const second: NormalizedSecurityEvent =
+      SplunkEnterpriseSecurityNormalizer.normalize({
+        _bkt: "main~1~bucket-b",
+        _cd: "12:34",
+        rule_name: "second",
+      });
+
+    expect(first.eventUid).toBe("main~1~bucket-a|12:34");
+    expect(second.eventUid).toBe("main~1~bucket-b|12:34");
+    expect(first.eventUid).not.toBe(second.eventUid);
+  });
+});

--- a/Common/Tests/Utils/SecurityEvent/Vendor/VendorSecurityEventNormalizer.test.ts
+++ b/Common/Tests/Utils/SecurityEvent/Vendor/VendorSecurityEventNormalizer.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "@jest/globals";
+import { JSONObject } from "../../../../Types/JSON";
+import SecurityEventConnectorType from "../../../../Types/SecurityEvent/SecurityEventConnectorType";
+import VendorSecurityEventNormalizer from "../../../../Utils/SecurityEvent/VendorSecurityEventNormalizer";
+
+describe("VendorSecurityEventNormalizer", () => {
+  test.each<[SecurityEventConnectorType, JSONObject, string]>([
+    [
+      SecurityEventConnectorType.AwsSecurityHub,
+      {
+        SchemaVersion: "2018-10-08",
+        Id: "arn:aws:securityhub:eu-west-1:123:finding/f-1",
+        ProductArn: "arn:aws:securityhub:eu-west-1::product/aws/guardduty",
+        AwsAccountId: "123456789012",
+        GeneratorId: "detector-1",
+      },
+      "Amazon Web Services",
+    ],
+    [
+      SecurityEventConnectorType.Cloudflare,
+      { Source: "waf", Action: "block", ClientIP: "198.51.100.1" },
+      "Cloudflare",
+    ],
+    [
+      SecurityEventConnectorType.CrowdStrikeFalcon,
+      { detection_id: "detection-1" },
+      "CrowdStrike",
+    ],
+    [
+      SecurityEventConnectorType.GoogleSecurityCommandCenter,
+      {
+        resourceName: "projects/project-1/resources/resource-1",
+        category: "MALWARE",
+        state: "ACTIVE",
+      },
+      "Google",
+    ],
+    [
+      SecurityEventConnectorType.MicrosoftDefender,
+      {
+        providerAlertId: "provider-alert-1",
+        serviceSource: "defender",
+      },
+      "Microsoft",
+    ],
+    [
+      SecurityEventConnectorType.Okta,
+      { uuid: "okta-1", eventType: "user.session.start" },
+      "Okta",
+    ],
+    [
+      SecurityEventConnectorType.SplunkEnterpriseSecurity,
+      { event_id: "notable-1" },
+      "Splunk",
+    ],
+  ])(
+    "routes %s detection and normalization",
+    (
+      provider: SecurityEventConnectorType,
+      payload: JSONObject,
+      vendorName: string,
+    ) => {
+      expect(VendorSecurityEventNormalizer.isEvent(provider, payload)).toBe(
+        true,
+      );
+      expect(
+        VendorSecurityEventNormalizer.normalize(provider, payload).vendorName,
+      ).toBe(vendorName);
+    },
+  );
+
+  test.each<[SecurityEventConnectorType]>([
+    [SecurityEventConnectorType.Cloudflare],
+    [SecurityEventConnectorType.CrowdStrikeFalcon],
+    [SecurityEventConnectorType.GoogleSecurityCommandCenter],
+    [SecurityEventConnectorType.MicrosoftDefender],
+    [SecurityEventConnectorType.Okta],
+    [SecurityEventConnectorType.SplunkEnterpriseSecurity],
+  ])(
+    "does not claim arbitrary payloads for %s",
+    (provider: SecurityEventConnectorType) => {
+      expect(
+        VendorSecurityEventNormalizer.isEvent(provider, {
+          message: "unrelated event",
+        }),
+      ).toBe(false);
+    },
+  );
+});

--- a/Common/Types/SecurityEvent/SecurityEventConnectorResult.ts
+++ b/Common/Types/SecurityEvent/SecurityEventConnectorResult.ts
@@ -1,0 +1,19 @@
+export default interface SecurityEventConnectorResult {
+  startedAt: string;
+  completedAt: string;
+  windowStart: string;
+  windowEnd: string;
+  fetchedCount: number;
+  ingestedCount: number;
+  duplicateCount: number;
+  rejectedCount: number;
+  failedCount: number;
+  markerCount: number;
+  requestCount: number;
+  complete: boolean;
+  warnings: Array<string>;
+  error?: string | undefined;
+  cursorAdvanced?: boolean | undefined;
+  retryScheduled?: boolean | undefined;
+  dataLossPossible?: boolean | undefined;
+}

--- a/Common/Types/SecurityEvent/SecurityEventConnectorType.ts
+++ b/Common/Types/SecurityEvent/SecurityEventConnectorType.ts
@@ -1,0 +1,14 @@
+enum SecurityEventConnectorType {
+  AwsSecurityHub = "AWS Security Hub",
+  MicrosoftDefender = "Microsoft Defender XDR and Sentinel",
+  Cloudflare = "Cloudflare",
+  CrowdStrikeFalcon = "CrowdStrike Falcon",
+  GoogleSecurityCommandCenter = "Google Security Command Center",
+  Okta = "Okta",
+  SplunkEnterpriseSecurity = "Splunk Enterprise Security",
+}
+
+export const SecurityEventConnectorTypes: Array<SecurityEventConnectorType> =
+  Object.values(SecurityEventConnectorType);
+
+export default SecurityEventConnectorType;

--- a/Common/Utils/SecurityEvent/Vendor/AwsSecurityHubNormalizer.ts
+++ b/Common/Utils/SecurityEvent/Vendor/AwsSecurityHubNormalizer.ts
@@ -1,0 +1,379 @@
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity, {
+  OcsfSeverityId,
+  normalizeOcsfSeverity,
+} from "../../../Types/SecurityEvent/OcsfSeverity";
+import { ocsfCategoryForClassUid } from "../../../Types/SecurityEvent/OcsfEventClass";
+import {
+  buildObservables,
+  contentHashEventUid,
+  flattenPayload,
+  parseEventTime,
+  readNumber,
+  readString,
+  readValue,
+} from "../NormalizerHelpers";
+
+const VULNERABILITY_FINDING_CLASS_UID: number = 2002;
+const COMPLIANCE_FINDING_CLASS_UID: number = 2003;
+const DETECTION_FINDING_CLASS_UID: number = 2004;
+
+function objectValue(value: JSONValue): JSONObject | null {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as JSONObject;
+  }
+
+  return null;
+}
+
+function objectArray(value: JSONValue): Array<JSONObject> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const result: Array<JSONObject> = [];
+  for (const item of value) {
+    if (item && typeof item === "object" && !Array.isArray(item)) {
+      result.push(item as JSONObject);
+    }
+  }
+  return result;
+}
+
+/*
+ * EventBridge delivers ASFF records under detail.findings, while polling
+ * integrations normally hand the normalizer a finding directly. Accept both
+ * shapes so callers do not have to know how the finding reached OneUptime.
+ */
+function unwrapFinding(payload: JSONObject): JSONObject {
+  const detail: JSONObject | null = objectValue(readValue(payload, "detail"));
+
+  if (detail) {
+    const detailFindings: Array<JSONObject> = objectArray(
+      readValue(detail, "findings"),
+    );
+
+    if (detailFindings[0]) {
+      return detailFindings[0];
+    }
+
+    if (readString(detail, "SchemaVersion")) {
+      return detail;
+    }
+  }
+
+  const findings: Array<JSONObject> = objectArray(
+    readValue(payload, "Findings") ?? readValue(payload, "findings"),
+  );
+
+  return findings[0] || payload;
+}
+
+function awsSeverityFromScore(score: number | null): OcsfSeverity | null {
+  if (score === null || score < 0 || score > 100) {
+    return null;
+  }
+
+  if (score >= 90) {
+    return OcsfSeverity.Critical;
+  }
+
+  if (score >= 70) {
+    return OcsfSeverity.High;
+  }
+
+  if (score >= 40) {
+    return OcsfSeverity.Medium;
+  }
+
+  if (score >= 1) {
+    return OcsfSeverity.Low;
+  }
+
+  return OcsfSeverity.Informational;
+}
+
+function readSeverity(finding: JSONObject): OcsfSeverity {
+  const textCandidates: Array<string> = [
+    readString(finding, "Severity.Label"),
+    readString(finding, "FindingProviderFields.Severity.Label"),
+    readString(finding, "Severity.Original"),
+    readString(finding, "FindingProviderFields.Severity.Original"),
+  ];
+
+  for (const candidate of textCandidates) {
+    const severity: OcsfSeverity | null = normalizeOcsfSeverity(candidate);
+
+    if (severity) {
+      return severity;
+    }
+  }
+
+  return (
+    awsSeverityFromScore(readNumber(finding, "Severity.Normalized")) ||
+    awsSeverityFromScore(
+      readNumber(finding, "FindingProviderFields.Severity.Normalized"),
+    ) ||
+    OcsfSeverity.Unknown
+  );
+}
+
+function findingClass(finding: JSONObject): {
+  classUid: number;
+  className: string;
+} {
+  if (readString(finding, "Compliance.Status")) {
+    return {
+      classUid: COMPLIANCE_FINDING_CLASS_UID,
+      className: "Compliance Finding",
+    };
+  }
+
+  if (objectArray(readValue(finding, "Vulnerabilities")).length > 0) {
+    return {
+      classUid: VULNERABILITY_FINDING_CLASS_UID,
+      className: "Vulnerability Finding",
+    };
+  }
+
+  return {
+    classUid: DETECTION_FINDING_CLASS_UID,
+    className: "Detection Finding",
+  };
+}
+
+function productName(finding: JSONObject): string {
+  const explicit: string = readString(finding, "ProductName");
+
+  if (explicit) {
+    return explicit;
+  }
+
+  const productArn: string = readString(finding, "ProductArn").toLowerCase();
+
+  if (productArn.includes("/guardduty")) {
+    return "Amazon GuardDuty";
+  }
+
+  return "AWS Security Hub";
+}
+
+function firstResource(
+  resources: Array<JSONObject>,
+  role: "actor" | "target",
+): JSONObject | null {
+  return (
+    resources.find((resource: JSONObject): boolean => {
+      return readString(resource, "ResourceRole").toLowerCase() === role;
+    }) || null
+  );
+}
+
+function firstAffectedResource(finding: JSONObject): string {
+  const affected: JSONObject | null = objectValue(
+    readValue(finding, "Action.AwsApiCallAction.AffectedResources"),
+  );
+
+  if (!affected) {
+    return "";
+  }
+
+  return Object.keys(affected)[0] || "";
+}
+
+function extractMitreIds(
+  attributes: JSONObject,
+  kind: "tactic" | "technique",
+): Array<string> {
+  const ids: Array<string> = [];
+  const pattern: RegExp =
+    kind === "tactic" ? /\bTA\d{4}\b/gi : /\bT\d{4}(?:\.\d{3})?\b/gi;
+
+  for (const [key, rawValue] of Object.entries(attributes)) {
+    if (!key.toLowerCase().includes(kind)) {
+      continue;
+    }
+
+    const matches: RegExpMatchArray | null = String(rawValue).match(pattern);
+
+    if (matches) {
+      ids.push(
+        ...matches.map((match: string): string => {
+          return match.toUpperCase();
+        }),
+      );
+    }
+  }
+
+  return buildObservables(ids);
+}
+
+function collectThreatObservables(finding: JSONObject): Array<string> {
+  const result: Array<string> = [];
+
+  for (const indicator of objectArray(
+    readValue(finding, "ThreatIntelIndicators"),
+  )) {
+    result.push(readString(indicator, "Value"));
+  }
+
+  for (const threat of objectArray(readValue(finding, "Threats"))) {
+    result.push(readString(threat, "Name"));
+
+    for (const filePath of objectArray(readValue(threat, "FilePaths"))) {
+      result.push(
+        readString(filePath, "Hash"),
+        readString(filePath, "FileName"),
+        readString(filePath, "ResourceId"),
+      );
+    }
+  }
+
+  return result;
+}
+
+export default class AwsSecurityHubNormalizer {
+  public static isAwsSecurityHubFinding(payload: JSONObject): boolean {
+    const finding: JSONObject = unwrapFinding(payload);
+    const detailType: string = readString(payload, "detail-type").toLowerCase();
+    const productArn: string = readString(finding, "ProductArn").toLowerCase();
+
+    return Boolean(
+      detailType.includes("security hub findings") ||
+        (readString(finding, "SchemaVersion") &&
+          readString(finding, "Id") &&
+          (productArn.includes(":securityhub:") ||
+            (readString(finding, "AwsAccountId") &&
+              readString(finding, "GeneratorId")))),
+    );
+  }
+
+  public static normalize(payload: JSONObject): NormalizedSecurityEvent {
+    const finding: JSONObject = unwrapFinding(payload);
+    const resources: Array<JSONObject> = objectArray(
+      readValue(finding, "Resources"),
+    );
+    const actorResource: JSONObject | null = firstResource(resources, "actor");
+    const targetResourceObject: JSONObject | null =
+      firstResource(resources, "target") || resources[0] || null;
+
+    const principalUser: string =
+      readString(finding, "Resource.Details.AwsIamAccessKey.PrincipalName") ||
+      readString(finding, "Resource.Details.AwsIamAccessKey.UserName") ||
+      (actorResource ? readString(actorResource, "Id") : "");
+    const principalHost: string =
+      readString(finding, "Network.SourceDomain") ||
+      readString(
+        finding,
+        "Action.NetworkConnectionAction.RemoteIpDetails.Organization.AsnOrg",
+      ) ||
+      "";
+    const principalIp: string =
+      readString(finding, "Network.SourceIpV4") ||
+      readString(finding, "Network.SourceIpV6") ||
+      readString(
+        finding,
+        "Action.NetworkConnectionAction.RemoteIpDetails.IpAddressV4",
+      ) ||
+      readString(
+        finding,
+        "Action.PortProbeAction.PortProbeDetails.RemoteIpDetails.IpAddressV4",
+      );
+    const targetHost: string =
+      readString(finding, "Network.DestinationDomain") || "";
+    const targetIp: string =
+      readString(finding, "Network.DestinationIpV4") ||
+      readString(finding, "Network.DestinationIpV6") ||
+      readString(
+        finding,
+        "Action.NetworkConnectionAction.LocalIpDetails.IpAddressV4",
+      );
+    const targetPort: number =
+      readNumber(finding, "Network.DestinationPort") ||
+      readNumber(
+        finding,
+        "Action.NetworkConnectionAction.LocalPortDetails.Port",
+      ) ||
+      readNumber(
+        finding,
+        "Action.PortProbeAction.PortProbeDetails.LocalPortDetails.Port",
+      ) ||
+      0;
+    const targetResource: string =
+      (targetResourceObject ? readString(targetResourceObject, "Id") : "") ||
+      firstAffectedResource(finding);
+
+    const severityName: OcsfSeverity = readSeverity(finding);
+    const classification: { classUid: number; className: string } =
+      findingClass(finding);
+    const { categoryUid, categoryName } = ocsfCategoryForClassUid(
+      classification.classUid,
+    );
+    const attributes: JSONObject = flattenPayload(payload);
+    const time: Date | null = parseEventTime(
+      readValue(finding, "LastObservedAt") ??
+        readValue(finding, "UpdatedAt") ??
+        readValue(finding, "CreatedAt") ??
+        readValue(finding, "FirstObservedAt"),
+    );
+    const findingId: string = readString(finding, "Id");
+    const productArn: string = readString(finding, "ProductArn");
+
+    return {
+      time: time || new Date(),
+      eventUid:
+        findingId && productArn
+          ? `${productArn}|${findingId}`
+          : findingId || contentHashEventUid(payload),
+      categoryUid,
+      categoryName,
+      classUid: classification.classUid,
+      className: classification.className,
+      activityName: "Create",
+      severityId: OcsfSeverityId[severityName],
+      severityName,
+      statusName:
+        readString(finding, "Workflow.Status") ||
+        readString(finding, "Compliance.Status") ||
+        readString(finding, "RecordState"),
+      message:
+        readString(finding, "Title") ||
+        readString(finding, "Description") ||
+        "AWS Security Hub finding",
+      vendorName: readString(finding, "CompanyName") || "Amazon Web Services",
+      productName: productName(finding),
+      ruleId: readString(finding, "GeneratorId"),
+      ruleName:
+        readString(finding, "Title") ||
+        readString(finding, "FindingProviderFields.Types") ||
+        readString(finding, "Types"),
+      mitreTactics: extractMitreIds(attributes, "tactic"),
+      mitreTechniques: extractMitreIds(attributes, "technique"),
+      principalUser,
+      principalHost,
+      principalIp,
+      principalProcess:
+        readString(finding, "Process.Name") ||
+        readString(finding, "Process.Path"),
+      targetUser: "",
+      targetHost,
+      targetIp,
+      targetPort,
+      targetResource,
+      observables: buildObservables([
+        principalUser,
+        principalHost,
+        principalIp,
+        targetHost,
+        targetIp,
+        targetResource,
+        ...resources.map((resource: JSONObject): string => {
+          return readString(resource, "Id");
+        }),
+        ...collectThreatObservables(finding),
+      ]),
+      attributes,
+    };
+  }
+}

--- a/Common/Utils/SecurityEvent/Vendor/CloudflareSecurityEventNormalizer.ts
+++ b/Common/Utils/SecurityEvent/Vendor/CloudflareSecurityEventNormalizer.ts
@@ -1,0 +1,366 @@
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity, {
+  OcsfSeverityId,
+  normalizeOcsfSeverity,
+} from "../../../Types/SecurityEvent/OcsfSeverity";
+import { ocsfCategoryForClassUid } from "../../../Types/SecurityEvent/OcsfEventClass";
+import {
+  buildObservables,
+  contentHashEventUid,
+  flattenPayload,
+  parseEventTime,
+  readNumber,
+  readString,
+  readValue,
+} from "../NormalizerHelpers";
+
+const DETECTION_FINDING_CLASS_UID: number = 2004;
+const HTTP_URL_PATTERN: RegExp = /^https?:\/\//i;
+
+const SECURITY_SOURCES: Set<string> = new Set<string>([
+  "asn",
+  "country",
+  "ip",
+  "iprange",
+  "securitylevel",
+  "zonelockdown",
+  "waf",
+  "firewallrules",
+  "uablock",
+  "ratelimit",
+  "bic",
+  "l7ddos",
+  "validation",
+  "botfight",
+  "apishield",
+  "botmanagement",
+  "dlp",
+  "firewallmanaged",
+  "firewallcustom",
+  "apishieldschemavalidation",
+  "apishieldtokenvalidation",
+  "apishieldsequencemitigation",
+]);
+
+function objectValue(value: JSONValue): JSONObject | null {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as JSONObject;
+  }
+
+  return null;
+}
+
+function objectArray(value: JSONValue): Array<JSONObject> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const result: Array<JSONObject> = [];
+  for (const item of value) {
+    if (item && typeof item === "object" && !Array.isArray(item)) {
+      result.push(item as JSONObject);
+    }
+  }
+  return result;
+}
+
+/*
+ * Covers Logpush/export records, REST result arrays, and the two common
+ * zone/account GraphQL Analytics response paths.
+ */
+function unwrapEvent(payload: JSONObject): JSONObject {
+  const candidates: Array<JSONValue> = [
+    readValue(payload, "result"),
+    readValue(payload, "data.viewer.zones.firewallEventsAdaptive"),
+    readValue(payload, "data.viewer.accounts.firewallEventsAdaptive"),
+    readValue(payload, "firewallEventsAdaptive"),
+  ];
+
+  let event: JSONObject = payload;
+
+  for (const candidate of candidates) {
+    const first: JSONObject | undefined = objectArray(candidate)[0];
+    if (first) {
+      event = first;
+      break;
+    }
+  }
+
+  return objectValue(readValue(event, "dimensions")) || event;
+}
+
+function readAny(payload: JSONObject, paths: Array<string>): string {
+  for (const path of paths) {
+    const value: string = readString(payload, path);
+    if (value) {
+      return value;
+    }
+  }
+
+  return "";
+}
+
+function prettyAction(action: string): string {
+  if (!action) {
+    return "";
+  }
+
+  return action
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (character: string): string => {
+      return character.toUpperCase();
+    });
+}
+
+function statusForAction(action: string): string {
+  const normalized: string = action.toLowerCase().replace(/[_-]+/g, "");
+
+  if (
+    normalized === "block" ||
+    normalized === "connectionclose" ||
+    normalized === "forceconnectionclose"
+  ) {
+    return "Blocked";
+  }
+
+  if (
+    normalized === "allow" ||
+    normalized === "bypass" ||
+    normalized.includes("solved") ||
+    normalized.includes("bypassed")
+  ) {
+    return "Allowed";
+  }
+
+  if (normalized.includes("challenge")) {
+    return "Challenge";
+  }
+
+  if (normalized === "log") {
+    return "Logged";
+  }
+
+  return prettyAction(action);
+}
+
+function productForSource(source: string): string {
+  const products: Record<string, string> = {
+    waf: "Cloudflare WAF",
+    firewallmanaged: "Cloudflare WAF",
+    firewallcustom: "Cloudflare WAF",
+    firewallrules: "Cloudflare WAF",
+    ratelimit: "Cloudflare Rate Limiting",
+    l7ddos: "Cloudflare DDoS Protection",
+    botfight: "Cloudflare Bot Management",
+    botmanagement: "Cloudflare Bot Management",
+    apishield: "Cloudflare API Shield",
+    apishieldschemavalidation: "Cloudflare API Shield",
+    apishieldtokenvalidation: "Cloudflare API Shield",
+    apishieldsequencemitigation: "Cloudflare API Shield",
+    dlp: "Cloudflare Data Loss Prevention",
+    bic: "Cloudflare Browser Integrity Check",
+  };
+
+  return products[source.toLowerCase()] || "Cloudflare Security Events";
+}
+
+function targetResourceFor(event: JSONObject): string {
+  const uri: string = readAny(event, [
+    "ClientRequestURI",
+    "clientRequestURI",
+    "uri",
+  ]);
+
+  if (HTTP_URL_PATTERN.test(uri)) {
+    return uri;
+  }
+
+  const host: string = readAny(event, [
+    "ClientRequestHost",
+    "clientRequestHTTPHost",
+    "clientRequestHost",
+    "host",
+    "ZoneName",
+  ]);
+  const path: string =
+    uri || readAny(event, ["ClientRequestPath", "clientRequestPath", "path"]);
+  const query: string = readAny(event, [
+    "ClientRequestQuery",
+    "clientRequestQuery",
+  ]);
+
+  if (!host) {
+    return path;
+  }
+
+  const scheme: string =
+    readAny(event, ["ClientRequestScheme", "clientRequestScheme"]) || "https";
+  const normalizedPath: string = path
+    ? path.startsWith("/")
+      ? path
+      : `/${path}`
+    : "";
+
+  return `${scheme}://${host}${normalizedPath}${query ? `?${query}` : ""}`;
+}
+
+function extractMitreIds(
+  attributes: JSONObject,
+  kind: "tactic" | "technique",
+): Array<string> {
+  const ids: Array<string> = [];
+  const pattern: RegExp =
+    kind === "tactic" ? /\bTA\d{4}\b/gi : /\bT\d{4}(?:\.\d{3})?\b/gi;
+
+  for (const [key, rawValue] of Object.entries(attributes)) {
+    if (!key.toLowerCase().includes(kind)) {
+      continue;
+    }
+
+    const matches: RegExpMatchArray | null = String(rawValue).match(pattern);
+    if (matches) {
+      ids.push(
+        ...matches.map((match: string): string => {
+          return match.toUpperCase();
+        }),
+      );
+    }
+  }
+
+  return buildObservables(ids);
+}
+
+function eventUid(
+  event: JSONObject,
+  payload: JSONObject,
+  source: string,
+  action: string,
+  ruleId: string,
+): string {
+  const explicitId: string = readAny(event, ["id", "eventId", "EventID"]);
+
+  if (explicitId) {
+    return explicitId;
+  }
+
+  const rayId: string = readAny(event, ["RayID", "rayName", "ray_id"]);
+
+  if (rayId && ruleId) {
+    return `${rayId}:${ruleId}:${source}:${action}`;
+  }
+
+  return rayId || contentHashEventUid(payload);
+}
+
+export default class CloudflareSecurityEventNormalizer {
+  public static isCloudflareSecurityEvent(payload: JSONObject): boolean {
+    const event: JSONObject = unwrapEvent(payload);
+    const source: string = readAny(event, ["Source", "source"]).toLowerCase();
+    const rayId: string = readAny(event, ["RayID", "rayName", "ray_id"]);
+    const action: string = readAny(event, ["Action", "action"]);
+
+    return Boolean(
+      SECURITY_SOURCES.has(source) ||
+        (rayId &&
+          action &&
+          readAny(event, ["ClientIP", "clientIP", "client_ip"])),
+    );
+  }
+
+  public static normalize(payload: JSONObject): NormalizedSecurityEvent {
+    const event: JSONObject = unwrapEvent(payload);
+    const action: string = readAny(event, ["Action", "action"]);
+    const source: string = readAny(event, ["Source", "source"]);
+    const ruleId: string = readAny(event, [
+      "RuleID",
+      "ruleId",
+      "rule_id",
+      "Ref",
+      "ref",
+    ]);
+    const ruleName: string = readAny(event, [
+      "Description",
+      "description",
+      "RuleName",
+      "ruleName",
+    ]);
+    const principalIp: string = readAny(event, [
+      "ClientIP",
+      "clientIP",
+      "client_ip",
+    ]);
+    const targetHost: string = readAny(event, [
+      "ClientRequestHost",
+      "clientRequestHTTPHost",
+      "clientRequestHost",
+      "host",
+      "ZoneName",
+    ]);
+    const targetIp: string = readAny(event, ["OriginIP", "originIP"]);
+    const targetResource: string = targetResourceFor(event);
+    const severityName: OcsfSeverity =
+      normalizeOcsfSeverity(
+        readAny(event, [
+          "Severity",
+          "severity",
+          "RuleSeverity",
+          "ruleSeverity",
+          "Metadata.severity",
+          "metadata.severity",
+        ]),
+      ) || OcsfSeverity.Unknown;
+    const attributes: JSONObject = flattenPayload(payload);
+    const time: Date | null = parseEventTime(
+      readValue(event, "Datetime") ??
+        readValue(event, "datetime") ??
+        readValue(event, "EdgeStartTimestamp") ??
+        readValue(event, "timestamp"),
+    );
+    const { categoryUid, categoryName } = ocsfCategoryForClassUid(
+      DETECTION_FINDING_CLASS_UID,
+    );
+
+    return {
+      time: time || new Date(),
+      eventUid: eventUid(event, payload, source, action, ruleId),
+      categoryUid,
+      categoryName,
+      classUid: DETECTION_FINDING_CLASS_UID,
+      className: "Detection Finding",
+      activityName: prettyAction(action),
+      severityId: OcsfSeverityId[severityName],
+      severityName,
+      statusName: statusForAction(action),
+      message:
+        ruleName ||
+        (action && principalIp
+          ? `${prettyAction(action)} request from ${principalIp}`
+          : "Cloudflare security event"),
+      vendorName: "Cloudflare",
+      productName: productForSource(source),
+      ruleId,
+      ruleName,
+      mitreTactics: extractMitreIds(attributes, "tactic"),
+      mitreTechniques: extractMitreIds(attributes, "technique"),
+      principalUser: readAny(event, ["FraudUserID", "fraudUserId"]),
+      principalHost: "",
+      principalIp,
+      principalProcess: "",
+      targetUser: "",
+      targetHost,
+      targetIp,
+      targetPort:
+        readNumber(event, "OriginPort") || readNumber(event, "originPort") || 0,
+      targetResource,
+      observables: buildObservables([
+        principalIp,
+        targetHost,
+        targetIp,
+        targetResource,
+      ]),
+      attributes,
+    };
+  }
+}

--- a/Common/Utils/SecurityEvent/Vendor/CrowdStrikeFalconNormalizer.ts
+++ b/Common/Utils/SecurityEvent/Vendor/CrowdStrikeFalconNormalizer.ts
@@ -1,0 +1,308 @@
+import { JSONObject } from "../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity, {
+  OcsfSeverityId,
+  normalizeOcsfSeverity,
+} from "../../../Types/SecurityEvent/OcsfSeverity";
+import { ocsfCategoryForClassUid } from "../../../Types/SecurityEvent/OcsfEventClass";
+import {
+  buildObservables,
+  contentHashEventUid,
+  flattenPayload,
+  parseEventTime,
+  readValue,
+} from "../NormalizerHelpers";
+import {
+  MitreReferences,
+  extractMitreReferences,
+  readAllStrings,
+  readFirstNumber,
+  readFirstString,
+  readObjects,
+  uniqueStrings,
+} from "./VendorNormalizerHelpers";
+
+const DETECTION_FINDING_CLASS_UID: number = 2004;
+
+function severityFromScore(score: number | null): OcsfSeverity | null {
+  if (score === null || score <= 0) {
+    return null;
+  }
+
+  if (score < 20) {
+    return OcsfSeverity.Informational;
+  }
+
+  if (score < 40) {
+    return OcsfSeverity.Low;
+  }
+
+  if (score < 60) {
+    return OcsfSeverity.Medium;
+  }
+
+  if (score < 80) {
+    return OcsfSeverity.High;
+  }
+
+  return OcsfSeverity.Critical;
+}
+
+function readSeverity(payload: JSONObject): OcsfSeverity {
+  const severityText: string = readFirstString(payload, [
+    "severity_name",
+    "severity_display_name",
+    "max_severity_displayname",
+    "max_severity_name",
+  ]);
+
+  return (
+    normalizeOcsfSeverity(severityText) ||
+    severityFromScore(
+      readFirstNumber(payload, ["severity", "max_severity", "severity_score"]),
+    ) ||
+    OcsfSeverity.Unknown
+  );
+}
+
+interface FalconEntitySummary {
+  user: string;
+  host: string;
+  localIp: string;
+  process: string;
+  targetResource: string;
+  observables: Array<string>;
+  mitre: MitreReferences;
+}
+
+function summarizeEntities(payload: JSONObject): FalconEntitySummary {
+  const behaviors: Array<JSONObject> = readObjects(payload, "behaviors");
+  const users: Array<string> = [
+    readFirstString(payload, [
+      "user_name",
+      "username",
+      "user.id",
+      "user.name",
+      "device.last_logged_on_user",
+    ]),
+  ];
+  const hosts: Array<string> = [
+    readFirstString(payload, [
+      "device.hostname",
+      "hostname",
+      "host_name",
+      "computer_name",
+    ]),
+  ];
+  const localIps: Array<string> = [
+    readFirstString(payload, [
+      "device.local_ip",
+      "local_ip",
+      "host.local_ip",
+      "source_ip",
+    ]),
+  ];
+  const processes: Array<string> = [
+    readFirstString(payload, [
+      "command_line",
+      "cmdline",
+      "process.command_line",
+      "filename",
+    ]),
+  ];
+  const resources: Array<string> = [
+    readFirstString(payload, [
+      "device.device_id",
+      "device.id",
+      "agent_id",
+      "aggregate_id",
+    ]),
+  ];
+  const observableValues: Array<string> = [];
+  const mitreValues: Array<string> = [];
+
+  for (const path of [
+    "tactic_id",
+    "technique_id",
+    "mitre_tactic_id",
+    "mitre_technique_id",
+  ]) {
+    mitreValues.push(...readAllStrings(payload, path));
+  }
+
+  for (const path of [
+    "domain_name",
+    "remote_ip",
+    "external_ip",
+    "sha256",
+    "sha1",
+    "md5",
+    "file_path",
+  ]) {
+    observableValues.push(...readAllStrings(payload, path));
+  }
+
+  for (const behavior of behaviors) {
+    users.push(readFirstString(behavior, ["user_name", "username"]));
+    hosts.push(readFirstString(behavior, ["hostname", "device.hostname"]));
+    localIps.push(readFirstString(behavior, ["local_ip", "source_ip"]));
+    processes.push(
+      readFirstString(behavior, ["cmdline", "command_line", "filename"]),
+    );
+
+    for (const path of ["tactic_id", "technique_id"]) {
+      mitreValues.push(...readAllStrings(behavior, path));
+    }
+
+    for (const path of [
+      "domain_name",
+      "remote_ip",
+      "sha256",
+      "sha1",
+      "md5",
+      "filename",
+      "filepath",
+    ]) {
+      observableValues.push(...readAllStrings(behavior, path));
+    }
+  }
+
+  const user: string = uniqueStrings(users)[0] || "";
+  const host: string = uniqueStrings(hosts)[0] || "";
+  const localIp: string = uniqueStrings(localIps)[0] || "";
+  const process: string = uniqueStrings(processes)[0] || "";
+  const targetResource: string = uniqueStrings(resources)[0] || "";
+
+  return {
+    user,
+    host,
+    localIp,
+    process,
+    targetResource,
+    observables: buildObservables([
+      ...users,
+      ...hosts,
+      ...localIps,
+      ...observableValues,
+    ]),
+    mitre: extractMitreReferences(mitreValues),
+  };
+}
+
+function firstBehaviorDescription(payload: JSONObject): string {
+  const behaviors: Array<JSONObject> = readObjects(payload, "behaviors");
+  return behaviors.length > 0
+    ? readFirstString(behaviors[0] as JSONObject, [
+        "description",
+        "display_name",
+        "scenario",
+      ])
+    : "";
+}
+
+export default class CrowdStrikeFalconNormalizer {
+  public static isCrowdStrikeFalconEvent(payload: JSONObject): boolean {
+    const vendor: string = readFirstString(payload, [
+      "vendor",
+      "vendor_name",
+      "metadata.vendor_name",
+    ]).toLowerCase();
+    const product: string = readFirstString(payload, [
+      "product",
+      "product_name",
+    ]).toLowerCase();
+
+    return Boolean(
+      readFirstString(payload, [
+        "composite_id",
+        "detection_id",
+        "aggregate_id",
+      ]) ||
+        readValue(payload, "behaviors") ||
+        vendor.includes("crowdstrike") ||
+        product.includes("falcon"),
+    );
+  }
+
+  public static isCrowdStrikeFalconAlert(payload: JSONObject): boolean {
+    return this.isCrowdStrikeFalconEvent(payload);
+  }
+
+  public static normalize(payload: JSONObject): NormalizedSecurityEvent {
+    const severityName: OcsfSeverity = readSeverity(payload);
+    const entities: FalconEntitySummary = summarizeEntities(payload);
+    const time: Date | null = parseEventTime(
+      readValue(payload, "timestamp") ??
+        readValue(payload, "created_timestamp") ??
+        readValue(payload, "first_behavior") ??
+        readValue(payload, "first_behavior_time") ??
+        readValue(payload, "last_behavior"),
+    );
+    const { categoryUid, categoryName } = ocsfCategoryForClassUid(
+      DETECTION_FINDING_CLASS_UID,
+    );
+
+    const displayName: string = readFirstString(payload, [
+      "display_name",
+      "name",
+      "scenario",
+      "description",
+    ]);
+    const ruleName: string = readFirstString(payload, [
+      "aggregation_rule_name",
+      "rule_name",
+      "pattern_name",
+      "scenario",
+      "display_name",
+    ]);
+
+    return {
+      time: time || new Date(),
+      eventUid:
+        readFirstString(payload, [
+          "composite_id",
+          "id",
+          "detection_id",
+          "aggregate_id",
+        ]) || contentHashEventUid(payload),
+      categoryUid,
+      categoryName,
+      classUid: DETECTION_FINDING_CLASS_UID,
+      className: "Detection Finding",
+      activityName: "Create",
+      severityId: OcsfSeverityId[severityName],
+      severityName,
+      statusName: readFirstString(payload, [
+        "status",
+        "state",
+        "disposition_name",
+      ]),
+      message:
+        displayName ||
+        firstBehaviorDescription(payload) ||
+        "CrowdStrike Falcon alert",
+      vendorName: "CrowdStrike",
+      productName: "Falcon",
+      ruleId: readFirstString(payload, [
+        "aggregation_rule_id",
+        "rule_id",
+        "pattern_id",
+        "cms_rule_id",
+      ]),
+      ruleName,
+      mitreTactics: entities.mitre.tactics,
+      mitreTechniques: entities.mitre.techniques,
+      principalUser: entities.user,
+      principalHost: "",
+      principalIp: "",
+      principalProcess: entities.process,
+      targetUser: "",
+      targetHost: entities.host,
+      targetIp: entities.localIp,
+      targetPort: 0,
+      targetResource: entities.targetResource,
+      observables: entities.observables,
+      attributes: flattenPayload(payload),
+    };
+  }
+}

--- a/Common/Utils/SecurityEvent/Vendor/GoogleSecurityCommandCenterNormalizer.ts
+++ b/Common/Utils/SecurityEvent/Vendor/GoogleSecurityCommandCenterNormalizer.ts
@@ -1,0 +1,329 @@
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity, {
+  OcsfSeverityId,
+  normalizeOcsfSeverity,
+} from "../../../Types/SecurityEvent/OcsfSeverity";
+import { ocsfCategoryForClassUid } from "../../../Types/SecurityEvent/OcsfEventClass";
+import {
+  buildObservables,
+  contentHashEventUid,
+  flattenPayload,
+  parseEventTime,
+  readValue,
+} from "../NormalizerHelpers";
+import {
+  MitreReferences,
+  collectScalarStrings,
+  extractMitreReferences,
+  prettifyToken,
+  readAllStrings,
+  readFirstString,
+  readObject,
+  readObjects,
+  uniqueStrings,
+} from "./VendorNormalizerHelpers";
+
+const DETECTION_FINDING_CLASS_UID: number = 2004;
+const VULNERABILITY_FINDING_CLASS_UID: number = 2002;
+const COMPLIANCE_FINDING_CLASS_UID: number = 2003;
+
+const SCC_TACTIC_IDS: Record<string, string> = {
+  RECONNAISSANCE: "TA0043",
+  RESOURCE_DEVELOPMENT: "TA0042",
+  INITIAL_ACCESS: "TA0001",
+  EXECUTION: "TA0002",
+  PERSISTENCE: "TA0003",
+  PRIVILEGE_ESCALATION: "TA0004",
+  DEFENSE_EVASION: "TA0005",
+  CREDENTIAL_ACCESS: "TA0006",
+  DISCOVERY: "TA0007",
+  LATERAL_MOVEMENT: "TA0008",
+  COLLECTION: "TA0009",
+  COMMAND_AND_CONTROL: "TA0011",
+  EXFILTRATION: "TA0010",
+  IMPACT: "TA0040",
+};
+
+interface SccPayload {
+  finding: JSONObject;
+  resource: JSONObject | null;
+  stateChange: string;
+}
+
+function unwrapPayload(payload: JSONObject): SccPayload {
+  const finding: JSONObject | null = readObject(payload, "finding");
+
+  return {
+    finding: finding || payload,
+    resource: readObject(payload, "resource"),
+    stateChange: readFirstString(payload, ["stateChange", "state_change"]),
+  };
+}
+
+function classUidForFinding(finding: JSONObject): number {
+  const findingClass: string = readFirstString(finding, [
+    "findingClass",
+    "finding_class",
+  ]).toUpperCase();
+
+  if (findingClass === "VULNERABILITY") {
+    return VULNERABILITY_FINDING_CLASS_UID;
+  }
+
+  if (
+    findingClass === "MISCONFIGURATION" ||
+    findingClass === "POSTURE_VIOLATION"
+  ) {
+    return COMPLIANCE_FINDING_CLASS_UID;
+  }
+
+  return DETECTION_FINDING_CLASS_UID;
+}
+
+function classNameForUid(classUid: number): string {
+  if (classUid === VULNERABILITY_FINDING_CLASS_UID) {
+    return "Vulnerability Finding";
+  }
+
+  if (classUid === COMPLIANCE_FINDING_CLASS_UID) {
+    return "Compliance Finding";
+  }
+
+  return "Detection Finding";
+}
+
+function activityForFinding(state: string, stateChange: string): string {
+  switch (stateChange.toUpperCase()) {
+    case "ADDED":
+      return "Create";
+    case "CHANGED":
+      return "Update";
+    case "REMOVED":
+      return "Close";
+    default:
+      return state.toUpperCase() === "INACTIVE" ? "Close" : "Create";
+  }
+}
+
+function summarizeMitre(finding: JSONObject): MitreReferences {
+  const mitreAttack: JSONValue =
+    readValue(finding, "mitreAttack") ?? readValue(finding, "mitre_attack");
+  const values: Array<string> = collectScalarStrings(mitreAttack);
+
+  for (const path of [
+    "sourceProperties.mitre_tactic_id",
+    "sourceProperties.mitre_technique_id",
+    "sourceProperties.mitre_attack",
+  ]) {
+    values.push(...readAllStrings(finding, path));
+  }
+
+  const extracted: MitreReferences = extractMitreReferences(values);
+  const tactics: Array<string> = [...extracted.tactics];
+
+  for (const value of values) {
+    const mapped: string | undefined =
+      SCC_TACTIC_IDS[
+        value
+          .trim()
+          .toUpperCase()
+          .replace(/[\s-]+/g, "_")
+      ];
+
+    if (mapped) {
+      tactics.push(mapped);
+    }
+  }
+
+  return {
+    tactics: uniqueStrings(tactics),
+    techniques: extracted.techniques,
+  };
+}
+
+interface SccEntities {
+  principalUser: string;
+  principalIp: string;
+  targetHost: string;
+  targetIp: string;
+  targetResource: string;
+  observables: Array<string>;
+}
+
+function summarizeEntities(
+  finding: JSONObject,
+  resource: JSONObject | null,
+): SccEntities {
+  const principalUser: string = readFirstString(finding, [
+    "access.principalEmail",
+    "access.principal_email",
+    "sourceProperties.principalEmail",
+    "sourceProperties.principal_email",
+  ]);
+  const principalIp: string = readFirstString(finding, [
+    "access.callerIp",
+    "access.caller_ip",
+    "sourceProperties.sourceIp",
+    "sourceProperties.source_ip",
+  ]);
+  const targetResource: string =
+    readFirstString(finding, ["resourceName", "resource_name"]) ||
+    (resource ? readFirstString(resource, ["name"]) : "");
+  const targetHost: string = resource
+    ? readFirstString(resource, [
+        "displayName",
+        "display_name",
+        "gcpMetadata.projectDisplayName",
+        "gcp_metadata.project_display_name",
+      ])
+    : "";
+
+  const values: Array<string> = [
+    principalUser,
+    principalIp,
+    targetHost,
+    targetResource,
+  ];
+
+  for (const path of [
+    "indicator.ipAddresses",
+    "indicator.ip_addresses",
+    "indicator.domains",
+    "indicator.uris",
+    "sourceProperties.sourceIp",
+    "sourceProperties.destinationIp",
+    "sourceProperties.source_ip",
+    "sourceProperties.destination_ip",
+  ]) {
+    values.push(...readAllStrings(finding, path));
+  }
+
+  for (const path of ["connections", "files", "exfiltration.sources"]) {
+    for (const entry of readObjects(finding, path)) {
+      values.push(...collectScalarStrings(entry));
+    }
+  }
+
+  const targetIp: string =
+    readFirstString(finding, [
+      "connections.destinationIp",
+      "connections.destination_ip",
+      "indicator.ipAddresses",
+      "indicator.ip_addresses",
+    ]) || "";
+
+  return {
+    principalUser,
+    principalIp,
+    targetHost,
+    targetIp,
+    targetResource,
+    observables: buildObservables(values),
+  };
+}
+
+export default class GoogleSecurityCommandCenterNormalizer {
+  public static isGoogleSecurityCommandCenterEvent(
+    payload: JSONObject,
+  ): boolean {
+    const unwrapped: SccPayload = unwrapPayload(payload);
+    const finding: JSONObject = unwrapped.finding;
+    const canonicalName: string = readFirstString(finding, [
+      "canonicalName",
+      "canonical_name",
+      "name",
+    ]);
+
+    return Boolean(
+      (canonicalName.includes("/sources/") &&
+        canonicalName.includes("/findings/")) ||
+        (readFirstString(finding, ["resourceName", "resource_name"]) &&
+          readFirstString(finding, ["category"]) &&
+          readFirstString(finding, ["state"])),
+    );
+  }
+
+  public static isGoogleSecurityCommandCenterFinding(
+    payload: JSONObject,
+  ): boolean {
+    return this.isGoogleSecurityCommandCenterEvent(payload);
+  }
+
+  public static normalize(payload: JSONObject): NormalizedSecurityEvent {
+    const unwrapped: SccPayload = unwrapPayload(payload);
+    const finding: JSONObject = unwrapped.finding;
+    const classUid: number = classUidForFinding(finding);
+    const { categoryUid, categoryName } = ocsfCategoryForClassUid(classUid);
+    const severityName: OcsfSeverity =
+      normalizeOcsfSeverity(
+        readFirstString(finding, ["severity"]).replace(
+          /_?SEVERITY_UNSPECIFIED/i,
+          "UNKNOWN",
+        ),
+      ) || OcsfSeverity.Unknown;
+    const time: Date | null = parseEventTime(
+      readValue(finding, "eventTime") ??
+        readValue(finding, "event_time") ??
+        readValue(finding, "createTime") ??
+        readValue(finding, "create_time"),
+    );
+    const state: string = readFirstString(finding, ["state"]);
+    const category: string = readFirstString(finding, ["category"]);
+    const name: string = readFirstString(finding, [
+      "canonicalName",
+      "canonical_name",
+      "name",
+    ]);
+    const description: string = readFirstString(finding, [
+      "description",
+      "sourceProperties.description",
+      "sourceProperties.Description",
+      "sourceProperties.explanation",
+      "sourceProperties.Explanation",
+    ]);
+    const entities: SccEntities = summarizeEntities(
+      finding,
+      unwrapped.resource,
+    );
+    const mitre: MitreReferences = summarizeMitre(finding);
+
+    return {
+      time: time || new Date(),
+      eventUid: name || contentHashEventUid(payload),
+      categoryUid,
+      categoryName,
+      classUid,
+      className: classNameForUid(classUid),
+      activityName: activityForFinding(state, unwrapped.stateChange),
+      severityId: OcsfSeverityId[severityName],
+      severityName,
+      statusName: state,
+      message:
+        description ||
+        prettifyToken(category) ||
+        "Security Command Center finding",
+      vendorName: "Google",
+      productName: "Security Command Center",
+      ruleId:
+        readFirstString(finding, [
+          "sourceProperties.ruleId",
+          "sourceProperties.rule_id",
+        ]) || category,
+      ruleName: prettifyToken(category),
+      mitreTactics: mitre.tactics,
+      mitreTechniques: mitre.techniques,
+      principalUser: entities.principalUser,
+      principalHost: "",
+      principalIp: entities.principalIp,
+      principalProcess: "",
+      targetUser: "",
+      targetHost: entities.targetHost,
+      targetIp: entities.targetIp,
+      targetPort: 0,
+      targetResource: entities.targetResource,
+      observables: entities.observables,
+      attributes: flattenPayload(payload),
+    };
+  }
+}

--- a/Common/Utils/SecurityEvent/Vendor/MicrosoftGraphSecurityNormalizer.ts
+++ b/Common/Utils/SecurityEvent/Vendor/MicrosoftGraphSecurityNormalizer.ts
@@ -1,0 +1,432 @@
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity, {
+  OcsfSeverityId,
+  normalizeOcsfSeverity,
+} from "../../../Types/SecurityEvent/OcsfSeverity";
+import { ocsfCategoryForClassUid } from "../../../Types/SecurityEvent/OcsfEventClass";
+import {
+  buildObservables,
+  contentHashEventUid,
+  flattenPayload,
+  parseEventTime,
+  readNumber,
+  readString,
+  readStringArray,
+  readValue,
+} from "../NormalizerHelpers";
+
+const DETECTION_FINDING_CLASS_UID: number = 2004;
+const INCIDENT_FINDING_CLASS_UID: number = 2005;
+const MAX_EXPANDED_ALERTS: number = 25;
+
+interface ExtractedEntities {
+  principalUser: string;
+  principalHost: string;
+  principalIp: string;
+  principalProcess: string;
+  targetUser: string;
+  targetHost: string;
+  targetIp: string;
+  targetPort: number;
+  targetResource: string;
+  observables: Array<string>;
+}
+
+function objectValue(value: JSONValue): JSONObject | null {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as JSONObject;
+  }
+
+  return null;
+}
+
+function objectArray(value: JSONValue): Array<JSONObject> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const result: Array<JSONObject> = [];
+  for (const item of value) {
+    if (item && typeof item === "object" && !Array.isArray(item)) {
+      result.push(item as JSONObject);
+    }
+  }
+  return result;
+}
+
+/* Accept a direct Graph resource, a list response, or a change notification. */
+function unwrapResource(payload: JSONObject): JSONObject {
+  const values: Array<JSONObject> = objectArray(readValue(payload, "value"));
+
+  if (values[0]) {
+    const resourceData: JSONObject | null = objectValue(
+      readValue(values[0], "resourceData"),
+    );
+    return resourceData || values[0];
+  }
+
+  for (const path of ["resourceData", "alert", "incident"]) {
+    const resource: JSONObject | null = objectValue(readValue(payload, path));
+    if (resource) {
+      return resource;
+    }
+  }
+
+  return payload;
+}
+
+function readAny(payload: JSONObject, paths: Array<string>): string {
+  for (const path of paths) {
+    const value: string = readString(payload, path);
+    if (value) {
+      return value;
+    }
+  }
+
+  return "";
+}
+
+function readLiteralString(payload: JSONObject, key: string): string {
+  const value: JSONValue = payload[key];
+  return typeof value === "string" ? value : "";
+}
+
+function isIncident(resource: JSONObject): boolean {
+  const odataType: string = readLiteralString(
+    resource,
+    "@odata.type",
+  ).toLowerCase();
+
+  return Boolean(
+    odataType.endsWith(".incident") ||
+      (readString(resource, "displayName") &&
+        (readValue(resource, "alerts") ||
+          readString(resource, "redirectIncidentId") ||
+          readString(resource, "summary"))),
+  );
+}
+
+function severityFor(resource: JSONObject): OcsfSeverity {
+  const textSeverity: OcsfSeverity | null = normalizeOcsfSeverity(
+    readString(resource, "severity"),
+  );
+
+  if (textSeverity) {
+    return textSeverity;
+  }
+
+  const priorityScore: number | null = readNumber(resource, "priorityScore");
+
+  if (priorityScore === null || priorityScore < 0 || priorityScore > 100) {
+    return OcsfSeverity.Unknown;
+  }
+
+  if (priorityScore > 85) {
+    return OcsfSeverity.High;
+  }
+
+  if (priorityScore >= 15) {
+    return OcsfSeverity.Medium;
+  }
+
+  return OcsfSeverity.Low;
+}
+
+function isSourceEvidence(evidence: JSONObject): boolean {
+  const roles: Array<string> = readStringArray(evidence, "roles").map(
+    (role: string): string => {
+      return role.toLowerCase();
+    },
+  );
+
+  return roles.some((role: string): boolean => {
+    return role === "source" || role === "attacker";
+  });
+}
+
+function pushValues(target: Array<string>, values: Array<string>): void {
+  target.push(
+    ...values.filter((value: string): boolean => {
+      return Boolean(value);
+    }),
+  );
+}
+
+function extractEntities(resources: Array<JSONObject>): ExtractedEntities {
+  const result: ExtractedEntities = {
+    principalUser: "",
+    principalHost: "",
+    principalIp: "",
+    principalProcess: "",
+    targetUser: "",
+    targetHost: "",
+    targetIp: "",
+    targetPort: 0,
+    targetResource: "",
+    observables: [],
+  };
+
+  for (const resource of resources) {
+    for (const evidence of objectArray(readValue(resource, "evidence"))) {
+      const type: string = readLiteralString(
+        evidence,
+        "@odata.type",
+      ).toLowerCase();
+      const source: boolean = isSourceEvidence(evidence);
+
+      if (type.includes("userevidence")) {
+        const user: string = readAny(evidence, [
+          "userAccount.userPrincipalName",
+          "userAccount.accountName",
+          "userPrincipalName",
+          "displayName",
+        ]);
+        if (source && !result.principalUser) {
+          result.principalUser = user;
+        } else if (!result.targetUser) {
+          result.targetUser = user;
+        }
+        pushValues(result.observables, [user]);
+      }
+
+      if (type.includes("deviceevidence")) {
+        const host: string = readAny(evidence, ["deviceDnsName", "hostName"]);
+        if (source && !result.principalHost) {
+          result.principalHost = host;
+        } else if (!result.targetHost) {
+          result.targetHost = host;
+        }
+        pushValues(result.observables, [
+          host,
+          ...readStringArray(evidence, "ipInterfaces"),
+        ]);
+      }
+
+      if (type.includes("ipevidence")) {
+        const ip: string = readString(evidence, "ipAddress");
+        if (source && !result.principalIp) {
+          result.principalIp = ip;
+        } else if (!result.targetIp) {
+          result.targetIp = ip;
+        }
+        pushValues(result.observables, [ip]);
+      }
+
+      if (type.includes("processevidence")) {
+        const process: string = readAny(evidence, [
+          "processCommandLine",
+          "imageFile.filePath",
+          "imageFile.fileName",
+        ]);
+        result.principalProcess ||= process;
+        pushValues(result.observables, [process]);
+      }
+
+      const fileValues: Array<string> = [
+        readString(evidence, "fileDetails.sha256"),
+        readString(evidence, "fileDetails.sha1"),
+        readString(evidence, "fileDetails.md5"),
+        readString(evidence, "fileDetails.fileName"),
+        readString(evidence, "fileDetails.filePath"),
+      ];
+      pushValues(result.observables, fileValues);
+
+      const targetResource: string = readAny(evidence, [
+        "url",
+        "resourceId",
+        "resourceName",
+        "fileDetails.filePath",
+        "fileDetails.fileName",
+      ]);
+      result.targetResource ||= targetResource;
+      pushValues(result.observables, [targetResource]);
+
+      const mailbox: string = readAny(evidence, [
+        "mailboxPrimaryAddress",
+        "mailboxAddress",
+      ]);
+      result.targetUser ||= mailbox;
+      pushValues(result.observables, [mailbox]);
+    }
+
+    const userState: JSONObject | undefined = objectArray(
+      readValue(resource, "userStates"),
+    )[0];
+    if (userState) {
+      result.principalUser ||= readAny(userState, [
+        "userPrincipalName",
+        "accountName",
+      ]);
+      pushValues(result.observables, [result.principalUser]);
+    }
+
+    const hostState: JSONObject | undefined = objectArray(
+      readValue(resource, "hostStates"),
+    )[0];
+    if (hostState) {
+      result.targetHost ||= readAny(hostState, [
+        "fqdn",
+        "netBiosHostName",
+        "os",
+      ]);
+      pushValues(result.observables, [result.targetHost]);
+    }
+
+    const connection: JSONObject | undefined = objectArray(
+      readValue(resource, "networkConnections"),
+    )[0];
+    if (connection) {
+      result.principalIp ||= readString(connection, "sourceAddress");
+      result.targetIp ||= readString(connection, "destinationAddress");
+      result.targetPort ||= readNumber(connection, "destinationPort") || 0;
+      pushValues(result.observables, [result.principalIp, result.targetIp]);
+    }
+
+    const process: JSONObject | undefined = objectArray(
+      readValue(resource, "processes"),
+    )[0];
+    if (process) {
+      result.principalProcess ||= readAny(process, ["commandLine", "name"]);
+    }
+  }
+
+  result.observables = buildObservables(result.observables);
+  return result;
+}
+
+function productFor(resource: JSONObject, alerts: Array<JSONObject>): string {
+  const explicit: string =
+    readString(resource, "productName") ||
+    (alerts[0] ? readString(alerts[0], "productName") : "");
+
+  if (explicit) {
+    return explicit;
+  }
+
+  const serviceSource: string = (
+    readString(resource, "serviceSource") ||
+    (alerts[0] ? readString(alerts[0], "serviceSource") : "")
+  ).toLowerCase();
+
+  if (serviceSource.includes("sentinel")) {
+    return "Microsoft Sentinel";
+  }
+
+  return "Microsoft Defender XDR";
+}
+
+function collectAttackValues(
+  resources: Array<JSONObject>,
+  path: string,
+): Array<string> {
+  const values: Array<string> = [];
+
+  for (const resource of resources) {
+    values.push(...readStringArray(resource, path));
+  }
+
+  return buildObservables(values);
+}
+
+export default class MicrosoftGraphSecurityNormalizer {
+  public static isMicrosoftGraphSecurityEvent(payload: JSONObject): boolean {
+    const resource: JSONObject = unwrapResource(payload);
+    const odataType: string = readLiteralString(
+      resource,
+      "@odata.type",
+    ).toLowerCase();
+    const context: string = readLiteralString(
+      payload,
+      "@odata.context",
+    ).toLowerCase();
+
+    return Boolean(
+      odataType.includes("microsoft.graph.security.alert") ||
+        odataType.includes("microsoft.graph.security.incident") ||
+        context.includes("$metadata#security/alerts") ||
+        context.includes("$metadata#security/incidents") ||
+        (readString(resource, "providerAlertId") &&
+          readString(resource, "serviceSource")) ||
+        (readString(resource, "tenantId") &&
+          readString(resource, "incidentWebUrl")),
+    );
+  }
+
+  public static normalize(payload: JSONObject): NormalizedSecurityEvent {
+    const resource: JSONObject = unwrapResource(payload);
+    const incident: boolean = isIncident(resource);
+    const alerts: Array<JSONObject> = incident
+      ? objectArray(readValue(resource, "alerts")).slice(0, MAX_EXPANDED_ALERTS)
+      : [];
+    const resources: Array<JSONObject> = [resource, ...alerts];
+    const entities: ExtractedEntities = extractEntities(resources);
+    const primaryAlert: JSONObject = alerts[0] || resource;
+    const classUid: number = incident
+      ? INCIDENT_FINDING_CLASS_UID
+      : DETECTION_FINDING_CLASS_UID;
+    const { categoryUid, categoryName } = ocsfCategoryForClassUid(classUid);
+    const severityName: OcsfSeverity = severityFor(resource);
+    const time: Date | null = parseEventTime(
+      readValue(resource, "lastActivityDateTime") ??
+        readValue(resource, "lastUpdateDateTime") ??
+        readValue(resource, "createdDateTime") ??
+        readValue(resource, "firstActivityDateTime"),
+    );
+
+    entities.principalUser ||=
+      readString(resource, "actorDisplayName") ||
+      readString(primaryAlert, "actorDisplayName");
+
+    return {
+      time: time || new Date(),
+      eventUid: readString(resource, "id") || contentHashEventUid(payload),
+      categoryUid,
+      categoryName,
+      classUid,
+      className: incident ? "Incident Finding" : "Detection Finding",
+      activityName: "Create",
+      severityId: OcsfSeverityId[severityName],
+      severityName,
+      statusName: readString(resource, "status"),
+      message:
+        readAny(resource, ["displayName", "title", "description", "summary"]) ||
+        (incident ? "Microsoft security incident" : "Microsoft security alert"),
+      vendorName: "Microsoft",
+      productName: productFor(resource, alerts),
+      ruleId: readAny(primaryAlert, ["alertPolicyId", "detectorId"]),
+      ruleName: readAny(primaryAlert, [
+        "threatDisplayName",
+        "detectionSource",
+        "category",
+      ]),
+      mitreTactics: buildObservables([
+        ...collectAttackValues(resources, "categories"),
+        ...resources.map((item: JSONObject): string => {
+          return readString(item, "category");
+        }),
+      ]),
+      mitreTechniques: collectAttackValues(resources, "mitreTechniques"),
+      principalUser: entities.principalUser,
+      principalHost: entities.principalHost,
+      principalIp: entities.principalIp,
+      principalProcess: entities.principalProcess,
+      targetUser: entities.targetUser,
+      targetHost: entities.targetHost,
+      targetIp: entities.targetIp,
+      targetPort: entities.targetPort,
+      targetResource: entities.targetResource,
+      observables: buildObservables([
+        entities.principalUser,
+        entities.principalHost,
+        entities.principalIp,
+        entities.targetUser,
+        entities.targetHost,
+        entities.targetIp,
+        entities.targetResource,
+        ...entities.observables,
+      ]),
+      attributes: flattenPayload(payload),
+    };
+  }
+}

--- a/Common/Utils/SecurityEvent/Vendor/OktaSystemLogNormalizer.ts
+++ b/Common/Utils/SecurityEvent/Vendor/OktaSystemLogNormalizer.ts
@@ -1,0 +1,265 @@
+import { JSONObject } from "../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity, {
+  OcsfSeverityId,
+  normalizeOcsfSeverity,
+} from "../../../Types/SecurityEvent/OcsfSeverity";
+import { ocsfCategoryForClassUid } from "../../../Types/SecurityEvent/OcsfEventClass";
+import {
+  buildObservables,
+  contentHashEventUid,
+  flattenPayload,
+  parseEventTime,
+  readValue,
+} from "../NormalizerHelpers";
+import {
+  prettifyToken,
+  readAllStrings,
+  readFirstString,
+  readObjects,
+} from "./VendorNormalizerHelpers";
+
+interface OktaClassMapping {
+  classUid: number;
+  activityName: string;
+}
+
+function classMappingForEventType(eventType: string): OktaClassMapping {
+  const normalized: string = eventType.toLowerCase();
+
+  if (
+    normalized.includes("authentication") ||
+    normalized.startsWith("user.session.") ||
+    normalized.startsWith("security.request.blocked")
+  ) {
+    return {
+      classUid: 3002,
+      activityName: normalized.endsWith(".end") ? "Logoff" : "Logon",
+    };
+  }
+
+  if (normalized.startsWith("user.lifecycle.")) {
+    const action: string = normalized.split(".").pop() || "update";
+    return { classUid: 3001, activityName: prettifyToken(action) };
+  }
+
+  if (
+    normalized.startsWith("group.lifecycle.") ||
+    normalized.startsWith("group.user_membership.")
+  ) {
+    const action: string = normalized.split(".").pop() || "update";
+    return { classUid: 3006, activityName: prettifyToken(action) };
+  }
+
+  if (
+    normalized.startsWith("application.lifecycle.") ||
+    normalized.startsWith("app.lifecycle.")
+  ) {
+    const action: string = normalized.split(".").pop() || "update";
+    return { classUid: 3004, activityName: prettifyToken(action) };
+  }
+
+  if (normalized.includes("policy.evaluate")) {
+    return { classUid: 3003, activityName: "Authorize" };
+  }
+
+  return { classUid: 6003, activityName: prettifyToken(eventType) };
+}
+
+function normalizeOutcome(value: string): string {
+  const outcomes: Record<string, string> = {
+    SUCCESS: "Success",
+    FAILURE: "Failure",
+    SKIPPED: "Skipped",
+    ALLOW: "Allowed",
+    DENY: "Denied",
+    CHALLENGE: "Challenge",
+    UNKNOWN: "Unknown",
+  };
+
+  return outcomes[value.toUpperCase()] || prettifyToken(value);
+}
+
+interface OktaTargetSummary {
+  targetUser: string;
+  targetHost: string;
+  targetResource: string;
+  observables: Array<string>;
+}
+
+function summarizeTargets(payload: JSONObject): OktaTargetSummary {
+  const targets: Array<JSONObject> = readObjects(payload, "target");
+  let targetUser: string = "";
+  let targetHost: string = "";
+  let targetResource: string = "";
+  const values: Array<string> = [];
+
+  for (const target of targets) {
+    const type: string = readFirstString(target, ["type"]).toLowerCase();
+    const id: string = readFirstString(target, [
+      "alternateId",
+      "alternate_id",
+      "displayName",
+      "display_name",
+      "id",
+    ]);
+
+    values.push(
+      ...readAllStrings(target, "id"),
+      ...readAllStrings(target, "alternateId"),
+      ...readAllStrings(target, "alternate_id"),
+      ...readAllStrings(target, "displayName"),
+      ...readAllStrings(target, "display_name"),
+    );
+
+    if (!targetUser && type.includes("user")) {
+      targetUser = id;
+    }
+
+    if (
+      !targetHost &&
+      (type.includes("device") ||
+        type.includes("client") ||
+        type.includes("host"))
+    ) {
+      targetHost = id;
+    }
+
+    if (!targetResource) {
+      targetResource = id;
+    }
+  }
+
+  return { targetUser, targetHost, targetResource, observables: values };
+}
+
+export default class OktaSystemLogNormalizer {
+  public static isOktaSystemLogEvent(payload: JSONObject): boolean {
+    const eventType: string = readFirstString(payload, [
+      "eventType",
+      "event_type",
+    ]);
+
+    return Boolean(
+      eventType &&
+        (readFirstString(payload, ["uuid", "published", "displayMessage"]) ||
+          readValue(payload, "actor") ||
+          readValue(payload, "outcome")),
+    );
+  }
+
+  public static normalize(payload: JSONObject): NormalizedSecurityEvent {
+    const eventType: string = readFirstString(payload, [
+      "eventType",
+      "event_type",
+      "legacyEventType",
+      "legacy_event_type",
+    ]);
+    const mapping: OktaClassMapping = classMappingForEventType(eventType);
+    const { categoryUid, categoryName } = ocsfCategoryForClassUid(
+      mapping.classUid,
+    );
+    const severityName: OcsfSeverity =
+      normalizeOcsfSeverity(readFirstString(payload, ["severity"])) ||
+      OcsfSeverity.Unknown;
+    const time: Date | null = parseEventTime(
+      readValue(payload, "published") ??
+        readValue(payload, "eventTime") ??
+        readValue(payload, "event_time"),
+    );
+    const principalUser: string = readFirstString(payload, [
+      "actor.alternateId",
+      "actor.alternate_id",
+      "actor.displayName",
+      "actor.display_name",
+      "actor.id",
+    ]);
+    const principalHost: string = readFirstString(payload, [
+      "client.device",
+      "device.displayName",
+      "device.display_name",
+      "device.name",
+    ]);
+    const principalIp: string = readFirstString(payload, [
+      "client.ipAddress",
+      "client.ip_address",
+      "request.ipChain.ip",
+      "request.ip_chain.ip",
+    ]);
+    const targets: OktaTargetSummary = summarizeTargets(payload);
+    const targetResource: string =
+      readFirstString(payload, [
+        "debugContext.debugData.requestUri",
+        "debugContext.debug_data.request_uri",
+        "request.uri",
+      ]) || targets.targetResource;
+
+    const observables: Array<string> = [
+      principalUser,
+      principalHost,
+      principalIp,
+      targets.targetUser,
+      targets.targetHost,
+      ...targets.observables,
+    ];
+
+    for (const path of ["request.ipChain", "request.ip_chain"]) {
+      for (const entry of readObjects(payload, path)) {
+        observables.push(readFirstString(entry, ["ip"]));
+      }
+    }
+
+    return {
+      time: time || new Date(),
+      eventUid:
+        readFirstString(payload, ["uuid", "eventId", "event_id"]) ||
+        contentHashEventUid(payload),
+      categoryUid,
+      categoryName,
+      classUid: mapping.classUid,
+      className:
+        mapping.classUid === 3002
+          ? "Authentication"
+          : mapping.classUid === 3001
+            ? "Account Change"
+            : mapping.classUid === 3006
+              ? "Group Management"
+              : mapping.classUid === 3004
+                ? "Entity Management"
+                : mapping.classUid === 3003
+                  ? "Authorize Session"
+                  : "API Activity",
+      activityName: mapping.activityName,
+      severityId: OcsfSeverityId[severityName],
+      severityName,
+      statusName: normalizeOutcome(
+        readFirstString(payload, ["outcome.result", "outcome.status"]),
+      ),
+      message:
+        readFirstString(payload, [
+          "displayMessage",
+          "display_message",
+          "outcome.reason",
+        ]) ||
+        prettifyToken(eventType) ||
+        "Okta System Log event",
+      vendorName: "Okta",
+      productName: "System Log",
+      ruleId: eventType,
+      ruleName: prettifyToken(eventType),
+      mitreTactics: [],
+      mitreTechniques: [],
+      principalUser,
+      principalHost,
+      principalIp,
+      principalProcess: "",
+      targetUser: targets.targetUser,
+      targetHost: targets.targetHost,
+      targetIp: "",
+      targetPort: 0,
+      targetResource,
+      observables: buildObservables(observables),
+      attributes: flattenPayload(payload),
+    };
+  }
+}

--- a/Common/Utils/SecurityEvent/Vendor/SplunkEnterpriseSecurityNormalizer.ts
+++ b/Common/Utils/SecurityEvent/Vendor/SplunkEnterpriseSecurityNormalizer.ts
@@ -1,0 +1,304 @@
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+import NormalizedSecurityEvent from "../../../Types/SecurityEvent/NormalizedSecurityEvent";
+import OcsfSeverity, {
+  OcsfSeverityId,
+  normalizeOcsfSeverity,
+} from "../../../Types/SecurityEvent/OcsfSeverity";
+import { ocsfCategoryForClassUid } from "../../../Types/SecurityEvent/OcsfEventClass";
+import {
+  buildObservables,
+  contentHashEventUid,
+  flattenPayload,
+  parseEventTime,
+  readValue,
+} from "../NormalizerHelpers";
+import {
+  MitreReferences,
+  collectScalarStrings,
+  extractMitreReferences,
+  isIpAddress,
+  prettifyToken,
+  readAllStrings,
+  readFirstNumber,
+  readFirstString,
+} from "./VendorNormalizerHelpers";
+
+function eventUid(payload: JSONObject): string {
+  const explicitId: string = readFirstString(payload, [
+    "event_id",
+    "notable_event_id",
+    "detection_id",
+    "id",
+  ]);
+  if (explicitId) {
+    return explicitId;
+  }
+
+  const rawDataAddress: string = readFirstString(payload, ["_cd"]);
+  if (rawDataAddress) {
+    const bucket: string = readFirstString(payload, ["_bkt"]);
+    if (bucket) {
+      return `${bucket}|${rawDataAddress}`;
+    }
+    const index: string = readFirstString(payload, ["index"]);
+    const splunkServer: string = readFirstString(payload, ["splunk_server"]);
+    if (index || splunkServer) {
+      return `${index}|${splunkServer}|${rawDataAddress}`;
+    }
+  }
+  return contentHashEventUid(payload);
+}
+
+const DETECTION_FINDING_CLASS_UID: number = 2004;
+
+function isRiskEvent(payload: JSONObject): boolean {
+  return Boolean(
+    readFirstString(payload, ["risk_object", "riskObject"]) &&
+      readFirstNumber(payload, ["risk_score", "riskScore"]) !== null,
+  );
+}
+
+function severityFromRiskScore(score: number | null): OcsfSeverity | null {
+  if (score === null || score <= 0) {
+    return null;
+  }
+
+  if (score >= 100) {
+    return OcsfSeverity.Critical;
+  }
+
+  if (score >= 80) {
+    return OcsfSeverity.High;
+  }
+
+  if (score >= 60) {
+    return OcsfSeverity.Medium;
+  }
+
+  if (score >= 40) {
+    return OcsfSeverity.Low;
+  }
+
+  return OcsfSeverity.Informational;
+}
+
+function statusName(payload: JSONObject): string {
+  const status: string = readFirstString(payload, [
+    "status_label",
+    "statusLabel",
+    "status",
+    "notable_status",
+  ]);
+  const statusCodes: Record<string, string> = {
+    "0": "Unassigned",
+    "1": "New",
+    "2": "In Progress",
+    "3": "Pending",
+    "4": "Resolved",
+    "5": "Closed",
+  };
+
+  return statusCodes[status] || prettifyToken(status);
+}
+
+function parseAnnotations(payload: JSONObject): Array<string> {
+  const value: JSONValue = readValue(payload, "annotations");
+
+  if (typeof value === "string") {
+    try {
+      return collectScalarStrings(JSON.parse(value) as JSONValue);
+    } catch {
+      return [value];
+    }
+  }
+
+  return collectScalarStrings(value);
+}
+
+function summarizeMitre(payload: JSONObject): MitreReferences {
+  const values: Array<string> = parseAnnotations(payload);
+
+  for (const path of [
+    "mitre_tactic_id",
+    "mitre_tactic",
+    "mitre_technique_id",
+    "mitre_technique",
+    "mitre_attack_id",
+  ]) {
+    values.push(...readAllStrings(payload, path));
+  }
+
+  return extractMitreReferences(values);
+}
+
+function eventTime(payload: JSONObject): Date | null {
+  for (const path of [
+    "_time",
+    "time",
+    "timestamp",
+    "orig_time",
+    "info_min_time",
+  ]) {
+    const parsed: Date | null = parseEventTime(readValue(payload, path));
+    if (parsed) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+export default class SplunkEnterpriseSecurityNormalizer {
+  public static isSplunkEnterpriseSecurityEvent(payload: JSONObject): boolean {
+    return Boolean(
+      isRiskEvent(payload) ||
+        readFirstString(payload, ["event_id", "notable_event_id"]) ||
+        (readFirstString(payload, ["rule_name", "search_name"]) &&
+          readFirstString(payload, ["urgency", "status", "owner"])),
+    );
+  }
+
+  public static isSplunkNotableOrRiskEvent(payload: JSONObject): boolean {
+    return this.isSplunkEnterpriseSecurityEvent(payload);
+  }
+
+  public static normalize(payload: JSONObject): NormalizedSecurityEvent {
+    const riskEvent: boolean = isRiskEvent(payload);
+    const riskScore: number | null = readFirstNumber(payload, [
+      "risk_score",
+      "riskScore",
+      "calculated_risk_score",
+    ]);
+    const severityName: OcsfSeverity =
+      normalizeOcsfSeverity(
+        readFirstString(payload, ["urgency", "severity", "priority"]),
+      ) ||
+      severityFromRiskScore(riskScore) ||
+      OcsfSeverity.Unknown;
+    const { categoryUid, categoryName } = ocsfCategoryForClassUid(
+      DETECTION_FINDING_CLASS_UID,
+    );
+    const riskObject: string = readFirstString(payload, [
+      "risk_object",
+      "riskObject",
+    ]);
+    const riskObjectType: string = readFirstString(payload, [
+      "risk_object_type",
+      "riskObjectType",
+    ]).toLowerCase();
+    const principalUser: string = readFirstString(payload, [
+      "src_user",
+      "user",
+      "user_name",
+    ]);
+    const source: string = readFirstString(payload, [
+      "src_ip",
+      "src",
+      "source_ip",
+      "host",
+    ]);
+    const destination: string = readFirstString(payload, [
+      "dest_ip",
+      "dest",
+      "destination_ip",
+    ]);
+    const targetUser: string =
+      readFirstString(payload, ["dest_user", "target_user"]) ||
+      (riskObjectType === "user" ? riskObject : "");
+    const targetHost: string =
+      readFirstString(payload, ["dest", "destination", "target_host"]) ||
+      (riskObjectType === "system" ? riskObject : "");
+    const targetIp: string = isIpAddress(destination) ? destination : "";
+    const principalIp: string = isIpAddress(source) ? source : "";
+    const principalHost: string = principalIp ? "" : source;
+    const ruleName: string = readFirstString(payload, [
+      "rule_name",
+      "search_name",
+      "detection_name",
+      "source",
+    ]);
+    const description: string = readFirstString(payload, [
+      "description",
+      "message",
+      "notable_title",
+    ]);
+    const mitre: MitreReferences = summarizeMitre(payload);
+
+    const observables: Array<string> = [
+      principalUser,
+      principalHost,
+      principalIp,
+      targetUser,
+      targetHost,
+      targetIp,
+      riskObject,
+    ];
+
+    for (const path of [
+      "src",
+      "src_ip",
+      "dest",
+      "dest_ip",
+      "user",
+      "src_user",
+      "dest_user",
+      "risk_object",
+      "file_hash",
+      "md5",
+      "sha1",
+      "sha256",
+      "url",
+      "domain",
+    ]) {
+      observables.push(...readAllStrings(payload, path));
+    }
+
+    return {
+      time: eventTime(payload) || new Date(),
+      eventUid: eventUid(payload),
+      categoryUid,
+      categoryName,
+      classUid: DETECTION_FINDING_CLASS_UID,
+      className: "Detection Finding",
+      activityName: riskEvent ? "Update" : "Create",
+      severityId: OcsfSeverityId[severityName],
+      severityName,
+      statusName: riskEvent ? "" : statusName(payload),
+      message:
+        description ||
+        ruleName ||
+        (riskObject
+          ? `Risk modifier for ${riskObject}`
+          : "Splunk notable event"),
+      vendorName: "Splunk",
+      productName: "Enterprise Security",
+      ruleId: readFirstString(payload, [
+        "rule_id",
+        "correlation_search_id",
+        "savedsearch_id",
+        "detection_id",
+      ]),
+      ruleName,
+      mitreTactics: mitre.tactics,
+      mitreTechniques: mitre.techniques,
+      principalUser,
+      principalHost,
+      principalIp,
+      principalProcess: readFirstString(payload, [
+        "process",
+        "process_name",
+        "process_path",
+        "cmd_line",
+      ]),
+      targetUser,
+      targetHost,
+      targetIp,
+      targetPort:
+        readFirstNumber(payload, ["dest_port", "destination_port", "port"]) ||
+        0,
+      targetResource: riskObject,
+      observables: buildObservables(observables),
+      attributes: flattenPayload(payload),
+    };
+  }
+}

--- a/Common/Utils/SecurityEvent/Vendor/VendorNormalizerHelpers.ts
+++ b/Common/Utils/SecurityEvent/Vendor/VendorNormalizerHelpers.ts
@@ -1,0 +1,222 @@
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+import { readNumber, readString, readValue } from "../NormalizerHelpers";
+
+const IPV4_PATTERN: RegExp = /^(?:\d{1,3}\.){3}\d{1,3}$/;
+const IPV6_PATTERN: RegExp = /^[0-9a-f:]+$/i;
+
+export function readFirstString(
+  payload: JSONObject,
+  paths: Array<string>,
+): string {
+  for (const path of paths) {
+    const value: string = readString(payload, path).trim();
+
+    if (value) {
+      return value;
+    }
+  }
+
+  return "";
+}
+
+export function readFirstNumber(
+  payload: JSONObject,
+  paths: Array<string>,
+): number | null {
+  for (const path of paths) {
+    const value: number | null = readNumber(payload, path);
+
+    if (value !== null) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+export function readObject(
+  payload: JSONObject,
+  path: string,
+): JSONObject | null {
+  const value: JSONValue = readValue(payload, path);
+
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as JSONObject;
+  }
+
+  return null;
+}
+
+export function readObjects(
+  payload: JSONObject,
+  path: string,
+): Array<JSONObject> {
+  const value: JSONValue = readValue(payload, path);
+
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const result: Array<JSONObject> = [];
+  for (const entry of value) {
+    if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+      result.push(entry as JSONObject);
+    }
+  }
+  return result;
+}
+
+export function readAllStrings(
+  payload: JSONObject,
+  path: string,
+): Array<string> {
+  const value: JSONValue = readValue(payload, path);
+
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry: JSONValue): boolean => {
+        return (
+          entry !== null && entry !== undefined && typeof entry !== "object"
+        );
+      })
+      .map((entry: JSONValue): string => {
+        return String(entry).trim();
+      })
+      .filter((entry: string): boolean => {
+        return Boolean(entry);
+      });
+  }
+
+  if (typeof value === "object") {
+    return [];
+  }
+
+  const text: string = String(value).trim();
+  return text ? [text] : [];
+}
+
+export function collectScalarStrings(
+  value: JSONValue,
+  maxDepth: number = 8,
+): Array<string> {
+  const values: Array<string> = [];
+
+  const visit: (candidate: JSONValue, depth: number) => void = (
+    candidate: JSONValue,
+    depth: number,
+  ): void => {
+    if (candidate === null || candidate === undefined || depth > maxDepth) {
+      return;
+    }
+
+    if (Array.isArray(candidate)) {
+      for (const entry of candidate) {
+        visit(entry, depth + 1);
+      }
+      return;
+    }
+
+    if (typeof candidate === "object") {
+      for (const entry of Object.values(candidate as JSONObject)) {
+        visit(entry, depth + 1);
+      }
+      return;
+    }
+
+    const text: string = String(candidate).trim();
+    if (text) {
+      values.push(text);
+    }
+  };
+
+  visit(value, 0);
+  return values;
+}
+
+export function uniqueStrings(values: Array<string>): Array<string> {
+  const seen: Set<string> = new Set<string>();
+  const result: Array<string> = [];
+
+  for (const value of values) {
+    const trimmed: string = value.trim();
+
+    if (!trimmed) {
+      continue;
+    }
+
+    const canonical: string = trimmed.toLowerCase();
+    if (seen.has(canonical)) {
+      continue;
+    }
+
+    seen.add(canonical);
+    result.push(trimmed);
+  }
+
+  return result;
+}
+
+export function prettifyToken(value: string): string {
+  return value
+    .trim()
+    .split(/[._\-\s]+/)
+    .filter((part: string): boolean => {
+      return Boolean(part);
+    })
+    .map((part: string): string => {
+      return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+    })
+    .join(" ");
+}
+
+export function lastPathSegment(value: string): string {
+  const segments: Array<string> = value.split("/").filter(Boolean);
+  return segments.length > 0
+    ? (segments[segments.length - 1] as string)
+    : value;
+}
+
+export function isIpAddress(value: string): boolean {
+  const trimmed: string = value.trim();
+
+  if (IPV4_PATTERN.test(trimmed)) {
+    return trimmed.split(".").every((part: string): boolean => {
+      const octet: number = Number(part);
+      return octet >= 0 && octet <= 255;
+    });
+  }
+
+  return trimmed.includes(":") && IPV6_PATTERN.test(trimmed);
+}
+
+export interface MitreReferences {
+  tactics: Array<string>;
+  techniques: Array<string>;
+}
+
+export function extractMitreReferences(values: Array<string>): MitreReferences {
+  const tactics: Array<string> = [];
+  const techniques: Array<string> = [];
+
+  for (const value of values) {
+    const matches: Array<string> =
+      value.toUpperCase().match(/TA\d{4}|T\d{4}(?:\.\d{3})?/g) || [];
+
+    for (const match of matches) {
+      if (match.startsWith("TA")) {
+        tactics.push(match);
+      } else {
+        techniques.push(match);
+      }
+    }
+  }
+
+  return {
+    tactics: uniqueStrings(tactics),
+    techniques: uniqueStrings(techniques),
+  };
+}

--- a/Common/Utils/SecurityEvent/VendorSecurityEventNormalizer.ts
+++ b/Common/Utils/SecurityEvent/VendorSecurityEventNormalizer.ts
@@ -1,0 +1,64 @@
+import { JSONObject } from "../../Types/JSON";
+import NormalizedSecurityEvent from "../../Types/SecurityEvent/NormalizedSecurityEvent";
+import SecurityEventConnectorType from "../../Types/SecurityEvent/SecurityEventConnectorType";
+import AwsSecurityHubNormalizer from "./Vendor/AwsSecurityHubNormalizer";
+import CloudflareSecurityEventNormalizer from "./Vendor/CloudflareSecurityEventNormalizer";
+import CrowdStrikeFalconNormalizer from "./Vendor/CrowdStrikeFalconNormalizer";
+import GoogleSecurityCommandCenterNormalizer from "./Vendor/GoogleSecurityCommandCenterNormalizer";
+import MicrosoftGraphSecurityNormalizer from "./Vendor/MicrosoftGraphSecurityNormalizer";
+import OktaSystemLogNormalizer from "./Vendor/OktaSystemLogNormalizer";
+import SplunkEnterpriseSecurityNormalizer from "./Vendor/SplunkEnterpriseSecurityNormalizer";
+
+export default class VendorSecurityEventNormalizer {
+  public static isEvent(
+    provider: SecurityEventConnectorType,
+    payload: JSONObject,
+  ): boolean {
+    switch (provider) {
+      case SecurityEventConnectorType.AwsSecurityHub:
+        return AwsSecurityHubNormalizer.isAwsSecurityHubFinding(payload);
+      case SecurityEventConnectorType.MicrosoftDefender:
+        return MicrosoftGraphSecurityNormalizer.isMicrosoftGraphSecurityEvent(
+          payload,
+        );
+      case SecurityEventConnectorType.Cloudflare:
+        return CloudflareSecurityEventNormalizer.isCloudflareSecurityEvent(
+          payload,
+        );
+      case SecurityEventConnectorType.CrowdStrikeFalcon:
+        return CrowdStrikeFalconNormalizer.isCrowdStrikeFalconEvent(payload);
+      case SecurityEventConnectorType.GoogleSecurityCommandCenter:
+        return GoogleSecurityCommandCenterNormalizer.isGoogleSecurityCommandCenterEvent(
+          payload,
+        );
+      case SecurityEventConnectorType.Okta:
+        return OktaSystemLogNormalizer.isOktaSystemLogEvent(payload);
+      case SecurityEventConnectorType.SplunkEnterpriseSecurity:
+        return SplunkEnterpriseSecurityNormalizer.isSplunkEnterpriseSecurityEvent(
+          payload,
+        );
+    }
+  }
+
+  public static normalize(
+    provider: SecurityEventConnectorType,
+    payload: JSONObject,
+  ): NormalizedSecurityEvent {
+    switch (provider) {
+      case SecurityEventConnectorType.AwsSecurityHub:
+        return AwsSecurityHubNormalizer.normalize(payload);
+      case SecurityEventConnectorType.MicrosoftDefender:
+        return MicrosoftGraphSecurityNormalizer.normalize(payload);
+      case SecurityEventConnectorType.Cloudflare:
+        return CloudflareSecurityEventNormalizer.normalize(payload);
+      case SecurityEventConnectorType.CrowdStrikeFalcon:
+        return CrowdStrikeFalconNormalizer.normalize(payload);
+      case SecurityEventConnectorType.GoogleSecurityCommandCenter:
+        return GoogleSecurityCommandCenterNormalizer.normalize(payload);
+      case SecurityEventConnectorType.Okta:
+        return OktaSystemLogNormalizer.normalize(payload);
+      case SecurityEventConnectorType.SplunkEnterpriseSecurity:
+        return SplunkEnterpriseSecurityNormalizer.normalize(payload);
+    }
+  }
+}


### PR DESCRIPTION
Google SecOps remains available, and security teams can now pull findings from AWS Security Hub, Microsoft Defender XDR/Sentinel, Cloudflare, CrowdStrike Falcon, Google Security Command Center, Okta, and Splunk Enterprise Security from the same Security Events page.

The new managed connector pipeline encrypts write-only credentials and checkpoints, validates provider settings and outbound destinations, normalizes vendor events into the shared security-event model, and deduplicates ingestion. Polling uses bounded concurrency, pagination, deadlines, retry-safe checkpoints, and atomic source resets when credentials or source settings change. This also adds the CRUD API, worker scheduling, dashboard management UI, Postgres migration, and setup documentation.

Validation:

- Common, App, and Dashboard TypeScript compiles
- Focused ESLint across every changed feature and test file
- 61 connection service validation, authorization, encryption, and update tests
- 35 polling, scheduling, pagination, concurrency, and checkpoint tests
- 25 provider HTTP contract and error-handling tests
- Vendor normalizer suites for all seven providers
- Database service update-routing and HTTP cancellation suites
- Dashboard render and static wiring suites
- PostgreSQL integration covering encrypted persistence, defaults, rotation, and optimistic checkpoints
- Fresh-database Postgres schema-drift check
- Local Docker application restart and HTTP smoke check
