### PR TITLE
fix(network-sites): let a site sit under any site the hierarchy allows

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/ImportSitesFromCsvModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/ImportSitesFromCsvModal.tsx
@@ -70,6 +70,7 @@ const EXAMPLE_CSV: string = [
   '"Franchise East",Franchisee,"East Region",,,',
   '"Springfield Market",Market,"Franchise East",,,',
   '"Unit 1042","Unit","Springfield Market","742 Evergreen Terrace, Springfield, IL",39.7817,-89.6501',
+  '"Warehouse 7",Other,"East Region",,,',
 ].join("\n");
 
 export interface ComponentProps {
@@ -124,6 +125,7 @@ const ImportSitesFromCsvModal: FunctionComponent<ComponentProps> = (
             select: {
               _id: true,
               name: true,
+              isUnitLevel: true,
               parentNetworkSiteTypeId: true,
             },
             sort: {
@@ -152,6 +154,7 @@ const ImportSitesFromCsvModal: FunctionComponent<ComponentProps> = (
               name: siteType.name!,
               parentNetworkSiteTypeId:
                 siteType.parentNetworkSiteTypeId?.toString() || null,
+              isUnitLevel: siteType.isUnitLevel === true,
             };
           }),
       );
@@ -319,6 +322,7 @@ const ImportSitesFromCsvModal: FunctionComponent<ComponentProps> = (
         rows: parseResult.rows,
         existingSiteIdByName: existingSiteIdByName,
         existingSiteTypeIdByName: existingSiteTypeIdByName,
+        siteTypes: siteTypes,
         createSite: createSite,
         onProgress: (progress: SiteImportProgress): void => {
           setRowResults(progress.results);
@@ -402,10 +406,12 @@ const ImportSitesFromCsvModal: FunctionComponent<ComponentProps> = (
         <p className="text-sm text-gray-500">
           Columns: {SITE_CSV_COLUMNS.join(", ")}. siteType must be one of this
           project&apos;s configured site types
-          {siteTypeNames ? ` (${siteTypeNames})` : ""}. Rows whose parentName is
-          empty or already exists import first, then their children — parents
-          and children can live in the same file. Rows with an unresolvable
-          parent are skipped and reported.
+          {siteTypeNames ? ` (${siteTypeNames})` : ""}. parentName is optional
+          for every type: leave it empty for a top-level site, or name any site
+          that is not below this one in your site type hierarchy. Rows whose
+          parentName is empty or already exists import first, then their
+          children — parents and children can live in the same file. Rows with
+          an unresolvable parent are skipped and reported.
         </p>
 
         <TextArea

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/NetworkSiteFormDropdownOptions.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/NetworkSiteFormDropdownOptions.ts
@@ -1,10 +1,15 @@
 import SiteTypeHierarchyFormUtil from "./SiteTypeHierarchyFormUtil";
 import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
 import NetworkSiteType from "Common/Models/DatabaseModels/NetworkSiteType";
+import NetworkSiteTypeHierarchyUtil from "Common/Utils/NetworkSite/TypeHierarchyUtil";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
+import Includes from "Common/Types/BaseDatabase/Includes";
 import ObjectID from "Common/Types/ObjectID";
-import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
+import {
+  DropdownOption,
+  DropdownOptionGroup,
+} from "Common/UI/Components/Dropdown/Dropdown";
 import FormValues from "Common/UI/Components/Forms/Types/FormValues";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 
@@ -22,16 +27,11 @@ const NETWORK_SITE_TYPE_SELECT: {
   parentNetworkSiteTypeId: true,
 };
 
-let cachedNetworkSiteTypes: Array<NetworkSiteType> = [];
-
-export function isParentSiteRequired(values: FormValues<NetworkSite>): boolean {
-  return SiteTypeHierarchyFormUtil.isParentSiteRequired({
-    selectedNetworkSiteTypeValue:
-      values.networkSiteType || values.networkSiteTypeId,
-    networkSiteTypes: cachedNetworkSiteTypes,
-  });
-}
-
+/*
+ * Re-read on every picker open. Site types are a settings table an operator
+ * can edit in another tab, and a stale catalog here would silently offer - or
+ * withhold - parents the server then disagrees about.
+ */
 export async function fetchNetworkSiteTypes(): Promise<Array<NetworkSiteType>> {
   const networkSiteTypes: Array<NetworkSiteType> = [];
   let skip: number = 0;
@@ -59,9 +59,7 @@ export async function fetchNetworkSiteTypes(): Promise<Array<NetworkSiteType>> {
     skip += result.data.length;
   }
 
-  cachedNetworkSiteTypes = networkSiteTypes;
-
-  return cachedNetworkSiteTypes;
+  return networkSiteTypes;
 }
 
 export async function fetchAllNetworkSiteTypeOptions(): Promise<
@@ -84,20 +82,45 @@ export async function fetchParentNetworkSiteTypeOptions(
   });
 }
 
+/*
+ * The selected type's configured parent no longer FILTERS this list - it only
+ * decides which candidates are offered first - because filtering on it left a
+ * project whose types are all top-level with a permanently empty picker and no
+ * way to link anything (GitHub issue #3744).
+ *
+ * What still narrows the read is the placement rule itself: the types a site of
+ * this type may sit under are computable from the catalog the browser already
+ * has, so the query asks for those types rather than for the whole project. In
+ * a franchise estate that is the difference between reading a handful of
+ * containers and reading every unit-level store. The self/subtree exclusion and
+ * the final placement filter run in SiteTypeHierarchyFormUtil, where they are
+ * testable without the API.
+ */
 export async function fetchParentNetworkSiteOptions(
   values: FormValues<NetworkSite>,
   currentNetworkSiteId?: ObjectID | undefined,
-): Promise<Array<DropdownOption>> {
+): Promise<Array<DropdownOption | DropdownOptionGroup>> {
   const networkSiteTypes: Array<NetworkSiteType> =
     await fetchNetworkSiteTypes();
-  const parentNetworkSiteTypeId: string | null =
-    SiteTypeHierarchyFormUtil.getConfiguredParentTypeId({
-      selectedNetworkSiteTypeValue:
-        values.networkSiteType || values.networkSiteTypeId,
-      networkSiteTypes,
-    });
 
-  if (!parentNetworkSiteTypeId) {
+  const childNetworkSiteTypeValue: unknown =
+    values.networkSiteType || values.networkSiteTypeId;
+
+  const allowedParentTypeIds: Array<string> =
+    NetworkSiteTypeHierarchyUtil.getValidSiteParentTypes({
+      networkSiteTypeId: SiteTypeHierarchyFormUtil.getEntityId(
+        childNetworkSiteTypeValue,
+      ),
+      networkSiteTypes,
+    })
+      .map((networkSiteType: NetworkSiteType) => {
+        return networkSiteType.id!.toString();
+      })
+      .filter((id: string) => {
+        return Boolean(id);
+      });
+
+  if (allowedParentTypeIds.length === 0) {
     return [];
   }
 
@@ -109,13 +132,14 @@ export async function fetchParentNetworkSiteOptions(
       {
         modelType: NetworkSite,
         query: {
-          networkSiteTypeId: new ObjectID(parentNetworkSiteTypeId),
+          networkSiteTypeId: new Includes(allowedParentTypeIds),
         },
         limit: LIMIT_PER_PROJECT,
         skip,
         select: {
           _id: true,
           name: true,
+          networkSiteTypeId: true,
           materializedPath: true,
         },
         sort: {
@@ -133,39 +157,14 @@ export async function fetchParentNetworkSiteOptions(
     skip += result.data.length;
   }
 
-  const currentId: string | null =
-    currentNetworkSiteId?.toString() ||
-    SiteTypeHierarchyFormUtil.getEntityId(values._id);
-  const normalizedCurrentId: string | null = currentId
-    ? currentId.toLowerCase()
-    : null;
-
-  return parentSites
-    .filter((networkSite: NetworkSite) => {
-      const candidateId: string | undefined = networkSite.id
-        ?.toString()
-        .toLowerCase();
-      if (!candidateId || candidateId === normalizedCurrentId) {
-        return false;
-      }
-
-      if (
-        normalizedCurrentId &&
-        networkSite.materializedPath
-          ?.toLowerCase()
-          .includes(`/${normalizedCurrentId}/`)
-      ) {
-        return false;
-      }
-
-      return true;
-    })
-    .map((networkSite: NetworkSite): DropdownOption => {
-      return {
-        value: networkSite.id!.toString(),
-        label: networkSite.name || "Unnamed Network Site",
-      };
-    });
+  return SiteTypeHierarchyFormUtil.buildParentSiteOptions({
+    networkSites: parentSites,
+    childNetworkSiteTypeValue,
+    networkSiteTypes,
+    currentNetworkSiteId:
+      currentNetworkSiteId?.toString() ||
+      SiteTypeHierarchyFormUtil.getEntityId(values._id),
+  });
 }
 
 export async function fetchChildNetworkSiteTypeOptions(
@@ -185,12 +184,8 @@ export async function fetchChildNetworkSiteTypeOptions(
     fetchNetworkSiteTypes(),
   ]);
 
-  if (!parentNetworkSite?.networkSiteTypeId) {
-    return [];
-  }
-
-  return SiteTypeHierarchyFormUtil.getChildTypeOptions({
-    parentNetworkSiteTypeValue: parentNetworkSite.networkSiteTypeId,
+  return SiteTypeHierarchyFormUtil.getAllowedChildTypeOptions({
+    parentNetworkSiteTypeValue: parentNetworkSite?.networkSiteTypeId || null,
     networkSiteTypes,
   });
 }

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteTypeHierarchyFormUtil.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteTypeHierarchyFormUtil.ts
@@ -1,9 +1,13 @@
+import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
 import NetworkSiteType from "Common/Models/DatabaseModels/NetworkSiteType";
 import NetworkSiteTypeHierarchyUtil, {
   NetworkSiteTypeHierarchyIndex,
   NetworkSiteTypeHierarchyNode,
 } from "Common/Utils/NetworkSite/TypeHierarchyUtil";
-import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
+import {
+  DropdownOption,
+  DropdownOptionGroup,
+} from "Common/UI/Components/Dropdown/Dropdown";
 
 /*
  * Pure form-facing helpers for the Network Site Type hierarchy. Keeping the
@@ -77,7 +81,13 @@ export default class SiteTypeHierarchyFormUtil {
     );
   }
 
-  public static getConfiguredParentTypeId(data: {
+  /*
+   * The type configured directly above the selected one. It is GUIDANCE, not
+   * a constraint: a parent site is always optional, and any site the placement
+   * rule permits may be chosen. Its only job is to float the most likely
+   * parents to the top of the picker.
+   */
+  public static getPreferredParentTypeId(data: {
     selectedNetworkSiteTypeValue: unknown;
     networkSiteTypes: Array<NetworkSiteType>;
   }): string | null {
@@ -91,11 +101,27 @@ export default class SiteTypeHierarchyFormUtil {
       : null;
   }
 
-  public static isParentSiteRequired(data: {
-    selectedNetworkSiteTypeValue: unknown;
+  /*
+   * The shared site placement rule, in form terms. A site may sit under any
+   * site except one whose type is below its own in the type tree, and except
+   * one of a unit-level type. See
+   * NetworkSiteTypeHierarchyUtil.isTypeAllowedAsSiteParentOfType, which the
+   * server enforces against the same catalog.
+   */
+  public static isParentSitePlacementAllowed(data: {
+    childNetworkSiteTypeValue: unknown;
+    parentNetworkSiteTypeValue: unknown;
     networkSiteTypes: Array<NetworkSiteType>;
+    index?: NetworkSiteTypeHierarchyIndex | undefined;
   }): boolean {
-    return Boolean(this.getConfiguredParentTypeId(data));
+    return NetworkSiteTypeHierarchyUtil.isTypeAllowedAsSiteParentOfType({
+      childNetworkSiteTypeId: this.getEntityId(data.childNetworkSiteTypeValue),
+      parentNetworkSiteTypeId: this.getEntityId(
+        data.parentNetworkSiteTypeValue,
+      ),
+      networkSiteTypes: data.networkSiteTypes,
+      index: data.index,
+    });
   }
 
   public static getAllTypeOptions(data: {
@@ -150,27 +176,146 @@ export default class SiteTypeHierarchyFormUtil {
     });
   }
 
-  public static getChildTypeOptions(data: {
+  /*
+   * Types a new site created UNDER a known parent site may take — the mirror
+   * of the parent picker, so the two forms can never disagree. Everything
+   * except the types above the parent's own is offered; nothing at all when
+   * the parent is unit level, which is the one site that cannot own children.
+   */
+  public static getAllowedChildTypeOptions(data: {
     parentNetworkSiteTypeValue: unknown;
     networkSiteTypes: Array<NetworkSiteType>;
   }): Array<DropdownOption> {
-    const parentId: string | null = this.getEntityId(
-      data.parentNetworkSiteTypeValue,
-    );
-    if (!parentId) {
-      return [];
-    }
-
     const index: NetworkSiteTypeHierarchyIndex =
       NetworkSiteTypeHierarchyUtil.buildIndex(data);
-    const childTypes: Array<NetworkSiteType> =
-      index.childrenByParentId.get(parentId.toLowerCase()) || [];
 
     return this.toBreadcrumbOptions({
-      networkSiteTypes: childTypes,
+      networkSiteTypes: NetworkSiteTypeHierarchyUtil.getValidSiteChildTypes({
+        networkSiteTypeId: this.getEntityId(data.parentNetworkSiteTypeValue),
+        networkSiteTypes: data.networkSiteTypes,
+        index,
+      }),
       allNetworkSiteTypes: data.networkSiteTypes,
       index,
     });
+  }
+
+  /*
+   * The parent-site picker's contents. Every site in the project is a
+   * candidate except the site itself, its own subtree (which would be a
+   * cycle), and the placements the type hierarchy forbids. Sites of the type
+   * configured directly above this one are listed first because they are the
+   * usual answer — but they are a suggestion, not the only choice, which is
+   * the whole point of GitHub issue #3744.
+   */
+  public static buildParentSiteOptions(data: {
+    networkSites: Array<NetworkSite>;
+    childNetworkSiteTypeValue: unknown;
+    networkSiteTypes: Array<NetworkSiteType>;
+    currentNetworkSiteId?: string | null | undefined;
+  }): Array<DropdownOption | DropdownOptionGroup> {
+    const index: NetworkSiteTypeHierarchyIndex =
+      NetworkSiteTypeHierarchyUtil.buildIndex(data);
+    const normalizedCurrentId: string | null = data.currentNetworkSiteId
+      ? data.currentNetworkSiteId.toString().toLowerCase()
+      : null;
+    const preferredParentTypeId: string | null = this.getPreferredParentTypeId({
+      selectedNetworkSiteTypeValue: data.childNetworkSiteTypeValue,
+      networkSiteTypes: data.networkSiteTypes,
+    });
+    const normalizedPreferredParentTypeId: string | null = preferredParentTypeId
+      ? preferredParentTypeId.toLowerCase()
+      : null;
+
+    const preferred: Array<DropdownOption> = [];
+    const others: Array<DropdownOption> = [];
+
+    for (const networkSite of data.networkSites) {
+      const candidateId: string | undefined = networkSite.id
+        ?.toString()
+        .toLowerCase();
+
+      if (!candidateId || candidateId === normalizedCurrentId) {
+        continue;
+      }
+
+      /*
+       * The materialized path ends with the site's own id, so this single
+       * containment test excludes the whole subtree below the current site.
+       */
+      if (
+        normalizedCurrentId &&
+        networkSite.materializedPath
+          ?.toLowerCase()
+          .includes(`/${normalizedCurrentId}/`)
+      ) {
+        continue;
+      }
+
+      const candidateTypeId: string | null = networkSite.networkSiteTypeId
+        ? networkSite.networkSiteTypeId.toString().toLowerCase()
+        : null;
+
+      if (
+        !this.isParentSitePlacementAllowed({
+          childNetworkSiteTypeValue: data.childNetworkSiteTypeValue,
+          parentNetworkSiteTypeValue: candidateTypeId,
+          networkSiteTypes: data.networkSiteTypes,
+          index,
+        })
+      ) {
+        continue;
+      }
+
+      const candidateType: NetworkSiteType | undefined = candidateTypeId
+        ? index.byId.get(candidateTypeId)
+        : undefined;
+      const option: DropdownOption = {
+        value: networkSite.id!.toString(),
+        label: candidateType?.name
+          ? `${networkSite.name || "Unnamed Network Site"} (${candidateType.name})`
+          : networkSite.name || "Unnamed Network Site",
+      };
+
+      if (
+        normalizedPreferredParentTypeId &&
+        candidateTypeId === normalizedPreferredParentTypeId
+      ) {
+        preferred.push(option);
+      } else {
+        others.push(option);
+      }
+    }
+
+    /*
+     * Two labelled groups rather than one concatenated list: a flat list that
+     * restarts its alphabet halfway down reads as a sorting bug, not as a
+     * recommendation. A project whose types are all top-level has no preferred
+     * type at all, so it sees one plain list.
+     */
+    if (preferred.length === 0) {
+      return others;
+    }
+
+    const preferredTypeName: string | undefined =
+      normalizedPreferredParentTypeId
+        ? index.byId.get(normalizedPreferredParentTypeId)?.name
+        : undefined;
+
+    const groups: Array<DropdownOptionGroup> = [
+      {
+        label: preferredTypeName
+          ? `Suggested — ${preferredTypeName}`
+          : "Suggested",
+        options: preferred,
+      },
+    ];
+
+    if (others.length > 0) {
+      groups.push({ label: "Other sites", options: others });
+    }
+
+    return groups;
   }
 
   private static toBreadcrumbOptions(data: {

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/Settings/SiteTypes.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/Settings/SiteTypes.tsx
@@ -17,9 +17,11 @@ Site Types describe the levels of your network site hierarchy. Every network sit
 
 ### Parent Site Type
 
-Choose the type directly above this one. For example, set Account Type as the parent of Region, Region as the parent of Franchisee, Franchisee as the parent of Market, and Market as the parent of Unit. Leave the parent empty for a top-level type. When you create a network site, this relationship determines which parent sites are valid.
+Choose the type directly above this one. For example, set Account Type as the parent of Region, Region as the parent of Franchisee, Franchisee as the parent of Market, and Market as the parent of Unit. Leave the parent empty for a top-level type. When you place a network site, this relationship decides which parent sites are suggested first.
 
-To keep existing site trees valid, a type that is already in use can move only when its sites already match the new relationship. For a larger reorganisation, create the replacement type under the new parent, then move each site and assign the replacement type together.
+It shapes placement without dictating it. A site can go under any site that is not **below** it in this tree, so you can skip a level, or hang a site under a catch-all type such as Other. The one arrangement OneUptime refuses is an inversion — a Region site under a Market site, say — and a unit-level site never takes children at all.
+
+Moving a type that is already in use is allowed unless the move would invert a site that already exists: if a site of the type you are moving is already the parent of a site whose type sits above it after the move, move that site first.
 
 ### Unit Level
 
@@ -148,7 +150,7 @@ const NetworkSiteTypesPage: FunctionComponent<
             stepId: "hierarchy",
             sectionTitle: "Parent Relationship",
             sectionDescription:
-              "Choose the type directly above this one. A type cannot be nested beneath itself, one of its descendants, or a unit-level type.",
+              "Choose the type directly above this one. A type cannot be nested beneath itself, one of its descendants, or a unit-level type. This shapes which parent sites are suggested first when you place a site; it does not restrict placement to that one type.",
             description:
               "Leave empty to make this a top-level type. Options show their full hierarchy path.",
             fieldType: FormFieldSchemaType.Dropdown,

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/Sites.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/Sites.tsx
@@ -7,7 +7,6 @@ import ImportSitesFromCsvModal from "../../Components/NetworkSite/ImportSitesFro
 import {
   fetchAllNetworkSiteTypeOptions,
   fetchParentNetworkSiteOptions,
-  isParentSiteRequired,
 } from "../../Components/NetworkSite/NetworkSiteFormDropdownOptions";
 import SiteHierarchyTree from "../../Components/NetworkSite/SiteHierarchyTree";
 import SiteSummaryCards from "../../Components/NetworkSite/SiteSummaryCards";
@@ -492,7 +491,7 @@ const NetworkSites: FunctionComponent<
             title: "Site Type",
             stepId: "site-details",
             description:
-              "Choose this first. The type's configured parent determines which parent sites are available on the next step.",
+              "Choose this first. On the next step you can place this site under any site that is not below it in the hierarchy, and sites of the type configured directly above are listed first.",
             fieldType: FormFieldSchemaType.Dropdown,
             fetchDropdownOptions: fetchAllNetworkSiteTypeOptions,
             onChange: (
@@ -538,12 +537,12 @@ const NetworkSites: FunctionComponent<
             stepId: "hierarchy",
             sectionTitle: "Place This Site",
             sectionDescription:
-              "Only sites whose type is the configured parent of the selected site type are shown.",
+              "Optional. Any site that is not below this one in your site type hierarchy can be the parent. Sites of the type configured directly above are listed first.",
             description:
-              "Top-level site types do not have a parent site. A child site type requires one of the matching sites below.",
+              "Leave this empty to keep the site at the top level. Sites of a type below this one, and sites of a unit-level type, cannot be parents.",
             fieldType: FormFieldSchemaType.Dropdown,
             fetchDropdownOptions: fetchParentNetworkSiteOptions,
-            required: isParentSiteRequired,
+            required: false,
             placeholder: "No parent site (top level)",
           },
           {

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/View/ChildSites.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/View/ChildSites.tsx
@@ -80,7 +80,7 @@ const NetworkSiteChildSites: FunctionComponent<
             title: "Site Type",
             stepId: "site-details",
             description:
-              "Only types configured directly beneath this site's type are available.",
+              "Any type except the ones above this site's own type in the hierarchy. A unit-level site holds devices rather than child sites, so it offers none.",
             fieldType: FormFieldSchemaType.Dropdown,
             fetchDropdownOptions: () => {
               return fetchChildNetworkSiteTypeOptions(modelId);

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/View/Index.tsx
@@ -4,7 +4,6 @@ import PageComponentProps from "../../PageComponentProps";
 import {
   fetchAllNetworkSiteTypeOptions,
   fetchParentNetworkSiteOptions,
-  isParentSiteRequired,
 } from "../../../Components/NetworkSite/NetworkSiteFormDropdownOptions";
 import SiteStatusHero from "../../../Components/NetworkSite/SiteStatusHero";
 import MonitorStatusElement from "../../../Components/MonitorStatus/MonitorStatusElement";
@@ -81,7 +80,7 @@ const NetworkSiteView: FunctionComponent<
             title: "Site Type",
             stepId: "site-details",
             description:
-              "Choose this first. The type's configured parent determines which parent sites are available on the next step.",
+              "Choose this first. On the next step you can place this site under any site that is not below it in the hierarchy, and sites of the type configured directly above are listed first.",
             fieldType: FormFieldSchemaType.Dropdown,
             fetchDropdownOptions: fetchAllNetworkSiteTypeOptions,
             onChange: (
@@ -127,14 +126,14 @@ const NetworkSiteView: FunctionComponent<
             stepId: "hierarchy",
             sectionTitle: "Place This Site",
             sectionDescription:
-              "Only sites whose type is the configured parent of the selected site type are shown.",
+              "Optional. Any site that is not below this one in your site type hierarchy can be the parent. Sites of the type configured directly above are listed first.",
             description:
-              "Top-level site types do not have a parent site. A child site type requires one of the matching sites below.",
+              "Leave this empty to keep the site at the top level. Sites of a type below this one, and sites of a unit-level type, cannot be parents.",
             fieldType: FormFieldSchemaType.Dropdown,
             fetchDropdownOptions: (values: FormValues<NetworkSite>) => {
               return fetchParentNetworkSiteOptions(values, modelId);
             },
-            required: isParentSiteRequired,
+            required: false,
             placeholder: "No parent site (top level)",
           },
           {

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/View/Settings.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/View/Settings.tsx
@@ -2,7 +2,6 @@ import PageComponentProps from "../../PageComponentProps";
 import {
   fetchAllNetworkSiteTypeOptions,
   fetchParentNetworkSiteOptions,
-  isParentSiteRequired,
 } from "../../../Components/NetworkSite/NetworkSiteFormDropdownOptions";
 import ObjectID from "Common/Types/ObjectID";
 import AlertSeverity from "Common/Models/DatabaseModels/AlertSeverity";
@@ -67,7 +66,7 @@ const NetworkSiteSettings: FunctionComponent<
             title: "Site Type",
             stepId: "site-details",
             description:
-              "Choose this first. The type's configured parent determines which parent sites are available on the next step.",
+              "Choose this first. On the next step you can place this site under any site that is not below it in the hierarchy, and sites of the type configured directly above are listed first.",
             fieldType: FormFieldSchemaType.Dropdown,
             fetchDropdownOptions: fetchAllNetworkSiteTypeOptions,
             onChange: (
@@ -113,14 +112,14 @@ const NetworkSiteSettings: FunctionComponent<
             stepId: "hierarchy",
             sectionTitle: "Place This Site",
             sectionDescription:
-              "Only sites whose type is the configured parent of the selected site type are shown.",
+              "Optional. Any site that is not below this one in your site type hierarchy can be the parent. Sites of the type configured directly above are listed first.",
             description:
-              "Top-level site types do not have a parent site. A child site type requires one of the matching sites below.",
+              "Leave this empty to keep the site at the top level. Sites of a type below this one, and sites of a unit-level type, cannot be parents.",
             fieldType: FormFieldSchemaType.Dropdown,
             fetchDropdownOptions: (values: FormValues<NetworkSite>) => {
               return fetchParentNetworkSiteOptions(values, modelId);
             },
-            required: isParentSiteRequired,
+            required: false,
             placeholder: "No parent site (top level)",
           },
           {

--- a/App/FeatureSet/Dashboard/src/Utils/NetworkSiteCsv.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/NetworkSiteCsv.ts
@@ -24,12 +24,20 @@ export interface NetworkSiteTypeOption {
   id: string;
   name: string;
   /*
-   * `undefined` is reserved for callers that do not have hierarchy metadata.
-   * The import modal always supplies either the configured parent id or null
-   * for a top-level type, which lets the parser enforce the same edge shape as
-   * the server before an import starts.
+   * The type's own place in the project's type tree. The parser needs the
+   * WHOLE catalog, not one row's direct parent: the placement rule asks
+   * whether one type sits below another, which is an ancestry question.
+   *
+   * `undefined`, or an id that names no type in the array, means "link
+   * unknown" and is treated as a root for ancestry — the parser never refuses
+   * a placement it cannot prove wrong.
    */
   parentNetworkSiteTypeId?: string | null | undefined;
+  /*
+   * Unit-level types are the declared leaves of the hierarchy, so their sites
+   * hold devices rather than more sites and can never be a parentName.
+   */
+  isUnitLevel?: boolean | undefined;
 }
 
 export interface ParsedSiteRow {
@@ -43,13 +51,6 @@ export interface ParsedSiteRow {
    */
   networkSiteTypeId: string;
   siteType: string;
-  /*
-   * The selected type's configured parent type. This is carried into the
-   * planner so parents that already exist in the project can be checked before
-   * the first POST. Undefined keeps the pure helper backwards-compatible with
-   * callers that genuinely lack hierarchy metadata.
-   */
-  requiredParentNetworkSiteTypeId?: string | null | undefined;
   // Empty string for root sites.
   parentName: string;
   address: string;
@@ -222,34 +223,123 @@ function indexSiteTypesById(
   return byId;
 }
 
-function configuredParentTypeName(data: {
-  parentNetworkSiteTypeId: string;
+function siteTypeNameById(data: {
+  networkSiteTypeId: string | null | undefined;
   siteTypeById: Map<string, NetworkSiteTypeOption>;
 }): string {
+  if (!data.networkSiteTypeId) {
+    return "no site type";
+  }
+
   return (
-    data.siteTypeById.get(normalizeId(data.parentNetworkSiteTypeId))?.name ||
-    "the configured parent site type"
+    data.siteTypeById.get(normalizeId(data.networkSiteTypeId))?.name ||
+    "an unknown site type"
   );
 }
 
-function incompatibleParentTypeMessage(data: {
+/*
+ * The shared site placement rule, over the plain option objects this module
+ * works in. It mirrors NetworkSiteTypeHierarchyUtil.isTypeAllowedAsSiteParent-
+ * OfType in Common exactly; the logic is restated rather than imported so this
+ * module keeps depending on nothing but Common/Types (see the file header).
+ *
+ * A site may sit under any site except one whose type is BELOW its own in the
+ * type tree, and except one whose type is the declared unit level. Skipped
+ * levels, unrelated types and the same type on both sides are all allowed —
+ * requiring an exact configured-parent match is what made valid hierarchies
+ * unbuildable in GitHub issue #3744.
+ */
+interface SiteTypePlacementRule {
+  isAllowedParentType: (data: {
+    childNetworkSiteTypeId: string | null | undefined;
+    parentNetworkSiteTypeId: string | null | undefined;
+  }) => boolean;
+}
+
+function buildSiteTypePlacementRule(
+  siteTypeById: Map<string, NetworkSiteTypeOption>,
+): SiteTypePlacementRule {
+  return {
+    isAllowedParentType: (data: {
+      childNetworkSiteTypeId: string | null | undefined;
+      parentNetworkSiteTypeId: string | null | undefined;
+    }): boolean => {
+      if (!data.parentNetworkSiteTypeId) {
+        return true;
+      }
+
+      const parentTypeId: string = normalizeId(data.parentNetworkSiteTypeId);
+      const parentType: NetworkSiteTypeOption | undefined =
+        siteTypeById.get(parentTypeId);
+
+      if (parentType?.isUnitLevel === true) {
+        return false;
+      }
+
+      if (!data.childNetworkSiteTypeId) {
+        return true;
+      }
+
+      const childTypeId: string = normalizeId(data.childNetworkSiteTypeId);
+      if (childTypeId === parentTypeId) {
+        return true;
+      }
+
+      /*
+       * Walk up from the parent type. Reaching the child type means the parent
+       * sits below it. The visited set bounds a catalog that has been made
+       * cyclic by a direct database edit.
+       */
+      const visited: Set<string> = new Set<string>([parentTypeId]);
+      let ancestorId: string | null =
+        parentType && parentType.parentNetworkSiteTypeId
+          ? normalizeId(parentType.parentNetworkSiteTypeId)
+          : null;
+
+      while (ancestorId) {
+        if (ancestorId === childTypeId) {
+          return false;
+        }
+
+        if (visited.has(ancestorId)) {
+          break;
+        }
+        visited.add(ancestorId);
+
+        const ancestor: NetworkSiteTypeOption | undefined =
+          siteTypeById.get(ancestorId);
+        if (!ancestor || !ancestor.parentNetworkSiteTypeId) {
+          break;
+        }
+
+        ancestorId = normalizeId(ancestor.parentNetworkSiteTypeId);
+      }
+
+      return true;
+    },
+  };
+}
+
+function invertedParentTypeMessage(data: {
   child: ParsedSiteRow;
   parentName: string;
-  actualParentNetworkSiteTypeId: string | null;
+  actualParentNetworkSiteTypeId: string | null | undefined;
   siteTypeById: Map<string, NetworkSiteTypeOption>;
 }): string {
-  const requiredParentTypeId: string =
-    data.child.requiredParentNetworkSiteTypeId!;
-  const requiredParentTypeName: string = configuredParentTypeName({
-    parentNetworkSiteTypeId: requiredParentTypeId,
+  const parentTypeName: string = siteTypeNameById({
+    networkSiteTypeId: data.actualParentNetworkSiteTypeId,
     siteTypeById: data.siteTypeById,
   });
-  const actualParentTypeName: string = data.actualParentNetworkSiteTypeId
-    ? data.siteTypeById.get(normalizeId(data.actualParentNetworkSiteTypeId))
-        ?.name || "an unknown site type"
-    : "no site type";
+  const parentType: NetworkSiteTypeOption | undefined =
+    data.actualParentNetworkSiteTypeId
+      ? data.siteTypeById.get(normalizeId(data.actualParentNetworkSiteTypeId))
+      : undefined;
 
-  return `Parent site "${data.parentName}" uses ${actualParentTypeName}, but siteType "${data.child.siteType}" requires a parent that uses ${requiredParentTypeName}.`;
+  if (parentType?.isUnitLevel === true) {
+    return `Parent site "${data.parentName}" uses siteType "${parentTypeName}", which is the unit level of the hierarchy and cannot have child sites.`;
+  }
+
+  return `Parent site "${data.parentName}" uses siteType "${parentTypeName}", which sits below "${data.child.siteType}" in the site type hierarchy.`;
 }
 
 type HeaderIndex = Map<string, number>;
@@ -440,24 +530,13 @@ export function parseSiteCsv(
       rowErrors.push("A site cannot be its own parent.");
     }
 
-    if (siteType && siteType.parentNetworkSiteTypeId !== undefined) {
-      if (siteType.parentNetworkSiteTypeId === null && parentName !== "") {
-        rowErrors.push(
-          `siteType "${siteType.name}" is top level and cannot have a parentName.`,
-        );
-      } else if (
-        siteType.parentNetworkSiteTypeId !== null &&
-        parentName === ""
-      ) {
-        const requiredParentTypeName: string = configuredParentTypeName({
-          parentNetworkSiteTypeId: siteType.parentNetworkSiteTypeId,
-          siteTypeById,
-        });
-        rowErrors.push(
-          `siteType "${siteType.name}" requires a parentName whose siteType is "${requiredParentTypeName}".`,
-        );
-      }
-    }
+    /*
+     * No per-row placement check exists any more. parentName is optional for
+     * every siteType — including one configured below another — and whether a
+     * given parent is legal depends on that parent's OWN type, which is not
+     * known until the whole file has been read. The cross-row pass below is
+     * the only place placement is judged.
+     */
 
     const address: string = cellAt(record, headerIndex, "address");
 
@@ -513,7 +592,6 @@ export function parseSiteCsv(
       name: name,
       networkSiteTypeId: siteType!.id,
       siteType: siteType!.name,
-      requiredParentNetworkSiteTypeId: siteType!.parentNetworkSiteTypeId,
       parentName: parentName,
       address: address,
       latitude: latitudeResult.value,
@@ -536,9 +614,11 @@ export function parseSiteCsv(
     importedRowByName.set(row.name, row);
   }
 
+  const placementRule: SiteTypePlacementRule =
+    buildSiteTypePlacementRule(siteTypeById);
   const incompatibleLines: Set<number> = new Set<number>();
   for (const row of rows) {
-    if (!row.requiredParentNetworkSiteTypeId || row.parentName === "") {
+    if (row.parentName === "") {
       continue;
     }
 
@@ -547,12 +627,14 @@ export function parseSiteCsv(
     );
     if (
       importedParent &&
-      normalizeId(importedParent.networkSiteTypeId) !==
-        normalizeId(row.requiredParentNetworkSiteTypeId)
+      !placementRule.isAllowedParentType({
+        childNetworkSiteTypeId: row.networkSiteTypeId,
+        parentNetworkSiteTypeId: importedParent.networkSiteTypeId,
+      })
     ) {
       errors.push({
         line: row.line,
-        message: incompatibleParentTypeMessage({
+        message: invertedParentTypeMessage({
           child: row,
           parentName: row.parentName,
           actualParentNetworkSiteTypeId: importedParent.networkSiteTypeId,
@@ -598,8 +680,19 @@ export function planSiteImport(
   rows: Array<ParsedSiteRow>,
   existingSiteNames: Array<string>,
   existingSiteTypeIdByName?: Map<string, string | null> | undefined,
+  siteTypes?: Array<NetworkSiteTypeOption> | undefined,
 ): SiteImportPlan {
   const existing: Set<string> = new Set<string>(existingSiteNames);
+  /*
+   * The project's type catalog decides which placements are legal. Without it
+   * the planner cannot judge one and lets the server have the final say, which
+   * is what callers that only order rows have always relied on.
+   */
+  const siteTypeById: Map<string, NetworkSiteTypeOption> = indexSiteTypesById(
+    siteTypes || [],
+  );
+  const placementRule: SiteTypePlacementRule =
+    buildSiteTypePlacementRule(siteTypeById);
   const importedRowByName: Map<string, ParsedSiteRow> = new Map<
     string,
     ParsedSiteRow
@@ -620,7 +713,7 @@ export function planSiteImport(
       continue;
     }
 
-    if (row.requiredParentNetworkSiteTypeId && row.parentName !== "") {
+    if (siteTypeById.size > 0 && row.parentName !== "") {
       let actualParentTypeId: string | null | undefined;
       let shouldValidateParentType: boolean = false;
 
@@ -639,13 +732,19 @@ export function planSiteImport(
 
       if (
         shouldValidateParentType &&
-        (!actualParentTypeId ||
-          normalizeId(actualParentTypeId) !==
-            normalizeId(row.requiredParentNetworkSiteTypeId))
+        !placementRule.isAllowedParentType({
+          childNetworkSiteTypeId: row.networkSiteTypeId,
+          parentNetworkSiteTypeId: actualParentTypeId,
+        })
       ) {
         skipped.push({
           row,
-          reason: `Parent site "${row.parentName}" does not use the Network Site Type required by "${row.siteType}".`,
+          reason: invertedParentTypeMessage({
+            child: row,
+            parentName: row.parentName,
+            actualParentNetworkSiteTypeId: actualParentTypeId,
+            siteTypeById,
+          }),
         });
         continue;
       }

--- a/App/FeatureSet/Dashboard/src/Utils/NetworkSiteImportRunner.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/NetworkSiteImportRunner.ts
@@ -1,4 +1,5 @@
 import {
+  NetworkSiteTypeOption,
   ParsedSiteRow,
   SiteImportPlan,
   SkippedSiteRow,
@@ -65,11 +66,16 @@ export interface RunSiteImportOptions {
    */
   existingSiteIdByName: Map<string, string>;
   /*
-   * The existing sites' type ids, loaded alongside their ids. When supplied,
-   * the planner rejects a child whose named existing parent has the wrong type
-   * before createSite is called for any row.
+   * The existing sites' type ids, loaded alongside their ids. Supplied
+   * together with `siteTypes`, they let the planner reject a placement the
+   * server would refuse before createSite is called for any row.
    */
   existingSiteTypeIdByName?: Map<string, string | null> | undefined;
+  /*
+   * The project's configured site types. The placement rule is an ancestry
+   * question, so the planner needs the whole catalog, not one type at a time.
+   */
+  siteTypes?: Array<NetworkSiteTypeOption> | undefined;
   createSite: CreateSiteFunction;
   // Called after the skip pass and after every attempted row.
   onProgress?: ((progress: SiteImportProgress) => void) | undefined;
@@ -124,6 +130,7 @@ export async function runSiteImport(
     options.rows,
     Array.from(siteIdByName.keys()),
     options.existingSiteTypeIdByName,
+    options.siteTypes,
   );
 
   const results: Array<SiteImportRowResult> = [];

--- a/App/Tests/Dashboard/NetworkSiteCsv.test.ts
+++ b/App/Tests/Dashboard/NetworkSiteCsv.test.ts
@@ -424,52 +424,100 @@ describe("parseSiteCsv", () => {
     expect(result.rows).toHaveLength(5);
     expect(result.rows[0]).toMatchObject({
       siteType: DefaultNetworkSiteType.Unit,
-      requiredParentNetworkSiteTypeId: siteTypeIdOf(
-        DefaultNetworkSiteType.Market,
-      ),
+      networkSiteTypeId: siteTypeIdOf(DefaultNetworkSiteType.Unit),
+      parentName: "Springfield Market",
     });
   });
 
-  test("rejects a child type without parentName and names its required parent type", () => {
+  /*
+   * The regression suite for GitHub issue #3744. Every one of these files was
+   * refused before the placement rule was relaxed, and each is a shape real
+   * estates are actually built in.
+   */
+  test("a nested type may be imported without a parentName", () => {
     const result: SiteCsvParseResult = parseSiteCsv(
       `${HEADER}\nEast Region,Region,,,,\n`,
       HIERARCHICAL_DEFAULT_SITE_TYPES,
     );
 
-    expect(result.rows).toEqual([]);
-    expect(result.errors).toEqual([
-      {
-        line: 2,
-        message:
-          'siteType "Region" requires a parentName whose siteType is "Account Type".',
-      },
-    ]);
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({
+      name: "East Region",
+      siteType: DefaultNetworkSiteType.Region,
+      parentName: "",
+    });
   });
 
-  test("rejects a top-level type that supplies parentName", () => {
+  test("a top-level type may supply a parentName", () => {
     const result: SiteCsvParseResult = parseSiteCsv(
-      `${HEADER}\nHQ,Data Center,Somewhere,,,\n`,
+      [HEADER, "Somewhere,Other,,,,", "HQ,Data Center,Somewhere,,,"].join("\n"),
       HIERARCHICAL_DEFAULT_SITE_TYPES,
     );
 
-    expect(result.rows).toEqual([]);
-    expect(result.errors).toEqual([
-      {
-        line: 2,
-        message:
-          'siteType "Data Center" is top level and cannot have a parentName.',
-      },
-    ]);
+    expect(result.errors).toEqual([]);
+    expect(
+      result.rows.map((row: ParsedSiteRow) => {
+        return row.name;
+      }),
+    ).toEqual(["Somewhere", "HQ"]);
   });
 
-  test("rejects an imported parent whose type is not the configured direct parent", () => {
+  // The exact file from the issue: a Market nested under an Other.
+  test("a Market may be imported under an Other, as reported in the issue", () => {
+    const result: SiteCsvParseResult = parseSiteCsv(
+      [HEADER, "Aramark,Other,,,,", "6241 Daikin Park,Market,Aramark,,,"].join(
+        "\n",
+      ),
+      HIERARCHICAL_DEFAULT_SITE_TYPES,
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(
+      result.rows.map((row: ParsedSiteRow) => {
+        return row.name;
+      }),
+    ).toEqual(["Aramark", "6241 Daikin Park"]);
+  });
+
+  test("a level may be skipped: a Market directly under a Region", () => {
     const result: SiteCsvParseResult = parseSiteCsv(
       [
         HEADER,
         "Acme Account,Account Type,,,,",
         "East Region,Region,Acme Account,,,",
-        // Market requires Franchisee, not Region.
         "Springfield Market,Market,East Region,,,",
+      ].join("\n"),
+      HIERARCHICAL_DEFAULT_SITE_TYPES,
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toHaveLength(3);
+  });
+
+  test("the same type may appear on both sides of an edge", () => {
+    const result: SiteCsvParseResult = parseSiteCsv(
+      [
+        HEADER,
+        "North Campus,Other,,,,",
+        "North Annexe,Other,North Campus,,,",
+      ].join("\n"),
+      HIERARCHICAL_DEFAULT_SITE_TYPES,
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toHaveLength(2);
+  });
+
+  test("rejects an imported parent whose type sits below the child's type", () => {
+    const result: SiteCsvParseResult = parseSiteCsv(
+      [
+        HEADER,
+        "Acme Account,Account Type,,,,",
+        "East Region,Region,Acme Account,,,",
+        // A Region cannot sit under a Market: Market is below Region.
+        "Springfield Market,Market,East Region,,,",
+        "Wrong Way Region,Region,Springfield Market,,,",
       ].join("\n"),
       HIERARCHICAL_DEFAULT_SITE_TYPES,
     );
@@ -478,14 +526,60 @@ describe("parseSiteCsv", () => {
       result.rows.map((row: ParsedSiteRow) => {
         return row.name;
       }),
-    ).toEqual(["Acme Account", "East Region"]);
+    ).toEqual(["Acme Account", "East Region", "Springfield Market"]);
     expect(result.errors).toEqual([
       {
-        line: 4,
+        line: 5,
         message:
-          'Parent site "East Region" uses Region, but siteType "Market" requires a parent that uses Franchisee.',
+          'Parent site "Springfield Market" uses siteType "Market", which sits below "Region" in the site type hierarchy.',
       },
     ]);
+  });
+
+  test("rejects a parent whose type is the unit level", () => {
+    const unitLevelTypes: Array<NetworkSiteTypeOption> =
+      HIERARCHICAL_DEFAULT_SITE_TYPES.map(
+        (siteType: NetworkSiteTypeOption): NetworkSiteTypeOption => {
+          return {
+            ...siteType,
+            isUnitLevel: siteType.name === DefaultNetworkSiteType.Unit,
+          };
+        },
+      );
+
+    const result: SiteCsvParseResult = parseSiteCsv(
+      [HEADER, "Unit 1042,Unit,,,,", "Closet A,Other,Unit 1042,,,"].join("\n"),
+      unitLevelTypes,
+    );
+
+    expect(
+      result.rows.map((row: ParsedSiteRow) => {
+        return row.name;
+      }),
+    ).toEqual(["Unit 1042"]);
+    expect(result.errors).toEqual([
+      {
+        line: 3,
+        message:
+          'Parent site "Unit 1042" uses siteType "Unit", which is the unit level of the hierarchy and cannot have child sites.',
+      },
+    ]);
+  });
+
+  test("a cyclic type catalog is survived rather than hung on", () => {
+    const cyclicTypes: Array<NetworkSiteTypeOption> = [
+      { id: "a-id", name: "A", parentNetworkSiteTypeId: "b-id" },
+      { id: "b-id", name: "B", parentNetworkSiteTypeId: "a-id" },
+      { id: "c-id", name: "C", parentNetworkSiteTypeId: null },
+    ];
+
+    const result: SiteCsvParseResult = parseSiteCsv(
+      `${HEADER}\nOuter,C,,,,\nInner,C,Outer,,,\n`,
+      cyclicTypes,
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toHaveLength(2);
   });
 
   test("uses configured ids rather than default names for custom hierarchies", () => {
@@ -505,7 +599,8 @@ describe("parseSiteCsv", () => {
     expect(result.errors).toEqual([]);
     expect(result.rows[1]).toMatchObject({
       networkSiteTypeId: "store-id",
-      requiredParentNetworkSiteTypeId: "brand-id",
+      siteType: "Store",
+      parentName: "Acme",
     });
   });
 
@@ -679,32 +774,114 @@ describe("planSiteImport", () => {
     expect(plan.skipped[0]!.reason).toContain("already exists");
   });
 
-  test("accepts an existing parent with the configured parent type", () => {
+  /*
+   * The planner is the last gate before the first POST, so it re-checks
+   * placement against the sites that already exist in the project. Its rule is
+   * the parser's rule: only an inversion is refused.
+   */
+  const PLANNER_SITE_TYPES: Array<NetworkSiteTypeOption> = [
+    { id: "type-region", name: "Region", parentNetworkSiteTypeId: null },
+    {
+      id: "type-franchisee",
+      name: "Franchisee",
+      parentNetworkSiteTypeId: "type-region",
+    },
+    {
+      id: "type-market",
+      name: "Market",
+      parentNetworkSiteTypeId: "type-franchisee",
+    },
+    {
+      id: "type-unit",
+      name: "Unit",
+      parentNetworkSiteTypeId: "type-market",
+      isUnitLevel: true,
+    },
+    { id: "type-other", name: "Other", parentNetworkSiteTypeId: null },
+  ];
+
+  test("accepts an existing parent of the preferred type", () => {
     const child: ParsedSiteRow = makeRow({
       name: "Unit 1042",
+      networkSiteTypeId: "type-unit",
       parentName: "Springfield Market",
-      requiredParentNetworkSiteTypeId: "type-market",
     });
     const plan: SiteImportPlan = planSiteImport(
       [child],
       ["Springfield Market"],
       new Map<string, string | null>([["Springfield Market", "type-market"]]),
+      PLANNER_SITE_TYPES,
     );
 
     expect(plan.batches).toEqual([[child]]);
     expect(plan.skipped).toEqual([]);
   });
 
-  test("rejects an existing parent with the wrong type before planning creates", () => {
+  test("accepts an existing parent of an unrelated type", () => {
     const child: ParsedSiteRow = makeRow({
-      name: "Unit 1042",
+      name: "6241 Daikin Park",
+      networkSiteTypeId: "type-market",
+      siteType: "Market",
+      parentName: "Aramark",
+    });
+    const plan: SiteImportPlan = planSiteImport(
+      [child],
+      ["Aramark"],
+      new Map<string, string | null>([["Aramark", "type-other"]]),
+      PLANNER_SITE_TYPES,
+    );
+
+    expect(plan.batches).toEqual([[child]]);
+    expect(plan.skipped).toEqual([]);
+  });
+
+  test("accepts an existing parent that skips a level", () => {
+    const child: ParsedSiteRow = makeRow({
+      name: "Springfield Market",
+      networkSiteTypeId: "type-market",
+      siteType: "Market",
       parentName: "East Region",
-      requiredParentNetworkSiteTypeId: "type-market",
     });
     const plan: SiteImportPlan = planSiteImport(
       [child],
       ["East Region"],
       new Map<string, string | null>([["East Region", "type-region"]]),
+      PLANNER_SITE_TYPES,
+    );
+
+    expect(plan.batches).toEqual([[child]]);
+    expect(plan.skipped).toEqual([]);
+  });
+
+  test("accepts an untyped existing parent", () => {
+    const child: ParsedSiteRow = makeRow({
+      name: "Unit 1042",
+      networkSiteTypeId: "type-unit",
+      parentName: "Legacy Market",
+    });
+    const plan: SiteImportPlan = planSiteImport(
+      [child],
+      ["Legacy Market"],
+      new Map<string, string | null>([["Legacy Market", null]]),
+      PLANNER_SITE_TYPES,
+    );
+
+    expect(plan.batches).toEqual([[child]]);
+    expect(plan.skipped).toEqual([]);
+  });
+
+  test("skips an existing parent whose type sits below the child's type", () => {
+    const child: ParsedSiteRow = makeRow({
+      name: "East Region",
+      networkSiteTypeId: "type-region",
+      siteType: "Region",
+      parentName: "Springfield Market",
+    });
+    const plan: SiteImportPlan = planSiteImport(
+      [child],
+      ["Springfield Market"],
+      new Map<string, string | null>([["Springfield Market", "type-market"]]),
+      PLANNER_SITE_TYPES,
     );
 
     expect(plan.batches).toEqual([]);
@@ -712,43 +889,68 @@ describe("planSiteImport", () => {
       {
         row: child,
         reason:
-          'Parent site "East Region" does not use the Network Site Type required by "Unit".',
+          'Parent site "Springfield Market" uses siteType "Market", which sits below "Region" in the site type hierarchy.',
       },
     ]);
   });
 
-  test("rejects an untyped existing parent", () => {
+  test("skips an existing parent of a unit-level type", () => {
     const child: ParsedSiteRow = makeRow({
-      name: "Unit 1042",
-      parentName: "Legacy Market",
-      requiredParentNetworkSiteTypeId: "type-market",
+      name: "Closet A",
+      networkSiteTypeId: "type-other",
+      siteType: "Other",
+      parentName: "Unit 1042",
     });
     const plan: SiteImportPlan = planSiteImport(
       [child],
-      ["Legacy Market"],
-      new Map<string, string | null>([["Legacy Market", null]]),
+      ["Unit 1042"],
+      new Map<string, string | null>([["Unit 1042", "type-unit"]]),
+      PLANNER_SITE_TYPES,
     );
 
     expect(plan.batches).toEqual([]);
     expect(plan.skipped[0]!.reason).toContain(
-      "does not use the Network Site Type required",
+      "which is the unit level of the hierarchy",
     );
   });
 
-  test("rejects an incompatible imported parent defensively without the parser", () => {
+  test("re-checks an in-file parent defensively, without the parser", () => {
     const parent: ParsedSiteRow = makeRow({
-      name: "East Region",
-      networkSiteTypeId: "type-region",
+      name: "Springfield Market",
+      networkSiteTypeId: "type-market",
+      siteType: "Market",
     });
     const child: ParsedSiteRow = makeRow({
-      name: "Springfield Market",
-      parentName: "East Region",
-      requiredParentNetworkSiteTypeId: "type-franchisee",
+      name: "East Region",
+      networkSiteTypeId: "type-region",
+      siteType: "Region",
+      parentName: "Springfield Market",
     });
-    const plan: SiteImportPlan = planSiteImport([parent, child], []);
+    const plan: SiteImportPlan = planSiteImport(
+      [parent, child],
+      [],
+      undefined,
+      PLANNER_SITE_TYPES,
+    );
 
     expect(plan.batches).toEqual([[parent]]);
     expect(plan.skipped).toHaveLength(1);
     expect(plan.skipped[0]!.row).toBe(child);
+  });
+
+  test("without the type catalog the planner only orders rows", () => {
+    const parent: ParsedSiteRow = makeRow({
+      name: "Springfield Market",
+      networkSiteTypeId: "type-market",
+    });
+    const child: ParsedSiteRow = makeRow({
+      name: "East Region",
+      networkSiteTypeId: "type-region",
+      parentName: "Springfield Market",
+    });
+    const plan: SiteImportPlan = planSiteImport([parent, child], []);
+
+    expect(plan.batches).toEqual([[parent], [child]]);
+    expect(plan.skipped).toEqual([]);
   });
 });

--- a/App/Tests/Dashboard/NetworkSiteImportRunner.test.ts
+++ b/App/Tests/Dashboard/NetworkSiteImportRunner.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "@jest/globals";
-import { ParsedSiteRow } from "../../FeatureSet/Dashboard/src/Utils/NetworkSiteCsv";
+import {
+  NetworkSiteTypeOption,
+  ParsedSiteRow,
+} from "../../FeatureSet/Dashboard/src/Utils/NetworkSiteCsv";
 import {
   CreateSiteFunction,
   SiteCreateResult,
@@ -42,6 +45,32 @@ const makeRow: MakeRowFunction = (
     ...overrides,
   };
 };
+
+/*
+ * The placement preflight is an ancestry question, so the runner hands the
+ * planner the whole catalog. Region › Franchisee › Market › Unit, plus an
+ * unrelated "Other" - the catch-all a real project uses as a parent.
+ */
+const SITE_TYPES: Array<NetworkSiteTypeOption> = [
+  { id: "type-region", name: "Region", parentNetworkSiteTypeId: null },
+  {
+    id: "type-franchisee",
+    name: "Franchisee",
+    parentNetworkSiteTypeId: "type-region",
+  },
+  {
+    id: "type-market",
+    name: "Market",
+    parentNetworkSiteTypeId: "type-franchisee",
+  },
+  {
+    id: "type-unit",
+    name: "Unit",
+    parentNetworkSiteTypeId: "type-market",
+    isUnitLevel: true,
+  },
+  { id: "type-other", name: "Other", parentNetworkSiteTypeId: null },
+];
 
 /*
  * A createSite that succeeds for every row, minting a predictable id, and
@@ -212,7 +241,7 @@ describe("runSiteImport — ordering", () => {
     ]);
   });
 
-  test("a correctly typed existing parent passes hierarchy preflight", async () => {
+  test("a preferred-type existing parent passes placement preflight", async () => {
     const recorder: Recorder = recordingCreator();
 
     const summary: SiteImportSummary = await runSiteImport({
@@ -221,7 +250,6 @@ describe("runSiteImport — ordering", () => {
           line: 2,
           name: "Unit 1042",
           parentName: "Springfield Market",
-          requiredParentNetworkSiteTypeId: "type-market",
         }),
       ],
       existingSiteIdByName: new Map<string, string>([
@@ -230,11 +258,42 @@ describe("runSiteImport — ordering", () => {
       existingSiteTypeIdByName: new Map<string, string | null>([
         ["Springfield Market", "type-market"],
       ]),
+      siteTypes: SITE_TYPES,
       createSite: recorder.createSite,
     });
 
     expect(recorder.calls).toEqual([
       { name: "Unit 1042", parentSiteId: "existing-market" },
+    ]);
+    expect(summary.createdCount).toBe(1);
+    expect(summary.skippedCount).toBe(0);
+  });
+
+  test("an unrelated-type existing parent also passes placement preflight", async () => {
+    const recorder: Recorder = recordingCreator();
+
+    const summary: SiteImportSummary = await runSiteImport({
+      rows: [
+        makeRow({
+          line: 2,
+          name: "6241 Daikin Park",
+          networkSiteTypeId: "type-market",
+          siteType: "Market",
+          parentName: "Aramark",
+        }),
+      ],
+      existingSiteIdByName: new Map<string, string>([
+        ["Aramark", "existing-aramark"],
+      ]),
+      existingSiteTypeIdByName: new Map<string, string | null>([
+        ["Aramark", "type-other"],
+      ]),
+      siteTypes: SITE_TYPES,
+      createSite: recorder.createSite,
+    });
+
+    expect(recorder.calls).toEqual([
+      { name: "6241 Daikin Park", parentSiteId: "existing-aramark" },
     ]);
     expect(summary.createdCount).toBe(1);
     expect(summary.skippedCount).toBe(0);
@@ -334,24 +393,26 @@ describe("runSiteImport — rows that can never be created", () => {
     expect(summary.createdCount).toBe(0);
   });
 
-  test("a wrongly typed existing parent is skipped before any create call", async () => {
+  test("an inverted existing parent is skipped before any create call", async () => {
     const recorder: Recorder = recordingCreator();
 
     const summary: SiteImportSummary = await runSiteImport({
       rows: [
         makeRow({
           line: 2,
-          name: "Unit 1042",
-          parentName: "East Region",
-          requiredParentNetworkSiteTypeId: "type-market",
+          name: "East Region",
+          networkSiteTypeId: "type-region",
+          siteType: "Region",
+          parentName: "Springfield Market",
         }),
       ],
       existingSiteIdByName: new Map<string, string>([
-        ["East Region", "existing-region"],
+        ["Springfield Market", "existing-market"],
       ]),
       existingSiteTypeIdByName: new Map<string, string | null>([
-        ["East Region", "type-region"],
+        ["Springfield Market", "type-market"],
       ]),
+      siteTypes: SITE_TYPES,
       createSite: recorder.createSite,
     });
 
@@ -364,10 +425,10 @@ describe("runSiteImport — rows that can never be created", () => {
     });
     expect(summary.results[0]).toEqual({
       line: 2,
-      name: "Unit 1042",
+      name: "East Region",
       status: "skipped",
       message:
-        'Parent site "East Region" does not use the Network Site Type required by "Unit".',
+        'Parent site "Springfield Market" uses siteType "Market", which sits below "Region" in the site type hierarchy.',
     });
   });
 
@@ -384,18 +445,20 @@ describe("runSiteImport — rows that can never be created", () => {
       rows: [
         makeRow({
           line: 2,
-          name: "Invalid Unit",
-          parentName: "East Region",
-          requiredParentNetworkSiteTypeId: "type-market",
+          name: "Invalid Region",
+          networkSiteTypeId: "type-region",
+          siteType: "Region",
+          parentName: "Springfield Market",
         }),
         makeRow({ line: 3, name: "Valid Root" }),
       ],
       existingSiteIdByName: new Map<string, string>([
-        ["East Region", "existing-region"],
+        ["Springfield Market", "existing-market"],
       ]),
       existingSiteTypeIdByName: new Map<string, string | null>([
-        ["East Region", "type-region"],
+        ["Springfield Market", "type-market"],
       ]),
+      siteTypes: SITE_TYPES,
       createSite,
       onProgress: (progress: SiteImportProgress) => {
         if (events.length === 0 && progress.results.length > 0) {
@@ -404,7 +467,7 @@ describe("runSiteImport — rows that can never be created", () => {
       },
     });
 
-    expect(events).toEqual(["preflight:Invalid Unit", "create:Valid Root"]);
+    expect(events).toEqual(["preflight:Invalid Region", "create:Valid Root"]);
   });
 
   test("skipped rows do not count toward the progress total", async () => {

--- a/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
@@ -153,10 +153,22 @@ describe("Import Sites modal disarms a stale parse", () => {
     expect(source).toContain('"Unit 1042","Unit","Springfield Market"');
   });
 
-  test("loads type metadata for existing-parent compatibility preflight", () => {
+  /*
+   * The example has to show the thing the importer was refusing in GitHub
+   * issue #3744 — a site hanging off a branch its type is not configured
+   * under — or it teaches the rule that caused the bug.
+   */
+  test("the bundled example also shows a cross-branch placement", () => {
+    expect(source).toContain('"Warehouse 7",Other,"East Region"');
+  });
+
+  test("loads the whole type catalog the placement rule needs", () => {
     expect(source).toContain("parentNetworkSiteTypeId: true");
     expect(source).toContain("networkSiteTypeId: true");
+    expect(source).toContain("isUnitLevel: true");
     expect(source).toContain("existingSiteTypeIdByName");
+    // The planner cannot answer an ancestry question from one type at a time.
+    expect(source).toContain("siteTypes: siteTypes");
   });
 
   test("loads every page of site types and existing parent sites", () => {

--- a/App/Tests/Dashboard/NetworkSiteTypeParentPageInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkSiteTypeParentPageInvariants.test.ts
@@ -40,10 +40,21 @@ describe("Network Site Type settings use parent relationships", () => {
     expect(source).not.toContain('sectionTitle: "Position in the Hierarchy"');
   });
 
-  test("the help explains that parent types constrain site placement", () => {
+  /*
+   * The parent type shapes site placement without dictating it. Copy that
+   * still calls it a validity rule is what sent operators looking for a way
+   * around it in GitHub issue #3744.
+   */
+  test("the help presents parent types as guidance, not a placement rule", () => {
     expect(source).toContain("Choose the type directly above this one");
     expect(source).toContain(
+      "this relationship decides which parent sites are suggested first",
+    );
+    expect(source).not.toContain(
       "this relationship determines which parent sites are valid",
+    );
+    expect(source).not.toContain(
+      "a type that is already in use can move only when its sites already match",
     );
   });
 });
@@ -78,9 +89,28 @@ describe.each([
       expect(source).toContain('title: "Parent Site"');
       expect(source).toContain('stepId: "hierarchy"');
       expect(source).toContain("fetchParentNetworkSiteOptions");
-      expect(source).toContain("required: isParentSiteRequired");
+    });
+
+    /*
+     * A required parent site is the first half of GitHub issue #3744: a
+     * project whose types were all top-level could not satisfy it, and a
+     * project with the seeded five-level tree had to build four ancestors
+     * before it could record one store.
+     */
+    test("never requires a parent site", () => {
+      expect(source).not.toContain("isParentSiteRequired");
+      expect(source).toContain('title: "Parent Site"');
+    });
+
+    test("describes the parent picker as a suggestion, not a filter", () => {
       expect(source).toContain(
+        "Any site that is not below this one in your site type hierarchy can be the parent",
+      );
+      expect(source).not.toContain(
         "Only sites whose type is the configured parent",
+      );
+      expect(source).not.toContain(
+        "A child site type requires one of the matching sites below",
       );
     });
   },
@@ -98,9 +128,12 @@ describe("Child Sites creation respects the known parent's type", () => {
     expect(source).toContain("item.parentSiteId = modelId");
   });
 
-  test("offers only configured direct child types", () => {
+  test("offers every child type the hierarchy does not place above this site", () => {
     expect(source).toContain("fetchChildNetworkSiteTypeOptions(modelId)");
     expect(source).toContain(
+      "Any type except the ones above this site's own type in the hierarchy",
+    );
+    expect(source).not.toContain(
       "Only types configured directly beneath this site's type are available",
     );
     expect(source).not.toContain("type: NetworkSiteType, labelField");
@@ -121,21 +154,58 @@ describe("Network Site hierarchy option loading", () => {
     "NetworkSiteFormDropdownOptions.ts",
   );
 
-  test("filters candidate parent sites by the configured parent type", () => {
-    expect(source).toContain("getConfiguredParentTypeId");
+  /*
+   * Filtering the query by the configured parent type is what made the picker
+   * come back empty for every type in the reporting project (GitHub issue
+   * #3744). The narrowing that replaced it asks for the types the placement
+   * rule allows, which is a superset that can never be empty while any
+   * container type exists.
+   */
+  test("asks for every type the placement rule allows, not one configured type", () => {
+    expect(source).toContain("getValidSiteParentTypes");
     expect(source).toContain(
+      "networkSiteTypeId: new Includes(allowedParentTypeIds)",
+    );
+    expect(source).not.toContain(
       "networkSiteTypeId: new ObjectID(parentNetworkSiteTypeId)",
     );
   });
 
-  test("does not offer the current site or one of its descendants", () => {
-    expect(source).toContain("candidateId === normalizedCurrentId");
-    expect(source).toContain("includes(`/${normalizedCurrentId}/`)");
+  test("reads each candidate's own type so the rule can be applied", () => {
+    expect(source).toContain("networkSiteTypeId: true");
+    expect(source).toContain("materializedPath: true");
+  });
+
+  test("no form field is gated on a required parent site any more", () => {
+    expect(source).not.toContain("isParentSiteRequired");
   });
 
   test("pages through every eligible type and parent site", () => {
     expect(source).toContain("networkSiteTypes.push(...result.data)");
     expect(source).toContain("parentSites.push(...result.data)");
     expect(source).toContain("skip += result.data.length");
+  });
+});
+
+describe("Network Site parent candidate filtering", () => {
+  const source: string = readSource(
+    "Components",
+    "NetworkSite",
+    "SiteTypeHierarchyFormUtil.ts",
+  );
+
+  test("does not offer the current site or one of its descendants", () => {
+    expect(source).toContain("candidateId === normalizedCurrentId");
+    expect(source).toContain("includes(`/${normalizedCurrentId}/`)");
+  });
+
+  test("routes every candidate through the shared placement rule", () => {
+    expect(source).toContain("isTypeAllowedAsSiteParentOfType");
+    expect(source).toContain("isParentSitePlacementAllowed");
+  });
+
+  test("labels the suggested group rather than relying on array order", () => {
+    expect(source).toContain("Suggested —");
+    expect(source).toContain('label: "Other sites"');
   });
 });

--- a/App/Tests/Dashboard/SiteTypeHierarchyFormUtil.test.ts
+++ b/App/Tests/Dashboard/SiteTypeHierarchyFormUtil.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "@jest/globals";
+import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
 import NetworkSiteType from "Common/Models/DatabaseModels/NetworkSiteType";
 import ObjectID from "Common/Types/ObjectID";
 import SiteTypeHierarchyFormUtil from "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteTypeHierarchyFormUtil";
@@ -93,52 +94,285 @@ describe("SiteTypeHierarchyFormUtil", () => {
     ]);
   });
 
-  test("child creation offers only direct children of the known parent type", () => {
+  test("child creation offers every type except the ones above the parent", () => {
     expect(
-      SiteTypeHierarchyFormUtil.getChildTypeOptions({
+      SiteTypeHierarchyFormUtil.getAllowedChildTypeOptions({
         parentNetworkSiteTypeValue: ROOT_ID,
         networkSiteTypes: hierarchy(),
       }),
-    ).toEqual([{ value: MARKET_ID.toString(), label: "Region › Market" }]);
+    ).toEqual([
+      { value: MARKET_ID.toString(), label: "Region › Market" },
+      { value: ROOT_ID.toString(), label: "Region" },
+      { value: UNIT_ID.toString(), label: "Region › Market › Unit" },
+      { value: BRANCH_ID.toString(), label: "Branch" },
+    ]);
   });
 
-  test("resolves the configured parent required by the selected type", () => {
+  test("child creation under a deeper parent drops that parent's ancestors", () => {
+    expect(
+      SiteTypeHierarchyFormUtil.getAllowedChildTypeOptions({
+        parentNetworkSiteTypeValue: MARKET_ID,
+        networkSiteTypes: hierarchy(),
+      }),
+    ).toEqual([
+      { value: MARKET_ID.toString(), label: "Region › Market" },
+      { value: UNIT_ID.toString(), label: "Region › Market › Unit" },
+      { value: BRANCH_ID.toString(), label: "Branch" },
+    ]);
+  });
+
+  test("child creation under a unit-level parent offers nothing", () => {
+    const types: Array<NetworkSiteType> = hierarchy().map(
+      (networkSiteType: NetworkSiteType): NetworkSiteType => {
+        if (networkSiteType.id?.toString() === UNIT_ID.toString()) {
+          networkSiteType.isUnitLevel = true;
+        }
+        return networkSiteType;
+      },
+    );
+
+    expect(
+      SiteTypeHierarchyFormUtil.getAllowedChildTypeOptions({
+        parentNetworkSiteTypeValue: UNIT_ID,
+        networkSiteTypes: types,
+      }),
+    ).toEqual([]);
+  });
+
+  test("child creation under an untyped parent offers every type", () => {
+    expect(
+      SiteTypeHierarchyFormUtil.getAllowedChildTypeOptions({
+        parentNetworkSiteTypeValue: null,
+        networkSiteTypes: hierarchy(),
+      }),
+    ).toHaveLength(4);
+  });
+
+  test("resolves the preferred parent type for the selected type", () => {
     const types: Array<NetworkSiteType> = hierarchy();
 
     expect(
-      SiteTypeHierarchyFormUtil.getConfiguredParentTypeId({
+      SiteTypeHierarchyFormUtil.getPreferredParentTypeId({
         selectedNetworkSiteTypeValue: MARKET_ID.toString(),
         networkSiteTypes: types,
       }),
     ).toBe(ROOT_ID.toString());
     expect(
-      SiteTypeHierarchyFormUtil.getConfiguredParentTypeId({
+      SiteTypeHierarchyFormUtil.getPreferredParentTypeId({
         selectedNetworkSiteTypeValue: ROOT_ID.toString(),
         networkSiteTypes: types,
       }),
     ).toBeNull();
   });
 
-  test("requires a parent site only when the selected type has a parent type", () => {
+  /*
+   * The placement rule behind GitHub issue #3744: a parent may be anything the
+   * hierarchy does not place BELOW the child, so unrelated types and skipped
+   * levels are fine and only an inversion is refused.
+   */
+  describe("site placement rule", () => {
     const types: Array<NetworkSiteType> = hierarchy();
 
-    expect(
-      SiteTypeHierarchyFormUtil.isParentSiteRequired({
-        selectedNetworkSiteTypeValue: MARKET_ID,
-        networkSiteTypes: types,
-      }),
-    ).toBe(true);
-    expect(
-      SiteTypeHierarchyFormUtil.isParentSiteRequired({
-        selectedNetworkSiteTypeValue: ROOT_ID,
-        networkSiteTypes: types,
-      }),
-    ).toBe(false);
-    expect(
-      SiteTypeHierarchyFormUtil.isParentSiteRequired({
-        selectedNetworkSiteTypeValue: undefined,
-        networkSiteTypes: types,
-      }),
-    ).toBe(false);
+    test("an unrelated type may be the parent", () => {
+      expect(
+        SiteTypeHierarchyFormUtil.isParentSitePlacementAllowed({
+          childNetworkSiteTypeValue: MARKET_ID,
+          parentNetworkSiteTypeValue: BRANCH_ID,
+          networkSiteTypes: types,
+        }),
+      ).toBe(true);
+    });
+
+    test("a skipped level is allowed", () => {
+      expect(
+        SiteTypeHierarchyFormUtil.isParentSitePlacementAllowed({
+          childNetworkSiteTypeValue: UNIT_ID,
+          parentNetworkSiteTypeValue: ROOT_ID,
+          networkSiteTypes: types,
+        }),
+      ).toBe(true);
+    });
+
+    test("the same type on both sides is allowed", () => {
+      expect(
+        SiteTypeHierarchyFormUtil.isParentSitePlacementAllowed({
+          childNetworkSiteTypeValue: MARKET_ID,
+          parentNetworkSiteTypeValue: MARKET_ID,
+          networkSiteTypes: types,
+        }),
+      ).toBe(true);
+    });
+
+    test("a parent with no type at all is allowed", () => {
+      expect(
+        SiteTypeHierarchyFormUtil.isParentSitePlacementAllowed({
+          childNetworkSiteTypeValue: MARKET_ID,
+          parentNetworkSiteTypeValue: null,
+          networkSiteTypes: types,
+        }),
+      ).toBe(true);
+    });
+
+    test("a parent whose type sits below the child's is refused", () => {
+      expect(
+        SiteTypeHierarchyFormUtil.isParentSitePlacementAllowed({
+          childNetworkSiteTypeValue: ROOT_ID,
+          parentNetworkSiteTypeValue: UNIT_ID,
+          networkSiteTypes: types,
+        }),
+      ).toBe(false);
+    });
+
+    test("a unit-level parent is refused whatever the child type", () => {
+      const unitLevelTypes: Array<NetworkSiteType> = hierarchy().map(
+        (networkSiteType: NetworkSiteType): NetworkSiteType => {
+          if (networkSiteType.id?.toString() === BRANCH_ID.toString()) {
+            networkSiteType.isUnitLevel = true;
+          }
+          return networkSiteType;
+        },
+      );
+
+      expect(
+        SiteTypeHierarchyFormUtil.isParentSitePlacementAllowed({
+          childNetworkSiteTypeValue: MARKET_ID,
+          parentNetworkSiteTypeValue: BRANCH_ID,
+          networkSiteTypes: unitLevelTypes,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("parent site picker", () => {
+    function makeSite(data: {
+      id: string;
+      name: string;
+      typeId?: ObjectID | undefined;
+      materializedPath?: string | undefined;
+    }): NetworkSite {
+      const site: NetworkSite = new NetworkSite(new ObjectID(data.id));
+      site.name = data.name;
+      if (data.typeId) {
+        site.networkSiteTypeId = data.typeId;
+      }
+      if (data.materializedPath) {
+        site.materializedPath = data.materializedPath;
+      }
+      return site;
+    }
+
+    const REGION_SITE_ID: string = "20000000-0000-4000-8000-000000000001";
+    const BRANCH_SITE_ID: string = "20000000-0000-4000-8000-000000000002";
+    const UNIT_SITE_ID: string = "20000000-0000-4000-8000-000000000003";
+    const SELF_SITE_ID: string = "20000000-0000-4000-8000-000000000004";
+    const DESCENDANT_SITE_ID: string = "20000000-0000-4000-8000-000000000005";
+
+    function candidates(): Array<NetworkSite> {
+      return [
+        makeSite({
+          id: REGION_SITE_ID,
+          name: "East Region",
+          typeId: ROOT_ID,
+          materializedPath: `/${REGION_SITE_ID}/`,
+        }),
+        makeSite({
+          id: BRANCH_SITE_ID,
+          name: "Warehouse 7",
+          typeId: BRANCH_ID,
+          materializedPath: `/${BRANCH_SITE_ID}/`,
+        }),
+        makeSite({
+          id: UNIT_SITE_ID,
+          name: "Unit 1042",
+          typeId: UNIT_ID,
+          materializedPath: `/${UNIT_SITE_ID}/`,
+        }),
+        makeSite({
+          id: SELF_SITE_ID,
+          name: "Springfield Market",
+          typeId: MARKET_ID,
+          materializedPath: `/${SELF_SITE_ID}/`,
+        }),
+        makeSite({
+          id: DESCENDANT_SITE_ID,
+          name: "Downtown Store",
+          typeId: UNIT_ID,
+          materializedPath: `/${SELF_SITE_ID}/${DESCENDANT_SITE_ID}/`,
+        }),
+      ];
+    }
+
+    test("suggests the configured parent type first and still offers the rest", () => {
+      expect(
+        SiteTypeHierarchyFormUtil.buildParentSiteOptions({
+          networkSites: candidates(),
+          childNetworkSiteTypeValue: MARKET_ID,
+          networkSiteTypes: hierarchy(),
+          currentNetworkSiteId: SELF_SITE_ID,
+        }),
+      ).toEqual([
+        {
+          label: "Suggested — Region",
+          options: [{ value: REGION_SITE_ID, label: "East Region (Region)" }],
+        },
+        {
+          label: "Other sites",
+          options: [{ value: BRANCH_SITE_ID, label: "Warehouse 7 (Branch)" }],
+        },
+      ]);
+    });
+
+    test("never offers the site itself or anything in its own subtree", () => {
+      const options: Array<unknown> =
+        SiteTypeHierarchyFormUtil.buildParentSiteOptions({
+          networkSites: candidates(),
+          childNetworkSiteTypeValue: MARKET_ID,
+          networkSiteTypes: hierarchy(),
+          currentNetworkSiteId: SELF_SITE_ID,
+        });
+
+      expect(JSON.stringify(options)).not.toContain(SELF_SITE_ID);
+      expect(JSON.stringify(options)).not.toContain(DESCENDANT_SITE_ID);
+    });
+
+    test("drops sites whose type sits below this one", () => {
+      const options: Array<unknown> =
+        SiteTypeHierarchyFormUtil.buildParentSiteOptions({
+          networkSites: candidates(),
+          childNetworkSiteTypeValue: ROOT_ID,
+          networkSiteTypes: hierarchy(),
+        });
+
+      expect(JSON.stringify(options)).not.toContain(UNIT_SITE_ID);
+      expect(JSON.stringify(options)).not.toContain(SELF_SITE_ID);
+      expect(JSON.stringify(options)).toContain(BRANCH_SITE_ID);
+    });
+
+    /*
+     * The reported project: no type has a configured parent, so there is
+     * nothing to suggest and the picker must still list every candidate as one
+     * plain group rather than coming back empty.
+     */
+    test("a flat type catalog still yields a full, ungrouped list", () => {
+      const flatTypes: Array<NetworkSiteType> = [
+        makeType({ id: ROOT_ID, name: "Other", order: 1 }),
+        makeType({ id: MARKET_ID, name: "Market", order: 2 }),
+      ];
+
+      expect(
+        SiteTypeHierarchyFormUtil.buildParentSiteOptions({
+          networkSites: [
+            makeSite({
+              id: REGION_SITE_ID,
+              name: "Aramark",
+              typeId: ROOT_ID,
+              materializedPath: `/${REGION_SITE_ID}/`,
+            }),
+          ],
+          childNetworkSiteTypeValue: MARKET_ID,
+          networkSiteTypes: flatTypes,
+        }),
+      ).toEqual([{ value: REGION_SITE_ID, label: "Aramark (Other)" }]);
+    });
   });
 });

--- a/Common/Server/Services/NetworkSiteService.ts
+++ b/Common/Server/Services/NetworkSiteService.ts
@@ -34,6 +34,7 @@ import NetworkDeviceHydrationUtil from "../Utils/Monitor/NetworkDeviceHydrationU
 import logger, { LogAttributes } from "../Utils/Logger";
 import PartialEntity from "../../Types/Database/PartialEntity";
 import { NetworkDeviceMonitoringMethodUtil } from "../../Types/NetworkDevice/NetworkDeviceMonitoringMethod";
+import ColumnLength from "../../Types/Database/ColumnLength";
 import LIMIT_MAX, { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import { FindWhereProperty } from "../../Types/BaseDatabase/Query";
@@ -126,6 +127,23 @@ const DIRECT_CHILD_TYPE_VALIDATION_PAGE_SIZE: number = 1000;
  * row from the old path prefix, so every page must start at offset zero.
  */
 const SUBTREE_REBASE_PAGE_SIZE: number = 1000;
+
+/*
+ * How deep a site tree may go, derived from the column that has to hold it:
+ * materializedPath is varchar(ColumnLength.LongText) and every segment costs a
+ * 36-character id plus its separator, after the leading slash.
+ *
+ * The bound has to be stated here now. It used to fall out of the placement
+ * rule for free - a site's depth was exactly its type's depth in the catalog,
+ * because the parent type was pinned recursively. Placement no longer pins
+ * anything (a site may sit under one of its own type), so without this a chain
+ * of thirteen sites would silently overflow the column: Postgres refuses the
+ * write, and it refuses it in onUpdateSuccess, after the parent change has
+ * already been committed.
+ */
+const MAX_SITE_HIERARCHY_PATH_SEGMENTS: number = Math.floor(
+  (ColumnLength.LongText - 1) / 37,
+);
 
 /*
  * Model instances initialise optional fields to undefined. Those properties
@@ -786,6 +804,27 @@ export class Service extends DatabaseService<Model> {
     networkSiteTypeId: ObjectID,
     cache: Map<string, NetworkSiteType>,
   ): Promise<NetworkSiteType> {
+    const networkSiteType: NetworkSiteType | null =
+      await this.findNetworkSiteTypeForHierarchy(networkSiteTypeId, cache);
+
+    if (!networkSiteType) {
+      throw new BadDataException("Network site type not found.");
+    }
+
+    return networkSiteType;
+  }
+
+  /*
+   * The nullable form, for rows that are read as CONTEXT rather than written.
+   * A parent site's type - or a link further up the catalog - can be missing
+   * after a direct database edit, and an unresolvable ancestor proves nothing
+   * about the proposed edge; refusing the whole write there would strand the
+   * site instead of describing a problem the operator can act on.
+   */
+  private async findNetworkSiteTypeForHierarchy(
+    networkSiteTypeId: ObjectID,
+    cache: Map<string, NetworkSiteType>,
+  ): Promise<NetworkSiteType | null> {
     const key: string = normalizeId(networkSiteTypeId);
     const cached: NetworkSiteType | undefined = cache.get(key);
 
@@ -798,7 +837,9 @@ export class Service extends DatabaseService<Model> {
         id: networkSiteTypeId,
         select: {
           _id: true,
+          name: true,
           projectId: true,
+          isUnitLevel: true,
           parentNetworkSiteTypeId: true,
         },
         props: {
@@ -806,19 +847,27 @@ export class Service extends DatabaseService<Model> {
         },
       });
 
-    if (!networkSiteType) {
-      throw new BadDataException("Network site type not found.");
+    if (networkSiteType) {
+      cache.set(key, networkSiteType);
     }
 
-    cache.set(key, networkSiteType);
     return networkSiteType;
   }
 
   /*
-   * Assert one proposed site edge against the type hierarchy. Untyped legacy
-   * root rows remain readable/editable, but as soon as a site has a type its
-   * placement is exact: a root type has no parent, and a non-root type has a
-   * parent site whose type is precisely the configured direct parent type.
+   * Assert one proposed site edge against the type hierarchy.
+   *
+   * The type tree describes which levels sit above which; it does NOT dictate
+   * an exact placement. A parent site is always optional, may skip levels, and
+   * may be of an unrelated type — the only inversion refused is a parent whose
+   * type sits BELOW the child's own type. The stricter reading this replaces
+   * (parent must be exactly the configured direct parent type, root types may
+   * never have a parent) made whole hierarchies impossible to build: see
+   * GitHub issue #3744, where every type in the project was top-level and no
+   * parent could be linked at all, by hand or by CSV.
+   *
+   * A unit-level type is the declared leaf of the hierarchy, so its sites hold
+   * devices rather than more sites and can never be a parent here.
    */
   private async validateSiteTypeEdge(data: {
     networkSiteTypeId: ObjectID | null;
@@ -852,32 +901,80 @@ export class Service extends DatabaseService<Model> {
       );
     }
 
-    const requiredParentTypeId: ObjectID | null =
-      networkSiteType.parentNetworkSiteTypeId || null;
-
-    if (!requiredParentTypeId) {
-      if (data.parentSite) {
-        throw new BadDataException(
-          "A site with a root network site type cannot have a parent site.",
-        );
-      }
-
+    if (!data.parentSite) {
       return;
     }
 
-    if (!data.parentSite) {
+    /*
+     * A parent that predates site types belongs to no level, so no inversion
+     * can be proven against it. Refusing it would make legacy rows permanently
+     * unusable as parents without a data migration nobody can safely write.
+     */
+    if (!data.parentSite.networkSiteTypeId) {
+      return;
+    }
+
+    const parentNetworkSiteType: NetworkSiteType | null =
+      await this.findNetworkSiteTypeForHierarchy(
+        data.parentSite.networkSiteTypeId,
+        data.typeCache,
+      );
+
+    if (!parentNetworkSiteType) {
+      return;
+    }
+
+    const childTypeName: string =
+      networkSiteType.name || "this site's network site type";
+    const parentTypeName: string =
+      parentNetworkSiteType.name || "the parent site's network site type";
+
+    if (parentNetworkSiteType.isUnitLevel === true) {
       throw new BadDataException(
-        "This network site type requires a parent site.",
+        `Sites of network site type "${parentTypeName}" are unit level, so they cannot have child sites.`,
       );
     }
 
-    if (
-      !data.parentSite.networkSiteTypeId ||
-      !sameId(data.parentSite.networkSiteTypeId, requiredParentTypeId)
-    ) {
-      throw new BadDataException(
-        "Parent site must use the configured parent network site type.",
-      );
+    if (sameId(data.networkSiteTypeId, data.parentSite.networkSiteTypeId)) {
+      return;
+    }
+
+    /*
+     * Walk UP from the parent's type. Reaching the child's type means the
+     * parent sits below it, which is the one arrangement that contradicts the
+     * configured hierarchy. The visited set bounds a catalog cycle written
+     * straight into the database, which must fail the request rather than
+     * spin the event loop.
+     */
+    const visited: Set<string> = new Set<string>([
+      normalizeId(data.parentSite.networkSiteTypeId),
+    ]);
+    let ancestorTypeId: ObjectID | null =
+      parentNetworkSiteType.parentNetworkSiteTypeId || null;
+
+    while (ancestorTypeId) {
+      if (sameId(ancestorTypeId, data.networkSiteTypeId)) {
+        throw new BadDataException(
+          `A site of network site type "${childTypeName}" cannot be placed under a site of network site type "${parentTypeName}", because "${parentTypeName}" sits below "${childTypeName}" in the site type hierarchy.`,
+        );
+      }
+
+      if (visited.has(normalizeId(ancestorTypeId))) {
+        break;
+      }
+      visited.add(normalizeId(ancestorTypeId));
+
+      const ancestorType: NetworkSiteType | null =
+        await this.findNetworkSiteTypeForHierarchy(
+          ancestorTypeId,
+          data.typeCache,
+        );
+
+      if (!ancestorType) {
+        break;
+      }
+
+      ancestorTypeId = ancestorType.parentNetworkSiteTypeId || null;
     }
   }
 
@@ -925,6 +1022,19 @@ export class Service extends DatabaseService<Model> {
       });
 
       for (const child of children) {
+        /*
+         * An untyped site is tolerated as a parent only where legacy data
+         * already made it one. Clearing the type of a site that still owns
+         * children would manufacture that shape deliberately, and every
+         * placement check below it would then have nothing to compare
+         * against.
+         */
+        if (!data.proposedNetworkSiteTypeId) {
+          throw new BadDataException(
+            "A network site with child sites must have a network site type.",
+          );
+        }
+
         await this.validateSiteTypeEdge({
           networkSiteTypeId: child.networkSiteTypeId || null,
           parentSite: proposedParent,
@@ -1216,6 +1326,10 @@ export class Service extends DatabaseService<Model> {
 
     if (parentSiteId) {
       parentPath = await this.getMaterializedPathForSite(parentSiteId);
+      this.assertHierarchyDepthFits({
+        parentPath: parentPath,
+        additionalSegments: 1,
+      });
     }
 
     return {
@@ -1224,6 +1338,80 @@ export class Service extends DatabaseService<Model> {
         parentPath: parentPath,
       },
     };
+  }
+
+  /*
+   * Refuse a placement whose resulting path would not fit the column, before
+   * anything is written. `additionalSegments` is the height of what is being
+   * hung off this parent: 1 for a new leaf, and for a move the moved site plus
+   * the deepest thing already under it.
+   */
+  private assertHierarchyDepthFits(data: {
+    parentPath: string | null;
+    additionalSegments: number;
+  }): void {
+    const parentSegments: number = MaterializedPathUtil.segmentsOf(
+      data.parentPath,
+    ).length;
+
+    if (
+      parentSegments + data.additionalSegments <=
+      MAX_SITE_HIERARCHY_PATH_SEGMENTS
+    ) {
+      return;
+    }
+
+    throw new BadDataException(
+      `A network site hierarchy can be at most ${MAX_SITE_HIERARCHY_PATH_SEGMENTS} levels deep, and this placement would make it deeper. Move the sites below it first, or attach this one higher up.`,
+    );
+  }
+
+  /*
+   * How many levels the subtree rooted at `site` occupies, itself included, so
+   * a move can be measured before it is made rather than discovered when the
+   * post-commit rebase writes an over-long path.
+   */
+  private async getSubtreeHeight(site: Model): Promise<number> {
+    if (!site.materializedPath || !site.projectId) {
+      return 1;
+    }
+
+    const ownSegments: number = MaterializedPathUtil.segmentsOf(
+      site.materializedPath,
+    ).length;
+
+    /*
+     * Ordering on the maintained `depth` column keeps this to one row. Rows
+     * with no depth at all are excluded rather than sorted first: such a row
+     * predates path maintenance and would otherwise answer the question with a
+     * shallow path, and leaving the bound permissive for already-broken data
+     * is better than refusing a move the operator can see is fine.
+     */
+    const deepest: Array<Model> = await this.findBy({
+      query: {
+        projectId: site.projectId,
+        materializedPath: this.pathStartsWith(site.materializedPath),
+        depth: QueryHelper.notNull(),
+      },
+      select: {
+        _id: true,
+        materializedPath: true,
+      },
+      sort: {
+        depth: SortOrder.Descending,
+      },
+      limit: 1,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    const deepestSegments: number = MaterializedPathUtil.segmentsOf(
+      deepest[0]?.materializedPath,
+    ).length;
+
+    return Math.max(1, deepestSegments - ownSegments + 1);
   }
 
   @CaptureSpan()
@@ -1499,6 +1687,17 @@ export class Service extends DatabaseService<Model> {
             "Cannot move a site under itself or one of its own descendants.",
           );
         }
+
+        /*
+         * The whole subtree moves with the site, so the deepest row in it is
+         * what decides whether the move fits. Measuring it here is the only
+         * chance: the rebase that writes those paths runs after the parent
+         * change has been committed.
+         */
+        this.assertHierarchyDepthFits({
+          parentPath: newParentPath,
+          additionalSegments: await this.getSubtreeHeight(item),
+        });
       }
     }
 
@@ -1825,11 +2024,16 @@ export class Service extends DatabaseService<Model> {
     );
 
     /*
-     * A valid child type explicitly names the deleted site's type as its
-     * required direct parent type. Legacy SET NULL/orphan-repair behaviour
-     * therefore cannot produce a valid edge: promoting the child to root or
-     * attaching it to the grandparent both violate its type. Reject the
-     * delete unless every direct child is part of this same bulk delete.
+     * Reject the delete unless every direct child is part of this same bulk
+     * delete.
+     *
+     * This used to be argued from the type rule - promoting an orphan to root
+     * or to its grandparent was said to be impossible without breaking its
+     * type. That argument no longer holds: a parent is optional now, and a
+     * grandparent is usually a legal parent. The guard stays on its own terms.
+     * Deleting one site is not permission to silently restructure the tree
+     * underneath it, and the operator, not the repair loop, should decide
+     * where those sites belong.
      *
      * Parent ids and result rows are both batched so neither a wide delete nor
      * a wide site is silently truncated at a service query limit.
@@ -1953,6 +2157,15 @@ export class Service extends DatabaseService<Model> {
    * Rewrites the deleted site's former subtree so the '/deletedId/' segment
    * is dropped from every path, and re-points its direct children at the
    * deleted site's parent.
+   *
+   * onBeforeDelete refuses a delete that would leave a surviving child, so
+   * this only runs for rows that got past it - a hard delete, or a child
+   * created in the window between the check and the write. It writes the
+   * promotion without re-checking the placement rule: the grandparent it
+   * promotes to is almost always legal, the alternative is leaving a site
+   * pointing at a row that no longer exists, and the result is visible and
+   * fixable in the parent picker. A repair prefers a whole tree to a
+   * perfectly modelled one.
    */
   private async reattachOrphanedSubtree(deletedSite: Model): Promise<void> {
     const oldPath: string | null = deletedSite.materializedPath || null;

--- a/Common/Server/Services/NetworkSiteTypeService.ts
+++ b/Common/Server/Services/NetworkSiteTypeService.ts
@@ -29,8 +29,8 @@ const PARENT_NETWORK_SITE_TYPE_KEYS: Array<string> = [
 
 const PROJECT_KEYS: Array<string> = ["projectId", "project"];
 
-const EXISTING_SITES_DO_NOT_MATCH_MESSAGE: string =
-  "This site type's parent cannot be changed because existing sites do not match the proposed hierarchy. Create a new site type under the desired parent, then move and reassign the sites to it.";
+const EXISTING_SITES_WOULD_INVERT_MESSAGE: string =
+  "This site type's parent cannot be changed because an existing site is already placed under a site that the move would push below it. Move that site first, then change the type.";
 
 const REFERENCE_VALIDATION_BATCH_SIZE: number = 1000;
 
@@ -742,111 +742,177 @@ export class Service extends DatabaseService<Model> {
   }
 
   /*
-   * Changing a type definition must not retroactively make the concrete site
-   * tree invalid. A root type may only describe root sites; a child type may
-   * only describe sites whose actual parent has the declared parent type.
+   * Changing a type's place in the catalog must not retroactively invert the
+   * concrete site tree. Site placement itself is permissive — a site may sit
+   * under any site whose type is not BELOW its own — so the rows at risk are
+   * not the moved type's own sites.
+   *
+   * Moving type X from its old ancestor chain to a new one adds "sits above"
+   * pairs (Z, Y) for exactly Z in newAncestors = chain(newParent) minus
+   * chain(oldParent), and Y in movedSubtree = {X} + descendants(X): X keeps
+   * its own subtree, so nothing below X changes relative to X. An existing
+   * edge breaks only when its CHILD site is typed in newAncestors and its
+   * PARENT site is typed in movedSubtree, because that edge would then place a
+   * higher-level site beneath a lower-level one.
+   *
+   * Two corollaries fall straight out and are worth knowing when reading the
+   * early returns: clearing a type's parent has an empty newAncestors, so it
+   * can never break anything; and moving a type DEEPER along the chain it is
+   * already under only adds ancestors the sites already had.
    */
-  private async assertExistingSitesMatchProposedParent(data: {
+  private async assertExistingSitesWouldNotInvert(data: {
     networkSiteTypeId: ObjectID;
+    projectId: ObjectID;
+    currentParentNetworkSiteTypeId: ObjectID | string | null;
     proposedParentNetworkSiteTypeId: ObjectID | null;
+    networkSiteTypes: Array<Model>;
   }): Promise<void> {
-    const sites: Array<NetworkSite> = await this.findAllNetworkSites({
-      query: { networkSiteTypeId: data.networkSiteTypeId },
-      select: {
-        _id: true,
-        parentSiteId: true,
-      },
+    if (!data.proposedParentNetworkSiteTypeId) {
+      return;
+    }
+
+    const chainOf: (startId: ObjectID | string | null) => Set<string> = (
+      startId: ObjectID | string | null,
+    ): Set<string> => {
+      const chain: Set<string> = new Set<string>();
+
+      if (!startId) {
+        return chain;
+      }
+
+      const start: Model | undefined = data.networkSiteTypes.find(
+        (networkSiteType: Model) => {
+          return Boolean(
+            networkSiteType.id && sameId(networkSiteType.id, startId),
+          );
+        },
+      );
+
+      chain.add(normalizeId(startId));
+
+      if (!start) {
+        return chain;
+      }
+
+      for (const ancestor of NetworkSiteTypeHierarchyUtil.getAncestorNetworkSiteTypes(
+        {
+          networkSiteType: start,
+          networkSiteTypes: data.networkSiteTypes,
+        },
+      )) {
+        if (ancestor.id) {
+          chain.add(normalizeId(ancestor.id));
+        }
+      }
+
+      return chain;
+    };
+
+    const oldChain: Set<string> = chainOf(data.currentParentNetworkSiteTypeId);
+    const newAncestorIds: Array<string> = [
+      ...chainOf(data.proposedParentNetworkSiteTypeId),
+    ].filter((typeId: string) => {
+      return !oldChain.has(typeId);
     });
 
-    if (sites.length === 0) {
+    if (newAncestorIds.length === 0) {
       return;
     }
 
-    if (!data.proposedParentNetworkSiteTypeId) {
-      if (
-        sites.some((site: NetworkSite) => {
-          return Boolean(site.parentSiteId);
-        })
-      ) {
-        throw new BadDataException(EXISTING_SITES_DO_NOT_MATCH_MESSAGE);
-      }
+    const movingType: Model = new Model();
+    movingType.id = data.networkSiteTypeId;
 
-      return;
-    }
-
-    const parentSiteIds: Array<ObjectID> = [];
-    const distinctParentSiteIds: Set<string> = new Set<string>();
-
-    for (const site of sites) {
-      if (!site.parentSiteId) {
-        throw new BadDataException(EXISTING_SITES_DO_NOT_MATCH_MESSAGE);
-      }
-
-      const normalizedParentSiteId: string = normalizeId(site.parentSiteId);
-      if (!distinctParentSiteIds.has(normalizedParentSiteId)) {
-        distinctParentSiteIds.add(normalizedParentSiteId);
-        parentSiteIds.push(site.parentSiteId);
+    const movedSubtreeTypeIds: Set<string> = new Set<string>([
+      normalizeId(data.networkSiteTypeId),
+    ]);
+    for (const descendant of NetworkSiteTypeHierarchyUtil.getDescendantNetworkSiteTypes(
+      {
+        networkSiteType: movingType,
+        networkSiteTypes: data.networkSiteTypes,
+      },
+    )) {
+      if (descendant.id) {
+        movedSubtreeTypeIds.add(normalizeId(descendant.id));
       }
     }
 
-    const parentSites: Array<NetworkSite> = [];
+    /*
+     * Only sites typed in the newly gained ancestor chain can break, and only
+     * through the parent they already point at. Reading that narrow slice
+     * rather than every site in the project is what keeps a settings save on a
+     * large estate proportional to the move.
+     */
+    const sitesAtRisk: Array<NetworkSite> = [];
 
     for (
       let offset: number = 0;
-      offset < parentSiteIds.length;
-      offset += LIMIT_MAX
+      offset < newAncestorIds.length;
+      offset += REFERENCE_VALIDATION_BATCH_SIZE
     ) {
-      const parentSiteIdBatch: Array<ObjectID> = parentSiteIds.slice(
-        offset,
-        offset + LIMIT_MAX,
-      );
-
-      parentSites.push(
+      sitesAtRisk.push(
         ...(await this.findAllNetworkSites({
           query: {
-            _id: QueryHelper.any(
-              parentSiteIdBatch.map((parentSiteId: ObjectID) => {
-                return parentSiteId.toString();
-              }),
+            projectId: data.projectId,
+            networkSiteTypeId: QueryHelper.any(
+              newAncestorIds.slice(
+                offset,
+                offset + REFERENCE_VALIDATION_BATCH_SIZE,
+              ),
             ),
           },
           select: {
             _id: true,
-            networkSiteTypeId: true,
+            parentSiteId: true,
           },
         })),
       );
     }
 
-    const parentTypeBySiteId: Map<string, ObjectID> = new Map<
-      string,
-      ObjectID
-    >();
+    const parentSiteIds: Array<string> = [
+      ...new Set<string>(
+        sitesAtRisk
+          .map((site: NetworkSite): string | null => {
+            return site.parentSiteId ? normalizeId(site.parentSiteId) : null;
+          })
+          .filter((parentSiteId: string | null): parentSiteId is string => {
+            return Boolean(parentSiteId);
+          }),
+      ),
+    ];
 
-    for (const parentSite of parentSites) {
-      if (parentSite.id && parentSite.networkSiteTypeId) {
-        parentTypeBySiteId.set(
-          normalizeId(parentSite.id),
-          parentSite.networkSiteTypeId,
-        );
-      }
+    if (parentSiteIds.length === 0) {
+      return;
     }
 
-    const hasMismatch: boolean = parentSiteIds.some(
-      (parentSiteId: ObjectID) => {
-        const actualParentTypeId: ObjectID | undefined = parentTypeBySiteId.get(
-          normalizeId(parentSiteId),
-        );
+    for (
+      let offset: number = 0;
+      offset < parentSiteIds.length;
+      offset += REFERENCE_VALIDATION_BATCH_SIZE
+    ) {
+      const parentSites: Array<NetworkSite> = await this.findAllNetworkSites({
+        query: {
+          projectId: data.projectId,
+          _id: QueryHelper.any(
+            parentSiteIds.slice(
+              offset,
+              offset + REFERENCE_VALIDATION_BATCH_SIZE,
+            ),
+          ),
+        },
+        select: {
+          _id: true,
+          networkSiteTypeId: true,
+        },
+      });
 
-        return (
-          !actualParentTypeId ||
-          !sameId(actualParentTypeId, data.proposedParentNetworkSiteTypeId!)
-        );
-      },
-    );
-
-    if (hasMismatch) {
-      throw new BadDataException(EXISTING_SITES_DO_NOT_MATCH_MESSAGE);
+      for (const parentSite of parentSites) {
+        if (
+          parentSite.networkSiteTypeId &&
+          movedSubtreeTypeIds.has(normalizeId(parentSite.networkSiteTypeId))
+        ) {
+          throw new BadDataException(EXISTING_SITES_WOULD_INVERT_MESSAGE);
+        }
+      }
     }
   }
 
@@ -1062,6 +1128,17 @@ export class Service extends DatabaseService<Model> {
     }
 
     if (isParentWritten) {
+      /*
+       * The catalog is read once for the whole update: the inversion check
+       * walks ancestors of the proposed parent and descendants of the moving
+       * type, and a bulk move would otherwise re-read the same rows per item.
+       * Clearing a parent cannot invert anything, so nothing is read for it.
+       */
+      const networkSiteTypesByProjectId: Map<string, Array<Model>> = new Map<
+        string,
+        Array<Model>
+      >();
+
       for (const networkSiteType of networkSiteTypesBeingUpdated) {
         if (!networkSiteType.id || !networkSiteType.projectId) {
           continue;
@@ -1083,10 +1160,33 @@ export class Service extends DatabaseService<Model> {
           : Boolean(currentParentId);
 
         if (parentChanged) {
-          await this.assertExistingSitesMatchProposedParent({
-            networkSiteTypeId: networkSiteType.id,
-            proposedParentNetworkSiteTypeId,
-          });
+          if (proposedParentNetworkSiteTypeId) {
+            const projectKey: string = normalizeId(networkSiteType.projectId);
+            let projectNetworkSiteTypes: Array<Model> | undefined =
+              networkSiteTypesByProjectId.get(projectKey);
+
+            if (!projectNetworkSiteTypes) {
+              projectNetworkSiteTypes = await this.findAllNetworkSiteTypes({
+                query: { projectId: networkSiteType.projectId },
+                select: {
+                  _id: true,
+                  parentNetworkSiteTypeId: true,
+                },
+              });
+              networkSiteTypesByProjectId.set(
+                projectKey,
+                projectNetworkSiteTypes,
+              );
+            }
+
+            await this.assertExistingSitesWouldNotInvert({
+              networkSiteTypeId: networkSiteType.id,
+              projectId: networkSiteType.projectId,
+              currentParentNetworkSiteTypeId: currentParentId,
+              proposedParentNetworkSiteTypeId,
+              networkSiteTypes: projectNetworkSiteTypes,
+            });
+          }
 
           if (
             networkSiteTypesBeingUpdated.length === 1 &&

--- a/Common/Tests/Server/Services/NetworkSiteService.test.ts
+++ b/Common/Tests/Server/Services/NetworkSiteService.test.ts
@@ -111,13 +111,17 @@ function fakeSite(overrides: Record<string, unknown>): NetworkSite {
 
 function fakeNetworkSiteType(data: {
   id: ObjectID;
+  name?: string | undefined;
   parentNetworkSiteTypeId?: ObjectID | undefined;
   projectId?: ObjectID | undefined;
+  isUnitLevel?: boolean | undefined;
 }): any {
   return {
     id: data.id,
     _id: data.id.toString(),
+    name: data.name,
     projectId: data.projectId || PROJECT_ID,
+    isUnitLevel: data.isUnitLevel,
     parentNetworkSiteTypeId: data.parentNetworkSiteTypeId,
   };
 }
@@ -1249,7 +1253,12 @@ describe("NetworkSiteService site-type hierarchy enforcement on create", () => {
     );
   });
 
-  it("rejects a parent for a root type", async () => {
+  /*
+   * Regression block for GitHub issue #3744. Each of these placements was
+   * refused before the placement rule was relaxed to "a parent may be any site
+   * whose type is not below this one's".
+   */
+  it("accepts a parent of the same type", async () => {
     mockNetworkSiteTypes([fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID })]);
     jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
       fakeSite({
@@ -1258,22 +1267,25 @@ describe("NetworkSiteService site-type hierarchy enforcement on create", () => {
         networkSiteTypeId: ROOT_SITE_TYPE_ID,
       }),
     );
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(`/${PARENT_SITE_ID.toString()}/`);
 
-    await expect(
-      (NetworkSiteService as any).onBeforeCreate({
-        data: {
-          projectId: PROJECT_ID,
-          networkSiteTypeId: ROOT_SITE_TYPE_ID,
-          parentSiteId: PARENT_SITE_ID,
-        },
-        props: { tenantId: PROJECT_ID },
-      }),
-    ).rejects.toThrow(
-      "A site with a root network site type cannot have a parent site.",
+    const result: any = await (NetworkSiteService as any).onBeforeCreate({
+      data: {
+        projectId: PROJECT_ID,
+        networkSiteTypeId: ROOT_SITE_TYPE_ID,
+        parentSiteId: PARENT_SITE_ID,
+      },
+      props: { tenantId: PROJECT_ID },
+    });
+
+    expect(result.carryForward.parentPath).toBe(
+      `/${PARENT_SITE_ID.toString()}/`,
     );
   });
 
-  it("requires a parent for a type configured below another type", async () => {
+  it("accepts no parent for a type configured below another type", async () => {
     mockNetworkSiteTypes([
       fakeNetworkSiteType({
         id: CHILD_SITE_TYPE_ID,
@@ -1281,15 +1293,15 @@ describe("NetworkSiteService site-type hierarchy enforcement on create", () => {
       }),
     ]);
 
-    await expect(
-      (NetworkSiteService as any).onBeforeCreate({
-        data: {
-          projectId: PROJECT_ID,
-          networkSiteTypeId: CHILD_SITE_TYPE_ID,
-        },
-        props: { tenantId: PROJECT_ID },
-      }),
-    ).rejects.toThrow("This network site type requires a parent site.");
+    const result: any = await (NetworkSiteService as any).onBeforeCreate({
+      data: {
+        projectId: PROJECT_ID,
+        networkSiteTypeId: CHILD_SITE_TYPE_ID,
+      },
+      props: { tenantId: PROJECT_ID },
+    });
+
+    expect(result.carryForward.parentPath).toBeNull();
   });
 
   it("accepts a direct parent with exactly the configured type through relation fields", async () => {
@@ -1298,6 +1310,7 @@ describe("NetworkSiteService site-type hierarchy enforcement on create", () => {
         id: CHILD_SITE_TYPE_ID,
         parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
       }),
+      fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID }),
     ]);
     jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
       fakeSite({
@@ -1324,7 +1337,79 @@ describe("NetworkSiteService site-type hierarchy enforcement on create", () => {
     );
   });
 
-  it("rejects a parent whose type is not the configured direct parent", async () => {
+  // The issue's own case: a Market (nested type) under an Other (root type).
+  it("accepts a parent whose type is unrelated to the configured one", async () => {
+    mockNetworkSiteTypes([
+      fakeNetworkSiteType({
+        id: CHILD_SITE_TYPE_ID,
+        name: "Market",
+        parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
+      }),
+      fakeNetworkSiteType({ id: ALTERNATE_ROOT_SITE_TYPE_ID, name: "Other" }),
+    ]);
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+        networkSiteTypeId: ALTERNATE_ROOT_SITE_TYPE_ID,
+      }),
+    );
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(`/${PARENT_SITE_ID.toString()}/`);
+
+    const result: any = await (NetworkSiteService as any).onBeforeCreate({
+      data: {
+        projectId: PROJECT_ID,
+        networkSiteTypeId: CHILD_SITE_TYPE_ID,
+        parentSiteId: PARENT_SITE_ID,
+      },
+      props: { tenantId: PROJECT_ID },
+    });
+
+    expect(result.carryForward.parentPath).toBe(
+      `/${PARENT_SITE_ID.toString()}/`,
+    );
+  });
+
+  it("accepts a parent that skips a configured level", async () => {
+    mockNetworkSiteTypes([
+      fakeNetworkSiteType({
+        id: GRANDCHILD_SITE_TYPE_ID,
+        parentNetworkSiteTypeId: CHILD_SITE_TYPE_ID,
+      }),
+      fakeNetworkSiteType({
+        id: CHILD_SITE_TYPE_ID,
+        parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
+      }),
+      fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID }),
+    ]);
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+        networkSiteTypeId: ROOT_SITE_TYPE_ID,
+      }),
+    );
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(`/${PARENT_SITE_ID.toString()}/`);
+
+    const result: any = await (NetworkSiteService as any).onBeforeCreate({
+      data: {
+        projectId: PROJECT_ID,
+        networkSiteTypeId: GRANDCHILD_SITE_TYPE_ID,
+        parentSiteId: PARENT_SITE_ID,
+      },
+      props: { tenantId: PROJECT_ID },
+    });
+
+    expect(result.carryForward.parentPath).toBe(
+      `/${PARENT_SITE_ID.toString()}/`,
+    );
+  });
+
+  it("accepts a parent that has no site type at all", async () => {
     mockNetworkSiteTypes([
       fakeNetworkSiteType({
         id: CHILD_SITE_TYPE_ID,
@@ -1335,7 +1420,40 @@ describe("NetworkSiteService site-type hierarchy enforcement on create", () => {
       fakeSite({
         id: PARENT_SITE_ID,
         _id: PARENT_SITE_ID.toString(),
-        networkSiteTypeId: ALTERNATE_ROOT_SITE_TYPE_ID,
+      }),
+    );
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(`/${PARENT_SITE_ID.toString()}/`);
+
+    const result: any = await (NetworkSiteService as any).onBeforeCreate({
+      data: {
+        projectId: PROJECT_ID,
+        networkSiteTypeId: CHILD_SITE_TYPE_ID,
+        parentSiteId: PARENT_SITE_ID,
+      },
+      props: { tenantId: PROJECT_ID },
+    });
+
+    expect(result.carryForward.parentPath).toBe(
+      `/${PARENT_SITE_ID.toString()}/`,
+    );
+  });
+
+  it("rejects a parent whose type sits below this site's type", async () => {
+    mockNetworkSiteTypes([
+      fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID, name: "Region" }),
+      fakeNetworkSiteType({
+        id: CHILD_SITE_TYPE_ID,
+        name: "Market",
+        parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
+      }),
+    ]);
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+        networkSiteTypeId: CHILD_SITE_TYPE_ID,
       }),
     );
 
@@ -1343,13 +1461,116 @@ describe("NetworkSiteService site-type hierarchy enforcement on create", () => {
       (NetworkSiteService as any).onBeforeCreate({
         data: {
           projectId: PROJECT_ID,
-          networkSiteTypeId: CHILD_SITE_TYPE_ID,
+          networkSiteTypeId: ROOT_SITE_TYPE_ID,
           parentSiteId: PARENT_SITE_ID,
         },
         props: { tenantId: PROJECT_ID },
       }),
     ).rejects.toThrow(
-      "Parent site must use the configured parent network site type.",
+      'A site of network site type "Region" cannot be placed under a site of network site type "Market", because "Market" sits below "Region" in the site type hierarchy.',
+    );
+  });
+
+  it("rejects a parent whose type sits below it through a skipped level", async () => {
+    mockNetworkSiteTypes([
+      fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID, name: "Region" }),
+      fakeNetworkSiteType({
+        id: CHILD_SITE_TYPE_ID,
+        name: "Franchisee",
+        parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
+      }),
+      fakeNetworkSiteType({
+        id: GRANDCHILD_SITE_TYPE_ID,
+        name: "Market",
+        parentNetworkSiteTypeId: CHILD_SITE_TYPE_ID,
+      }),
+    ]);
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+        networkSiteTypeId: GRANDCHILD_SITE_TYPE_ID,
+      }),
+    );
+
+    await expect(
+      (NetworkSiteService as any).onBeforeCreate({
+        data: {
+          projectId: PROJECT_ID,
+          networkSiteTypeId: ROOT_SITE_TYPE_ID,
+          parentSiteId: PARENT_SITE_ID,
+        },
+        props: { tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow('"Market" sits below "Region"');
+  });
+
+  it("rejects a parent whose type is the unit level", async () => {
+    mockNetworkSiteTypes([
+      fakeNetworkSiteType({ id: ALTERNATE_ROOT_SITE_TYPE_ID, name: "Other" }),
+      fakeNetworkSiteType({
+        id: CHILD_SITE_TYPE_ID,
+        name: "Unit",
+        parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
+        isUnitLevel: true,
+      }),
+    ]);
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+        networkSiteTypeId: CHILD_SITE_TYPE_ID,
+      }),
+    );
+
+    await expect(
+      (NetworkSiteService as any).onBeforeCreate({
+        data: {
+          projectId: PROJECT_ID,
+          networkSiteTypeId: ALTERNATE_ROOT_SITE_TYPE_ID,
+          parentSiteId: PARENT_SITE_ID,
+        },
+        props: { tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow(
+      'Sites of network site type "Unit" are unit level, so they cannot have child sites.',
+    );
+  });
+
+  it("terminates on a cyclic site type catalog instead of looping forever", async () => {
+    mockNetworkSiteTypes([
+      fakeNetworkSiteType({
+        id: ROOT_SITE_TYPE_ID,
+        parentNetworkSiteTypeId: CHILD_SITE_TYPE_ID,
+      }),
+      fakeNetworkSiteType({
+        id: CHILD_SITE_TYPE_ID,
+        parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
+      }),
+      fakeNetworkSiteType({ id: ALTERNATE_ROOT_SITE_TYPE_ID }),
+    ]);
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+        networkSiteTypeId: ROOT_SITE_TYPE_ID,
+      }),
+    );
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(`/${PARENT_SITE_ID.toString()}/`);
+
+    const result: any = await (NetworkSiteService as any).onBeforeCreate({
+      data: {
+        projectId: PROJECT_ID,
+        networkSiteTypeId: ALTERNATE_ROOT_SITE_TYPE_ID,
+        parentSiteId: PARENT_SITE_ID,
+      },
+      props: { tenantId: PROJECT_ID },
+    });
+
+    expect(result.carryForward.parentPath).toBe(
+      `/${PARENT_SITE_ID.toString()}/`,
     );
   });
 
@@ -1511,7 +1732,7 @@ describe("NetworkSiteService site-type hierarchy enforcement on update", () => {
     } as unknown as UpdateBy<NetworkSite>;
   }
 
-  it("rejects attaching a root-typed site to a parent", async () => {
+  it("attaches a root-typed site to a parent of the same type", async () => {
     mockNetworkSiteTypes([fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID })]);
     jest
       .spyOn(NetworkSiteService, "findBy")
@@ -1527,16 +1748,49 @@ describe("NetworkSiteService site-type hierarchy enforcement on update", () => {
       .spyOn(NetworkSiteService, "getMaterializedPathForSite")
       .mockResolvedValue(`/${PARENT_SITE_ID.toString()}/`);
 
-    await expect(
-      (NetworkSiteService as any).onBeforeUpdate(
-        makeTypeUpdate({ parentSiteId: PARENT_SITE_ID }),
-      ),
-    ).rejects.toThrow(
-      "A site with a root network site type cannot have a parent site.",
+    const result: any = await (NetworkSiteService as any).onBeforeUpdate(
+      makeTypeUpdate({ parentSiteId: PARENT_SITE_ID }),
+    );
+
+    expect(result.carryForward.newParentPath).toBe(
+      `/${PARENT_SITE_ID.toString()}/`,
     );
   });
 
-  it("rejects detaching a site whose type requires a parent", async () => {
+  // Linking an existing child to an existing parent - the second half of #3744.
+  it("attaches an existing site to a parent of an unrelated type", async () => {
+    mockNetworkSiteTypes([
+      fakeNetworkSiteType({
+        id: CHILD_SITE_TYPE_ID,
+        name: "Market",
+        parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
+      }),
+      fakeNetworkSiteType({ id: ALTERNATE_ROOT_SITE_TYPE_ID, name: "Other" }),
+    ]);
+    jest
+      .spyOn(NetworkSiteService, "findBy")
+      .mockResolvedValue([fakeSite({ networkSiteTypeId: CHILD_SITE_TYPE_ID })]);
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+        networkSiteTypeId: ALTERNATE_ROOT_SITE_TYPE_ID,
+      }),
+    );
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(`/${PARENT_SITE_ID.toString()}/`);
+
+    const result: any = await (NetworkSiteService as any).onBeforeUpdate(
+      makeTypeUpdate({ parentSiteId: PARENT_SITE_ID }),
+    );
+
+    expect(result.carryForward.newParentId.toString()).toBe(
+      PARENT_SITE_ID.toString(),
+    );
+  });
+
+  it("detaches a site whose type is configured below another type", async () => {
     mockNetworkSiteTypes([
       fakeNetworkSiteType({
         id: CHILD_SITE_TYPE_ID,
@@ -1550,17 +1804,50 @@ describe("NetworkSiteService site-type hierarchy enforcement on update", () => {
       }),
     ]);
 
+    const result: any = await (NetworkSiteService as any).onBeforeUpdate(
+      makeTypeUpdate({ parentSite: null }),
+    );
+
+    expect(result.carryForward.newParentId).toBeNull();
+    expect(result.carryForward.newParentPath).toBeNull();
+  });
+
+  it("rejects re-parenting a site under a site whose type sits below it", async () => {
+    mockNetworkSiteTypes([
+      fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID, name: "Region" }),
+      fakeNetworkSiteType({
+        id: CHILD_SITE_TYPE_ID,
+        name: "Market",
+        parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
+      }),
+    ]);
+    jest
+      .spyOn(NetworkSiteService, "findBy")
+      .mockResolvedValue([fakeSite({ networkSiteTypeId: ROOT_SITE_TYPE_ID })]);
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+        networkSiteTypeId: CHILD_SITE_TYPE_ID,
+      }),
+    );
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(`/${PARENT_SITE_ID.toString()}/`);
+
     await expect(
       (NetworkSiteService as any).onBeforeUpdate(
-        makeTypeUpdate({ parentSite: null }),
+        makeTypeUpdate({ parentSiteId: PARENT_SITE_ID }),
       ),
-    ).rejects.toThrow("This network site type requires a parent site.");
+    ).rejects.toThrow('"Market" sits below "Region"');
   });
 
   it("validates a type-only update against the site's existing parent", async () => {
     mockNetworkSiteTypes([
+      fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID, name: "Region" }),
       fakeNetworkSiteType({
         id: CHILD_SITE_TYPE_ID,
+        name: "Market",
         parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
       }),
     ]);
@@ -1625,13 +1912,50 @@ describe("NetworkSiteService site-type hierarchy enforcement on update", () => {
     );
   });
 
-  it("rejects a type change that would invalidate a direct child", async () => {
+  it("rejects a type change that would push this site below its own child", async () => {
     mockNetworkSiteTypes([
-      fakeNetworkSiteType({ id: ALTERNATE_ROOT_SITE_TYPE_ID }),
+      fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID, name: "Region" }),
       fakeNetworkSiteType({
         id: CHILD_SITE_TYPE_ID,
+        name: "Market",
         parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
       }),
+    ]);
+    const childId: ObjectID = new ObjectID(
+      "99999999-9999-4999-8999-999999999999",
+    );
+    jest
+      .spyOn(NetworkSiteService, "findBy")
+      .mockResolvedValueOnce([
+        fakeSite({ networkSiteTypeId: ALTERNATE_ROOT_SITE_TYPE_ID }),
+      ])
+      .mockResolvedValueOnce([
+        fakeSite({
+          id: childId,
+          _id: childId.toString(),
+          parentSiteId: SITE_ID,
+          networkSiteTypeId: ROOT_SITE_TYPE_ID,
+        }),
+      ]);
+
+    await expect(
+      (NetworkSiteService as any).onBeforeUpdate(
+        makeTypeUpdate({
+          networkSiteTypeId: CHILD_SITE_TYPE_ID,
+        }),
+      ),
+    ).rejects.toThrow('"Market" sits below "Region"');
+  });
+
+  it("rejects a type change to a unit-level type while the site has children", async () => {
+    mockNetworkSiteTypes([
+      fakeNetworkSiteType({
+        id: CHILD_SITE_TYPE_ID,
+        name: "Unit",
+        parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
+        isUnitLevel: true,
+      }),
+      fakeNetworkSiteType({ id: ALTERNATE_ROOT_SITE_TYPE_ID, name: "Other" }),
     ]);
     const childId: ObjectID = new ObjectID(
       "99999999-9999-4999-8999-999999999999",
@@ -1646,18 +1970,18 @@ describe("NetworkSiteService site-type hierarchy enforcement on update", () => {
           id: childId,
           _id: childId.toString(),
           parentSiteId: SITE_ID,
-          networkSiteTypeId: CHILD_SITE_TYPE_ID,
+          networkSiteTypeId: ALTERNATE_ROOT_SITE_TYPE_ID,
         }),
       ]);
 
     await expect(
       (NetworkSiteService as any).onBeforeUpdate(
         makeTypeUpdate({
-          networkSiteTypeId: ALTERNATE_ROOT_SITE_TYPE_ID,
+          networkSiteTypeId: CHILD_SITE_TYPE_ID,
         }),
       ),
     ).rejects.toThrow(
-      "Parent site must use the configured parent network site type.",
+      'Sites of network site type "Unit" are unit level, so they cannot have child sites.',
     );
   });
 
@@ -1703,31 +2027,34 @@ describe("NetworkSiteService site-type hierarchy enforcement on update", () => {
 
   it("pages past a full batch so wide sites cannot hide invalid direct children", async () => {
     mockNetworkSiteTypes([
-      fakeNetworkSiteType({ id: ALTERNATE_ROOT_SITE_TYPE_ID }),
-      fakeNetworkSiteType({
-        id: GRANDCHILD_SITE_TYPE_ID,
-        parentNetworkSiteTypeId: ALTERNATE_ROOT_SITE_TYPE_ID,
-      }),
+      fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID, name: "Region" }),
       fakeNetworkSiteType({
         id: CHILD_SITE_TYPE_ID,
+        name: "Market",
         parentNetworkSiteTypeId: ROOT_SITE_TYPE_ID,
       }),
+      fakeNetworkSiteType({ id: ALTERNATE_ROOT_SITE_TYPE_ID, name: "Other" }),
     ]);
+    /*
+     * Every child on page one is fine under the relaxed rule; the one that
+     * inverts the hierarchy is alone on page two, so only a loop that keeps
+     * reading finds it.
+     */
     const child: NetworkSite = fakeSite({
       id: new ObjectID("99999999-9999-4999-8999-999999999999"),
-      networkSiteTypeId: GRANDCHILD_SITE_TYPE_ID,
+      networkSiteTypeId: ALTERNATE_ROOT_SITE_TYPE_ID,
     });
     const childReadSkips: Array<number> = [];
     const invalidChildOnSecondPage: NetworkSite = fakeSite({
       id: new ObjectID("aaaaaaaa-1111-4111-8111-111111111111"),
-      networkSiteTypeId: CHILD_SITE_TYPE_ID,
+      networkSiteTypeId: ROOT_SITE_TYPE_ID,
     });
     const findBySpy: jest.SpyInstance = jest
       .spyOn(NetworkSiteService, "findBy")
       .mockImplementation((input: any) => {
         if (input.query._id) {
           return Promise.resolve([
-            fakeSite({ networkSiteTypeId: ROOT_SITE_TYPE_ID }),
+            fakeSite({ networkSiteTypeId: ALTERNATE_ROOT_SITE_TYPE_ID }),
           ]);
         }
 
@@ -1746,12 +2073,10 @@ describe("NetworkSiteService site-type hierarchy enforcement on update", () => {
     await expect(
       (NetworkSiteService as any).onBeforeUpdate(
         makeTypeUpdate({
-          networkSiteTypeId: ALTERNATE_ROOT_SITE_TYPE_ID,
+          networkSiteTypeId: CHILD_SITE_TYPE_ID,
         }),
       ),
-    ).rejects.toThrow(
-      "Parent site must use the configured parent network site type.",
-    );
+    ).rejects.toThrow('"Market" sits below "Region"');
 
     expect(findBySpy).toHaveBeenCalledTimes(3);
     expect(childReadSkips).toEqual([0, 1000]);
@@ -1785,7 +2110,7 @@ describe("NetworkSiteService site-type hierarchy enforcement on update", () => {
         makeTypeUpdate({ networkSiteTypeId: null }),
       ),
     ).rejects.toThrow(
-      "Parent site must use the configured parent network site type.",
+      "A network site with child sites must have a network site type.",
     );
   });
 
@@ -1872,6 +2197,187 @@ describe("NetworkSiteService site-type hierarchy enforcement on update", () => {
     await (NetworkSiteService as any).onBeforeUpdate(
       makeTypeUpdate({ networkSiteTypeId: ROOT_SITE_TYPE_ID }),
     );
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+/*
+ * materializedPath is varchar(500) and each segment costs 37 characters, so a
+ * path holds 13 ids. The old placement rule bounded depth for free by pinning
+ * a site's depth to its type's depth in the catalog. Nothing pins it now, so
+ * the bound is enforced here - and it has to be enforced BEFORE the write,
+ * because the subtree rebase that would overflow the column runs after the
+ * parent change has already been committed.
+ */
+describe("NetworkSiteService hierarchy depth bound", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function pathOfSegments(count: number): string {
+    return `/${Array.from(
+      { length: count },
+      (_unused: unknown, index: number) => {
+        return new ObjectID(
+          `eeeeeeee-eeee-4eee-8eee-${index.toString().padStart(12, "0")}`,
+        ).toString();
+      },
+    ).join("/")}/`;
+  }
+
+  function mockRootTypedParent(): void {
+    mockNetworkSiteTypes([fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID })]);
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+        networkSiteTypeId: ROOT_SITE_TYPE_ID,
+      }),
+    );
+  }
+
+  it("accepts a create that lands on the last usable level", async () => {
+    mockRootTypedParent();
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(pathOfSegments(12));
+
+    const result: any = await (NetworkSiteService as any).onBeforeCreate({
+      data: {
+        projectId: PROJECT_ID,
+        networkSiteTypeId: ROOT_SITE_TYPE_ID,
+        parentSiteId: PARENT_SITE_ID,
+      },
+      props: { tenantId: PROJECT_ID },
+    });
+
+    expect(result.carryForward.parentPath).toBe(pathOfSegments(12));
+  });
+
+  it("rejects a create one level past what the stored path can hold", async () => {
+    mockRootTypedParent();
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(pathOfSegments(13));
+
+    await expect(
+      (NetworkSiteService as any).onBeforeCreate({
+        data: {
+          projectId: PROJECT_ID,
+          networkSiteTypeId: ROOT_SITE_TYPE_ID,
+          parentSiteId: PARENT_SITE_ID,
+        },
+        props: { tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow("can be at most 13 levels deep");
+  });
+
+  /*
+   * The moved site takes its whole subtree with it, so the deepest row under
+   * it is what decides whether the move fits - not the site's own new depth.
+   */
+  it("measures the moved subtree, not just the moved site", async () => {
+    mockNetworkSiteTypes([fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID })]);
+    const ownPath: string = `/${SITE_ID.toString()}/`;
+    const deepestDescendantPath: string = `${ownPath}${new ObjectID(
+      "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    ).toString()}/${new ObjectID(
+      "dddddddd-dddd-4ddd-8ddd-ddddddddddde",
+    ).toString()}/`;
+
+    jest
+      .spyOn(NetworkSiteService, "findBy")
+      .mockImplementation((input: any) => {
+        if (input.query.materializedPath) {
+          return Promise.resolve([
+            fakeSite({ materializedPath: deepestDescendantPath }),
+          ]);
+        }
+
+        return Promise.resolve([
+          fakeSite({
+            networkSiteTypeId: ROOT_SITE_TYPE_ID,
+            materializedPath: ownPath,
+          }),
+        ]);
+      });
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+        networkSiteTypeId: ROOT_SITE_TYPE_ID,
+      }),
+    );
+    // Eleven ancestors + the moved site + its two levels = fourteen.
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(pathOfSegments(11));
+
+    await expect(
+      (NetworkSiteService as any).onBeforeUpdate({
+        query: { _id: SITE_ID.toString() },
+        data: { parentSiteId: PARENT_SITE_ID },
+        props: { tenantId: PROJECT_ID },
+      } as unknown as UpdateBy<NetworkSite>),
+    ).rejects.toThrow("can be at most 13 levels deep");
+  });
+
+  it("allows the same move when the subtree ends one level higher", async () => {
+    mockNetworkSiteTypes([fakeNetworkSiteType({ id: ROOT_SITE_TYPE_ID })]);
+    const ownPath: string = `/${SITE_ID.toString()}/`;
+    const deepestDescendantPath: string = `${ownPath}${new ObjectID(
+      "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    ).toString()}/`;
+
+    jest
+      .spyOn(NetworkSiteService, "findBy")
+      .mockImplementation((input: any) => {
+        if (input.query.materializedPath) {
+          return Promise.resolve([
+            fakeSite({ materializedPath: deepestDescendantPath }),
+          ]);
+        }
+
+        return Promise.resolve([
+          fakeSite({
+            networkSiteTypeId: ROOT_SITE_TYPE_ID,
+            materializedPath: ownPath,
+          }),
+        ]);
+      });
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+        networkSiteTypeId: ROOT_SITE_TYPE_ID,
+      }),
+    );
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(pathOfSegments(11));
+
+    const result: any = await (NetworkSiteService as any).onBeforeUpdate({
+      query: { _id: SITE_ID.toString() },
+      data: { parentSiteId: PARENT_SITE_ID },
+      props: { tenantId: PROJECT_ID },
+    } as unknown as UpdateBy<NetworkSite>);
+
+    expect(result.carryForward.newParentPath).toBe(pathOfSegments(11));
+  });
+
+  it("does not read the subtree when the site is being detached", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(NetworkSiteService, "findBy")
+      .mockResolvedValue([
+        fakeSite({ materializedPath: `/${SITE_ID.toString()}/` }),
+      ]);
+
+    await (NetworkSiteService as any).onBeforeUpdate({
+      query: { _id: SITE_ID.toString() },
+      data: { parentSiteId: null },
+      props: { tenantId: PROJECT_ID },
+    } as unknown as UpdateBy<NetworkSite>);
 
     expect(findBySpy).toHaveBeenCalledTimes(1);
   });

--- a/Common/Tests/Server/Services/NetworkSiteTypeService.test.ts
+++ b/Common/Tests/Server/Services/NetworkSiteTypeService.test.ts
@@ -468,22 +468,15 @@ describe("NetworkSiteTypeService update hierarchy validation", () => {
     }
   });
 
-  it("allows detaching a type when all existing sites of that type are roots", async () => {
+  /*
+   * Re-parenting a TYPE cannot invalidate the sites OF that type: their
+   * subtree moves with them. What it can do is push the moved type BELOW a
+   * type whose sites are already parented under it, and that inversion is the
+   * only thing refused here.
+   */
+  it("allows detaching a type whatever its sites' parents are", async () => {
     mockParentUpdate({});
-    jest
-      .spyOn(NetworkSiteService, "findBy")
-      .mockResolvedValue([makeSite({ index: 1, typeIndex: 2 })]);
-
-    await expect(
-      (NetworkSiteTypeService as any).onBeforeUpdate(
-        updateBy({ parentNetworkSiteTypeId: null }),
-      ),
-    ).resolves.toBeDefined();
-  });
-
-  it("rejects detaching a type while one of its sites still has a parent", async () => {
-    mockParentUpdate({});
-    jest
+    const siteFindSpy: jest.SpyInstance = jest
       .spyOn(NetworkSiteService, "findBy")
       .mockResolvedValue([
         makeSite({ index: 1, typeIndex: 2, parentIndex: 10 }),
@@ -493,12 +486,13 @@ describe("NetworkSiteTypeService update hierarchy validation", () => {
       (NetworkSiteTypeService as any).onBeforeUpdate(
         updateBy({ parentNetworkSiteTypeId: null }),
       ),
-    ).rejects.toThrow(
-      "Create a new site type under the desired parent, then move and reassign the sites to it",
-    );
+    ).resolves.toBeDefined();
+
+    // Clearing a parent adds no ancestors, so no site is even read.
+    expect(siteFindSpy).not.toHaveBeenCalled();
   });
 
-  it("accepts a new parent type when every site's actual parent has that type", async () => {
+  it("allows a new parent when no site of the gained ancestor types is affected", async () => {
     mockParentUpdate({ parent: makeType({ index: 4 }) });
     jest
       .spyOn(NetworkSiteService, "findBy")
@@ -520,36 +514,97 @@ describe("NetworkSiteTypeService update hierarchy validation", () => {
     ).resolves.toBeDefined();
   });
 
-  it("rejects a new parent when an existing site is root or its parent has another type", async () => {
-    const cases: Array<{
-      sites: Array<NetworkSite>;
-      parentSites: Array<NetworkSite>;
-    }> = [
-      {
-        sites: [makeSite({ index: 1, typeIndex: 2 })],
-        parentSites: [],
-      },
-      {
-        sites: [makeSite({ index: 1, typeIndex: 2, parentIndex: 10 })],
-        parentSites: [makeSite({ index: 10, typeIndex: 9 })],
-      },
-    ];
+  it("allows a new parent even when an existing site of the type is a root", async () => {
+    mockParentUpdate({ parent: makeType({ index: 4 }) });
+    jest
+      .spyOn(NetworkSiteService, "findBy")
+      .mockImplementation(async (findBy: any) => {
+        return findBy.query?._id ? [] : [makeSite({ index: 1, typeIndex: 2 })];
+      });
 
-    for (const testCase of cases) {
-      jest.restoreAllMocks();
-      mockParentUpdate({ parent: makeType({ index: 4 }) });
-      jest
-        .spyOn(NetworkSiteService, "findBy")
-        .mockImplementation(async (findBy: any) => {
-          return findBy.query?._id ? testCase.parentSites : testCase.sites;
-        });
+    await expect(
+      (NetworkSiteTypeService as any).onBeforeUpdate(
+        updateBy({ parentNetworkSiteTypeId: typeId(4) }),
+      ),
+    ).resolves.toBeDefined();
+  });
 
-      await expect(
-        (NetworkSiteTypeService as any).onBeforeUpdate(
-          updateBy({ parentNetworkSiteTypeId: typeId(4) }),
-        ),
-      ).rejects.toThrow("Create a new site type under the desired parent");
-    }
+  it("rejects a new parent that would put a site of the new ancestor type under this type", async () => {
+    mockParentUpdate({
+      parent: makeType({ index: 4 }),
+      projectTypes: [
+        makeType({ index: 2, parentIndex: 1 }),
+        makeType({ index: 4 }),
+      ],
+    });
+    jest
+      .spyOn(NetworkSiteService, "findBy")
+      .mockImplementation(async (findBy: any) => {
+        if (findBy.query?._id) {
+          return [makeSite({ index: 10, typeIndex: 2 })];
+        }
+
+        return [makeSite({ index: 1, typeIndex: 4, parentIndex: 10 })];
+      });
+
+    await expect(
+      (NetworkSiteTypeService as any).onBeforeUpdate(
+        updateBy({ parentNetworkSiteTypeId: typeId(4) }),
+      ),
+    ).rejects.toThrow(
+      "an existing site is already placed under a site that the move would push below it",
+    );
+  });
+
+  it("rejects the same inversion reached through a descendant of the moving type", async () => {
+    mockParentUpdate({
+      parent: makeType({ index: 4 }),
+      projectTypes: [
+        makeType({ index: 2, parentIndex: 1 }),
+        makeType({ index: 3, parentIndex: 2 }),
+        makeType({ index: 4 }),
+      ],
+    });
+    jest
+      .spyOn(NetworkSiteService, "findBy")
+      .mockImplementation(async (findBy: any) => {
+        if (findBy.query?._id) {
+          return [makeSite({ index: 10, typeIndex: 3 })];
+        }
+
+        return [makeSite({ index: 1, typeIndex: 4, parentIndex: 10 })];
+      });
+
+    await expect(
+      (NetworkSiteTypeService as any).onBeforeUpdate(
+        updateBy({ parentNetworkSiteTypeId: typeId(4) }),
+      ),
+    ).rejects.toThrow(
+      "an existing site is already placed under a site that the move would push below it",
+    );
+  });
+
+  it("reads nothing when the new parent is already an ancestor of the old one", async () => {
+    mockParentUpdate({
+      moving: makeType({ index: 2, parentIndex: 4 }),
+      parent: makeType({ index: 1 }),
+      projectTypes: [
+        makeType({ index: 2, parentIndex: 4 }),
+        makeType({ index: 4, parentIndex: 1 }),
+        makeType({ index: 1 }),
+      ],
+    });
+    const siteFindSpy: jest.SpyInstance = jest
+      .spyOn(NetworkSiteService, "findBy")
+      .mockResolvedValue([]);
+
+    await expect(
+      (NetworkSiteTypeService as any).onBeforeUpdate(
+        updateBy({ parentNetworkSiteTypeId: typeId(1) }),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(siteFindSpy).not.toHaveBeenCalled();
   });
 
   it("does not revalidate sites or reorder when the parent did not change", async () => {
@@ -724,29 +779,41 @@ describe("NetworkSiteTypeService update hierarchy validation", () => {
     expect(siteFindSpy).not.toHaveBeenCalled();
   });
 
-  it("validates site parent consistency beyond the first 10,000 rows", async () => {
-    mockParentUpdate({});
-    const rootSite: NetworkSite = makeSite({ index: 1, typeIndex: 2 });
-    const mismatch: NetworkSite = makeSite({
+  it("validates site placement beyond the first 10,000 rows", async () => {
+    mockParentUpdate({
+      parent: makeType({ index: 4 }),
+      projectTypes: [
+        makeType({ index: 2, parentIndex: 1 }),
+        makeType({ index: 4 }),
+      ],
+    });
+    const harmlessSite: NetworkSite = makeSite({ index: 1, typeIndex: 4 });
+    const inverting: NetworkSite = makeSite({
       index: 2,
-      typeIndex: 2,
+      typeIndex: 4,
       parentIndex: 10,
     });
     jest
       .spyOn(NetworkSiteService, "findBy")
       .mockImplementation(async (findBy: any) => {
-        if (findBy.skip === 0) {
-          return new Array<NetworkSite>(10_000).fill(rootSite);
+        if (findBy.query?._id) {
+          return [makeSite({ index: 10, typeIndex: 2 })];
         }
 
-        return [mismatch];
+        if (findBy.skip === 0) {
+          return new Array<NetworkSite>(10_000).fill(harmlessSite);
+        }
+
+        return [inverting];
       });
 
     await expect(
       (NetworkSiteTypeService as any).onBeforeUpdate(
-        updateBy({ parentNetworkSiteTypeId: null }),
+        updateBy({ parentNetworkSiteTypeId: typeId(4) }),
       ),
-    ).rejects.toThrow("Create a new site type under the desired parent");
+    ).rejects.toThrow(
+      "an existing site is already placed under a site that the move would push below it",
+    );
 
     expect(NetworkSiteService.findBy).toHaveBeenCalledWith(
       expect.objectContaining({ skip: 10_000 }),

--- a/Common/Tests/Utils/NetworkSite/TypeHierarchyUtil.test.ts
+++ b/Common/Tests/Utils/NetworkSite/TypeHierarchyUtil.test.ts
@@ -207,3 +207,177 @@ describe("NetworkSiteTypeHierarchyUtil", () => {
     ).toBe(3);
   });
 });
+
+/*
+ * The site PLACEMENT rule, as opposed to the catalog's own shape rule. A site
+ * may sit under any site whose type the hierarchy does not place below its
+ * own; requiring an exact configured-parent match is what made real
+ * hierarchies unbuildable in GitHub issue #3744.
+ */
+describe("NetworkSiteTypeHierarchyUtil site placement rule", () => {
+  /*
+   * Account › Region › Market › Unit (unit level), plus an unrelated root
+   * "Other" — the catch-all the reporting project was trying to nest under.
+   */
+  function catalog(): Array<NetworkSiteType> {
+    return [
+      makeType({ index: 1, name: "Account", order: 1 }),
+      makeType({ index: 2, name: "Region", order: 2, parentIndex: 1 }),
+      makeType({ index: 3, name: "Market", order: 3, parentIndex: 2 }),
+      makeType({
+        index: 4,
+        name: "Unit",
+        order: 4,
+        parentIndex: 3,
+        isUnitLevel: true,
+      }),
+      makeType({ index: 5, name: "Other", order: 5 }),
+    ];
+  }
+
+  function allowed(childIndex: number, parentIndex: number | null): boolean {
+    return NetworkSiteTypeHierarchyUtil.isTypeAllowedAsSiteParentOfType({
+      childNetworkSiteTypeId: typeId(childIndex).toString(),
+      parentNetworkSiteTypeId:
+        parentIndex === null ? null : typeId(parentIndex).toString(),
+      networkSiteTypes: catalog(),
+    });
+  }
+
+  it("allows the configured parent type", () => {
+    expect(allowed(3, 2)).toBe(true);
+  });
+
+  it("allows an unrelated type on either side", () => {
+    expect(allowed(3, 5)).toBe(true);
+    expect(allowed(5, 3)).toBe(true);
+  });
+
+  it("allows a skipped level", () => {
+    expect(allowed(4, 1)).toBe(true);
+  });
+
+  it("allows the same type on both sides", () => {
+    expect(allowed(5, 5)).toBe(true);
+    expect(allowed(2, 2)).toBe(true);
+  });
+
+  it("allows a parent with no type at all", () => {
+    expect(allowed(3, null)).toBe(true);
+  });
+
+  it("allows a child with no type", () => {
+    expect(
+      NetworkSiteTypeHierarchyUtil.isTypeAllowedAsSiteParentOfType({
+        childNetworkSiteTypeId: null,
+        parentNetworkSiteTypeId: typeId(3).toString(),
+        networkSiteTypes: catalog(),
+      }),
+    ).toBe(true);
+  });
+
+  it("refuses a parent whose type is a direct child of the child's type", () => {
+    expect(allowed(2, 3)).toBe(false);
+  });
+
+  it("refuses a parent whose type is a deeper descendant", () => {
+    expect(allowed(1, 3)).toBe(false);
+  });
+
+  it("refuses a unit-level parent whatever the child type", () => {
+    expect(allowed(5, 4)).toBe(false);
+    expect(allowed(1, 4)).toBe(false);
+    expect(allowed(4, 4)).toBe(false);
+  });
+
+  it("is case-insensitive about ids", () => {
+    expect(
+      NetworkSiteTypeHierarchyUtil.isTypeAllowedAsSiteParentOfType({
+        childNetworkSiteTypeId: typeId(2).toString().toUpperCase(),
+        parentNetworkSiteTypeId: typeId(3).toString().toUpperCase(),
+        networkSiteTypes: catalog(),
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a type whose parent link names nothing as a root", () => {
+    const orphan: NetworkSiteType = makeType({
+      index: 9,
+      name: "Orphan",
+      parentIndex: 99,
+    });
+
+    expect(
+      NetworkSiteTypeHierarchyUtil.isTypeAllowedAsSiteParentOfType({
+        childNetworkSiteTypeId: typeId(1).toString(),
+        parentNetworkSiteTypeId: typeId(9).toString(),
+        networkSiteTypes: [...catalog(), orphan],
+      }),
+    ).toBe(true);
+  });
+
+  it("terminates on a cyclic catalog instead of looping forever", () => {
+    const cyclic: Array<NetworkSiteType> = [
+      makeType({ index: 1, name: "A", parentIndex: 2 }),
+      makeType({ index: 2, name: "B", parentIndex: 1 }),
+      makeType({ index: 3, name: "C" }),
+    ];
+
+    expect(
+      NetworkSiteTypeHierarchyUtil.isTypeAllowedAsSiteParentOfType({
+        childNetworkSiteTypeId: typeId(3).toString(),
+        parentNetworkSiteTypeId: typeId(1).toString(),
+        networkSiteTypes: cyclic,
+      }),
+    ).toBe(true);
+
+    // The cycle still answers its own membership question correctly.
+    expect(
+      NetworkSiteTypeHierarchyUtil.isTypeAllowedAsSiteParentOfType({
+        childNetworkSiteTypeId: typeId(2).toString(),
+        parentNetworkSiteTypeId: typeId(1).toString(),
+        networkSiteTypes: cyclic,
+      }),
+    ).toBe(false);
+  });
+
+  it("lists the types a site may be placed under", () => {
+    expect(
+      NetworkSiteTypeHierarchyUtil.getValidSiteParentTypes({
+        networkSiteTypeId: typeId(2).toString(),
+        networkSiteTypes: catalog(),
+      }).map((networkSiteType: NetworkSiteType) => {
+        return networkSiteType.name;
+      }),
+    ).toEqual(["Account", "Region", "Other"]);
+  });
+
+  it("lists the types a new child site may take, mirroring the parent list", () => {
+    expect(
+      NetworkSiteTypeHierarchyUtil.getValidSiteChildTypes({
+        networkSiteTypeId: typeId(2).toString(),
+        networkSiteTypes: catalog(),
+      }).map((networkSiteType: NetworkSiteType) => {
+        return networkSiteType.name;
+      }),
+    ).toEqual(["Region", "Market", "Unit", "Other"]);
+  });
+
+  it("offers no child type at all under a unit-level site", () => {
+    expect(
+      NetworkSiteTypeHierarchyUtil.getValidSiteChildTypes({
+        networkSiteTypeId: typeId(4).toString(),
+        networkSiteTypes: catalog(),
+      }),
+    ).toEqual([]);
+  });
+
+  it("offers every type under a site that has no type", () => {
+    expect(
+      NetworkSiteTypeHierarchyUtil.getValidSiteChildTypes({
+        networkSiteTypeId: null,
+        networkSiteTypes: catalog(),
+      }),
+    ).toHaveLength(5);
+  });
+});

--- a/Common/Utils/NetworkSite/TypeHierarchyUtil.ts
+++ b/Common/Utils/NetworkSite/TypeHierarchyUtil.ts
@@ -160,8 +160,158 @@ export default class NetworkSiteTypeHierarchyUtil {
   }
 
   /*
-   * Parent picker candidates. A leaf/unit type cannot own child types, and a
-   * type cannot be placed under itself or anything already below it.
+   * SITE placement rule — the one predicate every surface must agree on.
+   *
+   * The type tree says which levels sit above which. A concrete site may
+   * never be placed under a site whose type sits BELOW its own, because that
+   * inverts the hierarchy the operator described. Everything else is allowed:
+   * an unrelated type (a catch-all "Other" owning a "Market"), a skipped
+   * level (a "Unit" straight under a "Region"), and the same type on both
+   * sides (a campus of campuses).
+   *
+   * It deliberately does NOT require the parent to be exactly the configured
+   * direct parent type. That stricter reading made whole estates impossible
+   * to build: a project whose types all ended up top-level — which is what
+   * the parent backfill leaves behind when a type's existing sites are all
+   * roots — could not link a single parent to a single child, by hand or by
+   * CSV. See GitHub issue #3744.
+   *
+   * A unit-level type is the leaf of the hierarchy by definition, so a site
+   * of that type never owns children.
+   */
+  public static isTypeAllowedAsSiteParentOfType(data: {
+    childNetworkSiteTypeId: string | null | undefined;
+    parentNetworkSiteTypeId: string | null | undefined;
+    networkSiteTypes: Array<NetworkSiteType>;
+    index?: NetworkSiteTypeHierarchyIndex | undefined;
+  }): boolean {
+    /*
+     * An untyped parent belongs to no level, so no inversion can be proven;
+     * legacy rows predating site types stay editable rather than becoming
+     * unreachable.
+     */
+    if (!data.parentNetworkSiteTypeId) {
+      return true;
+    }
+
+    const index: NetworkSiteTypeHierarchyIndex =
+      data.index || this.buildIndex(data);
+    const parentTypeId: string = data.parentNetworkSiteTypeId
+      .toString()
+      .toLowerCase();
+    const parentType: NetworkSiteType | undefined =
+      index.byId.get(parentTypeId);
+
+    if (parentType?.isUnitLevel === true) {
+      return false;
+    }
+
+    if (!data.childNetworkSiteTypeId) {
+      return true;
+    }
+
+    const childTypeId: string = data.childNetworkSiteTypeId
+      .toString()
+      .toLowerCase();
+
+    if (childTypeId === parentTypeId) {
+      return true;
+    }
+
+    /*
+     * Walk up from the PARENT type: reaching the child type means the parent
+     * sits below it. The visited set is what keeps a corrupted catalog (a
+     * cycle written straight into the database) from spinning here.
+     */
+    const visited: Set<string> = new Set<string>([parentTypeId]);
+    let ancestorId: string | null = parentType
+      ? this.getParentId(parentType)
+      : null;
+
+    while (ancestorId) {
+      const normalizedAncestorId: string = ancestorId.toLowerCase();
+
+      if (normalizedAncestorId === childTypeId) {
+        return false;
+      }
+
+      if (visited.has(normalizedAncestorId)) {
+        break;
+      }
+      visited.add(normalizedAncestorId);
+
+      const ancestor: NetworkSiteType | undefined =
+        index.byId.get(normalizedAncestorId);
+      if (!ancestor) {
+        break;
+      }
+
+      ancestorId = this.getParentId(ancestor);
+    }
+
+    return true;
+  }
+
+  /*
+   * Types a site of `networkSiteTypeId` may be placed under — the picker side
+   * of isTypeAllowedAsSiteParentOfType.
+   */
+  public static getValidSiteParentTypes(data: {
+    networkSiteTypeId: string | null | undefined;
+    networkSiteTypes: Array<NetworkSiteType>;
+    index?: NetworkSiteTypeHierarchyIndex | undefined;
+  }): Array<NetworkSiteType> {
+    const index: NetworkSiteTypeHierarchyIndex =
+      data.index || this.buildIndex(data);
+
+    return this.sort(
+      data.networkSiteTypes.filter((candidate: NetworkSiteType) => {
+        return (
+          Boolean(candidate.id) &&
+          this.isTypeAllowedAsSiteParentOfType({
+            childNetworkSiteTypeId: data.networkSiteTypeId,
+            parentNetworkSiteTypeId: candidate.id!.toString(),
+            networkSiteTypes: data.networkSiteTypes,
+            index,
+          })
+        );
+      }),
+    );
+  }
+
+  /*
+   * Types a new child site under a parent site of `networkSiteTypeId` may
+   * take. The mirror of getValidSiteParentTypes, so the "add a child site"
+   * form and the "pick my parent" form can never disagree.
+   */
+  public static getValidSiteChildTypes(data: {
+    networkSiteTypeId: string | null | undefined;
+    networkSiteTypes: Array<NetworkSiteType>;
+    index?: NetworkSiteTypeHierarchyIndex | undefined;
+  }): Array<NetworkSiteType> {
+    const index: NetworkSiteTypeHierarchyIndex =
+      data.index || this.buildIndex(data);
+
+    return this.sort(
+      data.networkSiteTypes.filter((candidate: NetworkSiteType) => {
+        return (
+          Boolean(candidate.id) &&
+          this.isTypeAllowedAsSiteParentOfType({
+            childNetworkSiteTypeId: candidate.id!.toString(),
+            parentNetworkSiteTypeId: data.networkSiteTypeId,
+            networkSiteTypes: data.networkSiteTypes,
+            index,
+          })
+        );
+      }),
+    );
+  }
+
+  /*
+   * Parent picker candidates for the TYPE catalog itself. A leaf/unit type
+   * cannot own child types, and a type cannot be placed under itself or
+   * anything already below it. This is the type tree's own shape rule and
+   * stays strict — it is site PLACEMENT that was relaxed, not the catalog.
    */
   public static getValidParentCandidates(data: {
     networkSiteType: NetworkSiteType;


### PR DESCRIPTION
Fixes #3744.

## The bug

A network site's placement was bound exactly to its type. A type with a configured parent type required a parent site of *precisely* that type, and a top-level type could never have a parent at all.

That makes whole estates unbuildable. The reporting project's types were all top-level — which is exactly what `BackfillNetworkSiteTypeParents` leaves behind when a type's existing sites are all roots — so no parent could be linked to any child, by hand or by CSV. The parent-site dropdown returned `[]` for every type, and the importer refused the reported file with:

```
Line 3: siteType "Market" is top level and cannot have a parentName.
```

Even on a freshly seeded project the rule bit: recording one store meant first creating an Account Type, a Region, a Franchisee and a Market, in that order, because each level's parent was mandatory.

## The rule now

One predicate, shared by the server, the forms and the CSV importer:

- A parent site is **always optional**.
- A site may sit under **any** site in the project **except** one whose type sits *below* its own in the configured type tree, and **except** one whose type is the declared unit level.
- Unrelated types (a Market under an Other), skipped levels (a Unit straight under a Region) and the same type on both sides (a campus of campuses) are all legal. Only an inversion — a Region under a Market — is refused.

The configured parent type becomes guidance rather than a constraint: the parent picker lists sites of that type first, under a "Suggested" heading, and everything else under "Other sites".

## What changed

| Surface | Change |
| --- | --- |
| `Common/Utils/NetworkSite/TypeHierarchyUtil.ts` | The shared rule, plus the two candidate lists it implies, so the parent picker and the "add a child site" picker can never disagree |
| `NetworkSiteService.validateSiteTypeEdge` | Walks up from the *parent's* type instead of comparing one configured id; tolerates a missing link and bounds a cyclic catalog |
| `NetworkSiteTypeService` | The type-move check no longer asks whether every site of the moved type matches — those sites move with it. It asks what can actually break: whether the move would push the type below a site already parented under it |
| `NetworkSiteFormDropdownOptions` | Asks the API for every type the rule allows rather than one configured type, so the picker cannot come back empty; unit-level sites are excluded at the database |
| `NetworkSiteCsv` | Both strict per-row errors are gone; placement is judged once the whole file is known, against the type tree |
| Copy across five pages | Every string that stated the old rule now states the new one |

## Depth bound

Relaxing placement also unpinned tree depth, which the type catalog used to bound for free. `materializedPath` is `varchar(500)` and each segment costs 37 characters, so it holds 13 levels. Depth is now checked explicitly — before the write, because the subtree rebase that would overflow the column runs *after* the parent change has been committed. A move is measured against the deepest row in the subtree it carries, not just the moved site.

## Tests

446 tests pass across the touched suites.

```bash
cd Common && npx jest ./Tests/Server/Services/NetworkSiteService.test.ts ./Tests/Server/Services/NetworkSiteTypeService.test.ts ./Tests/Utils/NetworkSite/TypeHierarchyUtil.test.ts
```

```bash
cd App && npx jest ./Tests/Dashboard/NetworkSiteCsv.test.ts ./Tests/Dashboard/NetworkSiteImportRunner.test.ts ./Tests/Dashboard/SiteTypeHierarchyFormUtil.test.ts ./Tests/Dashboard/NetworkSiteTypeParentPageInvariants.test.ts ./Tests/Dashboard/NetworkSitePageInvariants.test.ts
```

New coverage includes the issue's own CSV verbatim (a Market under an Other), unrelated-type and skipped-level parents on create and on re-parent, same-type nesting, untyped legacy parents, unit-level parents refused from every direction, inversions refused through a skipped level, cyclic type catalogs terminating rather than hanging, the type-move inversion check and its paging past 10,000 rows, and the depth bound on both create and move.

## Notes for review

- No schema migration. Nothing about the old rule was expressed as a database constraint, and every edge the strict rule accepted is still legal under the new one, so existing data needs no backfill.
- This is forward-only: nestings created under the new rule would be rejected by a rolled-back build.
- A site type's own catalog rules are unchanged — a type still cannot be nested beneath itself, one of its descendants, or a unit-level type. It is site *placement* that was relaxed.
- Two things this deliberately does not do: the network map still labels a level generically when its children carry different types, and there is no "expected placement" marker distinguishing a deliberate off-model nesting from a mistake. Both are worth a follow-up now that mixed-type levels are the designed steady state.