### PR TITLE
fix(inventory): move audit logs to the advanced menu

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Inventory/View/SideMenu.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Inventory/View/SideMenu.tsx
@@ -146,16 +146,6 @@ const InventoryItemSideMenu: FunctionComponent<ComponentProps> = (
           },
           icon: IconProp.Clock,
         },
-        {
-          link: {
-            title: "Audit Logs",
-            to: RouteUtil.populateRouteParams(
-              RouteMap[PageMap.INVENTORY_VIEW_AUDIT_LOGS] as Route,
-              { modelId: props.modelId },
-            ),
-          },
-          icon: IconProp.List,
-        },
       ],
     },
     {
@@ -170,6 +160,16 @@ const InventoryItemSideMenu: FunctionComponent<ComponentProps> = (
             ),
           },
           icon: IconProp.Settings,
+        },
+        {
+          link: {
+            title: "Audit Logs",
+            to: RouteUtil.populateRouteParams(
+              RouteMap[PageMap.INVENTORY_VIEW_AUDIT_LOGS] as Route,
+              { modelId: props.modelId },
+            ),
+          },
+          icon: IconProp.List,
         },
         {
           link: {

--- a/App/Tests/Dashboard/InventoryProductWiring.test.ts
+++ b/App/Tests/Dashboard/InventoryProductWiring.test.ts
@@ -262,11 +262,16 @@ describe("the side menu reaches the whole product", () => {
     for (const key of [
       "INVENTORY_VIEW",
       "INVENTORY_VIEW_RELATIONSHIPS",
+      "INVENTORY_VIEW_CUSTOM_FIELDS",
       "INVENTORY_VIEW_LOGS",
       "INVENTORY_VIEW_TRACES",
       "INVENTORY_VIEW_METRICS",
       "INVENTORY_VIEW_PROFILES",
       "INVENTORY_VIEW_EXCEPTIONS",
+      "INVENTORY_VIEW_INCIDENTS",
+      "INVENTORY_VIEW_ALERTS",
+      "INVENTORY_VIEW_SCHEDULED_MAINTENANCE",
+      "INVENTORY_VIEW_AUDIT_LOGS",
       "INVENTORY_VIEW_SETTINGS",
       "INVENTORY_VIEW_DELETE",
     ]) {
@@ -291,6 +296,85 @@ describe("the side menu reaches the whole product", () => {
     expect(itemSideMenu).toContain("INVENTORY_VIEW_SETTINGS");
     expect(itemSideMenu).toContain("INVENTORY_VIEW_DELETE");
     expect(itemSideMenu).not.toContain("props.canEdit");
+  });
+
+  describe("the item detail sections", () => {
+    const itemSideMenu: string = readSource(
+      "Pages",
+      "Inventory",
+      "View",
+      "SideMenu.tsx",
+    );
+
+    const section: (title: string, nextTitle?: string) => string = (
+      title: string,
+      nextTitle?: string,
+    ): string => {
+      const start: number = itemSideMenu.indexOf(`title: "${title}"`);
+      const end: number = nextTitle
+        ? itemSideMenu.indexOf(`title: "${nextTitle}"`, start + 1)
+        : itemSideMenu.indexOf("  ];", start);
+
+      expect(start).toBeGreaterThan(-1);
+      expect(end).toBeGreaterThan(start);
+
+      return itemSideMenu.slice(start, end);
+    };
+
+    const itemTitles: (sectionSource: string) => Array<string> = (
+      sectionSource: string,
+    ): Array<string> => {
+      return Array.from(
+        sectionSource.matchAll(/link:\s*\{\s*title:\s*"([^"]+)"/g),
+        (match: RegExpMatchArray): string => {
+          return match[1] as string;
+        },
+      );
+    };
+
+    test("Operations contains only live operational activity", () => {
+      const operations: string = section("Operations", "Advanced");
+
+      expect(itemTitles(operations)).toEqual([
+        "Incidents",
+        "Alerts",
+        "Scheduled Maintenance",
+      ]);
+      expect(operations).not.toContain("INVENTORY_VIEW_AUDIT_LOGS");
+    });
+
+    test("Advanced contains Settings, Audit Logs, and Delete Item in that order", () => {
+      const advanced: string = section("Advanced");
+
+      expect(itemTitles(advanced)).toEqual([
+        "Settings",
+        "Audit Logs",
+        "Delete Item",
+      ]);
+    });
+
+    test("the Audit Logs destination is declared exactly once", () => {
+      expect(
+        itemSideMenu.match(/PageMap\.INVENTORY_VIEW_AUDIT_LOGS/g),
+      ).toHaveLength(1);
+    });
+
+    test("the Advanced Audit Logs item keeps its route, item scope, and icon", () => {
+      const advanced: string = section("Advanced");
+      const auditStart: number = advanced.indexOf('title: "Audit Logs"');
+      const deleteStart: number = advanced.indexOf('title: "Delete Item"');
+
+      expect(auditStart).toBeGreaterThan(-1);
+      expect(deleteStart).toBeGreaterThan(auditStart);
+
+      const auditItem: string = squash(advanced.slice(auditStart, deleteStart));
+
+      expect(auditItem).toContain(
+        "RouteMap[PageMap.INVENTORY_VIEW_AUDIT_LOGS] as Route",
+      );
+      expect(auditItem).toContain("{ modelId: props.modelId }");
+      expect(auditItem).toContain("icon: IconProp.List");
+    });
   });
 
   test("the detail layout does not hide lifecycle navigation", () => {

--- a/Common/Tests/App/Dashboard/InventoryItemSideMenu.test.tsx
+++ b/Common/Tests/App/Dashboard/InventoryItemSideMenu.test.tsx
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { cleanup } from "@testing-library/react";
+import * as React from "react";
+import ObjectID from "../../../Types/ObjectID";
+import InventoryItemSideMenu from "../../../../App/FeatureSet/Dashboard/src/Pages/Inventory/View/SideMenu";
+import {
+  DESKTOP_WIDTH,
+  MOBILE_WIDTH,
+  MenuLink,
+  PROJECT_ID,
+  goTo,
+  hrefsInMenu,
+  iconCountIn,
+  isExpanded,
+  linksIn,
+  mobileSummaryText,
+  renderMenu,
+  sectionRoot,
+  sectionTitlesInOrder,
+  setViewportWidth,
+  titlesInMenu,
+} from "./SideMenuHarness";
+
+const ITEM_ID: string = "0193c0de-2222-4aaa-8bbb-000000000002";
+const ITEM_PATH: string = `/dashboard/${PROJECT_ID}/inventory/item/${ITEM_ID}`;
+const AUDIT_LOGS_PATH: string = `${ITEM_PATH}/audit-logs`;
+
+async function renderInventoryItemMenu(): Promise<void> {
+  await renderMenu(<InventoryItemSideMenu modelId={new ObjectID(ITEM_ID)} />);
+}
+
+describe("Inventory item side menu", () => {
+  beforeEach(() => {
+    setViewportWidth(DESKTOP_WIDTH);
+    goTo(AUDIT_LOGS_PATH);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders the item sections in their expected order", async () => {
+    await renderInventoryItemMenu();
+
+    expect(sectionTitlesInOrder()).toEqual([
+      "Item",
+      "Telemetry",
+      "Operations",
+      "Advanced",
+    ]);
+  });
+
+  test("keeps the unchanged item and telemetry destinations intact", async () => {
+    await renderInventoryItemMenu();
+
+    expect(linksIn("Item")).toEqual([
+      { title: "Overview", href: ITEM_PATH },
+      { title: "Connections", href: `${ITEM_PATH}/relationships` },
+      { title: "Custom Fields", href: `${ITEM_PATH}/custom-fields` },
+    ]);
+    expect(linksIn("Telemetry")).toEqual([
+      { title: "Logs", href: `${ITEM_PATH}/logs` },
+      { title: "Traces", href: `${ITEM_PATH}/traces` },
+      { title: "Metrics", href: `${ITEM_PATH}/metrics` },
+      { title: "Performance Profiles", href: `${ITEM_PATH}/profiles` },
+      { title: "Exceptions", href: `${ITEM_PATH}/exceptions` },
+    ]);
+  });
+
+  test("Operations contains only live operational activity", async () => {
+    await renderInventoryItemMenu();
+
+    expect(linksIn("Operations")).toEqual([
+      { title: "Incidents", href: `${ITEM_PATH}/incidents` },
+      { title: "Alerts", href: `${ITEM_PATH}/alerts` },
+      {
+        title: "Scheduled Maintenance",
+        href: `${ITEM_PATH}/scheduled-maintenance`,
+      },
+    ]);
+  });
+
+  test("Advanced contains Settings, Audit Logs, and Delete Item in order", async () => {
+    await renderInventoryItemMenu();
+
+    expect(linksIn("Advanced")).toEqual([
+      { title: "Settings", href: `${ITEM_PATH}/settings` },
+      { title: "Audit Logs", href: AUDIT_LOGS_PATH },
+      { title: "Delete Item", href: `${ITEM_PATH}/delete` },
+    ]);
+    expect(iconCountIn("Advanced")).toBe(3);
+  });
+
+  test("lists every destination exactly once and fully populates its route", async () => {
+    await renderInventoryItemMenu();
+
+    const hrefs: Array<string> = hrefsInMenu();
+    const titles: Array<string> = titlesInMenu();
+
+    expect(hrefs).toEqual(Array.from(new Set(hrefs)));
+    expect(titles).toEqual(Array.from(new Set(titles)));
+    expect(
+      hrefs.filter((href: string): boolean => {
+        return href === AUDIT_LOGS_PATH;
+      }),
+    ).toHaveLength(1);
+    expect(
+      titles.filter((title: string): boolean => {
+        return title === "Audit Logs";
+      }),
+    ).toHaveLength(1);
+
+    hrefs.forEach((href: string) => {
+      expect(href).toContain(ITEM_PATH);
+      expect(href).not.toContain(":projectId");
+      expect(href).not.toContain(":modelId");
+    });
+  });
+
+  test("marks Audit Logs active in the expanded Advanced section", async () => {
+    await renderInventoryItemMenu();
+
+    const auditLogAnchor: HTMLAnchorElement | undefined = Array.from(
+      sectionRoot("Advanced").querySelectorAll<HTMLAnchorElement>("a"),
+    ).find((anchor: HTMLAnchorElement): boolean => {
+      return anchor.getAttribute("href") === AUDIT_LOGS_PATH;
+    });
+
+    expect(auditLogAnchor).toBeDefined();
+    expect(auditLogAnchor).toHaveClass("bg-indigo-50", "text-indigo-700");
+    expect(isExpanded("Advanced")).toBe(true);
+  });
+
+  test("the mobile summary names Audit Logs as an Advanced page", async () => {
+    setViewportWidth(MOBILE_WIDTH);
+
+    await renderInventoryItemMenu();
+
+    expect(mobileSummaryText()).toContain("Advanced / Audit Logs");
+  });
+
+  test("all rendered links retain a visible label and icon", async () => {
+    await renderInventoryItemMenu();
+
+    sectionTitlesInOrder().forEach((sectionTitle: string) => {
+      const links: Array<MenuLink> = linksIn(sectionTitle);
+
+      expect(iconCountIn(sectionTitle)).toBe(links.length);
+      links.forEach((link: MenuLink) => {
+        expect(link.title).not.toBe("");
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Title of this pull request?

Move Inventory item Audit Logs to Advanced

### Small Description?

- Moves Audit Logs from Operations to Advanced in the Inventory item side menu, between Settings and Delete Item.
- Preserves its item-scoped route, list icon, active state, and mobile menu summary.
- Adds source-level wiring coverage and rendered desktop/mobile regression coverage.

Validation:

- `npm run fix`
- Dashboard `npm run compile`
- Common `npm run compile`
- `InventoryProductWiring.test.ts`: 153 passed
- `InventoryItemSideMenu.test.tsx`: 8 passed

### Pull Request Checklist:

- [ ] Please make sure all jobs pass before requesting a review.
- [x] Issue auto-close is not applicable; no issue was supplied.
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

None supplied.

### Screenshots (if appropriate):

The requested grouping is covered by rendered desktop and mobile menu tests.