### PR TITLE
Fix release provenance and publication gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,13 @@ on:
         type: boolean
         default: false
 
+# Publishing mutates npm, Helm, Docker, Terraform, and GitHub Releases. Never
+# overlap two production runs, and never cancel one after it may have published
+# only part of that immutable artifact set.
+concurrency:
+  group: oneuptime-production-release
+  cancel-in-progress: false
+
 permissions:
   contents: write
   packages: write
@@ -38,7 +45,7 @@ jobs:
   read-version:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     outputs:
       major_minor: ${{ steps.determine.outputs.semver_base }}
       semver_base: ${{ steps.determine.outputs.semver_base }}
@@ -48,7 +55,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          # A release can run for hours while master and release continue to
+          # move. Build every artifact from the immutable event commit so the
+          # source, images, Helm chart, and GitHub tag all have one provenance.
+          ref: ${{ github.sha }}
       - name: Check version and verify not already released
         id: determine
         env:
@@ -93,13 +103,14 @@ jobs:
           # workflow on 2026-08-17; this check happened not to be the step that
           # ran during it. Only a clean 404 counts as "not released".
           #
-          # Asking for the release *by tag* also stops the pipeline blocking on
-          # its own unfinished work: this workflow creates a draft release and
-          # publishes it in a later job, and a draft has no tag, so it 404s
-          # here. `gh release view` saw drafts, which meant one interrupted run
-          # left every later run failing "already released" for a version that
-          # had in fact never shipped. Published releases — the ones this guard
-          # is actually for — still return 200 and still stop the run.
+          # Asking for the *published* release by tag also stops the pipeline
+          # blocking on its own unfinished work. GitHub's endpoint deliberately
+          # excludes drafts, so the draft created later still 404s here even
+          # after this job has pinned the underlying Git ref. `gh release view`
+          # saw drafts, which meant one interrupted run left every later run
+          # failing "already released" for a version that had in fact never
+          # shipped. Published releases — the ones this guard is actually for
+          # — still return 200 and still stop the run.
           release_exists() {
             local tag="$1"
             local out status
@@ -155,6 +166,18 @@ jobs:
       - name: Verify package.json versions match VERSION
         run: node ./Scripts/Install/SyncPackageVersions.js --check
 
+      # Draft releases do not create their Git tag until publication. Pin the
+      # tag while this job still gates every downstream publishing job, so a
+      # later master/release movement cannot split artifact provenance. A
+      # same-SHA rerun verifies the existing tag; a different SHA never moves
+      # it and must use a new version.
+      - name: Pin and verify release tag provenance
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.determine.outputs.semver_base }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: Scripts/GHA/pin_release_tag.sh "$GITHUB_REPOSITORY" "$RELEASE_TAG" "$EXPECTED_SHA"
+
 
 
   helm-chart-deploy:
@@ -169,7 +192,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name:  Build and Package Helm chart
         run: |
@@ -229,7 +252,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -265,7 +288,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -306,7 +329,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -342,7 +365,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -394,7 +417,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -430,7 +453,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -471,7 +494,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -507,7 +530,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -548,7 +571,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -584,7 +607,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -625,7 +648,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -661,7 +684,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -702,7 +725,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -738,7 +761,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -779,7 +802,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -817,7 +840,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -858,7 +881,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -896,7 +919,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -937,7 +960,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -975,7 +998,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -1016,7 +1039,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -1054,7 +1077,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -1095,7 +1118,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -1131,7 +1154,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -1171,6 +1194,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -1211,6 +1236,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -1328,7 +1355,7 @@ jobs:
       # login step fails with "No such file or directory" (exit 127).
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -1454,6 +1481,8 @@ jobs:
           echo "=== Disk space after all cleanup ==="
           df -h /
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: 26
@@ -1673,6 +1702,8 @@ jobs:
           echo "=== Disk space after all cleanup ==="
           df -h /
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: 26
@@ -1748,13 +1779,37 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
+          fetch-depth: 0
       - run: echo "${{needs.generate-build-number.outputs.build_number}}"
+      - name: Resolve previous published release tag
+        id: previous_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          previous_tag="$(Scripts/GHA/get_latest_published_release_tag.sh "$GITHUB_REPOSITORY")"
+          echo "tag=${previous_tag}" >> "$GITHUB_OUTPUT"
+
+          previous_source_ref="$previous_tag"
+          # Release 13.0.1 was published with mixed provenance: its Docker
+          # images came from this release-workflow SHA, while the public Git
+          # tag was incorrectly created 42 commits later from moving master.
+          # Use the source users actually received as this recovery release's
+          # changelog boundary. Once a correctly pinned release is latest, the
+          # normal tag value above is used automatically.
+          if [ "$previous_tag" = "13.0.1" ]; then
+            previous_source_ref="9a2f47ddd997f7a6d356da6eb98b9717cc115136"
+            echo "::notice::Using the shipped 13.0.1 source commit as the changelog boundary because its public tag has incorrect provenance."
+          fi
+          echo "source_ref=${previous_source_ref}" >> "$GITHUB_OUTPUT"
       - name: "Build Changelog"
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v4.2.0
         with:
           configuration: "./Scripts/Release/ChangelogConfig.json"
+          fromTag: "${{ steps.previous_release.outputs.source_ref }}"
+          toTag: "${{ needs.read-version.outputs.major_minor }}"
+          failOnError: true
       - run: echo "Changelog:"
       - name: Print changelog
         env:
@@ -1765,18 +1820,22 @@ jobs:
         shell: bash
         env:
           CHANGELOG_CONTENT: ${{steps.build_changelog.outputs.changelog}}
+          FROM_TAG: ${{ steps.build_changelog.outputs.fromTag }}
+          TO_TAG: ${{ steps.build_changelog.outputs.toTag }}
         run: |
           set -euo pipefail
           OLD_PLACEHOLDER="No significant changes were made. We have just fixed minor bugs for this release. You can find the detailed information in the commit history."
           NEW_PLACEHOLDER="(auto) No categorized pull requests. Fallback will list raw commit messages."
           if echo "$CHANGELOG_CONTENT" | grep -Fq "$OLD_PLACEHOLDER" || echo "$CHANGELOG_CONTENT" | grep -Fq "$NEW_PLACEHOLDER"; then
             echo "Detected empty placeholder changelog. Building commit list fallback."
-            # Find previous tag (skip the most recent tag which might be for an older release). If none, include all commits.
-            if prev_tag=$(git describe --tags --abbrev=0 $(git rev-list --tags --skip=1 --max-count=1) 2>/dev/null); then
-              echo "Previous tag: $prev_tag"
-              commits=$(git log --pretty=format:'- %s (%h)' "$prev_tag"..HEAD)
+            # Use the exact range already resolved by the changelog action.
+            # Build-number tags are frequent and must never influence this
+            # fallback's release boundary.
+            if [ -n "$FROM_TAG" ] && [ -n "$TO_TAG" ]; then
+              echo "Release range: $FROM_TAG..$TO_TAG"
+              commits=$(git log --pretty=format:'- %s (%h)' "$FROM_TAG..$TO_TAG")
             else
-              echo "No previous tag found; using full commit history on this branch."
+              echo "No previous published release found; using full commit history."
               commits=$(git log --pretty=format:'- %s (%h)')
             fi
             # If still empty (e.g., no commits), keep placeholder to avoid empty body.
@@ -1822,6 +1881,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: "${{needs.read-version.outputs.major_minor}}"
+          commit: "${{ github.sha }}"
           artifactErrorsFailBuild: true
           draft: true
           allowUpdates: true
@@ -1840,6 +1900,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: "${{needs.read-version.outputs.major_minor}}"
+          commit: "${{ github.sha }}"
           artifactErrorsFailBuild: true
           draft: true
           allowUpdates: true
@@ -1856,6 +1917,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: "${{needs.read-version.outputs.major_minor}}"
+          commit: "${{ github.sha }}"
           artifactErrorsFailBuild: true
           draft: true
           allowUpdates: true
@@ -1902,7 +1964,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       # syft reads the manifest over the registry API using the credentials in
       # ~/.docker/config.json — no image pull, so this job stays small and fast.
@@ -1962,7 +2024,7 @@ jobs:
           swap-storage: true
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -2017,7 +2079,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Setup Java 17
         uses: actions/setup-java@v4
@@ -2073,7 +2135,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -2204,12 +2266,33 @@ jobs:
 
   finalize-github-release:
     name: Publish GitHub release
-    needs: [infrastructure-agent-deploy, generate-sboms, generate-build-number, read-version]
+    needs:
+      - infrastructure-agent-deploy
+      - generate-sboms
+      - mobile-app-android-deploy
+      - mobile-app-ios-deploy
+      - publish-terraform-provider
+      - generate-build-number
+      - read-version
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/release'
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      # The early read-version gate reserves the tag before any publishing can
+      # start. Verify it again after the long-running builds so a force-move or
+      # delete/recreate during the run can never be made public as this release.
+      - name: Verify release tag provenance before publication
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.read-version.outputs.major_minor }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: Scripts/GHA/verify_release_tag.sh "$GITHUB_REPOSITORY" "$RELEASE_TAG" "$EXPECTED_SHA"
+
       - name: Publish release
         uses: actions/github-script@v7
         with:
@@ -2290,7 +2373,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Setup Java 17
         uses: actions/setup-java@v4
@@ -2358,7 +2441,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-node@v4
         with:

--- a/Scripts/GHA/Tests/get_latest_published_release_tag_test.sh
+++ b/Scripts/GHA/Tests/get_latest_published_release_tag_test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+# Unit tests for get_latest_published_release_tag.sh. This file becomes a local
+# gh stub through a symlink, so the suite never contacts GitHub.
+
+set -uo pipefail
+
+gh_stub() {
+	printf '%s\n' "$*" >> "$LATEST_RELEASE_STUB_LOG"
+	call_count="$(<"$LATEST_RELEASE_STUB_COUNT")"
+	call_count=$(( call_count + 1 ))
+	printf '%s\n' "$call_count" > "$LATEST_RELEASE_STUB_COUNT"
+
+	case "$LATEST_RELEASE_STUB_SCENARIO" in
+	success)
+		printf '%s\n' "$LATEST_RELEASE_STUB_TAG"
+		;;
+	no_release)
+		echo "gh: Not Found (HTTP 404)" >&2
+		return 1
+		;;
+	transient_then_success)
+		if (( call_count < 3 )); then
+			echo "gh: Service Unavailable (HTTP 503)" >&2
+			return 1
+		fi
+		printf '%s\n' "$LATEST_RELEASE_STUB_TAG"
+		;;
+	exhausted_transient)
+		echo "gh: Bad Gateway (HTTP 502)" >&2
+		return 1
+		;;
+	permanent_error)
+		echo "gh: Resource forbidden (HTTP 403)" >&2
+		return 1
+		;;
+	empty_response)
+		printf '\n'
+		;;
+	*)
+		echo "unknown scenario: ${LATEST_RELEASE_STUB_SCENARIO}" >&2
+		return 64
+		;;
+	esac
+}
+
+if [[ "${0##*/}" == "gh" ]]; then
+	gh_stub "$@"
+	exit $?
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../get_latest_published_release_tag.sh"
+TEST_FILE="${SCRIPT_DIR}/$(basename "${BASH_SOURCE[0]}")"
+TEST_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/latest-release-tag-test.XXXXXX")"
+STUB_BIN_DIR="${TEST_TMP_DIR}/bin"
+mkdir -p "$STUB_BIN_DIR"
+ln -s "$TEST_FILE" "${STUB_BIN_DIR}/gh"
+
+cleanup() {
+	rm -rf "$TEST_TMP_DIR"
+}
+trap cleanup EXIT
+
+export LATEST_RELEASE_STUB_LOG="${TEST_TMP_DIR}/gh.log"
+export LATEST_RELEASE_STUB_COUNT="${TEST_TMP_DIR}/count"
+export LATEST_RELEASE_STUB_TAG="13.0.1"
+REPOSITORY="OneUptime/oneuptime"
+STDERR_FILE="${TEST_TMP_DIR}/stderr"
+PASS=0
+FAIL=0
+status=0
+output=""
+error_output=""
+
+pass() {
+	PASS=$(( PASS + 1 ))
+	echo "  ✅ $1"
+}
+
+fail() {
+	FAIL=$(( FAIL + 1 ))
+	echo "  ❌ $1" >&2
+}
+
+assert_eq() {
+	local expected="$1" actual="$2" what="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$what"
+	else
+		fail "$what — expected '${expected}', got '${actual}'"
+	fi
+}
+
+assert_contains() {
+	local haystack="$1" needle="$2" what="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		pass "$what"
+	else
+		fail "$what — '${needle}' not found in output"
+	fi
+}
+
+invoke() {
+	export LATEST_RELEASE_STUB_SCENARIO="$1"
+	printf '0\n' > "$LATEST_RELEASE_STUB_COUNT"
+	: > "$LATEST_RELEASE_STUB_LOG"
+	: > "$STDERR_FILE"
+	status=0
+	output="$(
+		PATH="${STUB_BIN_DIR}:$PATH" \
+			GET_LATEST_RELEASE_RETRY_DELAYS="$2" \
+			bash "$HELPER" "$REPOSITORY" 2>"$STDERR_FILE"
+	)" || status=$?
+	error_output="$(<"$STDERR_FILE")"
+}
+
+echo "get_latest_published_release_tag"
+
+invoke success "0 0"
+assert_eq 0 "$status" "resolves the latest published release"
+assert_eq "$LATEST_RELEASE_STUB_TAG" "$output" "prints only the published release tag"
+assert_eq 1 "$(<"$LATEST_RELEASE_STUB_COUNT")" "uses one request on success"
+assert_eq "api --method GET repos/${REPOSITORY}/releases/latest --jq .tag_name" "$(<"$LATEST_RELEASE_STUB_LOG")" "queries the published-latest endpoint"
+
+invoke no_release "0 0"
+assert_eq 0 "$status" "treats a clean 404 as a repository with no releases"
+assert_eq "" "$output" "prints an empty previous tag when no release exists"
+assert_eq 1 "$(<"$LATEST_RELEASE_STUB_COUNT")" "does not retry a clean 404"
+
+invoke transient_then_success "0 0"
+assert_eq 0 "$status" "recovers from transient GitHub failures"
+assert_eq "$LATEST_RELEASE_STUB_TAG" "$output" "prints the tag after recovery"
+assert_eq 3 "$(<"$LATEST_RELEASE_STUB_COUNT")" "retries transient failures"
+assert_contains "$error_output" "retrying in 0s" "reports transient retries"
+
+invoke exhausted_transient "0 0"
+assert_eq 1 "$status" "fails after transient retries are exhausted"
+assert_eq 3 "$(<"$LATEST_RELEASE_STUB_COUNT")" "bounds transient retries"
+assert_contains "$error_output" "after 3 attempts" "explains retry exhaustion"
+
+invoke permanent_error "0 0"
+assert_eq 1 "$status" "fails closed on a permanent API error"
+assert_eq 1 "$(<"$LATEST_RELEASE_STUB_COUNT")" "does not retry a permanent API error"
+assert_contains "$error_output" "permanent error" "explains the permanent failure"
+
+invoke empty_response "0 0"
+assert_eq 1 "$status" "rejects an empty successful API response"
+assert_contains "$error_output" "invalid tag" "explains the malformed response"
+
+export LATEST_RELEASE_STUB_SCENARIO=success
+printf '0\n' > "$LATEST_RELEASE_STUB_COUNT"
+status=0
+output="$(
+	PATH="${STUB_BIN_DIR}:$PATH" \
+		GET_LATEST_RELEASE_RETRY_DELAYS="0" \
+		bash "$HELPER" "not-a-repository" 2>&1
+)" || status=$?
+assert_eq 2 "$status" "rejects an invalid repository"
+assert_eq 0 "$(<"$LATEST_RELEASE_STUB_COUNT")" "validates input before calling GitHub"
+
+echo ""
+if (( FAIL > 0 )); then
+	echo "❌ ${FAIL} failed, ${PASS} passed" >&2
+	exit 1
+fi
+
+echo "✅ ${PASS} passed"

--- a/Scripts/GHA/Tests/npm_publish_provenance_test.sh
+++ b/Scripts/GHA/Tests/npm_publish_provenance_test.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+
+# Regression tests for npm release provenance checks. npm and sed are replaced
+# with local stubs, so these tests never access the registry or modify packages.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PUBLISH_SCRIPT="${SCRIPT_DIR}/../../NPM/PublishAllPackages.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+	PASS=$(( PASS + 1 ))
+	echo "  ✅ $1"
+}
+
+fail() {
+	FAIL=$(( FAIL + 1 ))
+	echo "  ❌ $1" >&2
+}
+
+assert_eq() {
+	local expected="$1" actual="$2" what="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$what"
+	else
+		fail "$what — expected '${expected}', got '${actual}'"
+	fi
+}
+
+assert_contains() {
+	local haystack="$1" needle="$2" what="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		pass "$what"
+	else
+		fail "$what — '${needle}' not found in output"
+	fi
+}
+
+assert_not_contains() {
+	local haystack="$1" needle="$2" what="$3"
+	if [[ "$haystack" != *"$needle"* ]]; then
+		pass "$what"
+	else
+		fail "$what — unexpectedly found '${needle}' in output"
+	fi
+}
+
+count_calls() {
+	local needle="$1"
+	awk -v needle="$needle" 'index($0, needle) { count++ } END { print count + 0 }' "$CALL_LOG"
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+FAKE_BIN="${WORK_DIR}/bin"
+mkdir -p "$FAKE_BIN"
+
+cat > "${FAKE_BIN}/npm" <<'FAKE_NPM'
+#!/usr/bin/env bash
+set -uo pipefail
+
+printf '%s|%s\n' "$PWD" "$*" >> "$NPM_PUBLISH_CALL_LOG"
+
+state_for_package() {
+	local package_name="$1" configured_state
+	case "$package_name" in
+		@oneuptime/common)
+			configured_state="${NPM_COMMON_STATE:-absent}"
+			if [[ -f "${NPM_PUBLISH_STATE_DIR}/common" ]]; then
+				configured_state="exact"
+			fi
+			;;
+		@oneuptime/cli)
+			configured_state="${NPM_CLI_STATE:-absent}"
+			if [[ -f "${NPM_PUBLISH_STATE_DIR}/cli" ]]; then
+				configured_state="exact"
+			fi
+			;;
+		*)
+			echo "Unexpected npm package: $package_name" >&2
+			exit 90
+			;;
+	esac
+	printf '%s\n' "$configured_state"
+}
+
+if [[ "${1:-}" == "view" ]]; then
+	spec="${2:-}"
+	field="${3:-}"
+	case "$spec" in
+		"@oneuptime/common@${PACKAGE_VERSION}") package_name="@oneuptime/common" ;;
+		"@oneuptime/cli@${PACKAGE_VERSION}") package_name="@oneuptime/cli" ;;
+		*)
+			echo "Unexpected npm view spec: $spec" >&2
+			exit 91
+			;;
+	esac
+	state="$(state_for_package "$package_name")"
+
+	if [[ "$field" == "version" ]]; then
+		case "$state" in
+			absent)
+				echo '{"error":{"code": "E404", "summary":"version not found"}}' >&2
+				exit 1
+				;;
+			legacy_absent)
+				echo 'npm ERR! code E404' >&2
+				exit 1
+				;;
+			registry_error)
+				echo 'npm error code E500' >&2
+				echo 'npm error registry unavailable' >&2
+				exit 1
+				;;
+			*)
+				if [[ "${4:-}" == "--json" ]]; then
+					printf '"%s"\n' "$PACKAGE_VERSION"
+				else
+					printf '%s\n' "$PACKAGE_VERSION"
+				fi
+				exit 0
+				;;
+		esac
+	fi
+
+	if [[ "$field" == "gitHead" ]]; then
+		case "$state" in
+			exact) printf '%s\n' "$GITHUB_SHA" ;;
+			mismatch) printf '%s\n' "$NPM_FOREIGN_SHA" ;;
+			uppercase) printf '%s\n' "$GITHUB_SHA" | tr '[:lower:]' '[:upper:]' ;;
+			missing_git_head) : ;;
+			git_head_error)
+				echo 'npm error code ENETUNREACH' >&2
+				exit 1
+				;;
+			*)
+				echo "gitHead requested for unexpected state: $state" >&2
+				exit 92
+				;;
+		esac
+		exit 0
+	fi
+
+	echo "Unexpected npm view field: $field" >&2
+	exit 93
+fi
+
+case "${1:-}" in
+	version|install|run)
+		exit 0
+		;;
+	publish)
+		case "$(basename "$PWD")" in
+			Common) touch "${NPM_PUBLISH_STATE_DIR}/common" ;;
+			CLI) touch "${NPM_PUBLISH_STATE_DIR}/cli" ;;
+			*)
+				echo "npm publish called outside a fixture package: $PWD" >&2
+				exit 94
+				;;
+		esac
+		exit 0
+		;;
+	*)
+		echo "Unexpected npm command: $*" >&2
+		exit 95
+		;;
+esac
+FAKE_NPM
+chmod +x "${FAKE_BIN}/npm"
+
+cat > "${FAKE_BIN}/sed" <<'FAKE_SED'
+#!/usr/bin/env bash
+# Package rewriting is unrelated to these provenance tests. Avoid changing the
+# fixture and keep the test portable across GNU and BSD sed.
+exit 0
+FAKE_SED
+chmod +x "${FAKE_BIN}/sed"
+
+CURRENT_SHA="0123456789abcdef0123456789abcdef01234567"
+FOREIGN_SHA="fedcba9876543210fedcba9876543210fedcba98"
+PACKAGE_VERSION_VALUE="9.8.7-test.1"
+
+new_case() {
+	local name="$1"
+	CASE_ROOT="${WORK_DIR}/${name}"
+	CALL_LOG="${CASE_ROOT}/npm.calls"
+	STATE_DIR="${CASE_ROOT}/registry-state"
+	mkdir -p "${CASE_ROOT}/Common" "${CASE_ROOT}/CLI" "$STATE_DIR"
+	printf '{"name":"@oneuptime/common"}\n' > "${CASE_ROOT}/Common/package.json"
+	printf '{"name":"@oneuptime/cli"}\n' > "${CASE_ROOT}/CLI/package.json"
+	: > "$CALL_LOG"
+}
+
+run_publish() {
+	(
+		unset PACKAGE_VERSION GITHUB_SHA NPM_COMMON_STATE NPM_CLI_STATE
+		cd "$CASE_ROOT" || exit 98
+		PATH="${FAKE_BIN}:$PATH" \
+			NPM_PUBLISH_CALL_LOG="$CALL_LOG" \
+			NPM_PUBLISH_STATE_DIR="$STATE_DIR" \
+			NPM_FOREIGN_SHA="$FOREIGN_SHA" \
+			env "$@" bash "$PUBLISH_SCRIPT"
+	) 2>&1
+}
+
+echo "PublishAllPackages.sh provenance"
+
+# Required release identity is validated before any registry access.
+new_case "missing-version"
+status=0
+output="$(run_publish GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=exact NPM_CLI_STATE=exact)" || status=$?
+assert_eq 1 "$status" "rejects a missing package version"
+assert_contains "$output" "Package version is required" "explains the missing package version"
+assert_eq 0 "$(count_calls "npm")" "does not access npm without a package version"
+
+new_case "missing-sha"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" NPM_COMMON_STATE=exact NPM_CLI_STATE=exact)" || status=$?
+assert_eq 1 "$status" "rejects a missing immutable commit"
+assert_contains "$output" "GITHUB_SHA is required" "explains the missing release commit"
+assert_eq 0 "$(count_calls "npm")" "does not access npm without a release commit"
+
+# A same-commit rerun is safe and performs no package mutation or publish.
+new_case "same-sha-rerun"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=exact NPM_CLI_STATE=exact)" || status=$?
+assert_eq 0 "$status" "allows a rerun of the exact same commit"
+assert_contains "$output" "@oneuptime/common@${PACKAGE_VERSION_VALUE} is already published from GITHUB_SHA ${CURRENT_SHA}. Safely skipping." "reports the verified Common skip"
+assert_contains "$output" "@oneuptime/cli@${PACKAGE_VERSION_VALUE} is already published from GITHUB_SHA ${CURRENT_SHA}. Safely skipping." "reports the verified CLI skip"
+assert_eq 2 "$(count_calls " gitHead")" "checks gitHead for every existing package"
+assert_eq 0 "$(count_calls "publish --access public")" "does not republish verified versions"
+assert_eq 0 "$(count_calls "version --allow-same-version")" "does not mutate verified packages"
+
+# A version from any other commit is an immutable collision, including a value
+# that differs only in letter case: equality must be exact.
+new_case "foreign-common"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=mismatch NPM_CLI_STATE=exact)" || status=$?
+assert_eq 1 "$status" "rejects an existing Common version from another commit"
+assert_contains "$output" "npm gitHead '${FOREIGN_SHA}' does not exactly match GITHUB_SHA '${CURRENT_SHA}'" "identifies both sides of the provenance mismatch"
+assert_not_contains "$(cat "$CALL_LOG")" "@oneuptime/cli@" "stops before inspecting dependent packages after a collision"
+assert_eq 0 "$(count_calls "publish --access public")" "does not publish over an immutable collision"
+
+new_case "case-mismatch"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=uppercase NPM_CLI_STATE=exact)" || status=$?
+assert_eq 1 "$status" "requires byte-for-byte gitHead equality"
+assert_contains "$output" "does not exactly match GITHUB_SHA" "reports a case-only mismatch"
+assert_eq 0 "$(count_calls "publish --access public")" "does not normalize and reuse a different gitHead"
+
+# Missing or unreadable registry provenance fails closed.
+new_case "missing-git-head"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=missing_git_head NPM_CLI_STATE=exact)" || status=$?
+assert_eq 1 "$status" "rejects an existing version without gitHead"
+assert_contains "$output" "npm did not return gitHead" "explains that registry provenance is absent"
+assert_contains "$output" "provenance cannot be verified" "states why the release cannot continue"
+assert_eq 0 "$(count_calls "publish --access public")" "does not publish when gitHead is missing"
+
+new_case "git-head-lookup-error"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=git_head_error NPM_CLI_STATE=exact)" || status=$?
+assert_eq 1 "$status" "rejects a failed gitHead lookup"
+assert_contains "$output" "Unable to read npm gitHead" "reports the failed provenance lookup"
+assert_contains "$output" "Refusing to reuse" "fails closed after the lookup error"
+assert_eq 0 "$(count_calls "publish --access public")" "does not publish after a provenance lookup error"
+
+# A registry or network failure is not proof that a version is absent.
+new_case "registry-error"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=registry_error NPM_CLI_STATE=exact)" || status=$?
+assert_eq 1 "$status" "rejects an indeterminate registry lookup"
+assert_contains "$output" "Refusing to publish while registry state is unknown" "distinguishes registry failure from absence"
+assert_contains "$output" "npm error code E500" "preserves the registry diagnostic"
+assert_eq 0 "$(count_calls "gitHead")" "does not invent provenance after a failed existence lookup"
+assert_eq 0 "$(count_calls "publish --access public")" "does not publish during registry uncertainty"
+
+# Preflight is atomic across the package set: discovering that Common is absent
+# must not publish it before CLI's existing provenance has also been verified.
+new_case "absent-common-foreign-cli"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=absent NPM_CLI_STATE=mismatch)" || status=$?
+assert_eq 1 "$status" "rejects a foreign CLI before publishing absent Common"
+assert_contains "$output" "@oneuptime/common@${PACKAGE_VERSION_VALUE} is not published on npm (E404)" "preflights Common absence"
+assert_contains "$output" "@oneuptime/cli@${PACKAGE_VERSION_VALUE}: npm gitHead '${FOREIGN_SHA}'" "finds the later immutable collision"
+assert_eq 0 "$(count_calls "version --allow-same-version")" "does not mutate Common before all preflight checks pass"
+assert_eq 0 "$(count_calls "publish --access public")" "publishes nothing when later package provenance collides"
+
+# The same atomicity guarantee applies when CLI's registry state is unknown.
+new_case "absent-common-cli-lookup-error"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=absent NPM_CLI_STATE=registry_error)" || status=$?
+assert_eq 1 "$status" "stops when CLI lookup fails after confirmed Common absence"
+assert_contains "$output" "@oneuptime/common@${PACKAGE_VERSION_VALUE} is not published on npm (E404)" "records Common as missing without publishing it"
+assert_contains "$output" "Unable to determine whether @oneuptime/cli@${PACKAGE_VERSION_VALUE} is published" "names the later indeterminate package"
+assert_contains "$output" "npm error code E500" "preserves the CLI lookup diagnostic"
+assert_eq 0 "$(count_calls "version --allow-same-version")" "does not mutate Common during later registry uncertainty"
+assert_eq 0 "$(count_calls "publish --access public")" "publishes nothing when a later lookup is uncertain"
+
+# A confirmed E404 remains the only path to a new publish. The fake registry
+# records each publish so the Common propagation check can also complete.
+new_case "new-release"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=absent NPM_CLI_STATE=absent)" || status=$?
+assert_eq 0 "$status" "publishes packages after confirmed E404 responses"
+assert_contains "$output" "@oneuptime/common@${PACKAGE_VERSION_VALUE} is not published on npm (E404). It will be published from GITHUB_SHA ${CURRENT_SHA} after all package preflight checks pass." "reports the verified Common absence"
+assert_contains "$output" "@oneuptime/cli@${PACKAGE_VERSION_VALUE} is not published on npm (E404). It will be published from GITHUB_SHA ${CURRENT_SHA} after all package preflight checks pass." "reports the verified CLI absence"
+assert_eq 2 "$(count_calls "version --allow-same-version ${PACKAGE_VERSION_VALUE}")" "versions both new packages"
+assert_eq 2 "$(count_calls "publish --access public")" "publishes both new packages"
+assert_contains "$(cat "$CALL_LOG")" "${CASE_ROOT}/Common|publish --access public" "publishes Common from its package directory"
+assert_contains "$(cat "$CALL_LOG")" "${CASE_ROOT}/CLI|publish --access public" "publishes CLI from its package directory"
+
+# A partial rerun verifies the completed package and publishes only the missing
+# dependent package. This is the recovery path for an interrupted release.
+new_case "partial-rerun"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=exact NPM_CLI_STATE=absent)" || status=$?
+assert_eq 0 "$status" "resumes a same-commit partial release"
+assert_contains "$output" "@oneuptime/common@${PACKAGE_VERSION_VALUE} is already published from GITHUB_SHA ${CURRENT_SHA}. Safely skipping." "verifies the completed package before resuming"
+assert_eq 1 "$(count_calls "publish --access public")" "publishes only the missing package"
+assert_not_contains "$(cat "$CALL_LOG")" "${CASE_ROOT}/Common|publish --access public" "does not republish Common"
+assert_contains "$(cat "$CALL_LOG")" "${CASE_ROOT}/CLI|publish --access public" "publishes the missing CLI package"
+
+# Provenance is enforced independently for later packages as well.
+new_case "foreign-cli"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=exact NPM_CLI_STATE=mismatch)" || status=$?
+assert_eq 1 "$status" "rejects an existing CLI version from another commit"
+assert_contains "$output" "@oneuptime/cli@${PACKAGE_VERSION_VALUE}: npm gitHead '${FOREIGN_SHA}'" "names the colliding dependent package"
+assert_eq 2 "$(count_calls " gitHead")" "checks provenance on both packages before detecting the CLI collision"
+assert_eq 0 "$(count_calls "publish --access public")" "does not publish anything during a partial collision"
+
+# npm 6 and earlier used the legacy error prefix; it is still an explicit 404,
+# so interrupted releases remain recoverable across supported npm output forms.
+new_case "legacy-e404"
+status=0
+output="$(run_publish PACKAGE_VERSION="$PACKAGE_VERSION_VALUE" GITHUB_SHA="$CURRENT_SHA" NPM_COMMON_STATE=legacy_absent NPM_CLI_STATE=exact)" || status=$?
+assert_eq 0 "$status" "recognizes the legacy npm E404 format"
+assert_eq 1 "$(count_calls "publish --access public")" "publishes only the legacy-E404 package"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi

--- a/Scripts/GHA/Tests/pin_release_tag_test.sh
+++ b/Scripts/GHA/Tests/pin_release_tag_test.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+# Unit tests for Scripts/GHA/pin_release_tag.sh. The test file also acts as
+# local git and verifier stubs through symlinks; no network or repository state
+# is touched.
+
+set -uo pipefail
+
+git_stub() {
+	printf '%s\n' "$*" >> "$PIN_STUB_GIT_LOG"
+
+	case "$1" in
+	check-ref-format)
+		[[ "$2" != *"invalid tag"* ]]
+		;;
+	ls-remote)
+		case "$PIN_STUB_SCENARIO" in
+			existing|verify_failure)
+				printf '%s\trefs/tags/%s\n' "$PIN_STUB_SHA" "$PIN_STUB_TAG"
+				;;
+			missing|push_failure)
+				return 2
+				;;
+			lookup_failure)
+				echo "fatal: unable to access origin" >&2
+				return 128
+				;;
+			*)
+				echo "unexpected scenario: ${PIN_STUB_SCENARIO}" >&2
+				return 64
+				;;
+		esac
+		;;
+	push)
+		if [[ "$PIN_STUB_SCENARIO" == "push_failure" ]]; then
+			echo "remote rejected tag" >&2
+			return 1
+		fi
+		;;
+	*)
+		echo "git stub received unexpected arguments: $*" >&2
+		return 64
+		;;
+	esac
+}
+
+verify_stub() {
+	printf '%s\n' "$*" >> "$PIN_STUB_VERIFY_LOG"
+	if [[ "$PIN_STUB_SCENARIO" == "verify_failure" ]]; then
+		echo "tag points to another commit" >&2
+		return 1
+	fi
+}
+
+case "${0##*/}" in
+git)
+	git_stub "$@"
+	exit $?
+	;;
+verify_release_tag.sh)
+	verify_stub "$@"
+	exit $?
+	;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../pin_release_tag.sh"
+TEST_FILE="${SCRIPT_DIR}/$(basename "${BASH_SOURCE[0]}")"
+TEST_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/pin-release-tag-test.XXXXXX")"
+STUB_BIN_DIR="${TEST_TMP_DIR}/bin"
+mkdir -p "$STUB_BIN_DIR"
+ln -s "$TEST_FILE" "${STUB_BIN_DIR}/git"
+ln -s "$TEST_FILE" "${STUB_BIN_DIR}/verify_release_tag.sh"
+
+cleanup() {
+	rm -rf "$TEST_TMP_DIR"
+}
+trap cleanup EXIT
+
+export PIN_STUB_GIT_LOG="${TEST_TMP_DIR}/git.log"
+export PIN_STUB_VERIFY_LOG="${TEST_TMP_DIR}/verify.log"
+export PIN_STUB_SHA="1111111111111111111111111111111111111111"
+export PIN_STUB_TAG="13.0.3"
+REPOSITORY="OneUptime/oneuptime"
+PASS=0
+FAIL=0
+status=0
+output=""
+
+pass() {
+	PASS=$(( PASS + 1 ))
+	echo "  ✅ $1"
+}
+
+fail() {
+	FAIL=$(( FAIL + 1 ))
+	echo "  ❌ $1" >&2
+}
+
+assert_eq() {
+	local expected="$1" actual="$2" what="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$what"
+	else
+		fail "$what — expected '${expected}', got '${actual}'"
+	fi
+}
+
+assert_contains() {
+	local haystack="$1" needle="$2" what="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		pass "$what"
+	else
+		fail "$what — '${needle}' not found in output"
+	fi
+}
+
+invoke() {
+	export PIN_STUB_SCENARIO="$1"
+	: > "$PIN_STUB_GIT_LOG"
+	: > "$PIN_STUB_VERIFY_LOG"
+	status=0
+	output="$(
+		PATH="${STUB_BIN_DIR}:$PATH" \
+			VERIFY_RELEASE_TAG_HELPER="${STUB_BIN_DIR}/verify_release_tag.sh" \
+			bash "$HELPER" "$REPOSITORY" "$PIN_STUB_TAG" "$PIN_STUB_SHA" 2>&1
+	)" || status=$?
+}
+
+echo "pin_release_tag"
+
+invoke existing
+assert_eq 0 "$status" "accepts an existing tag after provenance verification"
+assert_eq 2 "$(wc -l < "$PIN_STUB_GIT_LOG" | tr -d ' ')" "checks tag syntax and remote existence"
+assert_eq "$REPOSITORY $PIN_STUB_TAG $PIN_STUB_SHA" "$(<"$PIN_STUB_VERIFY_LOG")" "verifies the existing tag against the immutable identity"
+if grep -q '^push ' "$PIN_STUB_GIT_LOG"; then
+	fail "does not move an existing tag — push was attempted"
+else
+	pass "does not move an existing tag"
+fi
+
+invoke missing
+assert_eq 0 "$status" "creates a missing tag and verifies it"
+assert_contains "$(<"$PIN_STUB_GIT_LOG")" "push origin ${PIN_STUB_SHA}:refs/tags/${PIN_STUB_TAG}" "pins a missing tag directly to the workflow SHA"
+assert_eq "$REPOSITORY $PIN_STUB_TAG $PIN_STUB_SHA" "$(<"$PIN_STUB_VERIFY_LOG")" "verifies a newly created tag"
+assert_contains "$output" "does not exist" "reports first-release tag creation"
+
+invoke verify_failure
+assert_eq 1 "$status" "rejects an existing tag with failed provenance"
+if grep -q '^push ' "$PIN_STUB_GIT_LOG"; then
+	fail "never overwrites a mismatched existing tag — push was attempted"
+else
+	pass "never overwrites a mismatched existing tag"
+fi
+
+invoke lookup_failure
+assert_eq 1 "$status" "fails closed when remote tag state is unknown"
+assert_contains "$output" "Unable to determine" "explains an uncertain remote lookup"
+assert_eq "" "$(<"$PIN_STUB_VERIFY_LOG")" "does not verify after an uncertain lookup"
+
+invoke push_failure
+assert_eq 1 "$status" "propagates an atomic tag-push failure"
+assert_eq "" "$(<"$PIN_STUB_VERIFY_LOG")" "does not claim verification after a failed push"
+
+export PIN_STUB_SCENARIO=existing
+: > "$PIN_STUB_GIT_LOG"
+status=0
+output="$(
+	PATH="${STUB_BIN_DIR}:$PATH" \
+		VERIFY_RELEASE_TAG_HELPER="${STUB_BIN_DIR}/verify_release_tag.sh" \
+		bash "$HELPER" "$REPOSITORY" "invalid tag" "$PIN_STUB_SHA" 2>&1
+)" || status=$?
+assert_eq 2 "$status" "rejects an invalid Git tag name"
+assert_contains "$output" "not a valid Git tag name" "explains invalid tag input"
+
+: > "$PIN_STUB_GIT_LOG"
+status=0
+output="$(
+	PATH="${STUB_BIN_DIR}:$PATH" \
+		VERIFY_RELEASE_TAG_HELPER="${STUB_BIN_DIR}/verify_release_tag.sh" \
+		bash "$HELPER" "$REPOSITORY" "$PIN_STUB_TAG" "short-sha" 2>&1
+)" || status=$?
+assert_eq 2 "$status" "rejects an incomplete commit SHA"
+assert_eq "" "$(<"$PIN_STUB_GIT_LOG")" "rejects invalid identity before touching Git"
+
+echo ""
+if (( FAIL > 0 )); then
+	echo "❌ ${FAIL} failed, ${PASS} passed" >&2
+	exit 1
+fi
+
+echo "✅ ${PASS} passed"

--- a/Scripts/GHA/Tests/release_workflow_test.sh
+++ b/Scripts/GHA/Tests/release_workflow_test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# Regression coverage for release provenance. A production run used to build
+# from the release event but let ncipollo/release-action target moving `master`;
+# release 13.0.1 consequently mixed three commits across its Git tag, npm
+# packages, and images. The tag must be pinned before downstream publishing,
+# every checkout and draft-release attempt must use the immutable event SHA,
+# and publication must wait until every mandatory artifact is attached.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW="${SCRIPT_DIR}/../../../.github/workflows/release.yml"
+
+PASS=0
+FAIL=0
+
+pass() {
+	PASS=$(( PASS + 1 ))
+	echo "  ✅ $1"
+}
+
+fail() {
+	FAIL=$(( FAIL + 1 ))
+	echo "  ❌ $1" >&2
+}
+
+assert_eq() {
+	local expected="$1" actual="$2" what="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$what"
+	else
+		fail "$what — expected '${expected}', got '${actual}'"
+	fi
+}
+
+echo "release.yml provenance"
+
+release_action_count="$(grep -c 'uses: ncipollo/release-action@v1' "$WORKFLOW" || true)"
+pinned_action_count=0
+
+while IFS=: read -r line_number _; do
+	[[ -n "$line_number" ]] || continue
+	block="$(sed -n "${line_number},$(( line_number + 14 ))p" "$WORKFLOW")"
+	if grep -Fq 'commit: "${{ github.sha }}"' <<< "$block"; then
+		pinned_action_count=$(( pinned_action_count + 1 ))
+	fi
+done < <(grep -n 'uses: ncipollo/release-action@v1' "$WORKFLOW" || true)
+
+assert_eq 3 "$release_action_count" "keeps all three idempotent draft-release attempts"
+assert_eq "$release_action_count" "$pinned_action_count" "passes the release event SHA to every draft-release attempt"
+
+moving_checkout_count="$(grep -F -c 'ref: ${{ github.ref }}' "$WORKFLOW" || true)"
+immutable_checkout_count="$(grep -F -c 'ref: ${{ github.sha }}' "$WORKFLOW" || true)"
+checkout_count="$(grep -c 'uses: actions/checkout@v4' "$WORKFLOW" || true)"
+
+assert_eq 0 "$moving_checkout_count" "never checks out the moving release branch"
+assert_eq "$checkout_count" "$immutable_checkout_count" "pins every release checkout to the event SHA"
+
+assert_eq 1 "$(grep -F -c 'group: oneuptime-production-release' "$WORKFLOW" || true)" "serializes production release runs"
+assert_eq 1 "$(grep -F -c 'cancel-in-progress: false' "$WORKFLOW" || true)" "never cancels a partially published release"
+assert_eq 1 "$(grep -F -c 'name: Pin and verify release tag provenance' "$WORKFLOW" || true)" "pins the release tag at runtime"
+assert_eq 1 "$(grep -F -c 'run: Scripts/GHA/pin_release_tag.sh "$GITHUB_REPOSITORY" "$RELEASE_TAG" "$EXPECTED_SHA"' "$WORKFLOW" || true)" "passes the immutable release identity to the tested tag pinning helper"
+assert_eq 1 "$(grep -F -c 'name: Verify release tag provenance before publication' "$WORKFLOW" || true)" "re-verifies the tag immediately before publication"
+assert_eq 1 "$(grep -F -c 'run: Scripts/GHA/verify_release_tag.sh "$GITHUB_REPOSITORY" "$RELEASE_TAG" "$EXPECTED_SHA"' "$WORKFLOW" || true)" "passes the immutable identity to the final tag verifier"
+assert_eq 1 "$(grep -F -c 'name: Resolve previous published release tag' "$WORKFLOW" || true)" "resolves changelog history from published releases"
+assert_eq 1 "$(grep -F -c 'previous_tag="$(Scripts/GHA/get_latest_published_release_tag.sh "$GITHUB_REPOSITORY")"' "$WORKFLOW" || true)" "uses the tested published-release resolver"
+assert_eq 1 "$(grep -F -c 'fromTag: "${{ steps.previous_release.outputs.source_ref }}"' "$WORKFLOW" || true)" "starts changelog generation at the previously shipped source"
+assert_eq 1 "$(grep -F -c 'toTag: "${{ needs.read-version.outputs.major_minor }}"' "$WORKFLOW" || true)" "ends changelog generation at the pinned version tag"
+assert_eq 1 "$(grep -F -c 'failOnError: true' "$WORKFLOW" || true)" "fails the release when changelog generation fails"
+assert_eq 0 "$(grep -F -c 'git rev-list --tags --skip=1' "$WORKFLOW" || true)" "never derives release history from build-number tags"
+assert_eq 1 "$(grep -F -c 'commits=$(git log --pretty=format:'"'"'- %s (%h)'"'"' "$FROM_TAG..$TO_TAG")' "$WORKFLOW" || true)" "uses the changelog action's exact range for fallback notes"
+assert_eq 1 "$(grep -F -c 'previous_source_ref="9a2f47ddd997f7a6d356da6eb98b9717cc115136"' "$WORKFLOW" || true)" "recovers changelog history from the source actually shipped as 13.0.1"
+
+pin_tag_line="$(grep -n 'name: Pin and verify release tag provenance' "$WORKFLOW" | cut -d: -f1)"
+first_release_action_line="$(grep -n 'uses: ncipollo/release-action@v1' "$WORKFLOW" | head -n 1 | cut -d: -f1)"
+if [[ -n "$pin_tag_line" && -n "$first_release_action_line" ]] && (( pin_tag_line < first_release_action_line )); then
+	pass "pins the tag before creating the draft release"
+else
+	fail "pins the tag before creating the draft release — ordering is unsafe"
+fi
+
+read_version_line="$(grep -n '^  read-version:' "$WORKFLOW" | cut -d: -f1)"
+helm_job_line="$(grep -n '^  helm-chart-deploy:' "$WORKFLOW" | cut -d: -f1)"
+read_version_block="$(sed -n "${read_version_line},$(( helm_job_line - 1 ))p" "$WORKFLOW")"
+if grep -Fq 'contents: write' <<< "$read_version_block"; then
+	pass "grants the gating version job permission to create the tag"
+else
+	fail "grants the gating version job permission to create the tag — contents write is missing"
+fi
+
+draft_job_line="$(grep -n '^  draft-github-release:' "$WORKFLOW" | cut -d: -f1)"
+sbom_job_line="$(grep -n '^  generate-sboms:' "$WORKFLOW" | cut -d: -f1)"
+draft_job_block="$(sed -n "${draft_job_line},$(( sbom_job_line - 1 ))p" "$WORKFLOW")"
+if grep -Fq 'fetch-depth: 0' <<< "$draft_job_block"; then
+	pass "fetches full history for fallback release notes"
+else
+	fail "fetches full history for fallback release notes — draft checkout is shallow"
+fi
+
+finalizer_line="$(grep -n '^  finalize-github-release:' "$WORKFLOW" | cut -d: -f1)"
+finalizer_needs="$(sed -n "${finalizer_line},$(( finalizer_line + 20 ))p" "$WORKFLOW")"
+
+final_verify_line="$(grep -n 'name: Verify release tag provenance before publication' "$WORKFLOW" | cut -d: -f1)"
+publish_release_line="$(grep -n 'name: Publish release' "$WORKFLOW" | cut -d: -f1)"
+if [[ -n "$final_verify_line" && -n "$publish_release_line" ]] && (( final_verify_line < publish_release_line )); then
+	pass "checks tag provenance before making the release public"
+else
+	fail "checks tag provenance before making the release public — ordering is unsafe"
+fi
+
+for dependency in \
+	"infrastructure-agent-deploy" \
+	"generate-sboms" \
+	"mobile-app-android-deploy" \
+	"mobile-app-ios-deploy" \
+	"publish-terraform-provider"; do
+	if grep -Fq -- "- ${dependency}" <<< "$finalizer_needs"; then
+		pass "publishes only after ${dependency}"
+	else
+		fail "publishes only after ${dependency} — dependency missing from finalizer"
+	fi
+done
+
+echo ""
+if (( FAIL > 0 )); then
+	echo "❌ ${FAIL} failed, ${PASS} passed" >&2
+	exit 1
+fi
+
+echo "✅ ${PASS} passed"

--- a/Scripts/GHA/Tests/verify_release_tag_test.sh
+++ b/Scripts/GHA/Tests/verify_release_tag_test.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+
+# Unit tests for Scripts/GHA/verify_release_tag.sh.
+#
+# This file doubles as the `gh` stub when invoked through the temporary `gh`
+# symlink below. Every API response is local and deterministic; the suite never
+# contacts GitHub.
+#
+# Run with:
+#   bash Scripts/GHA/Tests/run.sh verify_release_tag
+#   bash Scripts/GHA/Tests/verify_release_tag_test.sh
+
+set -uo pipefail
+
+gh_stub() {
+	if (( $# != 4 )) || [[ "$1" != "api" || "$2" != "--method" || "$3" != "GET" ]]; then
+		echo "gh stub received unexpected arguments: $*" >&2
+		return 64
+	fi
+
+	local endpoint="$4"
+	local call_count
+	call_count="$(<"$GH_STUB_STATE_FILE")"
+	call_count=$(( call_count + 1 ))
+	printf '%s\n' "$call_count" > "$GH_STUB_STATE_FILE"
+	printf '%s\n' "$endpoint" >> "$GH_STUB_ENDPOINT_LOG"
+
+	emit_object() {
+		printf '{"object":{"type":"%s","sha":"%s"}}\n' "$1" "$2"
+	}
+
+	case "$GH_STUB_SCENARIO" in
+	lightweight_match)
+		emit_object commit "$STUB_MATCH_SHA"
+		;;
+	lightweight_mismatch)
+		emit_object commit "$STUB_OTHER_SHA"
+		;;
+	annotated_match)
+		if [[ "$endpoint" == *"/git/ref/tags/"* ]]; then
+			emit_object tag "$STUB_TAG_OBJECT_SHA"
+		elif [[ "$endpoint" == "repos/${STUB_REPOSITORY}/git/tags/${STUB_TAG_OBJECT_SHA}" ]]; then
+			emit_object commit "$STUB_MATCH_SHA"
+		else
+			echo "gh stub received unexpected endpoint: ${endpoint}" >&2
+			return 64
+		fi
+		;;
+	malformed_json)
+		printf '{not-json\n'
+		;;
+	missing_object)
+		printf '{"sha":"%s"}\n' "$STUB_MATCH_SHA"
+		;;
+	malformed_sha)
+		emit_object commit "not-a-complete-sha"
+		;;
+	non_commit)
+		emit_object tree "$STUB_OTHER_SHA"
+		;;
+	transient_then_match)
+		if (( call_count <= 2 )); then
+			echo "gh: Service Unavailable (HTTP 503)" >&2
+			return 1
+		fi
+		emit_object commit "$STUB_MATCH_SHA"
+		;;
+	transient_while_peeling)
+		if (( call_count == 1 )); then
+			emit_object tag "$STUB_TAG_OBJECT_SHA"
+		elif (( call_count == 2 )); then
+			echo "gh: connection reset by peer" >&2
+			return 1
+		else
+			emit_object commit "$STUB_MATCH_SHA"
+		fi
+		;;
+	exhausted_transient)
+		echo "gh: Bad Gateway (HTTP 502)" >&2
+		return 1
+		;;
+	permanent_404)
+		echo "gh: Not Found (HTTP 404)" >&2
+		return 1
+		;;
+	endless_annotations)
+		emit_object tag "$STUB_TAG_OBJECT_SHA"
+		;;
+	*)
+		echo "Unknown gh stub scenario: ${GH_STUB_SCENARIO}" >&2
+		return 64
+		;;
+	esac
+}
+
+# The suite creates a symlink named `gh` pointing back to itself. Branch before
+# initializing any test-runner state when this process is that stub.
+if [[ "${0##*/}" == "gh" ]]; then
+	gh_stub "$@"
+	exit $?
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../verify_release_tag.sh"
+TEST_FILE="${SCRIPT_DIR}/$(basename "${BASH_SOURCE[0]}")"
+TEST_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/verify-release-tag-test.XXXXXX")"
+STUB_BIN_DIR="${TEST_TMP_DIR}/bin"
+mkdir -p "$STUB_BIN_DIR"
+ln -s "$TEST_FILE" "${STUB_BIN_DIR}/gh"
+
+cleanup() {
+	rm -rf "$TEST_TMP_DIR"
+}
+trap cleanup EXIT
+
+export GH_STUB_STATE_FILE="${TEST_TMP_DIR}/call-count"
+export GH_STUB_ENDPOINT_LOG="${TEST_TMP_DIR}/endpoints"
+export STUB_REPOSITORY="OneUptime/oneuptime"
+export STUB_MATCH_SHA="1111111111111111111111111111111111111111"
+export STUB_OTHER_SHA="2222222222222222222222222222222222222222"
+export STUB_TAG_OBJECT_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+TEST_TAG="13.0.1"
+PASS=0
+FAIL=0
+status=0
+output=""
+
+pass() {
+	PASS=$(( PASS + 1 ))
+	echo "  ✅ $1"
+}
+
+fail() {
+	FAIL=$(( FAIL + 1 ))
+	echo "  ❌ $1" >&2
+}
+
+assert_eq() {
+	local expected="$1" actual="$2" what="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$what"
+	else
+		fail "$what — expected '${expected}', got '${actual}'"
+	fi
+}
+
+assert_contains() {
+	local haystack="$1" needle="$2" what="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		pass "$what"
+	else
+		fail "$what — '${needle}' not found in output"
+	fi
+}
+
+reset_stub() {
+	export GH_STUB_SCENARIO="$1"
+	printf '0\n' > "$GH_STUB_STATE_FILE"
+	: > "$GH_STUB_ENDPOINT_LOG"
+}
+
+stub_call_count() {
+	local count
+	count="$(<"$GH_STUB_STATE_FILE")"
+	printf '%s' "$count"
+}
+
+# invoke_with_args <scenario> <retry delays> <tag> <expected sha> [max peels]
+invoke_with_args() {
+	local scenario="$1"
+	local delays="$2"
+	local tag="$3"
+	local expected="$4"
+	local max_peels="${5:-20}"
+	reset_stub "$scenario"
+	status=0
+	output="$(
+		PATH="${STUB_BIN_DIR}:$PATH" \
+			VERIFY_RELEASE_TAG_RETRY_DELAYS="$delays" \
+			VERIFY_RELEASE_TAG_MAX_PEELS="$max_peels" \
+			bash "$HELPER" "$STUB_REPOSITORY" "$tag" "$expected" 2>&1
+	)" || status=$?
+}
+
+echo "verify_release_tag"
+
+# A lightweight tag exposes the commit directly from the ref endpoint.
+invoke_with_args lightweight_match "0 0" "$TEST_TAG" "$STUB_MATCH_SHA"
+assert_eq 0 "$status" "accepts a lightweight tag at the expected commit"
+assert_eq 1 "$(stub_call_count)" "uses one API request for a lightweight tag"
+assert_contains "$output" "is pinned to ${STUB_MATCH_SHA}" "reports the verified commit"
+
+# Environment-only invocation is the convenient form for GitHub Actions.
+reset_stub lightweight_match
+status=0
+output="$(
+	PATH="${STUB_BIN_DIR}:$PATH" \
+		GITHUB_REPOSITORY="$STUB_REPOSITORY" \
+		RELEASE_TAG="$TEST_TAG" \
+		EXPECTED_SHA="$STUB_MATCH_SHA" \
+		VERIFY_RELEASE_TAG_RETRY_DELAYS="0 0" \
+		bash "$HELPER" 2>&1
+)" || status=$?
+assert_eq 0 "$status" "accepts repository, tag, and SHA from the environment"
+assert_eq 1 "$(stub_call_count)" "environment invocation still makes one API request"
+
+# A valid tag at another commit must stop the release.
+invoke_with_args lightweight_mismatch "0 0" "$TEST_TAG" "$STUB_MATCH_SHA"
+assert_eq 1 "$status" "rejects a lightweight tag at the wrong commit"
+assert_eq 1 "$(stub_call_count)" "does not retry a provenance mismatch"
+assert_contains "$output" "points to ${STUB_OTHER_SHA}" "reports the tag's actual commit"
+assert_contains "$output" "releasing ${STUB_MATCH_SHA}" "reports the expected release commit"
+
+# Annotated tags are peeled through the git/tags endpoint before comparison.
+invoke_with_args annotated_match "0 0" "$TEST_TAG" "$STUB_MATCH_SHA"
+assert_eq 0 "$status" "accepts an annotated tag at the expected commit"
+assert_eq 2 "$(stub_call_count)" "peels an annotated tag with a second API request"
+expected_endpoints="repos/${STUB_REPOSITORY}/git/ref/tags/${TEST_TAG}
+repos/${STUB_REPOSITORY}/git/tags/${STUB_TAG_OBJECT_SHA}"
+assert_eq "$expected_endpoints" "$(<"$GH_STUB_ENDPOINT_LOG")" "requests the ref and its annotated tag object"
+
+# Tag names are encoded before they become part of the API endpoint.
+slash_tag="release/${TEST_TAG}"
+invoke_with_args lightweight_match "0 0" "$slash_tag" "$STUB_MATCH_SHA"
+assert_eq 0 "$status" "accepts a tag name containing a slash"
+assert_eq "repos/${STUB_REPOSITORY}/git/ref/tags/release%2F${TEST_TAG}" "$(<"$GH_STUB_ENDPOINT_LOG")" "URL-encodes the tag path"
+
+# Successful HTTP responses still have to contain a trustworthy Git object.
+invoke_with_args malformed_json "0 0" "$TEST_TAG" "$STUB_MATCH_SHA"
+assert_eq 1 "$status" "rejects malformed JSON"
+assert_eq 1 "$(stub_call_count)" "does not retry malformed JSON"
+assert_contains "$output" "malformed response" "explains the malformed JSON failure"
+
+invoke_with_args missing_object "0 0" "$TEST_TAG" "$STUB_MATCH_SHA"
+assert_eq 1 "$status" "rejects a response with no object"
+assert_contains "$output" "object.type and object.sha are required" "explains missing object fields"
+
+invoke_with_args malformed_sha "0 0" "$TEST_TAG" "$STUB_MATCH_SHA"
+assert_eq 1 "$status" "rejects an incomplete object SHA"
+assert_contains "$output" "malformed Git object" "explains the invalid object SHA"
+
+invoke_with_args non_commit "0 0" "$TEST_TAG" "$STUB_MATCH_SHA"
+assert_eq 1 "$status" "rejects a tag that resolves to a non-commit object"
+assert_eq 1 "$(stub_call_count)" "does not retry a non-commit object"
+assert_contains "$output" "resolves to tree, not a commit" "reports the non-commit object type"
+
+# Transient failures are retried with test-overridden zero delays.
+invoke_with_args transient_then_match "0 0" "$TEST_TAG" "$STUB_MATCH_SHA"
+assert_eq 0 "$status" "recovers from transient ref API failures"
+assert_eq 3 "$(stub_call_count)" "retries until the ref API recovers"
+assert_contains "$output" "retrying in 0s" "announces a transient API retry"
+assert_contains "$output" "succeeded on attempt 3/3" "reports recovery after retries"
+
+# The same retry policy applies while peeling an annotated tag.
+invoke_with_args transient_while_peeling "0 0" "$TEST_TAG" "$STUB_MATCH_SHA"
+assert_eq 0 "$status" "recovers from a transient annotated-tag API failure"
+assert_eq 3 "$(stub_call_count)" "retries only the failed peel request"
+assert_contains "$output" "annotated tag object ${STUB_TAG_OBJECT_SHA}" "identifies the retried tag object"
+
+# A persistent transient error gets exactly delays+1 attempts and then fails.
+invoke_with_args exhausted_transient "0 0" "$TEST_TAG" "$STUB_MATCH_SHA"
+assert_eq 1 "$status" "fails when transient API retries are exhausted"
+assert_eq 3 "$(stub_call_count)" "stops after the configured transient attempts"
+assert_contains "$output" "still failed after 3 attempts" "reports exhausted API retries"
+
+# Empty delays disable retries without disabling the initial request.
+invoke_with_args exhausted_transient "" "$TEST_TAG" "$STUB_MATCH_SHA"
+assert_eq 1 "$status" "fails cleanly when retries are disabled"
+assert_eq 1 "$(stub_call_count)" "an empty delay list makes one API attempt"
+
+# A permanent API response, such as a missing tag, must fail immediately.
+invoke_with_args permanent_404 "0 0" "$TEST_TAG" "$STUB_MATCH_SHA"
+assert_eq 1 "$status" "fails on a permanent GitHub API error"
+assert_eq 1 "$(stub_call_count)" "does not retry a permanent GitHub API error"
+assert_contains "$output" "not transient" "explains why a permanent error was not retried"
+
+# Bound tag-object traversal even if an API returns an endless annotation chain.
+invoke_with_args endless_annotations "0 0" "$TEST_TAG" "$STUB_MATCH_SHA" 2
+assert_eq 1 "$status" "fails an annotated-tag chain beyond the peel limit"
+assert_eq 3 "$(stub_call_count)" "stops fetching at the configured peel limit"
+assert_contains "$output" "2-object annotated-tag peel limit" "reports the traversal bound"
+
+# Invalid local inputs fail before gh can be called.
+invoke_with_args lightweight_match "0 0" "$TEST_TAG" "not-a-sha"
+assert_eq 2 "$status" "rejects an invalid expected SHA"
+assert_eq 0 "$(stub_call_count)" "does not call GitHub for invalid local input"
+
+echo ""
+if (( FAIL > 0 )); then
+	echo "❌ ${FAIL} failed, ${PASS} passed" >&2
+	exit 1
+fi
+
+echo "✅ ${PASS} passed"

--- a/Scripts/GHA/get_latest_published_release_tag.sh
+++ b/Scripts/GHA/get_latest_published_release_tag.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# Print the tag of the latest published GitHub release. Drafts and prereleases
+# are intentionally excluded by GitHub's /releases/latest endpoint. A clean
+# 404 means the repository has never published a release; every uncertain API
+# failure is retried and then fails closed.
+
+set -euo pipefail
+
+if (( $# > 1 )); then
+	echo "::error::get_latest_published_release_tag.sh accepts at most one repository argument." >&2
+	exit 2
+fi
+
+repository="${1:-${REPOSITORY:-${GITHUB_REPOSITORY:-}}}"
+if [[ ! "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+	echo "::error::Repository must have the form owner/name; got '${repository}'." >&2
+	exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+	echo "::error::The GitHub CLI (gh) is required to resolve the previous release." >&2
+	exit 2
+fi
+
+GET_LATEST_RELEASE_RETRY_DELAYS="${GET_LATEST_RELEASE_RETRY_DELAYS-5 15 30}"
+declare -a retry_delays=()
+read -ra retry_delays <<< "$GET_LATEST_RELEASE_RETRY_DELAYS" || true
+
+for retry_delay in "${retry_delays[@]}"; do
+	if [[ ! "$retry_delay" =~ ^[0-9]+$ ]]; then
+		echo "::error::GET_LATEST_RELEASE_RETRY_DELAYS must contain non-negative integer seconds." >&2
+		exit 2
+	fi
+done
+
+api_stderr_file="$(mktemp "${TMPDIR:-/tmp}/latest-published-release-api.XXXXXX")"
+cleanup() {
+	rm -f "$api_stderr_file"
+}
+trap cleanup EXIT
+
+transient_api_errors='HTTP (408|425|429|500|502|503|504)|Request Timeout|Too Many Requests|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Time|rate limit|connection reset|connection refused|Could not resolve host|temporary failure in name resolution|TLS handshake timeout|operation timed out|context deadline exceeded|unexpected EOF'
+max_attempts=$(( ${#retry_delays[@]} + 1 ))
+attempt=1
+
+while true; do
+	response=""
+	status=0
+	: > "$api_stderr_file"
+
+	if response="$(gh api --method GET "repos/${repository}/releases/latest" --jq .tag_name 2>"$api_stderr_file")"; then
+		if [[ -z "$response" || "$response" == "null" || "$response" == *$'\n'* || "$response" == *$'\r'* ]]; then
+			echo "::error::GitHub returned an invalid tag for the latest published release." >&2
+			exit 1
+		fi
+
+		printf '%s\n' "$response"
+		exit 0
+	else
+		status=$?
+	fi
+
+	error_text="$(<"$api_stderr_file")"
+	if grep -q "HTTP 404" <<< "$error_text"; then
+		echo "No previous published GitHub release exists." >&2
+		exit 0
+	fi
+
+	if ! grep -qiE "$transient_api_errors" <<< "$error_text"; then
+		echo "::error::Unable to resolve the latest published release (exit ${status}); GitHub returned a permanent error." >&2
+		printf '%s\n' "$error_text" >&2
+		exit "$status"
+	fi
+
+	if (( attempt >= max_attempts )); then
+		echo "::error::Unable to resolve the latest published release after ${max_attempts} attempts (exit ${status})." >&2
+		printf '%s\n' "$error_text" >&2
+		exit "$status"
+	fi
+
+	delay="${retry_delays[attempt - 1]}"
+	echo "Latest published release lookup failed on attempt ${attempt}/${max_attempts}; retrying in ${delay}s. GitHub said: ${error_text}" >&2
+	sleep "$delay"
+	attempt=$(( attempt + 1 ))
+done

--- a/Scripts/GHA/pin_release_tag.sh
+++ b/Scripts/GHA/pin_release_tag.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# Create the release tag at the immutable workflow commit before any downstream
+# publishing job can start, or verify an existing tag on a safe same-commit
+# rerun. GitHub draft releases do not create their Git tag until publication,
+# so relying on release creation alone leaves the eventual tag vulnerable to a
+# moving target branch.
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: pin_release_tag.sh <owner/repository> <tag> <expected-commit-sha>
+
+Create a missing lightweight release tag at the expected commit, then verify
+that the remote tag resolves to that exact commit. Existing tags are never
+moved.
+EOF
+}
+
+if (( $# != 3 )); then
+	echo "::error::pin_release_tag.sh requires repository, tag, and expected commit SHA." >&2
+	usage >&2
+	exit 2
+fi
+
+repository="$1"
+release_tag="$2"
+expected_sha="$3"
+
+if [[ ! "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+	echo "::error::Repository must have the form owner/name; got '${repository}'." >&2
+	exit 2
+fi
+
+if [[ ! "$expected_sha" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+	echo "::error::Expected commit SHA must be a complete 40-character Git SHA." >&2
+	exit 2
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+	echo "::error::Git is required to pin the release tag." >&2
+	exit 2
+fi
+
+if ! git check-ref-format "refs/tags/${release_tag}" >/dev/null 2>&1; then
+	echo "::error::'${release_tag}' is not a valid Git tag name." >&2
+	exit 2
+fi
+
+script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+verify_helper="${VERIFY_RELEASE_TAG_HELPER:-${script_directory}/verify_release_tag.sh}"
+
+if [[ ! -f "$verify_helper" ]]; then
+	echo "::error::Release tag verifier was not found at '${verify_helper}'." >&2
+	exit 2
+fi
+
+remote_ref="refs/tags/${release_tag}"
+lookup_output=""
+lookup_status=0
+
+if lookup_output="$(git ls-remote --exit-code --tags origin "$remote_ref" 2>&1)"; then
+	echo "Release tag ${release_tag} already exists; verifying that this is a safe same-commit rerun."
+else
+	lookup_status=$?
+
+	# git ls-remote --exit-code reserves status 2 for a successful lookup with
+	# no matching refs. Every other failure leaves the remote state unknown.
+	if (( lookup_status != 2 )); then
+		echo "::error::Unable to determine whether release tag ${release_tag} exists (git ls-remote exited ${lookup_status})." >&2
+		printf '%s\n' "$lookup_output" >&2
+		exit 1
+	fi
+
+	echo "Release tag ${release_tag} does not exist; pinning it to ${expected_sha}."
+	# A direct <sha>:<ref> push creates a lightweight tag atomically. Git
+	# refuses to overwrite a tag if another actor wins a race, so this command
+	# fails closed and the next run verifies the winner instead of moving it.
+	git push origin "${expected_sha}:${remote_ref}"
+fi
+
+bash "$verify_helper" "$repository" "$release_tag" "$expected_sha"

--- a/Scripts/GHA/verify_release_tag.sh
+++ b/Scripts/GHA/verify_release_tag.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+
+# Verify that a release tag ultimately resolves to the commit being released.
+#
+# GitHub's ref API returns a commit directly for a lightweight tag and a tag
+# object for an annotated tag. Annotated tags therefore have to be peeled via
+# the git/tags API before their commit can be compared with the immutable
+# workflow SHA.
+#
+# Usage:
+#   verify_release_tag.sh <owner/repository> <tag> <expected-commit-sha>
+#
+# Each positional argument can instead be supplied through the environment:
+#   repository: REPOSITORY or GITHUB_REPOSITORY
+#   tag:        RELEASE_TAG
+#   commit:     EXPECTED_SHA or GITHUB_SHA
+#
+# VERIFY_RELEASE_TAG_RETRY_DELAYS is a space-separated list of delays before
+# retries. Its length determines the retry count; setting it to an empty value
+# disables retries. Tests set the delays to zero so no network or wall-clock
+# time is involved.
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: verify_release_tag.sh [repository] [tag] [expected-commit-sha]
+
+Verify that a GitHub release tag resolves to the expected commit. Values may
+be supplied positionally or with GITHUB_REPOSITORY/REPOSITORY, RELEASE_TAG,
+and EXPECTED_SHA/GITHUB_SHA.
+EOF
+}
+
+if (( $# > 3 )); then
+	echo "::error::verify_release_tag.sh accepts at most three arguments." >&2
+	usage >&2
+	exit 2
+fi
+
+repository="${1:-${REPOSITORY:-${GITHUB_REPOSITORY:-}}}"
+release_tag="${2:-${RELEASE_TAG:-}}"
+expected_sha="${3:-${EXPECTED_SHA:-${GITHUB_SHA:-}}}"
+
+if [[ -z "$repository" || -z "$release_tag" || -z "$expected_sha" ]]; then
+	echo "::error::Repository, release tag, and expected commit SHA are required." >&2
+	usage >&2
+	exit 2
+fi
+
+if [[ ! "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+	echo "::error::Repository must have the form owner/name; got '${repository}'." >&2
+	exit 2
+fi
+
+if [[ "$release_tag" == *$'\n'* || "$release_tag" == *$'\r'* ]]; then
+	echo "::error::Release tag must not contain a newline." >&2
+	exit 2
+fi
+
+if [[ ! "$expected_sha" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+	echo "::error::Expected commit SHA must be a complete 40-character Git SHA." >&2
+	exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+	echo "::error::The GitHub CLI (gh) is required to verify the release tag." >&2
+	exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+	echo "::error::jq is required to parse the GitHub API response." >&2
+	exit 2
+fi
+
+VERIFY_RELEASE_TAG_RETRY_DELAYS="${VERIFY_RELEASE_TAG_RETRY_DELAYS-5 15 30}"
+VERIFY_RELEASE_TAG_MAX_PEELS="${VERIFY_RELEASE_TAG_MAX_PEELS-20}"
+
+if [[ ! "$VERIFY_RELEASE_TAG_MAX_PEELS" =~ ^[1-9][0-9]*$ ]]; then
+	echo "::error::VERIFY_RELEASE_TAG_MAX_PEELS must be a positive integer." >&2
+	exit 2
+fi
+
+declare -a retry_delays=()
+# `read` reports failure for an empty override under some bash versions. An
+# empty list intentionally means one attempt with no retries.
+read -ra retry_delays <<< "$VERIFY_RELEASE_TAG_RETRY_DELAYS" || true
+retry_delay_count="${#retry_delays[@]}"
+for (( retry_delay_index = 0; retry_delay_index < retry_delay_count; retry_delay_index++ )); do
+	retry_delay="${retry_delays[retry_delay_index]}"
+	if [[ ! "$retry_delay" =~ ^[0-9]+$ ]]; then
+		echo "::error::VERIFY_RELEASE_TAG_RETRY_DELAYS must contain non-negative integer seconds." >&2
+		exit 2
+	fi
+done
+
+api_stderr_file="$(mktemp "${TMPDIR:-/tmp}/verify-release-tag-api.XXXXXX")"
+parse_stderr_file="$(mktemp "${TMPDIR:-/tmp}/verify-release-tag-parse.XXXXXX")"
+cleanup() {
+	rm -f "$api_stderr_file" "$parse_stderr_file"
+}
+trap cleanup EXIT
+
+# GitHub CLI usually includes an HTTP status and reason phrase in API errors.
+# The network phrases cover failures that occur before an HTTP response exists.
+transient_api_errors='HTTP (408|425|429|500|502|503|504)|Request Timeout|Too Many Requests|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Time|rate limit|connection reset|connection refused|Could not resolve host|temporary failure in name resolution|TLS handshake timeout|operation timed out|context deadline exceeded|unexpected EOF'
+
+is_transient_api_error() {
+	local error_text="$1"
+	grep -qiE "$transient_api_errors" <<< "$error_text"
+}
+
+API_RESPONSE=""
+
+# gh_api_with_retry <endpoint> <human-readable object description>
+#
+# On success, the response is placed in API_RESPONSE. Logs stay on stderr so
+# JSON never gets mixed with retry messages.
+gh_api_with_retry() {
+	local endpoint="$1"
+	local description="$2"
+	local max_attempts=$(( retry_delay_count + 1 ))
+	local attempt=1
+	local status=0
+	local error_text=""
+
+	while true; do
+		API_RESPONSE=""
+		: > "$api_stderr_file"
+		status=0
+
+		if API_RESPONSE="$(gh api --method GET "$endpoint" 2>"$api_stderr_file")"; then
+			if (( attempt > 1 )); then
+				echo "✅ GitHub API request for ${description} succeeded on attempt ${attempt}/${max_attempts}." >&2
+			fi
+			return 0
+		else
+			status=$?
+		fi
+
+		error_text="$(<"$api_stderr_file")"
+		if [[ -n "$error_text" ]]; then
+			printf '%s\n' "$error_text" >&2
+		fi
+
+		if ! is_transient_api_error "$error_text"; then
+			echo "::error::GitHub API request for ${description} failed (exit ${status}); the error is not transient, so it will not be retried." >&2
+			return "$status"
+		fi
+
+		if (( attempt >= max_attempts )); then
+			echo "::error::GitHub API request for ${description} still failed after ${max_attempts} attempts (exit ${status})." >&2
+			return "$status"
+		fi
+
+		local delay="${retry_delays[attempt - 1]}"
+		echo "⚠️  GitHub API request for ${description} failed on attempt ${attempt}/${max_attempts}; retrying in ${delay}s." >&2
+		sleep "$delay"
+		attempt=$(( attempt + 1 ))
+	done
+}
+
+OBJECT_TYPE=""
+OBJECT_SHA=""
+
+# Parse the common `.object.type` / `.object.sha` shape returned by both the
+# refs and annotated-tags endpoints. A successful HTTP response with invalid or
+# incomplete JSON is a hard failure; retrying cannot turn that response into a
+# trustworthy provenance result.
+parse_git_object() {
+	local description="$1"
+	local object_record=""
+	local extra_field=""
+
+	: > "$parse_stderr_file"
+	if ! object_record="$(jq -er '
+		if (.object | type) == "object"
+			and (.object.type | type) == "string"
+			and (.object.sha | type) == "string"
+		then [.object.type, .object.sha] | @tsv
+		else empty
+		end
+	' <<< "$API_RESPONSE" 2>"$parse_stderr_file")"; then
+		if [[ -s "$parse_stderr_file" ]]; then
+			cat "$parse_stderr_file" >&2
+		fi
+		echo "::error::GitHub returned a malformed response for ${description}; object.type and object.sha are required." >&2
+		return 1
+	fi
+
+	IFS=$'\t' read -r OBJECT_TYPE OBJECT_SHA extra_field <<< "$object_record"
+	if [[ -n "$extra_field" || ! "$OBJECT_TYPE" =~ ^(commit|tag|tree|blob)$ || ! "$OBJECT_SHA" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+		echo "::error::GitHub returned a malformed Git object for ${description}." >&2
+		return 1
+	fi
+
+	OBJECT_SHA="$(tr '[:upper:]' '[:lower:]' <<< "$OBJECT_SHA")"
+}
+
+expected_sha="$(tr '[:upper:]' '[:lower:]' <<< "$expected_sha")"
+encoded_release_tag="$(jq -rn --arg value "$release_tag" '$value | @uri')"
+
+ref_endpoint="repos/${repository}/git/ref/tags/${encoded_release_tag}"
+gh_api_with_retry "$ref_endpoint" "release tag ${release_tag}"
+parse_git_object "release tag ${release_tag}"
+
+peel_count=0
+while [[ "$OBJECT_TYPE" == "tag" ]]; do
+	if (( peel_count >= VERIFY_RELEASE_TAG_MAX_PEELS )); then
+		echo "::error::Release tag ${release_tag} exceeds the ${VERIFY_RELEASE_TAG_MAX_PEELS}-object annotated-tag peel limit." >&2
+		exit 1
+	fi
+	peel_count=$(( peel_count + 1 ))
+
+	tag_object_sha="$OBJECT_SHA"
+	gh_api_with_retry "repos/${repository}/git/tags/${tag_object_sha}" "annotated tag object ${tag_object_sha}"
+	parse_git_object "annotated tag object ${tag_object_sha}"
+done
+
+if [[ "$OBJECT_TYPE" != "commit" ]]; then
+	echo "::error::Release tag ${release_tag} resolves to ${OBJECT_TYPE}, not a commit." >&2
+	exit 1
+fi
+
+if [[ "$OBJECT_SHA" != "$expected_sha" ]]; then
+	echo "::error::Release tag ${release_tag} points to ${OBJECT_SHA}; this workflow is releasing ${expected_sha}." >&2
+	exit 1
+fi
+
+echo "✅ Release tag ${release_tag} is pinned to ${expected_sha}."

--- a/Scripts/NPM/PublishAllPackages.sh
+++ b/Scripts/NPM/PublishAllPackages.sh
@@ -1,12 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Set the package name and version
-package_version=$PACKAGE_VERSION
+package_version="${PACKAGE_VERSION:-}"
+github_sha="${GITHUB_SHA:-}"
 
 # If no package version is provided, exit
 if [ -z "$package_version" ]; then
-  echo "Package version is required"
+  echo "Package version is required" >&2
+  exit 1
+fi
+
+# GITHUB_SHA identifies the immutable source commit for this release. It is
+# required even on a rerun so an existing registry version is never silently
+# accepted from a different build.
+if [ -z "$github_sha" ]; then
+  echo "GITHUB_SHA is required to verify npm package provenance" >&2
   exit 1
 fi
 
@@ -29,25 +38,99 @@ fi
 # Workflow filename: release.yml
 # Save the configuration
 
-publish_to_npm() {
-    directory_name=$1
+is_npm_not_found_response() {
+    local response=$1
+
+    # npm has used both the legacy "npm ERR!" and current "npm error" prefixes.
+    # With --json it also emits the error code in a JSON object.
+    case "$response" in
+        *'"code":"E404"'*|*'"code": "E404"'*|*"npm ERR! code E404"*|*"npm error code E404"*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+common_publish_required=false
+cli_publish_required=false
+
+preflight_npm_package() {
+    local directory_name=$1
+    local npm_package_name
+    local npm_package_spec
+    local npm_view_output
+    local npm_view_status
+    local published_git_head
+
     # Read the npm package name from the directory's package.json
     npm_package_name=$(node -p "require('./$directory_name/package.json').name")
+    npm_package_spec="$npm_package_name@$package_version"
 
-    # Check if this version is already published on npm
-    if npm view "$npm_package_name@$package_version" version 2>/dev/null; then
-        echo "$npm_package_name@$package_version is already published on npm. Skipping."
-        return 0
+    # npm versions are immutable. A rerun may reuse an existing version only
+    # when the registry records that it came from this exact release commit.
+    # Treat only an explicit E404 as absence; connectivity and registry errors
+    # leave the state unknown and must fail closed instead of attempting publish.
+    if npm_view_output=$(npm view "$npm_package_spec" version --json 2>&1); then
+        if published_git_head=$(npm view "$npm_package_spec" gitHead); then
+            if [ -z "$published_git_head" ]; then
+                echo "Refusing to reuse $npm_package_spec: npm did not return gitHead, so its provenance cannot be verified." >&2
+                return 1
+            fi
+
+            if [ "$published_git_head" != "$github_sha" ]; then
+                echo "Refusing to reuse $npm_package_spec: npm gitHead '$published_git_head' does not exactly match GITHUB_SHA '$github_sha'." >&2
+                return 1
+            fi
+
+            echo "$npm_package_spec is already published from GITHUB_SHA $github_sha. Safely skipping."
+            return 0
+        fi
+
+        echo "Unable to read npm gitHead for $npm_package_spec. Refusing to reuse a package whose provenance cannot be verified." >&2
+        return 1
+    else
+        npm_view_status=$?
+        if ! is_npm_not_found_response "$npm_view_output"; then
+            echo "Unable to determine whether $npm_package_spec is published (npm view exited $npm_view_status). Refusing to publish while registry state is unknown." >&2
+            printf '%s\n' "$npm_view_output" >&2
+            return 1
+        fi
     fi
 
-    echo "Publishing $npm_package_name@$package_version to npm"
-    cd $directory_name
+    case "$directory_name" in
+        Common)
+            common_publish_required=true
+            ;;
+        CLI)
+            cli_publish_required=true
+            ;;
+        *)
+            echo "Unknown npm package directory '$directory_name' during preflight" >&2
+            return 1
+            ;;
+    esac
+
+    echo "$npm_package_spec is not published on npm (E404). It will be published from GITHUB_SHA $github_sha after all package preflight checks pass."
+}
+
+publish_to_npm() {
+    local directory_name=$1
+    local npm_package_name
+    local npm_package_spec
+
+    npm_package_name=$(node -p "require('./$directory_name/package.json').name")
+    npm_package_spec="$npm_package_name@$package_version"
+
+    echo "Publishing $npm_package_spec from GITHUB_SHA $github_sha."
+    cd "$directory_name"
 
     # `--allow-same-version` because Scripts/Install/SyncPackageVersions.js
     # (run via the workflow's `npm run prerun`) has already pinned every
     # internal package.json to VERSION. Without this flag, `npm version`
     # exits 1 with "Version not changed" and aborts the publish step.
-    npm version --allow-same-version $package_version
+    npm version --allow-same-version "$package_version"
 
     # Replace any Common dependency with the pinned version being published
     sed -i "s/\"Common\": \"file:..\/Common\"/\"Common\": \"npm:@oneuptime\/common@$package_version\"/g" package.json
@@ -60,9 +143,16 @@ publish_to_npm() {
     cd ..
 }
 
+# Resolve every package's immutable registry state before publishing anything.
+# This prevents a partial release when a later package has a provenance
+# collision or its registry state cannot be determined.
+preflight_npm_package "Common"
+preflight_npm_package "CLI"
 
-# Publish Common first - other packages depend on it
-publish_to_npm "Common"
+# Publish Common first - other packages depend on it.
+if [ "$common_publish_required" = true ]; then
+    publish_to_npm "Common"
+fi
 
 # Wait for @oneuptime/common to be available on the npm registry.
 # There is a propagation delay after publishing, so we poll until
@@ -81,5 +171,7 @@ until npm view "@oneuptime/common@$package_version" version 2>/dev/null; do
 done
 echo "@oneuptime/common@$package_version is now available on npm"
 
-# Publish packages that depend on Common (after Common is available on npm)
-publish_to_npm "CLI"
+# Publish packages that depend on Common (after Common is available on npm).
+if [ "$cli_publish_required" = true ]; then
+    publish_to_npm "CLI"
+fi

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ export default tseslint.config(
       "**/node_modules/",
       "**/dist/",
       "**/build/",
+      "**/output/",
       "**/assets/",
       "**/out/",
       "**/coverage/",


### PR DESCRIPTION
## Root cause

The last production release was reported green while its artifacts came from three different commits: the 13.0.1 Git tag followed moving master, npm packages came from an earlier cancelled run, and Docker images came from the release push. The workflow checked out the moving release ref throughout a multi-hour run, allowed overlapping production runs, skipped existing npm versions without proving their source, and published the GitHub release before every required asset job completed.

The same moving-tag behavior also made the 13.0.1 changelog compare 12.0.34 to 13.0.0. Its public tag is 42 commits ahead of the source actually shipped in its Docker images.

## Fix

- Pin all 39 production checkouts and release creation attempts to the immutable event SHA.
- Serialize production releases without cancelling a partially published run.
- Reserve the semantic Git tag in the upstream version gate, refuse to move an existing tag, and verify the exact commit again immediately before publication.
- Preflight both npm packages before publishing either; reuse an existing version only when its gitHead exactly matches the event SHA and fail closed on uncertain registry state.
- Wait for Terraform, SBOM, infrastructure-agent, Android, and iOS artifact jobs before publishing the GitHub release.
- Resolve changelog boundaries from published releases, use the pinned current tag, fail on builder errors, and use full history plus the exact resolved range for fallback notes.
- Recover the 13.0.1 changelog boundary from the source commit actually shipped; the override naturally expires after the next correctly pinned release.
- Exclude git-ignored generated output from the repository lint pass.

## Validation

- npm run fix
- npm run test-gha-scripts: 282 assertions passed
- release workflow YAML parse
- shell syntax checks for every changed/new script
- package-version consistency check across all 24 package manifests
- generated-output lint exclusion regression check
- whitespace validation
- independent correctness/race review: no remaining findings
