### PR TITLE
fix(app): unbreak master — type the exception entity-key assertion as IncludesType

### DIFF
--- a/App/Tests/Dashboard/ExceptionsEntityScope.test.ts
+++ b/App/Tests/Dashboard/ExceptionsEntityScope.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "@jest/globals";
 import ExceptionInstance from "Common/Models/AnalyticsModels/ExceptionInstance";
 import TelemetryException from "Common/Models/DatabaseModels/TelemetryException";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
-import Includes from "Common/Types/BaseDatabase/Includes";
+import Includes, { IncludesType } from "Common/Types/BaseDatabase/Includes";
 import Query from "Common/Types/BaseDatabase/Query";
 import Search from "Common/Types/BaseDatabase/Search";
 import ObjectID from "Common/Types/ObjectID";
@@ -132,7 +132,7 @@ describe("buildExceptionEntityKeyScope", () => {
       }),
     ).toBe(true);
     expect(
-      predicates.map((predicate: Includes): Array<string> => {
+      predicates.map((predicate: Includes): IncludesType => {
         return predicate.values;
       }),
     ).toEqual(expect.arrayContaining([["service:checkout"], [POD_A]]));


### PR DESCRIPTION
## What is red

Three master jobs have been failing since `50c31284e9` landed:

- `Compile` / `compile-app`
- `Build` / `docker-build-app`
- `Push Test Images…` / `app-docker-image-build (linux/arm64)`

All three fail on the same line:

```
Tests/Dashboard/ExceptionsEntityScope.test.ts(136,9): error TS2322: Type 'IncludesType' is not assignable to type 'string[]'.
  Type 'number[]' is not assignable to type 'string[]'.
```

## Root cause

`Includes.values` is typed `IncludesType`, a union of `Array<string> | Array<ObjectID> | Array<number>`. The test annotated its `map` callback as returning `Array<string>`, which the union is not assignable to. The annotation was wrong from the moment it was written.

It reached master because Jest transpiles TypeScript without typechecking, so `App Test` stayed green and the defect only ever appeared in the compile jobs. `compile-app` and `docker-build-app` were already failing on #3758 when it was merged, and `master` has no required status checks, so nothing blocked the merge.

## Fix

Annotate the callback with the type the expression actually has. The assertion compares plain values through `toEqual`, so it is unchanged and still asserts the same thing. No cast, no `any`, no weakening of the test.

## Verification

Run locally against this branch:

- `cd App && npx tsc --noEmit` — clean, exit 0
- `npx jest Tests/Dashboard/ExceptionsEntityScope.test.ts` — 13 passed
- `npx eslint App/Tests/Dashboard/ExceptionsEntityScope.test.ts` — clean
- `npx prettier --check` — clean

## Follow-up worth considering

`master` has branch protection but no `required_status_checks`. That is why a PR with two red compile jobs could merge. Adding `compile-app` and `docker-build-app` as required checks would stop this class of breakage at the gate.